### PR TITLE
Remove constraint on network_profile_id of azurerm_container_group

### DIFF
--- a/azurerm/internal/services/containers/container_group_resource.go
+++ b/azurerm/internal/services/containers/container_group_resource.go
@@ -71,10 +71,9 @@ func resourceArmContainerGroup() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 				/* Container groups deployed to a virtual network don't currently support exposing containers directly to the internet with a public IP address or a fully qualified domain name.
 				 * Name resolution for Azure resources in the virtual network via the internal Azure DNS is not supported
-				 * You cannot use a managed identity in a container group deployed to a virtual network.
 				 * https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet#virtual-network-deployment-limitations
 				 * https://docs.microsoft.com/en-us/azure/container-instances/container-instances-vnet#preview-limitations */
-				ConflictsWith: []string{"dns_name_label", "identity"},
+				ConflictsWith: []string{"dns_name_label"},
 			},
 
 			"os_type": {

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -65,8 +65,6 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-~> **Note:** managed identities are not supported for containers in virtual networks.
-
 * `container` - (Required) The definition of a container that is part of the group as documented in the `container` block below. Changing this forces a new resource to be created.
 
 * `os_type` - (Required) The OS for the container group. Allowed values are `Linux` and `Windows`. Changing this forces a new resource to be created.
@@ -83,7 +81,7 @@ The following arguments are supported:
 
 * `ip_address_type` - (Optional) Specifies the ip address type of the container. `Public` or `Private`. Changing this forces a new resource to be created. If set to `Private`, `network_profile_id` also needs to be set.
 
-~> **Note:** `dns_name_label`, `identity` and `os_type` set to `windows` are not compatible with `Private` `ip_address_type`
+~> **Note:** `dns_name_label` and `os_type` set to `windows` are not compatible with `Private` `ip_address_type`
 
 * `network_profile_id` - (Optional) Network profile ID for deploying to virtual network.
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/8307

--- PASS: TestAccAzureRMContainerGroup_withVirtualNetworkAndIdentity (479.58s)