### PR TITLE
azurerm_kubernetes_cluster - ensure OMS Agent log analytics workspace case is preserved after disabling/enabling

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -331,6 +331,11 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 			zoneName = *v
 		}
 
+		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
+		if v := httpApplicationRouting.Config["httpapplicationroutingzonename"]; v != nil {
+			zoneName = *v
+		}
+
 		httpApplicationRoutes = append(httpApplicationRoutes, map[string]interface{}{
 			"enabled":                            enabled,
 			"http_application_routing_zone_name": zoneName,

--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -277,20 +277,8 @@ func filterUnsupportedKubernetesAddOns(input map[string]*containerservice.Manage
 }
 
 func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.ManagedClusterAddonProfile) []interface{} {
-	// when the Kubernetes Cluster is updated in the Portal - Azure updates the casing on the keys
-	// meaning what's submitted could be different to what's returned..
-	var locateInProfile = func(key string) *containerservice.ManagedClusterAddonProfile {
-		for k, v := range profile {
-			if strings.EqualFold(k, key) {
-				return v
-			}
-		}
-
-		return nil
-	}
-
 	aciConnectors := make([]interface{}, 0)
-	if aciConnector := locateInProfile(aciConnectorKey); aciConnector != nil {
+	if aciConnector := kubernetesAddonProfileLocate(profile, aciConnectorKey); aciConnector != nil {
 		enabled := false
 		if enabledVal := aciConnector.Enabled; enabledVal != nil {
 			enabled = *enabledVal
@@ -308,7 +296,7 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 	}
 
 	azurePolicies := make([]interface{}, 0)
-	if azurePolicy := locateInProfile(azurePolicyKey); azurePolicy != nil {
+	if azurePolicy := kubernetesAddonProfileLocate(profile, azurePolicyKey); azurePolicy != nil {
 		enabled := false
 		if enabledVal := azurePolicy.Enabled; enabledVal != nil {
 			enabled = *enabledVal
@@ -320,19 +308,14 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 	}
 
 	httpApplicationRoutes := make([]interface{}, 0)
-	if httpApplicationRouting := locateInProfile(httpApplicationRoutingKey); httpApplicationRouting != nil {
+	if httpApplicationRouting := kubernetesAddonProfileLocate(profile, httpApplicationRoutingKey); httpApplicationRouting != nil {
 		enabled := false
 		if enabledVal := httpApplicationRouting.Enabled; enabledVal != nil {
 			enabled = *enabledVal
 		}
 
 		zoneName := ""
-		if v := httpApplicationRouting.Config["HTTPApplicationRoutingZoneName"]; v != nil {
-			zoneName = *v
-		}
-
-		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
-		if v := httpApplicationRouting.Config["httpapplicationroutingzonename"]; v != nil {
+		if v := kubernetesAddonProfilelocateInConfig(httpApplicationRouting.Config, "HTTPApplicationRoutingZoneName"); v != nil {
 			zoneName = *v
 		}
 
@@ -343,7 +326,7 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 	}
 
 	kubeDashboards := make([]interface{}, 0)
-	if kubeDashboard := locateInProfile(kubernetesDashboardKey); kubeDashboard != nil {
+	if kubeDashboard := kubernetesAddonProfileLocate(profile, kubernetesDashboardKey); kubeDashboard != nil {
 		enabled := false
 		if enabledVal := kubeDashboard.Enabled; enabledVal != nil {
 			enabled = *enabledVal
@@ -355,19 +338,15 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 	}
 
 	omsAgents := make([]interface{}, 0)
-	if omsAgent := locateInProfile(omsAgentKey); omsAgent != nil {
+	if omsAgent := kubernetesAddonProfileLocate(profile, omsAgentKey); omsAgent != nil {
 		enabled := false
 		if enabledVal := omsAgent.Enabled; enabledVal != nil {
 			enabled = *enabledVal
 		}
 
 		workspaceID := ""
-		if workspaceResourceID := omsAgent.Config["logAnalyticsWorkspaceResourceID"]; workspaceResourceID != nil {
-			workspaceID = *workspaceResourceID
-		}
-		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
-		if workspaceResourceID := omsAgent.Config["loganalyticsworkspaceresourceid"]; workspaceResourceID != nil {
-			workspaceID = *workspaceResourceID
+		if v := kubernetesAddonProfilelocateInConfig(omsAgent.Config, "logAnalyticsWorkspaceResourceID"); v != nil {
+			workspaceID = *v
 		}
 
 		omsagentIdentity := flattenKubernetesClusterOmsAgentIdentityProfile(omsAgent.Identity)
@@ -423,4 +402,29 @@ func flattenKubernetesClusterOmsAgentIdentityProfile(profile *containerservice.M
 	})
 
 	return identity
+}
+
+// when the Kubernetes Cluster is updated in the Portal - Azure updates the casing on the keys
+// meaning what's submitted could be different to what's returned..
+func kubernetesAddonProfileLocate(profile map[string]*containerservice.ManagedClusterAddonProfile, key string) *containerservice.ManagedClusterAddonProfile {
+	for k, v := range profile {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+
+	return nil
+}
+
+// when the Kubernetes Cluster is updated in the Portal - Azure updates the casing on the keys
+// meaning what's submitted could be different to what's returned..
+// Related issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
+func kubernetesAddonProfilelocateInConfig(config map[string]*string, key string) *string {
+	for k, v := range config {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+
+	return nil
 }

--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -360,6 +360,10 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 		if workspaceResourceID := omsAgent.Config["logAnalyticsWorkspaceResourceID"]; workspaceResourceID != nil {
 			workspaceID = *workspaceResourceID
 		}
+		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
+		if workspaceResourceID := omsAgent.Config["loganalyticsworkspaceresourceid"]; workspaceResourceID != nil {
+			workspaceID = *workspaceResourceID
+		}
 
 		omsagentIdentity := flattenKubernetesClusterOmsAgentIdentityProfile(omsAgent.Identity)
 

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -745,18 +745,14 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 	values := make(map[string]interface{})
 
 	routes := make([]interface{}, 0)
-	if httpApplicationRouting := profile["httpApplicationRouting"]; httpApplicationRouting != nil {
+	if httpApplicationRouting := kubernetesAddonProfileLocate(profile, httpApplicationRoutingKey); httpApplicationRouting != nil {
 		enabled := false
 		if enabledVal := httpApplicationRouting.Enabled; enabledVal != nil {
 			enabled = *enabledVal
 		}
 
 		zoneName := ""
-		if v := httpApplicationRouting.Config["HTTPApplicationRoutingZoneName"]; v != nil {
-			zoneName = *v
-		}
-		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
-		if v := httpApplicationRouting.Config["httpapplicationroutingzonename"]; v != nil {
+		if v := kubernetesAddonProfilelocateInConfig(httpApplicationRouting.Config, "HTTPApplicationRoutingZoneName"); v != nil {
 			zoneName = *v
 		}
 
@@ -769,20 +765,15 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 	values["http_application_routing"] = routes
 
 	agents := make([]interface{}, 0)
-	if omsAgent := profile["omsagent"]; omsAgent != nil {
+	if omsAgent := kubernetesAddonProfileLocate(profile, omsAgentKey); omsAgent != nil {
 		enabled := false
 		if enabledVal := omsAgent.Enabled; enabledVal != nil {
 			enabled = *enabledVal
 		}
 
 		workspaceID := ""
-		if workspaceResourceID := omsAgent.Config["logAnalyticsWorkspaceResourceID"]; workspaceResourceID != nil {
-			workspaceID = *workspaceResourceID
-		}
-
-		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
-		if workspaceResourceID := omsAgent.Config["loganalyticsworkspaceresourceid"]; workspaceResourceID != nil {
-			workspaceID = *workspaceResourceID
+		if v := kubernetesAddonProfilelocateInConfig(omsAgent.Config, "logAnalyticsWorkspaceResourceID"); v != nil {
+			workspaceID = *v
 		}
 
 		omsagentIdentity := flattenKubernetesClusterDataSourceOmsAgentIdentityProfile(omsAgent.Identity)
@@ -797,7 +788,7 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 	values["oms_agent"] = agents
 
 	kubeDashboards := make([]interface{}, 0)
-	if kubeDashboard := profile["kubeDashboard"]; kubeDashboard != nil {
+	if kubeDashboard := kubernetesAddonProfileLocate(profile, kubernetesDashboardKey); kubeDashboard != nil {
 		enabled := false
 		if enabledVal := kubeDashboard.Enabled; enabledVal != nil {
 			enabled = *enabledVal
@@ -811,7 +802,7 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 	values["kube_dashboard"] = kubeDashboards
 
 	azurePolicies := make([]interface{}, 0)
-	if azurePolicy := profile["azurepolicy"]; azurePolicy != nil {
+	if azurePolicy := kubernetesAddonProfileLocate(profile, azurePolicyKey); azurePolicy != nil {
 		enabled := false
 		if enabledVal := azurePolicy.Enabled; enabledVal != nil {
 			enabled = *enabledVal

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -776,6 +776,11 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 			workspaceID = *workspaceResourceID
 		}
 
+		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
+		if workspaceResourceID := omsAgent.Config["loganalyticsworkspaceresourceid"]; workspaceResourceID != nil {
+			workspaceID = *workspaceResourceID
+		}
+
 		omsagentIdentity := flattenKubernetesClusterDataSourceOmsAgentIdentityProfile(omsAgent.Identity)
 
 		output := map[string]interface{}{

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -755,6 +755,10 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 		if v := httpApplicationRouting.Config["HTTPApplicationRoutingZoneName"]; v != nil {
 			zoneName = *v
 		}
+		// This is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10716
+		if v := httpApplicationRouting.Config["httpapplicationroutingzonename"]; v != nil {
+			zoneName = *v
+		}
 
 		output := map[string]interface{}{
 			"enabled":                            enabled,

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_addons_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_addons_resource_test.go
@@ -228,6 +228,18 @@ func testAccAzureRMKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 				),
 			},
 			data.ImportStep(),
+			{
+				Config: testAccAzureRMKubernetesCluster_addonProfileOMSConfig(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.http_application_routing.#", "0"),
+					resource.TestCheckResourceAttr(data.ResourceName, "default_node_pool.0.node_count", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.oms_agent.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.oms_agent.0.enabled", "true"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "addon_profile.0.oms_agent.0.log_analytics_workspace_id"),
+				),
+			},
+			data.ImportStep(),
 		},
 	})
 }


### PR DESCRIPTION
AKS service will somehow ignore the config key cases after disable then enable the omsagent. Opened an issue to track this issue: Azure/azure-rest-api-specs#10716.

This PR is a workaround to unblock #8344.