### PR TITLE
r/key_vault_(key|secret): updating the latest version when updating metadata

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_key_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource.go
@@ -313,7 +313,7 @@ func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) erro
 		parameters.KeyAttributes.Expires = &expirationUnixTime
 	}
 
-	if _, err = client.UpdateKey(ctx, id.KeyVaultBaseUrl, id.Name, id.Version, parameters); err != nil {
+	if _, err = client.UpdateKey(ctx, id.KeyVaultBaseUrl, id.Name, "", parameters); err != nil {
 		return err
 	}
 

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -241,19 +241,6 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 		if _, err = client.SetSecret(ctx, id.KeyVaultBaseUrl, id.Name, parameters); err != nil {
 			return err
 		}
-
-		// "" indicates the latest version
-		read, err2 := client.GetSecret(ctx, id.KeyVaultBaseUrl, id.Name, "")
-		if err2 != nil {
-			return fmt.Errorf("Error getting Key Vault Secret %q : %+v", id.Name, err2)
-		}
-
-		if _, err = azure.ParseKeyVaultChildID(*read.ID); err != nil {
-			return err
-		}
-
-		// the ID is suffixed with the secret version
-		d.SetId(*read.ID)
 	} else {
 		parameters := keyvault.SecretUpdateParameters{
 			ContentType:      utils.String(contentType),
@@ -261,10 +248,23 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 			SecretAttributes: secretAttributes,
 		}
 
-		if _, err = client.UpdateSecret(ctx, id.KeyVaultBaseUrl, id.Name, id.Version, parameters); err != nil {
+		if _, err = client.UpdateSecret(ctx, id.KeyVaultBaseUrl, id.Name, "", parameters); err != nil {
 			return err
 		}
 	}
+
+	// "" indicates the latest version
+	read, err2 := client.GetSecret(ctx, id.KeyVaultBaseUrl, id.Name, "")
+	if err2 != nil {
+		return fmt.Errorf("Error getting Key Vault Secret %q : %+v", id.Name, err2)
+	}
+
+	if _, err = azure.ParseKeyVaultChildID(*read.ID); err != nil {
+		return err
+	}
+
+	// the ID is suffixed with the secret version
+	d.SetId(*read.ID)
 
 	return resourceArmKeyVaultSecretRead(d, meta)
 }

--- a/azurerm/internal/services/keyvault/tests/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_key_resource_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -218,6 +221,37 @@ func TestAccAzureRMKeyVaultKey_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKeyVaultKey_updatedExternally(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKeyVaultKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKeyVaultKey_basicEC(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultKeyExists(data.ResourceName),
+					updateExpiryDateForKeyVaultKey(data.ResourceName, "2029-02-02T12:59:00Z"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAzureRMKeyVaultKey_basicECUpdatedExternally(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultKeyExists(data.ResourceName),
+				),
+			},
+			{
+				Config:   testAccAzureRMKeyVaultKey_basicECUpdatedExternally(data),
+				PlanOnly: true,
+			},
+			data.ImportStep("key_size"),
+		},
+	})
+}
+
 func TestAccAzureRMKeyVaultKey_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
 
@@ -340,6 +374,60 @@ func testCheckAzureRMKeyVaultKeyExists(resourceName string) resource.TestCheckFu
 	}
 }
 
+func updateExpiryDateForKeyVaultKey(resourceName string, expiryDate string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
+		vaultClient := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		name := rs.Primary.Attributes["name"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
+		}
+
+		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
+
+		expirationDate, err := time.Parse(time.RFC3339, expiryDate)
+		if err != nil {
+			return err
+		}
+		expirationUnixTime := date.UnixTime(expirationDate)
+		update := keyvault.KeyUpdateParameters{
+			KeyAttributes: &keyvault.KeyAttributes{
+				Expires: &expirationUnixTime,
+			},
+		}
+		if _, err = client.UpdateKey(ctx, vaultBaseUrl, name, "", update); err != nil {
+			return fmt.Errorf("updating secret: %+v", err)
+		}
+
+		resp, err := client.GetKey(ctx, vaultBaseUrl, name, "")
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Key Vault Key %q (resource group: %q) does not exist", name, vaultBaseUrl)
+			}
+
+			return fmt.Errorf("Bad: Get on keyVaultManagementClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
 func testCheckAzureRMKeyVaultKeyDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
@@ -411,6 +499,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "update",
     ]
 
     secret_permissions = [
@@ -435,6 +524,70 @@ resource "azurerm_key_vault_key" "test" {
     "sign",
     "verify",
   ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMKeyVaultKey_basicECUpdatedExternally(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+    ]
+
+    secret_permissions = [
+      "get",
+      "delete",
+      "set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name            = "key-%s"
+  key_vault_id    = azurerm_key_vault.test.id
+  key_type        = "EC"
+  key_size        = 2048
+  expiration_date = "2029-02-02T12:59:00Z"
+
+  key_opts = [
+    "sign",
+    "verify",
+  ]
+
+  tags = {
+    Rick = "Morty"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }

--- a/azurerm/internal/services/keyvault/tests/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_secret_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -142,6 +143,38 @@ func TestAccAzureRMKeyVaultSecret_update(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "value", "szechuan"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAzureRMKeyVaultSecret_updatingValueChangedExternally(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_secret", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKeyVaultSecretDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKeyVaultSecret_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultSecretExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "value", "rick-and-morty"),
+					updateKeyVaultSecretValue(data.ResourceName, "mad-scientist"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccAzureRMKeyVaultSecret_updateTags(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultSecretExists(data.ResourceName),
+				),
+			},
+			{
+				Config:   testAccAzureRMKeyVaultSecret_updateTags(data),
+				PlanOnly: true,
+			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -299,6 +332,43 @@ func testCheckAzureRMKeyVaultSecretDisappears(resourceName string) resource.Test
 	}
 }
 
+func updateKeyVaultSecretValue(resourceName, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
+		vaultClient := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+		name := rs.Primary.Attributes["name"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
+		}
+
+		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
+
+		updated := keyvault.SecretSetParameters{
+			Value: utils.String(value),
+		}
+		if _, err = client.SetSecret(ctx, vaultBaseUrl, name, updated); err != nil {
+			return fmt.Errorf("updating secret: %+v", err)
+		}
+		return nil
+	}
+}
+
 func testAccAzureRMKeyVaultSecret_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -345,6 +415,60 @@ resource "azurerm_key_vault_secret" "test" {
   name         = "secret-%s"
   value        = "rick-and-morty"
   key_vault_id = azurerm_key_vault.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMKeyVaultSecret_updateTags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "get",
+    ]
+
+    secret_permissions = [
+      "get",
+      "delete",
+      "set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%s"
+  value        = "mad-scientist"
+  key_vault_id = azurerm_key_vault.test.id
+
+  tags = {
+    Rick = "Morty"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }


### PR DESCRIPTION
This PR updates the Key Vault Key & Key Vault Secret resources to update the latest version of the Key/Secret, rather than for an older version

Since this resource doesn't have a concept of managing multiple versions - and we currently update the latest version for other fields, this behaviourally makes sense; but arguably there's a case for a singular version of these resources (e.g. "this version of this key vault secret") - but I'm not sure how useful that would be in a TF context.

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/keyvault/tests/ -run=TestAccAzureRMKeyVaultKey_updatedExternally
=== RUN   TestAccAzureRMKeyVaultKey_updatedExternally
=== PAUSE TestAccAzureRMKeyVaultKey_updatedExternally
=== CONT  TestAccAzureRMKeyVaultKey_updatedExternally
--- PASS: TestAccAzureRMKeyVaultKey_updatedExternally (284.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/tests	284.541s
```

Fixes #6222
Supersedes #7841