### PR TITLE
Allow for manually scaled eventhub clusters

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -3,6 +3,7 @@ package eventhub
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -55,9 +56,10 @@ func resourceArmEventHubCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Dedicated_1",
-				}, false),
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^Dedicated_[0-9]+$"),
+					"The event hub cluster sku_name can contain only 'Dedicated_X', where X is number of CU's allocated to the cluster",
+				),
 			},
 
 			"tags": tags.Schema(),

--- a/website/docs/r/eventhub_cluster.html.markdown
+++ b/website/docs/r/eventhub_cluster.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The sku name of the EventHub Cluster. The only supported value at this time is `Dedicated_1`.
+* `sku_name` - (Required) The sku name of the EventHub Cluster. Supported values at this time are `Dedicated_<X>`, where `X` is number of CUs allocated.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
In case of scaling eventhub clusters by logging support ticket to MSFT, the `sku_name` of the cluster will change from `Dedicated_1` to `Dedicated_<X>`, where `X` is number of CUs allocated to the cluster. In current mode, TF will try to revert the change, forcing users to use `ignore_changes`. This PR should alleviate that need.