### PR TITLE
[Refactor] bring back the `SystemAssigned, UserAssigned` defined in go SDK to app service

### DIFF
--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -7,6 +7,7 @@ var services = mapOf(
         "appconfiguration" to "App Configuration",
         "appplatform" to "App Platform",
         "applicationinsights" to "Application Insights",
+        "attestation" to "Attestation",
         "authorization" to "Authorization",
         "automation" to "Automation",
         "batch" to "Batch",

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -14,11 +14,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-const (
-	// TODO: switch back once https://github.com/Azure/azure-rest-api-specs/pull/8435 has been fixed
-	SystemAssignedUserAssigned web.ManagedServiceIdentityType = "SystemAssigned, UserAssigned"
-)
-
 func schemaAppServiceAadAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -253,7 +248,7 @@ func schemaAppServiceIdentity() *schema.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						string(web.ManagedServiceIdentityTypeNone),
 						string(web.ManagedServiceIdentityTypeSystemAssigned),
-						string(SystemAssignedUserAssigned),
+						string(web.ManagedServiceIdentityTypeSystemAssignedUserAssigned),
 						string(web.ManagedServiceIdentityTypeUserAssigned),
 					}, true),
 					DiffSuppressFunc: suppress.CaseDifference,
@@ -1441,7 +1436,7 @@ func expandAppServiceIdentity(input []interface{}) *web.ManagedServiceIdentity {
 		Type: identityType,
 	}
 
-	if managedServiceIdentity.Type == web.ManagedServiceIdentityTypeUserAssigned || managedServiceIdentity.Type == SystemAssignedUserAssigned {
+	if managedServiceIdentity.Type == web.ManagedServiceIdentityTypeUserAssigned || managedServiceIdentity.Type == web.ManagedServiceIdentityTypeSystemAssignedUserAssigned {
 		managedServiceIdentity.UserAssignedIdentities = identityIds
 	}
 


### PR DESCRIPTION
Despite swagger PR https://github.com/ArcturusZhang/terraform-provider-azurerm/pull/new/bring-back-systemuserassigned-for-web is still pending, this issue has been resolved in another swagger PR https://github.com/Azure/azure-rest-api-specs/pull/9250 with some other changes from the service team.


The `.teamcity` file change is automatically generated when running `make build`