### PR TITLE
refactor: splitting Resource Providers out to their own package

### DIFF
--- a/azurerm/internal/acceptance/required_test.go
+++ b/azurerm/internal/acceptance/required_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-azure-helpers/resourceproviders"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
+	rmResourceProviders "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceproviders"
 )
 
 // since this depends on GetAuthConfig which lives in this package
 // unfortunately this has to live in a different package to the other func
 
-func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
+func TestAccEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 	config := GetAuthConfig(t)
 	if config == nil {
 		return
@@ -43,8 +43,8 @@ func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 	}
 
 	availableResourceProviders := providerList.Values()
-	requiredResourceProviders := provider.RequiredResourceProviders()
-	err = provider.EnsureResourceProvidersAreRegistered(ctx, *client, availableResourceProviders, requiredResourceProviders)
+	requiredResourceProviders := rmResourceProviders.Required()
+	err = rmResourceProviders.EnsureRegistered(ctx, *client, availableResourceProviders, requiredResourceProviders)
 	if err != nil {
 		t.Fatalf("Error registering Resource Providers: %+v", err)
 	}

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceproviders"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -301,9 +302,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 			if !skipProviderRegistration {
 				availableResourceProviders := providerList.Values()
-				requiredResourceProviders := RequiredResourceProviders()
+				requiredResourceProviders := resourceproviders.Required()
 
-				err := EnsureResourceProvidersAreRegistered(ctx, *client.Resource.ProvidersClient, availableResourceProviders, requiredResourceProviders)
+				err := resourceproviders.EnsureRegistered(ctx, *client.Resource.ProvidersClient, availableResourceProviders, requiredResourceProviders)
 				if err != nil {
 					return nil, fmt.Errorf(resourceProviderRegistrationErrorFmt, err)
 				}

--- a/azurerm/internal/resourceproviders/registration.go
+++ b/azurerm/internal/resourceproviders/registration.go
@@ -1,0 +1,25 @@
+package resourceproviders
+
+import (
+	"context"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
+	"github.com/hashicorp/go-azure-helpers/resourceproviders"
+)
+
+func EnsureRegistered(ctx context.Context, client resources.ProvidersClient, availableRPs []resources.Provider, requiredRPs map[string]struct{}) error {
+	log.Printf("[DEBUG] Determining which Resource Providers require Registration")
+	providersToRegister := resourceproviders.DetermineResourceProvidersRequiringRegistration(availableRPs, requiredRPs)
+
+	if len(providersToRegister) > 0 {
+		log.Printf("[DEBUG] Registering %d Resource Providers", len(providersToRegister))
+		if err := resourceproviders.RegisterForSubscription(ctx, client, providersToRegister); err != nil {
+			return err
+		}
+	} else {
+		log.Printf("[DEBUG] All required Resource Providers are registered")
+	}
+
+	return nil
+}

--- a/azurerm/internal/resourceproviders/required.go
+++ b/azurerm/internal/resourceproviders/required.go
@@ -1,19 +1,11 @@
-package provider
-
-import (
-	"context"
-	"log"
-
-	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
-	"github.com/hashicorp/go-azure-helpers/resourceproviders"
-)
+package resourceproviders
 
 // RequiredResourceProviders returns all of the Resource Providers used by the AzureRM Provider
 // whilst all may not be used by every user - the intention is that we determine which should be
 // registered such that we can avoid obscure errors where Resource Providers aren't registered.
 // new Resource Providers should be added to this list as they're used in the Provider
 // (this is the approach used by Microsoft in their tooling)
-func RequiredResourceProviders() map[string]struct{} {
+func Required() map[string]struct{} {
 	// NOTE: Resource Providers in this list are case sensitive
 	return map[string]struct{}{
 		"Microsoft.ApiManagement":           {},
@@ -77,20 +69,4 @@ func RequiredResourceProviders() map[string]struct{} {
 		"Microsoft.TimeSeriesInsights":      {},
 		"Microsoft.Web":                     {},
 	}
-}
-
-func EnsureResourceProvidersAreRegistered(ctx context.Context, client resources.ProvidersClient, availableRPs []resources.Provider, requiredRPs map[string]struct{}) error {
-	log.Printf("[DEBUG] Determining which Resource Providers require Registration")
-	providersToRegister := resourceproviders.DetermineResourceProvidersRequiringRegistration(availableRPs, requiredRPs)
-
-	if len(providersToRegister) > 0 {
-		log.Printf("[DEBUG] Registering %d Resource Providers", len(providersToRegister))
-		if err := resourceproviders.RegisterForSubscription(ctx, client, providersToRegister); err != nil {
-			return err
-		}
-	} else {
-		log.Printf("[DEBUG] All required Resource Providers are registered")
-	}
-
-	return nil
 }


### PR DESCRIPTION
This is required to unblock #7951, which has a circular reference otherwise