### PR TITLE
`api_management_x.y.api_name` - validation fix

### DIFF
--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -49,6 +49,17 @@ func SchemaApiManagementChildName() *schema.Schema {
 	}
 }
 
+// SchemaApiManagementChildName returns the Schema for the identifier
+// used by resources within nested under the API Management Service resource
+func SchemaApiManagementApiName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validate.ApiManagementApiName,
+	}
+}
+
 // SchemaApiManagementChildDataSourceName returns the Schema for the identifier
 // used by resources within nested under the API Management Service resource
 func SchemaApiManagementChildDataSourceName() *schema.Schema {

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	helpersvalidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/validate"
@@ -53,12 +52,7 @@ func resourceArmApiManagementApiDiagnostic() *schema.Resource {
 
 			"api_management_name": azure.SchemaApiManagementName(),
 
-			"api_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: helpersvalidate.ApiManagementApiName,
-			},
+			"api_name": azure.SchemaApiManagementApiName(),
 
 			"api_management_logger_id": {
 				Type:         schema.TypeString,

--- a/azurerm/internal/services/apimanagement/api_management_api_operation_policy_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_operation_policy_resource.go
@@ -37,7 +37,7 @@ func resourceArmApiManagementApiOperationPolicy() *schema.Resource {
 
 			"api_management_name": azure.SchemaApiManagementName(),
 
-			"api_name": azure.SchemaApiManagementChildName(),
+			"api_name": azure.SchemaApiManagementApiName(),
 
 			"operation_id": azure.SchemaApiManagementChildName(),
 

--- a/azurerm/internal/services/apimanagement/api_management_api_operation_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_operation_resource.go
@@ -34,7 +34,7 @@ func resourceArmApiManagementApiOperation() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"operation_id": azure.SchemaApiManagementChildName(),
 
-			"api_name": azure.SchemaApiManagementChildName(),
+			"api_name": azure.SchemaApiManagementApiName(),
 
 			"api_management_name": azure.SchemaApiManagementName(),
 

--- a/azurerm/internal/services/apimanagement/api_management_api_policy_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_policy_resource.go
@@ -37,7 +37,7 @@ func resourceArmApiManagementApiPolicy() *schema.Resource {
 
 			"api_management_name": azure.SchemaApiManagementName(),
 
-			"api_name": azure.SchemaApiManagementChildName(),
+			"api_name": azure.SchemaApiManagementApiName(),
 
 			"xml_content": {
 				Type:             schema.TypeString,

--- a/azurerm/internal/services/apimanagement/api_management_api_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_resource.go
@@ -35,12 +35,7 @@ func resourceArmApiManagementApi() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.ApiManagementApiName,
-			},
+			"name": azure.SchemaApiManagementApiName(),
 
 			"api_management_name": azure.SchemaApiManagementName(),
 

--- a/azurerm/internal/services/apimanagement/api_management_api_schema_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_schema_resource.go
@@ -35,7 +35,7 @@ func resourceArmApiManagementApiSchema() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"schema_id": azure.SchemaApiManagementChildName(),
 
-			"api_name": azure.SchemaApiManagementChildName(),
+			"api_name": azure.SchemaApiManagementApiName(),
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 

--- a/azurerm/internal/services/apimanagement/api_management_product_api_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_product_api_resource.go
@@ -30,7 +30,7 @@ func resourceArmApiManagementProductApi() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"api_name": azure.SchemaApiManagementChildName(),
+			"api_name": azure.SchemaApiManagementApiName(),
 
 			"product_id": azure.SchemaApiManagementChildName(),
 


### PR DESCRIPTION
Creating a schema for API names as the SchemaApiManagementChildName validation rule is incorrect for APIs