### PR TITLE
New resource/data source `azurerm_storage_sync_group`

### DIFF
--- a/azurerm/internal/services/storage/client/client.go
+++ b/azurerm/internal/services/storage/client/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	CachesClient             *storagecache.CachesClient
 	StorageTargetsClient     *storagecache.StorageTargetsClient
 	SyncServiceClient        *storagesync.ServicesClient
+	StoragesyncGroupClient   storagesync.SyncGroupsClient
 	SubscriptionId           string
 
 	environment   az.Environment
@@ -57,6 +58,9 @@ func NewClient(options *common.ClientOptions) *Client {
 	syncServiceClient := storagesync.NewServicesClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
 	options.ConfigureClient(&syncServiceClient.Client, options.ResourceManagerAuthorizer)
 
+	storagesyncgroupClient := storagesync.NewSyncGroupsClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
+	options.ConfigureClient(&storagesyncgroupClient.Client, options.ResourceManagerAuthorizer)
+
 	// TODO: switch Storage Containers to using the storage.BlobContainersClient
 	// (which should fix #2977) when the storage clients have been moved in here
 	client := Client{
@@ -68,6 +72,7 @@ func NewClient(options *common.ClientOptions) *Client {
 		SubscriptionId:           options.SubscriptionId,
 		StorageTargetsClient:     &storageTargetsClient,
 		SyncServiceClient:        &syncServiceClient,
+		StoragesyncGroupClient:   storagesyncgroupClient,
 		environment:              options.Environment,
 	}
 

--- a/azurerm/internal/services/storage/data_source_storage_sync_group.go
+++ b/azurerm/internal/services/storage/data_source_storage_sync_group.go
@@ -2,12 +2,12 @@ package storage
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"

--- a/azurerm/internal/services/storage/data_source_storage_sync_group.go
+++ b/azurerm/internal/services/storage/data_source_storage_sync_group.go
@@ -1,0 +1,68 @@
+package storage
+
+import (
+	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmStorageSyncGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmStorageSyncGroupRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.StorageSyncName,
+			},
+
+			"storage_sync_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.StorageSyncId,
+			},
+		},
+	}
+}
+
+func dataSourceArmStorageSyncGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Storage.StoragesyncGroupClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	ssID := d.Get("storage_sync_id").(string)
+	ssId, _ := parsers.ParseStorageSyncID(ssID)
+
+	resp, err := client.Get(ctx, ssId.ResourceGroup, ssId.Name, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Storage Sync Group %q does not exist - removing from state", name)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading Storage Sync Group %q (Storage Sync Name %q / Resource Group %q): %+v", name, ssId.Name, ssId.ResourceGroup, err)
+	}
+
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("reading Storage Sync Group %q (Storage Sync Name %q /Resource Group %q) ID is empty or nil", name, ssId.Name, ssId.ResourceGroup)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", name)
+	d.Set("storage_sync_id", ssID)
+	return nil
+}

--- a/azurerm/internal/services/storage/parsers/id.go
+++ b/azurerm/internal/services/storage/parsers/id.go
@@ -15,6 +15,12 @@ type StorageSyncId struct {
 	ResourceGroup string
 }
 
+type StorageSyncGroupId struct {
+	Name            string
+	StorageSyncName string
+	ResourceGroup   string
+}
+
 func ParseAccountID(input string) (*AccountID, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
@@ -56,4 +62,29 @@ func ParseStorageSyncID(input string) (*StorageSyncId, error) {
 	}
 
 	return &storageSync, nil
+}
+
+func StorageSyncGroupID(input string) (*StorageSyncGroupId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	storageSyncGroup := StorageSyncGroupId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if storageSyncGroup.StorageSyncName, err = id.PopSegment("storageSyncServices"); err != nil {
+		return nil, err
+	}
+
+	if storageSyncGroup.Name, err = id.PopSegment("syncGroups"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &storageSyncGroup, nil
 }

--- a/azurerm/internal/services/storage/parsers/id_test.go
+++ b/azurerm/internal/services/storage/parsers/id_test.go
@@ -140,3 +140,81 @@ func TestParseStorageSyncID(t *testing.T) {
 		}
 	}
 }
+
+func TestParseStorageSyncGroupID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *StorageSyncGroupId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sync Group",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.StorageSync/storageSyncServices/sync1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sync Group Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.StorageSync/storageSyncServices/sync1/syncGroups/",
+			Expected: nil,
+		},
+		{
+			Name:  "Sync Group Id",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.StorageSync/storageSyncServices/sync1/syncGroups/group1",
+			Expected: &StorageSyncGroupId{
+				Name:            "group1",
+				StorageSyncName: "sync1",
+				ResourceGroup:   "resGroup1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.StorageSync/storageSyncServices/sync1/SyncGroups/group1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := StorageSyncGroupID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.StorageSyncName != v.Expected.StorageSyncName {
+			t.Fatalf("Expected %q but got %q for Storage Sync Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/storage/registration.go
+++ b/azurerm/internal/services/storage/registration.go
@@ -27,6 +27,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 		"azurerm_storage_container":                  dataSourceArmStorageContainer(),
 		"azurerm_storage_management_policy":          dataSourceArmStorageManagementPolicy(),
 		"azurerm_storage_sync":                       dataSourceArmStorageSync(),
+		"azurerm_storage_sync_group":                 dataSourceArmStorageSyncGroup(),
 	}
 }
 
@@ -49,5 +50,6 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_storage_table":                        resourceArmStorageTable(),
 		"azurerm_storage_table_entity":                 resourceArmStorageTableEntity(),
 		"azurerm_storage_sync":                         resourceArmStorageSync(),
+		"azurerm_storage_sync_group":                   resourceArmStorageSyncGroup(),
 	}
 }

--- a/azurerm/internal/services/storage/resource_arm_storage_sync_group.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_sync_group.go
@@ -62,7 +62,7 @@ func resourceArmStorageSyncGroupCreate(d *schema.ResourceData, meta interface{})
 	existing, err := client.Get(ctx, ssId.ResourceGroup, ssId.Name, name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for present of existing Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", name, ssId.Name, ssId.ResourceGroup, err)
+			return fmt.Errorf("checking for presence of existing Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", name, ssId.Name, ssId.ResourceGroup, err)
 		}
 	}
 	if existing.ID != nil && *existing.ID != "" {

--- a/azurerm/internal/services/storage/resource_arm_storage_sync_group.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_sync_group.go
@@ -1,0 +1,142 @@
+package storage
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/storagesync/mgmt/2020-03-01/storagesync"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmStorageSyncGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStorageSyncGroupCreate,
+		Read:   resourceArmStorageSyncGroupRead,
+		Delete: resourceArmStorageSyncGroupDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parsers.StorageSyncGroupID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.StorageSyncName,
+			},
+
+			"storage_sync_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.StorageSyncId,
+			},
+		},
+	}
+}
+
+func resourceArmStorageSyncGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Storage.StoragesyncGroupClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	ssId, _ := parsers.ParseStorageSyncID(d.Get("storage_sync_id").(string))
+
+	existing, err := client.Get(ctx, ssId.ResourceGroup, ssId.Name, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for present of existing Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", name, ssId.Name, ssId.ResourceGroup, err)
+		}
+	}
+	if existing.ID != nil && *existing.ID != "" {
+		return tf.ImportAsExistsError("azurerm_storage_sync_group", *existing.ID)
+	}
+
+	if _, err := client.Create(ctx, ssId.ResourceGroup, ssId.Name, name, storagesync.SyncGroupCreateParameters{}); err != nil {
+		return fmt.Errorf("creating Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", name, ssId.Name, ssId.ResourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, ssId.ResourceGroup, ssId.Name, name)
+	if err != nil {
+		return fmt.Errorf("retrieving Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", name, ssId.Name, ssId.ResourceGroup, err)
+	}
+
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("reading Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q) ID is empty or nil", name, ssId.Name, ssId.ResourceGroup)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmStorageSyncGroupRead(d, meta)
+}
+
+func resourceArmStorageSyncGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Storage.StoragesyncGroupClient
+	ssClient := meta.(*clients.Client).Storage.SyncServiceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parsers.StorageSyncGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.StorageSyncName, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Storage Sync Group %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", id.Name, id.StorageSyncName, id.ResourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+
+	ssResp, err := ssClient.Get(ctx, id.ResourceGroup, id.StorageSyncName)
+	if err != nil {
+		return fmt.Errorf("reading Storage Sync %q (Resource Group %q): %+v", id.StorageSyncName, id.ResourceGroup, err)
+	}
+
+	if ssResp.ID == nil || *ssResp.ID == "" {
+		return fmt.Errorf("reading Storage Sync %q (Resource Group %q) ID is empty or nil", id.StorageSyncName, id.ResourceGroup)
+	}
+
+	d.Set("storage_sync_id", ssResp.ID)
+
+	return nil
+}
+
+func resourceArmStorageSyncGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Storage.StoragesyncGroupClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parsers.StorageSyncGroupID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.StorageSyncName, id.Name); err != nil {
+		return fmt.Errorf("deleting Storage Sync Group (Storage Sync Group Name %q / Storage Sync Name %q /Resource Group %q): %+v", id.Name, id.StorageSyncName, id.ResourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/storage/tests/data_source_storage_sync_group_test.go
+++ b/azurerm/internal/services/storage/tests/data_source_storage_sync_group_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMStorageSyncGroup_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_sync_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageSyncGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMStorageSyncGroup_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageSyncGroupExists(data.ResourceName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMStorageSyncGroup_basic(data acceptance.TestData) string {
+	basic := testAccAzureRMStorageSyncGroup_basic(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_storage_sync_group" "test" {
+  name            = azurerm_storage_sync_group.test.name
+  storage_sync_id = azurerm_storage_sync.test.id
+}
+`, basic)
+}

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_sync_group_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_sync_group_test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMStorageSyncGroup_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_sync_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageSyncGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageSyncGroup_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageSyncGroupExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMStorageSyncGroup_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_sync_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageSyncGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageSyncGroup_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageSyncGroupExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMStorageSyncGroup_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMStorageSyncGroupExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("storage Sync Group not found: %s", resourceName)
+		}
+		id, err := parsers.StorageSyncGroupID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Storage.StoragesyncGroupClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.StorageSyncName, id.Name); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("bad: Storage Sync Group (Storage Sync Group Name %q / Resource Group %q) does not exist", id.Name, id.ResourceGroup)
+			}
+			return fmt.Errorf("bad: Get on StorageSyncGroupsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStorageSyncGroupDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Storage.StoragesyncGroupClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_storage_sync_group" {
+			continue
+		}
+
+		id, err := parsers.StorageSyncGroupID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.StorageSyncName, id.Name); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("bad: Get on StorageSyncGroupsClient: %+v", err)
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+func testAccAzureRMStorageSyncGroup_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-SS-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_storage_sync" "test" {
+  name                = "acctest-StorageSync-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_storage_sync_group" "test" {
+  name            = "acctest-StorageSyncGroup-%[1]d"
+  storage_sync_id = azurerm_storage_sync.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAccAzureRMStorageSyncGroup_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMStorageSyncGroup_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_sync_group" "import" {
+  name            = azurerm_storage_sync_group.test.name
+  storage_sync_id = azurerm_storage_sync.test.id
+}
+`, template)
+}

--- a/azurerm/internal/services/storage/validate/storage_sync.go
+++ b/azurerm/internal/services/storage/validate/storage_sync.go
@@ -3,6 +3,8 @@ package validate
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 )
 
 func StorageSyncName(v interface{}, _ string) (warnings []string, errors []error) {
@@ -10,6 +12,20 @@ func StorageSyncName(v interface{}, _ string) (warnings []string, errors []error
 
 	if !regexp.MustCompile("^[0-9a-zA-Z-_. ]*[0-9a-zA-Z-_]$").MatchString(input) {
 		errors = append(errors, fmt.Errorf("name (%q) can only consist of letters, numbers, spaces, and any of the following characters: '.-_' and that does not end with characters: '. '", input))
+	}
+
+	return warnings, errors
+}
+
+func StorageSyncId(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := parsers.ParseStorageSyncID(v); err != nil {
+		errors = append(errors, fmt.Errorf("can not parse %q as a Storage Sync resource id: %v", k, err))
 	}
 
 	return warnings, errors

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -618,6 +618,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/storage_sync_group.html">azurerm_storage_sync_group</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/storage_management_policy.html">azurerm_storage_management_policy</a>
                 </li>
 
@@ -2734,6 +2738,10 @@
 
                 <li>
                   <a href="/docs/providers/azurerm/r/storage_sync.html">azurerm_storage_sync</a>
+                </li>
+
+                <li>
+                  <a href="/docs/providers/azurerm/r/storage_sync_group.html">azurerm_storage_sync_group</a>
                 </li>
 
                 <li>

--- a/website/docs/d/storage_sync_group.html.markdown
+++ b/website/docs/d/storage_sync_group.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Storage"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_storage_sync_group"
+description: |-
+  Gets information about an existing Storage Sync Group.
+---
+
+# Data Source: azurerm_storage_sync_group
+
+Use this data source to access information about an existing Storage Sync Group.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_storage_sync_group" "example" {
+  name            = "existing-ss-group"
+  storage_sync_id = "existing-ss-id"
+}
+
+output "id" {
+  value = data.azurerm_storage_sync_group.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Storage Sync Group.
+
+* `storage_sync_id` - (Required) The resource ID of the Storage Sync where this Storage Sync Group is.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Storage Sync Group.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Storage Sync Group.

--- a/website/docs/r/storage_sync_group.html.markdown
+++ b/website/docs/r/storage_sync_group.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Storage"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_sync_group"
+description: |-
+  Manages a Storage Sync Group.
+---
+
+# azurerm_storage_sync_group
+
+Manages a Storage Sync Group.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_sync" "example" {
+  name                = "example-ss"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_storage_sync_group" "example" {
+  name            = "example-ss-group"
+  storage_sync_id = azurerm_storage_sync.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Storage Sync Group. Changing this forces a new Storage Sync Group to be created.
+
+* `storage_sync_id` - (Required) The resource ID of the Storage Sync where this Storage Sync Group is. Changing this forces a new Storage Sync Group to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Storage Sync Group.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Storage Sync Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Storage Sync Group.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Storage Sync Group.
+
+## Import
+
+Storage Sync Groups can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_sync_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.StorageSync/storageSyncServices/sync1/syncGroups/group1
+```


### PR DESCRIPTION
Partial fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/2315.

Extend: https://github.com/terraform-providers/terraform-provider-azurerm/pull/7843

Totally there will be three resources:
`azurerm_storage_sync`
`azurerm_storage_sync_group`
`azurerm_cloud_endpoint`

=== RUN   TestAccAzureRMStorageSyncGroup_basic
=== PAUSE TestAccAzureRMStorageSyncGroup_basic
=== CONT  TestAccAzureRMStorageSyncGroup_basic
--- PASS: TestAccAzureRMStorageSyncGroup_basic (254.76s)
=== RUN   TestAccAzureRMStorageSyncGroup_requiresImport
=== PAUSE TestAccAzureRMStorageSyncGroup_requiresImport
=== CONT  TestAccAzureRMStorageSyncGroup_requiresImport
--- PASS: TestAccAzureRMStorageSyncGroup_requiresImport (265.42s)

=== RUN   TestAccDataSourceAzureRMStorageSyncGroup_basic
=== PAUSE TestAccDataSourceAzureRMStorageSyncGroup_basic
=== CONT  TestAccDataSourceAzureRMStorageSyncGroup_basic
--- PASS: TestAccDataSourceAzureRMStorageSyncGroup_basic (258.85s)