### PR TITLE
New resource `azurerm_mssql_server_extended_auditing_policy` 

### DIFF
--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -151,7 +151,7 @@ func resourceArmMsSqlServerExtendedAuditingPolicyRead(d *schema.ResourceData, me
 	}
 
 	serverResp, err := serverClient.Get(ctx, id.ResourceGroup, id.MsSqlServer)
-	if err != nil || *serverResp.ID == "" {
+	if err != nil || serverResp.ID == nil || *serverResp.ID == "" {
 		return fmt.Errorf("reading MsSql Server %q ID is empty or nil(Resource Group %q): %s", id.MsSqlServer, id.ResourceGroup, err)
 	}
 

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -112,8 +112,13 @@ func resourceArmMsSqlServerExtendedAuditingPolicyCreateUpdate(d *schema.Resource
 		params.ExtendedServerBlobAuditingPolicyProperties.StorageAccountAccessKey = utils.String(v.(string))
 	}
 
-	if _, err = client.CreateOrUpdate(ctx, serverId.ResourceGroup, serverId.Name, params); err != nil {
+	future, err := client.CreateOrUpdate(ctx, serverId.ResourceGroup, serverId.Name, params)
+	if err != nil {
 		return fmt.Errorf("creating MsSql Server %q Extended Auditing Policy (Resource Group %q): %+v", serverId.Name, serverId.ResourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation of MsSql Server %q Extended Auditing Policy (Resource Group %q): %+v", serverId.Name, serverId.ResourceGroup, err)
 	}
 
 	read, err := client.Get(ctx, serverId.ResourceGroup, serverId.Name)
@@ -182,8 +187,13 @@ func resourceArmMsSqlServerExtendedAuditingPolicyDelete(d *schema.ResourceData, 
 		},
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MsSqlServer, params); err != nil {
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MsSqlServer, params)
+	if err != nil {
 		return fmt.Errorf("deleting MsSql Server %q Extended Auditing Policy(Resource Group %q): %+v", id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of MsSql Server %q Extended Auditing Policy (Resource Group %q): %+v", id.MsSqlServer, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -155,7 +155,7 @@ func resourceArmMsSqlServerExtendedAuditingPolicyRead(d *schema.ResourceData, me
 		return fmt.Errorf("reading MsSql Server %q ID is empty or nil(Resource Group %q): %s", id.MsSqlServer, id.ResourceGroup, err)
 	}
 
-	d.Set("database_id", serverResp.ID)
+	d.Set("server_id", serverResp.ID)
 
 	if props := resp.ExtendedServerBlobAuditingPolicyProperties; props != nil {
 		d.Set("storage_endpoint", props.StorageEndpoint)

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -1,0 +1,190 @@
+package mssql
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmMsSqlServerExtendedAuditingPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmMsSqlServerExtendedAuditingPolicyCreateUpdate,
+		Read:   resourceArmMsSqlServerExtendedAuditingPolicyRead,
+		Update: resourceArmMsSqlServerExtendedAuditingPolicyCreateUpdate,
+		Delete: resourceArmMsSqlServerExtendedAuditingPolicyDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.MssqlServerExtendedAuditingPolicyID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"server_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.MsSqlServerID,
+			},
+
+			"storage_endpoint": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsURLWithHTTPS,
+			},
+
+			"storage_account_access_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"storage_account_access_key_is_secondary": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"retention_in_days": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				ValidateFunc: validation.IntBetween(0, 3285),
+			},
+		},
+	}
+}
+
+func resourceArmMsSqlServerExtendedAuditingPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.ServerExtendedBlobAuditingPoliciesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for MsSql Server Extended Auditing Policy creation.")
+
+	serverId, err := parse.MsSqlServerID(d.Get("server_id").(string))
+	if err != nil {
+		return err
+	}
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, serverId.ResourceGroup, serverId.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Failed to check for presence of existing Server %q Sql Auditing (Resource Group %q): %s", serverId.Name, serverId.ResourceGroup, err)
+			}
+		}
+
+		// if state is not disabled, we should import it.
+		if existing.ID != nil && *existing.ID != "" && existing.ExtendedServerBlobAuditingPolicyProperties != nil && existing.ExtendedServerBlobAuditingPolicyProperties.State != sql.BlobAuditingPolicyStateDisabled {
+			return tf.ImportAsExistsError("azurerm_mssql_server_extended_auditing_policy", *existing.ID)
+		}
+	}
+
+	params := sql.ExtendedServerBlobAuditingPolicy{
+		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
+			State:                      sql.BlobAuditingPolicyStateEnabled,
+			StorageEndpoint:            utils.String(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse: utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:              utils.Int32(int32(d.Get("retention_in_days").(int))),
+		},
+	}
+
+	if v, ok := d.GetOk("storage_account_access_key"); ok {
+		params.ExtendedServerBlobAuditingPolicyProperties.StorageAccountAccessKey = utils.String(v.(string))
+	}
+
+	if _, err = client.CreateOrUpdate(ctx, serverId.ResourceGroup, serverId.Name, params); err != nil {
+		return fmt.Errorf("creating MsSql Server %q Extended Auditing Policy (Resource Group %q): %+v", serverId.Name, serverId.ResourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, serverId.ResourceGroup, serverId.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving MsSql Server %q Extended Auditing Policy (Resource Group %q): %+v", serverId.Name, serverId.ResourceGroup, err)
+	}
+
+	if read.ID == nil || *read.ID == "" {
+		return fmt.Errorf("reading MsSql Server %q Extended Auditing Policy (Resource Group %q) ID is empty or nil", serverId.Name, serverId.ResourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmMsSqlServerExtendedAuditingPolicyRead(d, meta)
+}
+
+func resourceArmMsSqlServerExtendedAuditingPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.ServerExtendedBlobAuditingPoliciesClient
+	serverClient := meta.(*clients.Client).MSSQL.ServersClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.MssqlServerExtendedAuditingPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.MsSqlServer)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading MsSql Server %s Extended Auditing Policy (Resource Group %q): %s", id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	serverResp, err := serverClient.Get(ctx, id.ResourceGroup, id.MsSqlServer)
+	if err != nil || *serverResp.ID == "" {
+		return fmt.Errorf("reading MsSql Server %q ID is empty or nil(Resource Group %q): %s", id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	d.Set("database_id", serverResp.ID)
+
+	if props := resp.ExtendedServerBlobAuditingPolicyProperties; props != nil {
+		d.Set("storage_endpoint", props.StorageEndpoint)
+		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
+		d.Set("retention_in_days", props.RetentionDays)
+	}
+
+	return nil
+}
+
+func resourceArmMsSqlServerExtendedAuditingPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.ServerExtendedBlobAuditingPoliciesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.MssqlServerExtendedAuditingPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	params := sql.ExtendedServerBlobAuditingPolicy{
+		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
+			State: sql.BlobAuditingPolicyStateDisabled,
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MsSqlServer, params); err != nil {
+		return fmt.Errorf("deleting MsSql Server %q Extended Auditing Policy(Resource Group %q): %+v", id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/mssql/parse/mssql.go
+++ b/azurerm/internal/services/mssql/parse/mssql.go
@@ -29,6 +29,11 @@ type MsSqlDatabaseExtendedAuditingPolicyId struct {
 	ResourceGroup string
 }
 
+type MsSqlServerExtendedAuditingPolicyId struct {
+	MsSqlServer   string
+	ResourceGroup string
+}
+
 func NewMsSqlDatabaseID(resourceGroup, msSqlServer, name string) MsSqlDatabaseId {
 	return MsSqlDatabaseId{
 		ResourceGroup: resourceGroup,
@@ -165,4 +170,29 @@ func MssqlDatabaseExtendedAuditingPolicyID(input string) (*MsSqlDatabaseExtended
 	}
 
 	return &sqlDatabaseExtendedAuditingPolicyId, nil
+}
+
+func MssqlServerExtendedAuditingPolicyID(input string) (*MsSqlServerExtendedAuditingPolicyId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Microsoft Sql Server Extended Auditing Policy %q: %+v", input, err)
+	}
+
+	sqlServerExtendedAuditingPolicyId := MsSqlServerExtendedAuditingPolicyId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if sqlServerExtendedAuditingPolicyId.MsSqlServer, err = id.PopSegment("servers"); err != nil {
+		return nil, err
+	}
+
+	if _, err = id.PopSegment("extendedAuditingSettings"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &sqlServerExtendedAuditingPolicyId, nil
 }

--- a/azurerm/internal/services/mssql/parse/mssql_test.go
+++ b/azurerm/internal/services/mssql/parse/mssql_test.go
@@ -319,3 +319,81 @@ func TestMssqlDatabaseExtendedAuditingPolicy(t *testing.T) {
 		}
 	}
 }
+
+func TestMssqlServerExtendedAuditingPolicy(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *MsSqlServerExtendedAuditingPolicyId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Server Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Extended Auditing Policy",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Extended Auditing Policy Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/extendedAuditingSettings",
+			Expected: nil,
+		},
+		{
+			Name:  "Extended Auditing Policy",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/extendedAuditingSettings/default",
+			Expected: &MsSqlServerExtendedAuditingPolicyId{
+				ResourceGroup: "resGroup1",
+				MsSqlServer:   "sqlServer1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/ExtendedAuditingSettings/default",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := MssqlServerExtendedAuditingPolicyID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.MsSqlServer != v.Expected.MsSqlServer {
+			t.Fatalf("Expected %q but got %q for Server Name", v.Expected.MsSqlServer, actual.MsSqlServer)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/mssql/registration.go
+++ b/azurerm/internal/services/mssql/registration.go
@@ -34,6 +34,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_mssql_database_vulnerability_assessment_rule_baseline": resourceArmMssqlDatabaseVulnerabilityAssessmentRuleBaseline(),
 		"azurerm_mssql_elasticpool":                                     resourceArmMsSqlElasticPool(),
 		"azurerm_mssql_server":                                          resourceArmMsSqlServer(),
+		"azurerm_mssql_server_extended_auditing_policy":                 resourceArmMsSqlServerExtendedAuditingPolicy(),
 		"azurerm_mssql_server_security_alert_policy":                    resourceArmMssqlServerSecurityAlertPolicy(),
 		"azurerm_mssql_server_vulnerability_assessment":                 resourceArmMssqlServerVulnerabilityAssessment(),
 		"azurerm_mssql_virtual_machine":                                 resourceArmMsSqlVirtualMachine(),

--- a/azurerm/internal/services/mssql/tests/mssql_server_extended_auditing_policy_resource_test.go
+++ b/azurerm/internal/services/mssql/tests/mssql_server_extended_auditing_policy_resource_test.go
@@ -1,0 +1,343 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMMsSqlServerExtendedAuditingPolicy_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlServerExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlServerExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlServerExtendedAuditingPolicy_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlServerExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlServerExtendedAuditingPolicy_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlServerExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_update(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlServerExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccountBehindFireWall(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func testCheckAzureRMMsSqlServerExtendedAuditingPolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).MSSQL.ServerExtendedBlobAuditingPoliciesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id, err := parse.MssqlServerExtendedAuditingPolicyID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, id.ResourceGroup, id.MsSqlServer)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("msSql Server ExtendedAuditingPolicy %q (resource group: %q) does not exist", id.MsSqlServer, id.ResourceGroup)
+			}
+
+			return fmt.Errorf("get on MsSql Server ExtendedAuditingPolicy Client: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMMsSqlServerExtendedAuditingPolicyDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).MSSQL.ServerExtendedBlobAuditingPoliciesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_mssql_server_extended_auditing_policy" {
+			continue
+		}
+
+		id, err := parse.MssqlServerExtendedAuditingPolicyID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.MsSqlServer); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("get on MsSql Server ExtendedAuditingPolicy Client: %+v", err)
+			}
+
+			if resp.ExtendedServerBlobAuditingPolicyProperties != nil && resp.ExtendedServerBlobAuditingPolicyProperties.State == sql.BlobAuditingPolicyStateEnabled {
+				return fmt.Errorf("`azurerm_mssql_server_extended_auditing_policy` is still enabled")
+			}
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMMsSqlServerExtendedAuditingPolicy_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest-sqlserver-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMMsSqlServerExtendedAuditingPolicy_basic(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlServerExtendedAuditingPolicy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server_extended_auditing_policy" "test" {
+  server_id                  = azurerm_mssql_server.test.id
+  storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+}
+`, template)
+}
+
+func testAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlServerExtendedAuditingPolicy_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server_extended_auditing_policy" "import" {
+  server_id                  = azurerm_mssql_server.test.id
+  storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+}
+`, template)
+}
+
+func testAccAzureRMMsSqlServerExtendedAuditingPolicy_complete(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlServerExtendedAuditingPolicy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_server_extended_auditing_policy" "test" {
+  server_id                               = azurerm_mssql_server.test.id
+  storage_endpoint                        = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.test.primary_access_key
+  storage_account_access_key_is_secondary = false
+  retention_in_days                       = 6
+}
+`, template)
+}
+
+func testAccAzureRMMsSqlServerExtendedAuditingPolicy_update(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlServerExtendedAuditingPolicy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "unlikely23exst2acc2%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "test" {
+  server_id                               = azurerm_mssql_server.test.id
+  storage_endpoint                        = azurerm_storage_account.test2.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.test2.primary_access_key
+  storage_account_access_key_is_secondary = true
+  retention_in_days                       = 3
+}
+`, template, data.RandomString)
+}
+
+func testAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccountBehindFireWall(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest-sqlserver-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Deny"
+    ip_rules                   = ["127.0.0.1"]
+    virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  }
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_mssql_server.test.identity.0.principal_id
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "test" {
+  server_id        = azurerm_mssql_server.test.id
+  storage_endpoint = azurerm_storage_account.test.primary_blob_endpoint
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1420,6 +1420,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/mssql_server_extended_auditing_policy.html">azurerm_mssql_server_extended_auditing_policy</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/mssql_server_security_alert_policy.html">azurerm_mssql_server_security_alert_policy</a>
                 </li>
 

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -1,0 +1,90 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_mssql_server_extended_auditing_policy"
+description: |-
+  Manages a Ms Sql Server Extended Auditing Policy.
+---
+
+# azurerm_mssql_server_extended_auditing_policy
+
+Manages a Ms Sql Server Extended Auditing Policy.
+
+~> **NOTE:** The Server Extended Auditing Policy Can be set inline here as well as with the [mssql_server_extended_auditing_policy resource](mssql_server_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_mssql_server" "example" {
+  name                         = "example-sqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplesa"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "example" {
+  server_id                               = azurerm_mssql_server.example.id
+  storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.example.primary_access_key
+  storage_account_access_key_is_secondary = false
+  retention_in_days                       = 6
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `server_id` - (Required) The ID of the sql server to set the extended auditing policy. Changing this forces a new resource to be created.
+
+* `storage_endpoint` - (Required) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
+
+---
+
+* `retention_in_days` - (Optional) The number of days to retain logs for in the storage account.
+
+* `storage_account_access_key` - (Optional) The access key to use for the auditing storage account.
+
+* `storage_account_access_key_is_secondary` - (Optional) Is `storage_account_access_key` value the storage's secondary key?
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Ms Sql Server Extended Auditing Policy.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Ms Sql Server Extended Auditing Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Ms Sql Server Extended Auditing Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Ms Sql Server Extended Auditing Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Ms Sql Server Extended Auditing Policy.
+
+## Import
+
+Ms Sql Server Extended Auditing Policys can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_mssql_server_extended_auditing_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Sql/servers/sqlServer1/extendedAuditingSettings/default
+```


### PR DESCRIPTION
Extend: https://github.com/terraform-providers/terraform-provider-azurerm/pull/7793
Fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7486
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/6906
https://github.com/terraform-providers/terraform-provider-azurerm/issues/8437

=== RUN   TestAccAzureRMMsSqlServerExtendedAuditingPolicy_basic
=== PAUSE TestAccAzureRMMsSqlServerExtendedAuditingPolicy_basic
=== CONT  TestAccAzureRMMsSqlServerExtendedAuditingPolicy_basic
--- PASS: TestAccAzureRMMsSqlServerExtendedAuditingPolicy_basic (195.94s)
=== RUN   TestAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport
=== PAUSE TestAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport
=== CONT  TestAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport
--- PASS: TestAccAzureRMMsSqlServerExtendedAuditingPolicy_requiresImport (244.87s)
=== RUN   TestAccAzureRMMsSqlServerExtendedAuditingPolicy_complete
=== PAUSE TestAccAzureRMMsSqlServerExtendedAuditingPolicy_complete
=== CONT  TestAccAzureRMMsSqlServerExtendedAuditingPolicy_complete
--- PASS: TestAccAzureRMMsSqlServerExtendedAuditingPolicy_complete (175.96s)
=== RUN   TestAccAzureRMMsSqlServerExtendedAuditingPolicy_update
=== PAUSE TestAccAzureRMMsSqlServerExtendedAuditingPolicy_update
=== CONT  TestAccAzureRMMsSqlServerExtendedAuditingPolicy_update
--- PASS: TestAccAzureRMMsSqlServerExtendedAuditingPolicy_update (280.84s)
=== RUN   TestAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall
=== PAUSE TestAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall
=== CONT  TestAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall
--- PASS: TestAccAzureRMMsSqlServerExtendedAuditingPolicy_storageAccBehindFireWall (290.78s)
PASS


Process finished with exit code 0
