### PR TITLE
Change `API` to `Api` in few testcases name

### DIFF
--- a/azurerm/internal/services/apimanagement/tests/api_management_authorization_server_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_authorization_server_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementAuthorizationServer_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementAuthorizationServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementAuthorizationServer_basic(data),
+				Config: testAccAzureRMApiManagementAuthorizationServer_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementAuthorizationServerExists(data.ResourceName),
 				),
@@ -39,12 +39,12 @@ func TestAccAzureRMApiManagementAuthorizationServer_requiresImport(t *testing.T)
 		CheckDestroy: testCheckAzureRMAPIManagementAuthorizationServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementAuthorizationServer_basic(data),
+				Config: testAccAzureRMApiManagementAuthorizationServer_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementAuthorizationServerExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementAuthorizationServer_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementAuthorizationServer_requiresImport),
 		},
 	})
 }
@@ -58,7 +58,7 @@ func TestAccAzureRMApiManagementAuthorizationServer_complete(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementAuthorizationServerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementAuthorizationServer_complete(data),
+				Config: testAccAzureRMApiManagementAuthorizationServer_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementAuthorizationServerExists(data.ResourceName),
 				),
@@ -120,8 +120,8 @@ func testCheckAzureRMAPIManagementAuthorizationServerExists(resourceName string)
 	}
 }
 
-func testAccAzureRMAPIManagementAuthorizationServer_basic(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementAuthorizationServer_template(data)
+func testAccAzureRMApiManagementAuthorizationServer_basic(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementAuthorizationServer_template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -145,8 +145,8 @@ resource "azurerm_api_management_authorization_server" "test" {
 `, template, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementAuthorizationServer_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementAuthorizationServer_basic(data)
+func testAccAzureRMApiManagementAuthorizationServer_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementAuthorizationServer_basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -167,8 +167,8 @@ resource "azurerm_api_management_authorization_server" "import" {
 `, template)
 }
 
-func testAccAzureRMAPIManagementAuthorizationServer_complete(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementAuthorizationServer_template(data)
+func testAccAzureRMApiManagementAuthorizationServer_complete(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementAuthorizationServer_template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -204,7 +204,7 @@ resource "azurerm_api_management_authorization_server" "test" {
 `, template, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementAuthorizationServer_template(data acceptance.TestData) string {
+func testAccAzureRMApiManagementAuthorizationServer_template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/apimanagement/tests/api_management_authorization_server_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_authorization_server_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementAuthorizationServer_basic(t *testing.T) {
+func TestAccAzureRMApiManagementAuthorizationServer_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_authorization_server", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccAzureRMAPIManagementAuthorizationServer_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementAuthorizationServer_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementAuthorizationServer_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_authorization_server", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -49,7 +49,7 @@ func TestAccAzureRMAPIManagementAuthorizationServer_requiresImport(t *testing.T)
 	})
 }
 
-func TestAccAzureRMAPIManagementAuthorizationServer_complete(t *testing.T) {
+func TestAccAzureRMApiManagementAuthorizationServer_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_authorization_server", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_certificate_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_certificate_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementCertificate_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementCertificate_basic(data),
+				Config: testAccAzureRMApiManagementCertificate_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementCertificateExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "expiration"),
@@ -51,12 +51,12 @@ func TestAccAzureRMApiManagementCertificate_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementCertificateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementCertificate_basic(data),
+				Config: testAccAzureRMApiManagementCertificate_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementCertificateExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementCertificate_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementCertificate_requiresImport),
 		},
 	})
 }
@@ -113,7 +113,7 @@ func testCheckAzureRMAPIManagementCertificateExists(resourceName string) resourc
 	}
 }
 
-func testAccAzureRMAPIManagementCertificate_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementCertificate_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -143,8 +143,8 @@ resource "azurerm_api_management_certificate" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementCertificate_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementCertificate_basic(data)
+func testAccAzureRMApiManagementCertificate_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementCertificate_basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_certificate_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_certificate_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementCertificate_basic(t *testing.T) {
+func TestAccAzureRMApiManagementCertificate_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_certificate", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -42,7 +42,7 @@ func TestAccAzureRMAPIManagementCertificate_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementCertificate_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementCertificate_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_certificate", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_group_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_group_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementGroup_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementGroup_basic(data),
+				Config: testAccAzureRMApiManagementGroup_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Test Group"),
@@ -41,14 +41,14 @@ func TestAccAzureRMApiManagementGroup_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementGroup_basic(data),
+				Config: testAccAzureRMApiManagementGroup_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Test Group"),
 					resource.TestCheckResourceAttr(data.ResourceName, "type", "custom"),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementGroup_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementGroup_requiresImport),
 		},
 	})
 }
@@ -62,7 +62,7 @@ func TestAccAzureRMApiManagementGroup_complete(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementGroup_complete(data, "Test Group", "A test description."),
+				Config: testAccAzureRMApiManagementGroup_complete(data, "Test Group", "A test description."),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Test Group"),
@@ -84,7 +84,7 @@ func TestAccAzureRMApiManagementGroup_descriptionDisplayNameUpdate(t *testing.T)
 		CheckDestroy: testCheckAzureRMAPIManagementGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementGroup_complete(data, "Original Group", "The original description."),
+				Config: testAccAzureRMApiManagementGroup_complete(data, "Original Group", "The original description."),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Original Group"),
@@ -93,7 +93,7 @@ func TestAccAzureRMApiManagementGroup_descriptionDisplayNameUpdate(t *testing.T)
 				),
 			},
 			{
-				Config: testAccAzureRMAPIManagementGroup_complete(data, "Modified Group", "A modified description."),
+				Config: testAccAzureRMApiManagementGroup_complete(data, "Modified Group", "A modified description."),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Modified Group"),
@@ -102,7 +102,7 @@ func TestAccAzureRMApiManagementGroup_descriptionDisplayNameUpdate(t *testing.T)
 				),
 			},
 			{
-				Config: testAccAzureRMAPIManagementGroup_complete(data, "Original Group", "The original description."),
+				Config: testAccAzureRMApiManagementGroup_complete(data, "Original Group", "The original description."),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Original Group"),
@@ -166,7 +166,7 @@ func testCheckAzureRMAPIManagementGroupExists(resourceName string) resource.Test
 	}
 }
 
-func testAccAzureRMAPIManagementGroup_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementGroup_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -196,8 +196,8 @@ resource "azurerm_api_management_group" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementGroup_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementGroup_basic(data)
+func testAccAzureRMApiManagementGroup_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementGroup_basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -210,7 +210,7 @@ resource "azurerm_api_management_group" "import" {
 `, template)
 }
 
-func testAccAzureRMAPIManagementGroup_complete(data acceptance.TestData, displayName, description string) string {
+func testAccAzureRMApiManagementGroup_complete(data acceptance.TestData, displayName, description string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/apimanagement/tests/api_management_group_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_group_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementGroup_basic(t *testing.T) {
+func TestAccAzureRMApiManagementGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,7 +32,7 @@ func TestAccAzureRMAPIManagementGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementGroup_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementGroup_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -53,7 +53,7 @@ func TestAccAzureRMAPIManagementGroup_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementGroup_complete(t *testing.T) {
+func TestAccAzureRMApiManagementGroup_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -75,7 +75,7 @@ func TestAccAzureRMAPIManagementGroup_complete(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementGroup_descriptionDisplayNameUpdate(t *testing.T) {
+func TestAccAzureRMApiManagementGroup_descriptionDisplayNameUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_group_user_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_group_user_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementGroupUser_basic(t *testing.T) {
+func TestAccAzureRMApiManagementGroupUser_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group_user", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccAzureRMAPIManagementGroupUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementGroupUser_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementGroupUser_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_group_user", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_group_user_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_group_user_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementGroupUser_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementGroupUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementGroupUser_basic(data),
+				Config: testAccAzureRMApiManagementGroupUser_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupUserExists(data.ResourceName),
 				),
@@ -39,12 +39,12 @@ func TestAccAzureRMApiManagementGroupUser_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementGroupUserDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementGroupUser_basic(data),
+				Config: testAccAzureRMApiManagementGroupUser_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementGroupUserExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementGroupUser_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementGroupUser_requiresImport),
 		},
 	})
 }
@@ -102,7 +102,7 @@ func testCheckAzureRMAPIManagementGroupUserExists(resourceName string) resource.
 	}
 }
 
-func testAccAzureRMAPIManagementGroupUser_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementGroupUser_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -148,8 +148,8 @@ resource "azurerm_api_management_group_user" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementGroupUser_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementGroupUser_basic(data)
+func testAccAzureRMApiManagementGroupUser_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementGroupUser_basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_named_value_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_named_value_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementNamedValue_basic(t *testing.T) {
+func TestAccAzureRMApiManagementNamedValue_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_named_value", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccAzureRMAPIManagementNamedValue_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementNamedValue_update(t *testing.T) {
+func TestAccAzureRMApiManagementNamedValue_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_named_value", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_named_value_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_named_value_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementNamedValue_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementNamedValueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementNamedValue_basic(data),
+				Config: testAccAzureRMApiManagementNamedValue_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementNamedValueExists(data.ResourceName),
 				),
@@ -39,14 +39,14 @@ func TestAccAzureRMApiManagementNamedValue_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementNamedValueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementNamedValue_basic(data),
+				Config: testAccAzureRMApiManagementNamedValue_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementNamedValueExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMAPIManagementNamedValue_update(data),
+				Config: testAccAzureRMApiManagementNamedValue_update(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementNamedValueExists(data.ResourceName),
 				),
@@ -112,7 +112,7 @@ func testCheckAzureRMAPIManagementNamedValueExists(resourceName string) resource
 
  */
 
-func testAccAzureRMAPIManagementNamedValue_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementNamedValue_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -144,7 +144,7 @@ resource "azurerm_api_management_named_value" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementNamedValue_update(data acceptance.TestData) string {
+func testAccAzureRMApiManagementNamedValue_update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/apimanagement/tests/api_management_product_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_product_api_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementProductApi_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementProductApiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementProductApi_basic(data),
+				Config: testAccAzureRMApiManagementProductApi_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementProductApiExists(data.ResourceName),
 				),
@@ -39,12 +39,12 @@ func TestAccAzureRMApiManagementProductApi_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementProductApiDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementProductApi_basic(data),
+				Config: testAccAzureRMApiManagementProductApi_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementProductApiExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementProductApi_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementProductApi_requiresImport),
 		},
 	})
 }
@@ -102,7 +102,7 @@ func testCheckAzureRMAPIManagementProductApiExists(resourceName string) resource
 	}
 }
 
-func testAccAzureRMAPIManagementProductApi_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementProductApi_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -152,8 +152,8 @@ resource "azurerm_api_management_product_api" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementProductApi_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementProductApi_basic(data)
+func testAccAzureRMApiManagementProductApi_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementProductApi_basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_product_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_product_api_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementProductApi_basic(t *testing.T) {
+func TestAccAzureRMApiManagementProductApi_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_api", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccAzureRMAPIManagementProductApi_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementProductApi_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementProductApi_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_api", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_product_group_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_product_group_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementProductGroup_basic(t *testing.T) {
+func TestAccAzureRMApiManagementProductGroup_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -30,7 +30,7 @@ func TestAccAzureRMAPIManagementProductGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementProductGroup_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementProductGroup_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_product_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_product_group_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_product_group_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementProductGroup_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementProductGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementProductGroup_basic(data),
+				Config: testAccAzureRMApiManagementProductGroup_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementProductGroupExists(data.ResourceName),
 				),
@@ -39,12 +39,12 @@ func TestAccAzureRMApiManagementProductGroup_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementProductGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementProductGroup_basic(data),
+				Config: testAccAzureRMApiManagementProductGroup_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementProductGroupExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementProductGroup_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementProductGroup_requiresImport),
 		},
 	})
 }
@@ -102,7 +102,7 @@ func testCheckAzureRMAPIManagementProductGroupExists(resourceName string) resour
 	}
 }
 
-func testAccAzureRMAPIManagementProductGroup_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementProductGroup_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -149,8 +149,8 @@ resource "azurerm_api_management_product_group" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementProductGroup_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementProductGroup_basic(data)
+func testAccAzureRMApiManagementProductGroup_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementProductGroup_basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_property_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_property_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementProperty_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementPropertyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementProperty_basic(data),
+				Config: testAccAzureRMApiManagementProperty_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementPropertyExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("TestProperty%d", data.RandomInteger)),
@@ -43,7 +43,7 @@ func TestAccAzureRMApiManagementProperty_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementPropertyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementProperty_basic(data),
+				Config: testAccAzureRMApiManagementProperty_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementPropertyExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("TestProperty%d", data.RandomInteger)),
@@ -54,7 +54,7 @@ func TestAccAzureRMApiManagementProperty_update(t *testing.T) {
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMAPIManagementProperty_update(data),
+				Config: testAccAzureRMApiManagementProperty_update(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementPropertyExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("TestProperty2%d", data.RandomInteger)),
@@ -124,7 +124,7 @@ func testCheckAzureRMAPIManagementPropertyExists(resourceName string) resource.T
 
  */
 
-func testAccAzureRMAPIManagementProperty_basic(data acceptance.TestData) string {
+func testAccAzureRMApiManagementProperty_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -156,7 +156,7 @@ resource "azurerm_api_management_property" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAPIManagementProperty_update(data acceptance.TestData) string {
+func testAccAzureRMApiManagementProperty_update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/apimanagement/tests/api_management_property_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_property_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementProperty_basic(t *testing.T) {
+func TestAccAzureRMApiManagementProperty_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_property", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +34,7 @@ func TestAccAzureRMAPIManagementProperty_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementProperty_update(t *testing.T) {
+func TestAccAzureRMApiManagementProperty_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_property", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/apimanagement/tests/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_subscription_resource_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMApiManagementSubscription_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementSubscription_basic(data),
+				Config: testAccAzureRMApiManagementSubscription_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "allow_tracing", "true"),
@@ -43,7 +43,7 @@ func TestAccAzureRMApiManagementSubscription_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementSubscription_basic(data),
+				Config: testAccAzureRMApiManagementSubscription_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "subscription_id"),
@@ -51,7 +51,7 @@ func TestAccAzureRMApiManagementSubscription_requiresImport(t *testing.T) {
 					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_key"),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMAPIManagementSubscription_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementSubscription_requiresImport),
 		},
 	})
 }
@@ -65,7 +65,7 @@ func TestAccAzureRMApiManagementSubscription_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementSubscription_update(data, "submitted", "true"),
+				Config: testAccAzureRMApiManagementSubscription_update(data, "submitted", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "state", "submitted"),
@@ -76,28 +76,28 @@ func TestAccAzureRMApiManagementSubscription_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMAPIManagementSubscription_update(data, "active", "true"),
+				Config: testAccAzureRMApiManagementSubscription_update(data, "active", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "state", "active"),
 				),
 			},
 			{
-				Config: testAccAzureRMAPIManagementSubscription_update(data, "suspended", "true"),
+				Config: testAccAzureRMApiManagementSubscription_update(data, "suspended", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "state", "suspended"),
 				),
 			},
 			{
-				Config: testAccAzureRMAPIManagementSubscription_update(data, "cancelled", "true"),
+				Config: testAccAzureRMApiManagementSubscription_update(data, "cancelled", "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "state", "cancelled"),
 				),
 			},
 			{
-				Config: testAccAzureRMAPIManagementSubscription_update(data, "active", "false"),
+				Config: testAccAzureRMApiManagementSubscription_update(data, "active", "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "allow_tracing", "false"),
@@ -116,7 +116,7 @@ func TestAccAzureRMApiManagementSubscription_complete(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAPIManagementSubscription_complete(data),
+				Config: testAccAzureRMApiManagementSubscription_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAPIManagementSubscriptionExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "state", "active"),
@@ -181,8 +181,8 @@ func testCheckAzureRMAPIManagementSubscriptionExists(resourceName string) resour
 	}
 }
 
-func testAccAzureRMAPIManagementSubscription_basic(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementSubscription_template(data)
+func testAccAzureRMApiManagementSubscription_basic(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementSubscription_template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -196,8 +196,8 @@ resource "azurerm_api_management_subscription" "test" {
 `, template)
 }
 
-func testAccAzureRMAPIManagementSubscription_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementSubscription_basic(data)
+func testAccAzureRMApiManagementSubscription_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementSubscription_basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -212,8 +212,8 @@ resource "azurerm_api_management_subscription" "import" {
 `, template)
 }
 
-func testAccAzureRMAPIManagementSubscription_update(data acceptance.TestData, state string, allow_tracing string) string {
-	template := testAccAzureRMAPIManagementSubscription_template(data)
+func testAccAzureRMApiManagementSubscription_update(data acceptance.TestData, state string, allow_tracing string) string {
+	template := testAccAzureRMApiManagementSubscription_template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -229,8 +229,8 @@ resource "azurerm_api_management_subscription" "test" {
 `, template, state, allow_tracing)
 }
 
-func testAccAzureRMAPIManagementSubscription_complete(data acceptance.TestData) string {
-	template := testAccAzureRMAPIManagementSubscription_template(data)
+func testAccAzureRMApiManagementSubscription_complete(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementSubscription_template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -246,7 +246,7 @@ resource "azurerm_api_management_subscription" "test" {
 `, template)
 }
 
-func testAccAzureRMAPIManagementSubscription_template(data acceptance.TestData) string {
+func testAccAzureRMApiManagementSubscription_template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/apimanagement/tests/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_subscription_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAPIManagementSubscription_basic(t *testing.T) {
+func TestAccAzureRMApiManagementSubscription_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -34,7 +34,7 @@ func TestAccAzureRMAPIManagementSubscription_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementSubscription_requiresImport(t *testing.T) {
+func TestAccAzureRMApiManagementSubscription_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -56,7 +56,7 @@ func TestAccAzureRMAPIManagementSubscription_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementSubscription_update(t *testing.T) {
+func TestAccAzureRMApiManagementSubscription_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -107,7 +107,7 @@ func TestAccAzureRMAPIManagementSubscription_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAPIManagementSubscription_complete(t *testing.T) {
+func TestAccAzureRMApiManagementSubscription_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
Follow to resource name format rule.