### PR TITLE
Update api_management.html.markdown

### DIFF
--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -252,7 +252,7 @@ A `sign_up` block supports the following:
 
 * `enabled` - (Required) Can users sign up on the development portal?
 
-* `terms_of_service` - (Optional) A `terms_of_service` block as defined below.
+* `terms_of_service` - (Required) A `terms_of_service` block as defined below.
 
 ---
 


### PR DESCRIPTION
Update the documentation to show that terms of service are required when specifying a sign up block. 

**terraform version - output**
```
Your version of Terraform is out of date! The latest version
is 0.13.2. You can update by downloading from https://www.terraform.io/downloads.html
Terraform v0.13.0
+ provider registry.terraform.io/hashicorp/azurerm v2.25.0`` 
``` 

Having a sign up block like this
```
  sign_up {
    enabled = false
  }
```

Results in this error in _terraform validate_ 
```
Error: "sign_up.0.terms_of_service": required field is not set

  on apim.tf line 1, in resource "azurerm_api_management" "main":
   1: resource "azurerm_api_management" "main" {
```