### PR TITLE
Updating firewall_network_rule_collection docs to revert FQDN doc change

### DIFF
--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -110,7 +110,7 @@ A `rule` block supports the following:
 
 * `source_addresses` - (Required) A list of source IP addresses and/or IP ranges.
 
-* `destination_addresses` - (Required) A list of destination IP addresses, IP ranges, or FQDNs.
+* `destination_addresses` - (Required) A list of destination IP addresses and/or IP ranges.
 
 * `destination_ports` - (Required) A list of destination ports.
 


### PR DESCRIPTION
Hey team, 

Upon further testing, FQDN isn't accepted yet in this field. Reverting previously pushed change. 