### PR TITLE
make sku_name suppress case difference - azurerm_key_vault

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -7,9 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
-
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -17,9 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/set"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -73,6 +73,7 @@ func resourceArmKeyVault() *schema.Resource {
 					string(keyvault.Standard),
 					string(keyvault.Premium),
 				}, false),
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"tenant_id": {

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -73,6 +73,8 @@ func resourceArmKeyVault() *schema.Resource {
 					string(keyvault.Standard),
 					string(keyvault.Premium),
 				}, false),
+				// issue: https://github.com/Azure/azure-rest-api-specs/issues/10943
+				// to avoid import problem, add Suppress Case Diff
 				DiffSuppressFunc: suppress.CaseDifference,
 			},
 


### PR DESCRIPTION
fix #8457

now, the portal's default behaviour for "sku" is "Standard". after terraform import there will be diff because only "standard" and "premium" is accepted.

