### PR TITLE
azurerm_firewall_network_rule_collection: add doc/test to highlight dest addr service tag support

### DIFF
--- a/azurerm/internal/services/network/tests/firewall_network_rule_collection_resource_test.go
+++ b/azurerm/internal/services/network/tests/firewall_network_rule_collection_resource_test.go
@@ -280,6 +280,29 @@ func TestAccAzureRMFirewallNetworkRuleCollection_updateFirewallTags(t *testing.T
 	})
 }
 
+func TestAccAzureRMFirewallNetworkRuleCollection_serviceTag(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_network_rule_collection", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMFirewallNetworkRuleCollection_serviceTag(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFirewallNetworkRuleCollectionExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", "acctestnrc"),
+					resource.TestCheckResourceAttr(data.ResourceName, "priority", "100"),
+					resource.TestCheckResourceAttr(data.ResourceName, "action", "Allow"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.#", "1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMFirewallNetworkRuleCollectionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.AzureFirewallsClient
@@ -699,6 +722,41 @@ resource "azurerm_firewall_network_rule_collection" "test" {
 
     destination_addresses = [
       "8.8.8.8",
+    ]
+
+    protocols = [
+      "Any",
+    ]
+  }
+}
+`, template)
+}
+
+func testAccAzureRMFirewallNetworkRuleCollection_serviceTag(data acceptance.TestData) string {
+	template := testAccAzureRMFirewall_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_firewall_network_rule_collection" "test" {
+  name                = "acctestnrc"
+  azure_firewall_name = azurerm_firewall.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  priority            = 100
+  action              = "Allow"
+
+  rule {
+    name = "rule1"
+
+    source_addresses = [
+      "10.0.0.0/16",
+    ]
+
+    destination_ports = [
+      "53",
+    ]
+
+    destination_addresses = [
+      "ApiManagement",
     ]
 
     protocols = [

--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -110,7 +110,7 @@ A `rule` block supports the following:
 
 * `source_addresses` - (Required) A list of source IP addresses and/or IP ranges.
 
-* `destination_addresses` - (Required) A list of destination IP addresses and/or IP ranges.
+* `destination_addresses` - (Required) Either a list of destination IP addresses and/or IP ranges, or a list of destination [Service Tags](https://docs.microsoft.com/en-us/azure/virtual-network/service-tags-overview#available-service-tags).
 
 * `destination_ports` - (Required) A list of destination ports.
 


### PR DESCRIPTION
Fixes: #8440

## Test Result

```bash
terraform-provider-azurerm on  master [⇡$!] via 🐹 v1.14.6 took 16m29s 
💢 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMFirewallNetworkRuleCollection_serviceTag'"
==> Checking that code complies with gofmt requirements...                 
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...                                                                                                                                   
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMFirewallNetworkRuleCollection_serviceTag' -timeout 180m -ldflags="-X=github.com/terraform-providers/ter
raform-provider-azurerm/version.ProviderVersion=acc"                    
=== RUN   TestAccAzureRMFirewallNetworkRuleCollection_serviceTag
=== PAUSE TestAccAzureRMFirewallNetworkRuleCollection_serviceTag
=== CONT  TestAccAzureRMFirewallNetworkRuleCollection_serviceTag
--- PASS: TestAccAzureRMFirewallNetworkRuleCollection_serviceTag (1034.03s)
PASS                                                                                        
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       1034.058s
```