### PR TITLE
azurerm_application_insights_webtests: .Kind turns to null after editing in Portal

### DIFF
--- a/azurerm/internal/services/applicationinsights/application_insights_webtests_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_webtests_resource.go
@@ -237,13 +237,13 @@ func resourceArmApplicationInsightsWebTestsRead(d *schema.ResourceData, meta int
 	d.Set("application_insights_id", appInsightsId)
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resGroup)
-	d.Set("kind", resp.Kind)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
 	if props := resp.WebTestProperties; props != nil {
+		d.Set("kind", string(props.WebTestKind))
 		d.Set("synthetic_monitor_id", props.SyntheticMonitorID)
 		d.Set("description", props.Description)
 		d.Set("enabled", props.Enabled)

--- a/azurerm/internal/services/applicationinsights/application_insights_webtests_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_webtests_resource.go
@@ -237,13 +237,17 @@ func resourceArmApplicationInsightsWebTestsRead(d *schema.ResourceData, meta int
 	d.Set("application_insights_id", appInsightsId)
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resGroup)
+	d.Set("kind", resp.Kind)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
 	if props := resp.WebTestProperties; props != nil {
-		d.Set("kind", string(props.WebTestKind))
+		// It is possible that the root level `kind` in response is empty in some cases (see PR #8372 for more info)
+		if resp.Kind == "" {
+			d.Set("kind", props.WebTestKind)
+		}
 		d.Set("synthetic_monitor_id", props.SyntheticMonitorID)
 		d.Set("description", props.Description)
 		d.Set("enabled", props.Enabled)


### PR DESCRIPTION
After doing some trivial operation on a terraform managed application insights webtest on Portal, the `kind` will turn into `null`. This seems because the request in Portal doesn't set the `.kind` property but the `.properties.Kind`. To mitigate the impact for those poor souls who want to mix the two, we side pass this problem by keeping the same way as Portal does, in read.

This fixes #8356.