### PR TITLE
azurerm_app_service_hybrid_connection - support relays in different namespaces

### DIFF
--- a/azurerm/internal/services/web/app_service_hybrid_connection_resource.go
+++ b/azurerm/internal/services/web/app_service_hybrid_connection_resource.go
@@ -201,7 +201,7 @@ func resourceArmAppServiceHybridConnectionRead(d *schema.ResourceData, meta inte
 		relayNSClient := meta.(*clients.Client).Relay.NamespacesClient
 		relayNamespaceRG, err := findRelayNamespace(relayNSClient, ctx, *resp.ServiceBusNamespace)
 		if err != nil {
-			return nil
+			return err
 		}
 		accessKeys, err := relayNSClient.ListKeys(ctx, relayNamespaceRG, *resp.ServiceBusNamespace, *resp.SendKeyName)
 		if err != nil {

--- a/azurerm/internal/services/web/app_service_hybrid_connection_resource.go
+++ b/azurerm/internal/services/web/app_service_hybrid_connection_resource.go
@@ -1,10 +1,12 @@
 package web
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
+	relayMngt "github.com/Azure/azure-sdk-for-go/services/relay/mgmt/2017-04-01/relay"
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2019-08-01/web"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -195,12 +197,18 @@ func resourceArmAppServiceHybridConnectionRead(d *schema.ResourceData, meta inte
 	}
 
 	// key values are not returned in the response, so we get the primary key from the relay namespace ListKeys func
-	relayNSClient := meta.(*clients.Client).Relay.NamespacesClient
-	accessKeys, err := relayNSClient.ListKeys(ctx, resourceGroup, *resp.ServiceBusNamespace, *resp.SendKeyName)
-	if err != nil {
-		return fmt.Errorf("unable to List Access Keys for Namespace %q (Resource Group %q): %+v", *resp.ServiceBusNamespace, resourceGroup, err)
-	} else {
-		d.Set("send_key_value", accessKeys.PrimaryKey)
+	if resp.ServiceBusNamespace != nil && resp.SendKeyName != nil {
+		relayNSClient := meta.(*clients.Client).Relay.NamespacesClient
+		relayNamespaceRG, err := findRelayNamespace(relayNSClient, ctx, *resp.ServiceBusNamespace)
+		if err != nil {
+			return nil
+		}
+		accessKeys, err := relayNSClient.ListKeys(ctx, relayNamespaceRG, *resp.ServiceBusNamespace, *resp.SendKeyName)
+		if err != nil {
+			return fmt.Errorf("unable to List Access Keys for Namespace %q (Resource Group %q): %+v", *resp.ServiceBusNamespace, resourceGroup, err)
+		} else {
+			d.Set("send_key_value", accessKeys.PrimaryKey)
+		}
 	}
 
 	return nil
@@ -229,4 +237,33 @@ func resourceArmAppServiceHybridConnectionDelete(d *schema.ResourceData, meta in
 	}
 
 	return nil
+}
+
+func findRelayNamespace(client *relayMngt.NamespacesClient, ctx context.Context, name string) (string, error) {
+	relayNSIterator, err := client.ListComplete(ctx)
+	if err != nil {
+		return "", fmt.Errorf("listing Relay Namespaces: %+v", err)
+	}
+
+	var found *relayMngt.Namespace
+	for relayNSIterator.NotDone() {
+		namespace := relayNSIterator.Value()
+		if namespace.Name != nil && *namespace.Name == name {
+			found = &namespace
+			break
+		}
+		if err := relayNSIterator.NextWithContext(ctx); err != nil {
+			return "", fmt.Errorf("listing Relay Namespaces: %+v", err)
+		}
+	}
+
+	if found == nil || found.ID == nil {
+		return "", fmt.Errorf("could not find Relay Namespace with name: %q", name)
+	}
+
+	id, err := relay.ParseNamespaceID(*found.ID)
+	if err != nil {
+		return "", fmt.Errorf("relay Namespace id not valid: %+v", err)
+	}
+	return id.ResourceGroup, nil
 }

--- a/azurerm/internal/services/web/tests/app_service_hybrid_connection_resource_test.go
+++ b/azurerm/internal/services/web/tests/app_service_hybrid_connection_resource_test.go
@@ -74,6 +74,25 @@ func TestAccAzureRMAppServiceHybridConnection_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceHybridConnection_differentResourceGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_hybrid_connection", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceHybridConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceHybridConnection_differentResourceGroup(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceHybridConnectionExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMAppServiceHybridConnectionDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
 
@@ -220,4 +239,64 @@ resource "azurerm_app_service_hybrid_connection" "import" {
   send_key_name       = azurerm_app_service_hybrid_connection.test.send_key_name
 }
 `, template)
+}
+
+func testAccAzureRMAppServiceHybridConnection_differentResourceGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_resource_group" "relay" {
+  name     = "acctestRG-relay-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest-ASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctest-AS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_relay_namespace" "test" {
+  name                = "acctest-RN-%d"
+  location            = azurerm_resource_group.relay.location
+  resource_group_name = azurerm_resource_group.relay.name
+
+  sku_name = "Standard"
+}
+
+resource "azurerm_relay_hybrid_connection" "test" {
+  name                 = "acctest-RHC-%d"
+  resource_group_name  = azurerm_resource_group.relay.name
+  relay_namespace_name = azurerm_relay_namespace.test.name
+  user_metadata        = "metadatatest"
+}
+
+resource "azurerm_app_service_hybrid_connection" "test" {
+  app_service_name    = azurerm_app_service.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  relay_id            = azurerm_relay_hybrid_connection.test.id
+  hostname            = "testhostname.azuretest"
+  port                = 443
+  send_key_name       = "RootManageSharedAccessKey"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
fix #8354
![image](https://user-images.githubusercontent.com/2786738/92361585-28dcdf80-f121-11ea-96f8-3c076c5b2e3a.png)
