### PR TITLE
`azurerm_[linux|windows]_virtual_machine` in-line data disks beta

### DIFF
--- a/azurerm/internal/features/beta_features_opt_in.go
+++ b/azurerm/internal/features/beta_features_opt_in.go
@@ -12,3 +12,11 @@ import (
 func VMSSExtensionsBeta() bool {
 	return strings.EqualFold(os.Getenv("ARM_PROVIDER_VMSS_EXTENSIONS_BETA"), "true")
 }
+
+// VMDataDiskBeta returns whether or not the beta for VMSS Extensions for Linux and Windows VMSS resources is
+// enabled.
+//
+// Set the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to `true`
+func VMDataDiskBeta() bool {
+	return strings.EqualFold(os.Getenv("ARM_PROVIDER_VM_DATADISKS_BETA"), "true")
+}

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -9,7 +9,8 @@ type UserFeatures struct {
 }
 
 type VirtualMachineFeatures struct {
-	DeleteOSDiskOnDeletion bool
+	DeleteOSDiskOnDeletion   bool
+	DeleteDataDiskOnDeletion bool
 }
 
 type VirtualMachineScaleSetFeatures struct {

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -9,8 +9,8 @@ type UserFeatures struct {
 }
 
 type VirtualMachineFeatures struct {
-	DeleteOSDiskOnDeletion   bool
-	DeleteDataDiskOnDeletion bool
+	DeleteOSDiskOnDeletion    bool
+	DeleteDataDisksOnDeletion bool
 }
 
 type VirtualMachineScaleSetFeatures struct {

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -66,7 +66,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 						Type:     schema.TypeBool,
 						Optional: true,
 					},
-					"delete_data_disk_on_deletion": {
+					"delete_data_disks_on_deletion": {
 						Type:     schema.TypeBool,
 						Optional: true,
 					},
@@ -180,6 +180,8 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			virtualMachinesRaw := items[0].(map[string]interface{})
 			if v, ok := virtualMachinesRaw["delete_os_disk_on_deletion"]; ok {
 				features.VirtualMachine.DeleteOSDiskOnDeletion = v.(bool)
+			}
+			if v, ok := virtualMachinesRaw["delete_data_disks_on_deletion"]; ok {
 				features.VirtualMachine.DeleteDataDisksOnDeletion = v.(bool)
 			}
 		}

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -127,8 +127,8 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			DeleteNestedItemsDuringDeletion: true,
 		},
 		VirtualMachine: features.VirtualMachineFeatures{
-			DeleteOSDiskOnDeletion:   true,
-			DeleteDataDiskOnDeletion: true,
+			DeleteOSDiskOnDeletion:    true,
+			DeleteDataDisksOnDeletion: true,
 		},
 		VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,
@@ -180,7 +180,7 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			virtualMachinesRaw := items[0].(map[string]interface{})
 			if v, ok := virtualMachinesRaw["delete_os_disk_on_deletion"]; ok {
 				features.VirtualMachine.DeleteOSDiskOnDeletion = v.(bool)
-				features.VirtualMachine.DeleteDataDiskOnDeletion = v.(bool)
+				features.VirtualMachine.DeleteDataDisksOnDeletion = v.(bool)
 			}
 		}
 	}

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -64,7 +64,11 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"delete_os_disk_on_deletion": {
 						Type:     schema.TypeBool,
-						Required: true,
+						Optional: true,
+					},
+					"delete_data_disk_on_deletion": {
+						Type:     schema.TypeBool,
+						Optional: true,
 					},
 				},
 			},
@@ -123,7 +127,8 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			DeleteNestedItemsDuringDeletion: true,
 		},
 		VirtualMachine: features.VirtualMachineFeatures{
-			DeleteOSDiskOnDeletion: true,
+			DeleteOSDiskOnDeletion:   true,
+			DeleteDataDiskOnDeletion: true,
 		},
 		VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,
@@ -175,6 +180,7 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			virtualMachinesRaw := items[0].(map[string]interface{})
 			if v, ok := virtualMachinesRaw["delete_os_disk_on_deletion"]; ok {
 				features.VirtualMachine.DeleteOSDiskOnDeletion = v.(bool)
+				features.VirtualMachine.DeleteDataDiskOnDeletion = v.(bool)
 			}
 		}
 	}

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -30,6 +30,7 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -59,6 +60,7 @@ func TestExpandFeatures(t *testing.T) {
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion": true,
+							"delete_data_disk_on_deletion": true,
 						},
 					},
 					"virtual_machine_scale_set": []interface{}{
@@ -81,6 +83,7 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -94,6 +97,7 @@ func TestExpandFeatures(t *testing.T) {
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion": false,
+							"delete_data_disk_on_deletion": false,
 						},
 					},
 					"network_locking": []interface{}{
@@ -132,6 +136,7 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: false,
+					DeleteDataDiskOnDeletion: false,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: false,
@@ -366,6 +371,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: true,
 				},
 			},
 		},
@@ -383,6 +389,25 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: true,
+				},
+			},
+		},
+		{
+			Name: "Delete Data Disk Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine": []interface{}{
+						map[string]interface{}{
+							"delete_data_disk_on_deletion": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachine: features.VirtualMachineFeatures{
+					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: true,
 				},
 			},
 		},
@@ -400,6 +425,25 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: false,
+					DeleteDataDiskOnDeletion: true,
+				},
+			},
+		},
+		{
+			Name: "Delete Data Disk Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine": []interface{}{
+						map[string]interface{}{
+							"delete_data_disk_on_deletion": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachine: features.VirtualMachineFeatures{
+					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: false,
 				},
 			},
 		},

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -59,7 +59,7 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion":   true,
+							"delete_os_disk_on_deletion":    true,
 							"delete_data_disks_on_deletion": true,
 						},
 					},
@@ -96,7 +96,7 @@ func TestExpandFeatures(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion":   false,
+							"delete_os_disk_on_deletion":    false,
 							"delete_data_disks_on_deletion": false,
 						},
 					},
@@ -430,7 +430,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 		},
 		{
-			Name: "Delete Data Disk Disabled",
+			Name: "Delete Data Disks Disabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"virtual_machine": []interface{}{

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -29,7 +29,7 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 					DeleteDataDiskOnDeletion: true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
@@ -59,7 +59,7 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion": true,
+							"delete_os_disk_on_deletion":   true,
 							"delete_data_disk_on_deletion": true,
 						},
 					},
@@ -82,7 +82,7 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 					DeleteDataDiskOnDeletion: true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
@@ -96,7 +96,7 @@ func TestExpandFeatures(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion": false,
+							"delete_os_disk_on_deletion":   false,
 							"delete_data_disk_on_deletion": false,
 						},
 					},
@@ -135,7 +135,7 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: false,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: false,
+					DeleteOSDiskOnDeletion:   false,
 					DeleteDataDiskOnDeletion: false,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
@@ -370,7 +370,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 					DeleteDataDiskOnDeletion: true,
 				},
 			},
@@ -388,7 +388,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 					DeleteDataDiskOnDeletion: true,
 				},
 			},
@@ -406,7 +406,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 					DeleteDataDiskOnDeletion: true,
 				},
 			},
@@ -424,7 +424,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: false,
+					DeleteOSDiskOnDeletion:   false,
 					DeleteDataDiskOnDeletion: true,
 				},
 			},
@@ -442,7 +442,7 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 					DeleteDataDiskOnDeletion: false,
 				},
 			},

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -29,8 +29,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   true,
-					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					DeleteDataDisksOnDeletion: true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -60,7 +60,7 @@ func TestExpandFeatures(t *testing.T) {
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion":   true,
-							"delete_data_disk_on_deletion": true,
+							"delete_data_disks_on_deletion": true,
 						},
 					},
 					"virtual_machine_scale_set": []interface{}{
@@ -82,8 +82,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   true,
-					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					DeleteDataDisksOnDeletion: true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -97,7 +97,7 @@ func TestExpandFeatures(t *testing.T) {
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion":   false,
-							"delete_data_disk_on_deletion": false,
+							"delete_data_disks_on_deletion": false,
 						},
 					},
 					"network_locking": []interface{}{
@@ -135,8 +135,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: false,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   false,
-					DeleteDataDiskOnDeletion: false,
+					DeleteOSDiskOnDeletion:    false,
+					DeleteDataDisksOnDeletion: false,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: false,
@@ -370,8 +370,8 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   true,
-					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					DeleteDataDisksOnDeletion: true,
 				},
 			},
 		},
@@ -388,26 +388,26 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   true,
-					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					DeleteDataDisksOnDeletion: true,
 				},
 			},
 		},
 		{
-			Name: "Delete Data Disk Enabled",
+			Name: "Delete Data Disks Enabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_data_disk_on_deletion": true,
+							"delete_data_disks_on_deletion": true,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   true,
-					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					DeleteDataDisksOnDeletion: true,
 				},
 			},
 		},
@@ -424,8 +424,8 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   false,
-					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:    false,
+					DeleteDataDisksOnDeletion: true,
 				},
 			},
 		},
@@ -435,15 +435,15 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_data_disk_on_deletion": false,
+							"delete_data_disks_on_deletion": false,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion:   true,
-					DeleteDataDiskOnDeletion: false,
+					DeleteOSDiskOnDeletion:    true,
+					DeleteDataDisksOnDeletion: false,
 				},
 			},
 		},

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
@@ -340,8 +341,7 @@ func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{})
 
 	dataDisks := &[]compute.DataDisk{}
 
-	// TODO - put beta env var flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		dataDisks, err = expandVirtualMachineDataDisks(d, meta)
 		if err != nil {
 			return err
@@ -640,8 +640,7 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("setting `source_image_reference`: %+v", err)
 		}
 
-		// TODO beta env var here
-		if true {
+		if features.VMDataDiskBeta() {
 			d.Set("data_disk", flattenVirtualMachineDataDisks(profile.DataDisks))
 		}
 	}
@@ -1204,8 +1203,7 @@ func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{})
 		log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	}
 
-	// TODO - put beta env var flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		deleteDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 		if deleteDataDisks {
 			if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.DataDisks != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -1001,7 +1001,7 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("Once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
 	}
-	deleteRemovedDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+	deleteRemovedDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 	dataDisksToDeleted := make([]compute.DataDisk, 0)
 	// TODO Beta flag here
 	if true {
@@ -1202,7 +1202,7 @@ func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{})
 
 	// TODO - put beta env var flag here
 	if true {
-		deleteDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+		deleteDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 		if deleteDataDisks {
 			if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.DataDisks != nil {
 				for _, v := range *props.StorageProfile.DataDisks {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -342,11 +342,7 @@ func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{})
 
 	// TODO - put beta env var flag here
 	if true {
-		dataDiskRaw := d.Get("data_disk").([]interface{})
-		dataDisks, err = expandVirtualMachineDataDisks(dataDiskRaw)
-		if err != nil {
-			return err
-		}
+		dataDisks = expandVirtualMachineDataDisks(d.Get("data_disk").([]interface{}))
 	}
 
 	secretsRaw := d.Get("secret").([]interface{})
@@ -643,12 +639,7 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 
 		// TODO beta env var here
 		if true {
-			if dataDisks := profile.DataDisks; dataDisks != nil {
-				flattenedDataDisks, err := flattenVirtualMachineDataDisks(dataDisks, d)
-				if err != nil {
-					return fmt.Errorf("flattening `data_disk`: %+v", err)
-				}
-			}
+			d.Set("data_disk", flattenVirtualMachineDataDisks(profile.DataDisks, d))
 		}
 	}
 

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -1001,6 +1001,8 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("Once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
 	}
+	deleteRemovedDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+	dataDisksToDeleted := make([]compute.DataDisk, 0)
 	// TODO Beta flag here
 	if true {
 		if d.HasChange("data_disk") {
@@ -1012,11 +1014,16 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 				// Because some values are computed we need to use the existing disk data or a change of order will break values such as `managed_disk_id`
 				// This also filters out removed disks
 				for _, existingDataDisk := range *existing.VirtualMachineProperties.StorageProfile.DataDisks {
+					found := false
 					for _, dataDisk := range *updatedDataDisks {
 						if *dataDisk.Name == *existingDataDisk.Name {
 							dataDisks = append(dataDisks, existingDataDisk)
+							found = true
 							break
 						}
+					}
+					if !found && deleteRemovedDisks {
+						dataDisksToDeleted = append(dataDisksToDeleted, existingDataDisk)
 					}
 				}
 				// and add any new disks
@@ -1043,7 +1050,6 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 					DataDisks: &dataDisks,
 				}
 			}
-			// TODO - delete removed disks if feature flag set
 		}
 	}
 
@@ -1059,6 +1065,32 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		log.Printf("[DEBUG] Updated Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+	}
+
+	// TODO Beta flag here
+	if true {
+		// TODO - delete removed disks if feature flag set
+		if deleteRemovedDisks && len(dataDisksToDeleted) > 0 {
+			for _, v := range dataDisksToDeleted {
+				if v.ManagedDisk != nil && v.ManagedDisk.ID != nil {
+					diskId, err := parse.ManagedDiskID(*v.ManagedDisk.ID)
+					if err != nil {
+						return fmt.Errorf("failed to parse ID for Data Disk to delete from Virtual Machine %q (resource group %q), %+v", id.Name, id.ResourceGroup, err)
+					}
+					diskDeleteFuture, err := disksClient.Delete(ctx, diskId.ResourceGroup, diskId.Name)
+					if err != nil {
+						if !response.WasNotFound(diskDeleteFuture.Response()) {
+							return fmt.Errorf("deleting Data Disk %q (resource group %q) for Linux Virtual Machine %q (resource group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+						}
+					}
+					if !response.WasNotFound(diskDeleteFuture.Response()) {
+						if err := diskDeleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
+							return fmt.Errorf("waiting for delete on Data Disk Data Disk %q (resource group %q) for Linux Virtual Machine %q (resource group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// if we've shut it down and it was turned off, let's boot it back up

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -342,7 +342,7 @@ func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{})
 
 	// TODO - put beta env var flag here
 	if true {
-		dataDisks = expandVirtualMachineDataDisks(d.Get("data_disk").([]interface{}))
+		dataDisks, err = expandVirtualMachineDataDisks(d, meta)
 	}
 
 	secretsRaw := d.Get("secret").([]interface{})
@@ -1007,7 +1007,10 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 	if true {
 		if d.HasChange("data_disk") {
 			shouldUpdate = true
-			updatedDataDisks := expandVirtualMachineDataDisks(d.Get("data_disk").([]interface{}))
+			updatedDataDisks, err := expandVirtualMachineDataDisks(d, meta)
+			if err != nil {
+				return err
+			}
 			dataDisks := make([]compute.DataDisk, 0)
 			// Reconcile the data disks if previously specified
 			if existing.VirtualMachineProperties.StorageProfile != nil && existing.VirtualMachineProperties.StorageProfile.DataDisks != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -1005,8 +1005,7 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 	}
 	deleteRemovedDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 	dataDisksToDeleted := make([]compute.DataDisk, 0)
-	// TODO Beta flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		if d.HasChange("data_disk") {
 			shouldUpdate = true
 			updatedDataDisks, err := expandVirtualMachineDataDisks(d, meta)
@@ -1072,8 +1071,7 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 		log.Printf("[DEBUG] Updated Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
 	}
 
-	// TODO Beta flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		if deleteRemovedDataDisks && len(dataDisksToDeleted) > 0 {
 			for _, v := range dataDisksToDeleted {
 				if v.ManagedDisk != nil && v.ManagedDisk.ID != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -1028,11 +1028,7 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 					found := false
 					for _, dataDisk := range *updatedDataDisks {
 						if existingDataDisk.Name != nil && *dataDisk.Name == *existingDataDisk.Name {
-							updateDisk, err := rationaliseDataDiskForUpdate(&existingDataDisk, &dataDisk, id.Name)
-							if err != nil {
-								return err
-							}
-							dataDisks = append(dataDisks, *updateDisk)
+							dataDisks = append(dataDisks, existingDataDisk)
 							found = true
 							break
 						}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
@@ -1,0 +1,204 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccLinuxVirtualMachine_dataDiskBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_dataDiskBasic(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDiskDeleteOnTermination(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_dataDiskDeleteOnTermination(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("data_disk.0.delete_on_termination"),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDiskMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_dataDiskMultiple(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_dataDiskBasic(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                 = "testdatadisk"
+    lun                  = 1
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 1
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_dataDiskDeleteOnTermination(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                  = "testdatadisk"
+    lun                   = 1
+    caching               = "None"
+    storage_account_type  = "Standard_LRS"
+    disk_size_gb          = 1
+	delete_on_termination = true
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_dataDiskMultiple(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                 = "testdatadisk"
+    lun                  = 1
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 1
+  }
+
+  data_disk {
+    name                 = "testdatadisk2"
+    lun                  = 2
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 2
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
@@ -2,6 +2,10 @@ package tests
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -17,7 +21,7 @@ func TestAccLinuxVirtualMachine_dataDiskBasic(t *testing.T) {
 		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testLinuxVirtualMachine_dataDiskBasic(data),
+				Config: testLinuxVirtualMachine_dataDiskBasic(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkLinuxVirtualMachineExists(data.ResourceName),
 				),
@@ -36,12 +40,18 @@ func TestAccLinuxVirtualMachine_dataDiskDeleteOnTermination(t *testing.T) {
 		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testLinuxVirtualMachine_dataDiskDeleteOnTermination(data),
+				Config: testLinuxVirtualMachine_dataDiskBasic(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkLinuxVirtualMachineExists(data.ResourceName),
 				),
 			},
-			data.ImportStep("data_disk.0.delete_on_termination"),
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_dataDiskBasicVMRemoved(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineDataDiskIsDeleted(fmt.Sprintf("acctestRG-%d", data.RandomInteger), "testdatadisk", fmt.Sprintf("acctestVM-%d", data.RandomInteger)),
+				),
+			},
 		},
 	})
 }
@@ -55,7 +65,7 @@ func TestAccLinuxVirtualMachine_dataDiskMultiple(t *testing.T) {
 		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testLinuxVirtualMachine_dataDiskMultiple(data),
+				Config: testLinuxVirtualMachine_dataDiskMultiple(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkLinuxVirtualMachineExists(data.ResourceName),
 				),
@@ -74,23 +84,60 @@ func TestAccLinuxVirtualMachine_dataDiskUpdate(t *testing.T) {
 		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testLinuxVirtualMachine_dataDiskBasic(data),
+				Config: testLinuxVirtualMachine_dataDiskBasic(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkLinuxVirtualMachineExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testLinuxVirtualMachine_dataDiskMultiple(data),
+				Config: testLinuxVirtualMachine_dataDiskMultiple(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkLinuxVirtualMachineExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testLinuxVirtualMachine_dataDiskRemoveFirst(data),
+				Config: testLinuxVirtualMachine_dataDiskRemoveFirst(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkLinuxVirtualMachineExists(data.ResourceName),
+					checkLinuxVirtualMachineDataDiskIsDeleted(fmt.Sprintf("acctestRG-%d", data.RandomInteger), "testdatadisk", fmt.Sprintf("acctestVM-%d", data.RandomInteger)),
+				),
+				// Check disk is not deleted
+				ExpectError: regexp.MustCompile("bad: Data Disk \"testdatadisk\" for Virtual Machine"),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDiskUpdateWithDeleteDataDisk(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_dataDiskBasic(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_dataDiskMultiple(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_dataDiskRemoveFirst(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					checkLinuxVirtualMachineDataDiskIsDeleted(fmt.Sprintf("acctestRG-%d", data.RandomInteger), "testdatadisk", fmt.Sprintf("acctestVM-%d", data.RandomInteger)),
 				),
 			},
 			data.ImportStep(),
@@ -98,10 +145,35 @@ func TestAccLinuxVirtualMachine_dataDiskUpdate(t *testing.T) {
 	})
 }
 
-func testLinuxVirtualMachine_dataDiskBasic(data acceptance.TestData) string {
+func checkLinuxVirtualMachineDataDiskIsDeleted(resourceGroup string, dataDiskName string, vmName string) resource.TestCheckFunc {
+	// Since we cannot rely on the state to provide the information, as it may be deleted, to find the disk we expect it to follow the acc test pattern
+	return func(s *terraform.State) error {
+		disksClient := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DisksClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		if resp, err := disksClient.Get(ctx, resourceGroup, dataDiskName); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			} else {
+				return fmt.Errorf("bad: failed to check Data Disk %q for Virtual Machine %q (resource group %q) was deleted: %+v", dataDiskName, vmName, resourceGroup, err)
+			}
+		}
+		return fmt.Errorf("bad: Data Disk %q for Virtual Machine %q (resource group %q) was not deleted", dataDiskName, vmName, resourceGroup)
+	}
+}
+
+func testLinuxVirtualMachine_dataDiskBasic(data acceptance.TestData, deleteDataDisks bool) string {
 	template := testLinuxVirtualMachine_template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {
+    virtual_machine { 
+	  delete_data_disk_on_deletion = %t
+    }
+  }
+}
 
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
@@ -138,57 +210,34 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, template, data.RandomInteger)
-}
+`, template, deleteDataDisks, data.RandomInteger)}
 
-func testLinuxVirtualMachine_dataDiskDeleteOnTermination(data acceptance.TestData) string {
+func testLinuxVirtualMachine_dataDiskBasicVMRemoved(data acceptance.TestData, deleteDataDisks bool) string {
 	template := testLinuxVirtualMachine_template(data)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  data_disk {
-    name                  = "testdatadisk"
-    lun                   = 1
-    caching               = "None"
-    storage_account_type  = "Standard_LRS"
-    disk_size_gb          = 1
-	delete_on_termination = true
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "latest"
+provider "azurerm" {
+  features {
+    virtual_machine { 
+	  delete_data_disk_on_deletion = %t
+    }
   }
 }
-`, template, data.RandomInteger)
-}
+`, template, deleteDataDisks)}
 
-func testLinuxVirtualMachine_dataDiskMultiple(data acceptance.TestData) string {
+func testLinuxVirtualMachine_dataDiskMultiple(data acceptance.TestData, deleteDataDisks bool) string {
 	template := testLinuxVirtualMachine_template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {
+    virtual_machine { 
+	  delete_data_disk_on_deletion = %t
+    }
+  }
+}
 
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
@@ -233,13 +282,21 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, template, data.RandomInteger)
+`, template, deleteDataDisks, data.RandomInteger)
 }
 
-func testLinuxVirtualMachine_dataDiskRemoveFirst(data acceptance.TestData) string {
+func testLinuxVirtualMachine_dataDiskRemoveFirst(data acceptance.TestData, deleteDateDisks bool) string {
 	template := testLinuxVirtualMachine_template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {
+    virtual_machine { 
+	  delete_data_disk_on_deletion = %t
+    }
+  }
+}
 
 resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
@@ -276,5 +333,5 @@ resource "azurerm_linux_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, template, data.RandomInteger)
+`, template, deleteDateDisks, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
@@ -501,7 +501,6 @@ resource "azurerm_linux_virtual_machine" "test" {
     lun                  = 1
     caching              = "None"
     storage_account_type = "Standard_LRS"
-    disk_size_gb         = azurerm_managed_disk.test.disk_size_gb
     managed_disk_id      = azurerm_managed_disk.test.id
   }
 

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
@@ -402,66 +402,6 @@ resource "azurerm_linux_virtual_machine" "test" {
 `, template, deleteDataDisks, data.RandomInteger)
 }
 
-func testLinuxVirtualMachine_dataDiskChangeManagedDiskID(data acceptance.TestData, deleteDataDisks bool) string {
-	template := testLinuxVirtualMachine_template(data)
-	return fmt.Sprintf(`
-%s
-
-provider "azurerm" {
-  features {
-    virtual_machine {
-      delete_data_disks_on_deletion = %t
-    }
-  }
-}
-
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  data_disk {
-    name                 = "testdatadisk"
-    lun                  = 1
-    caching              = "None"
-    storage_account_type = "Standard_LRS"
-    disk_size_gb         = 10
-  }
-
-  data_disk {
-    name                 = "testdatadisk2"
-    lun                  = 2
-    caching              = "None"
-    storage_account_type = "Standard_LRS"
-    disk_size_gb         = 2
-    managed_disk_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/disks/manageddisk1"
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "latest"
-  }
-}
-`, template, deleteDataDisks, data.RandomInteger)
-}
-
 func testLinuxVirtualMachine_dataDiskRemoveFirst(data acceptance.TestData, deleteDateDisks bool) string {
 	template := testLinuxVirtualMachine_template(data)
 	return fmt.Sprintf(`

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_data_disk_test.go
@@ -162,58 +162,6 @@ func TestAccLinuxVirtualMachine_dataDiskUpdate(t *testing.T) {
 	})
 }
 
-func TestAccLinuxVirtualMachine_dataDiskUpdateStorageAccount(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
-		Steps: []resource.TestStep{
-			{
-				Config: testLinuxVirtualMachine_dataDiskMultiple(data, false),
-				Check: resource.ComposeTestCheckFunc(
-					checkLinuxVirtualMachineExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: testLinuxVirtualMachine_dataDiskChangeAccountType(data, false),
-				Check: resource.ComposeTestCheckFunc(
-					checkLinuxVirtualMachineExists(data.ResourceName),
-				),
-				ExpectError: regexp.MustCompile("Error: changing Storage Account Type for \"testdatadisk2\""),
-			},
-		},
-	})
-}
-
-func TestAccLinuxVirtualMachine_dataDiskChangeManagedDiskID(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
-		Steps: []resource.TestStep{
-			{
-				Config: testLinuxVirtualMachine_dataDiskMultiple(data, false),
-				Check: resource.ComposeTestCheckFunc(
-					checkLinuxVirtualMachineExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: testLinuxVirtualMachine_dataDiskChangeManagedDiskID(data, false),
-				Check: resource.ComposeTestCheckFunc(
-					checkLinuxVirtualMachineExists(data.ResourceName),
-				),
-				ExpectError: regexp.MustCompile("Error: cannot update in place Managed Disk ID  for \"testdatadisk2\""),
-			},
-		},
-	})
-}
-
 func TestAccLinuxVirtualMachine_dataDiskUpdateWithDeleteDataDisk(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 
@@ -441,65 +389,6 @@ resource "azurerm_linux_virtual_machine" "test" {
     lun                  = 2
     caching              = "None"
     storage_account_type = "Standard_LRS"
-    disk_size_gb         = 2
-  }
-
-  source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
-    version   = "latest"
-  }
-}
-`, template, deleteDataDisks, data.RandomInteger)
-}
-
-func testLinuxVirtualMachine_dataDiskChangeAccountType(data acceptance.TestData, deleteDataDisks bool) string {
-	template := testLinuxVirtualMachine_template(data)
-	return fmt.Sprintf(`
-%s
-
-provider "azurerm" {
-  features {
-    virtual_machine {
-      delete_data_disks_on_deletion = %t
-    }
-  }
-}
-
-resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = local.first_public_key
-  }
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  data_disk {
-    name                 = "testdatadisk"
-    lun                  = 1
-    caching              = "None"
-    storage_account_type = "Standard_LRS"
-    disk_size_gb         = 10
-  }
-
-  data_disk {
-    name                 = "testdatadisk2"
-    lun                  = 2
-    caching              = "None"
-    storage_account_type = "Premium_LRS"
     disk_size_gb         = 2
   }
 

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
@@ -146,7 +146,7 @@ func testWindowsVirtualMachine_dataDiskBasic(data acceptance.TestData, deleteDat
 provider "azurerm" {
   features {
     virtual_machine {
-      delete_data_disk_on_deletion = %t
+      delete_data_disks_on_deletion = %t
     }
   }
 }
@@ -193,7 +193,7 @@ func testWindowsVirtualMachine_dataDiskMultiple(data acceptance.TestData, delete
 provider "azurerm" {
   features {
     virtual_machine {
-      delete_data_disk_on_deletion = %t
+      delete_data_disks_on_deletion = %t
     }
   }
 }
@@ -248,7 +248,7 @@ func testWindowsVirtualMachine_dataDiskRemoveFirst(data acceptance.TestData, del
 provider "azurerm" {
   features {
     virtual_machine {
-      delete_data_disk_on_deletion = %t
+      delete_data_disks_on_deletion = %t
     }
   }
 }
@@ -295,7 +295,7 @@ func testWindowsVirtualMachine_dataDiskVMRemoved(data acceptance.TestData, delet
 provider "azurerm" {
   features {
     virtual_machine {
-      delete_data_disk_on_deletion = %t
+      delete_data_disks_on_deletion = %t
     }
   }
 }

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
@@ -17,7 +17,7 @@ func TestAccWindowsVirtualMachine_dataDiskBasic(t *testing.T) {
 		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testWindowsVirtualMachine_dataDiskBasic(data),
+				Config: testWindowsVirtualMachine_dataDiskBasic(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkWindowsVirtualMachineExists(data.ResourceName),
 				),
@@ -36,12 +36,19 @@ func TestAccWindowsVirtualMachine_dataDiskDeleteOnTermination(t *testing.T) {
 		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testWindowsVirtualMachine_dataDiskDeleteOnTermination(data),
+				Config: testWindowsVirtualMachine_dataDiskBasic(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkWindowsVirtualMachineExists(data.ResourceName),
 				),
 			},
-			data.ImportStep("admin_password", "data_disk.0.delete_on_termination"),
+			data.ImportStep("admin_password"),
+			{
+				Config: testWindowsVirtualMachine_dataDiskVMRemoved(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					checkVirtualMachineManagedDiskIsDeleted(fmt.Sprintf("acctestRG-%d", data.RandomInteger), "testdatadisk", fmt.Sprintf("acctestvm%s", data.RandomString)),
+				),
+			},
 		},
 	})
 }
@@ -55,7 +62,7 @@ func TestAccWindowsVirtualMachine_dataDiskMultiple(t *testing.T) {
 		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testWindowsVirtualMachine_dataDiskMultiple(data),
+				Config: testWindowsVirtualMachine_dataDiskMultiple(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					checkWindowsVirtualMachineExists(data.ResourceName),
 				),
@@ -65,10 +72,85 @@ func TestAccWindowsVirtualMachine_dataDiskMultiple(t *testing.T) {
 	})
 }
 
-func testWindowsVirtualMachine_dataDiskBasic(data acceptance.TestData) string {
+func TestAccWindowsVirtualMachine_dataDiskUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_dataDiskBasic(data, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+			{
+				Config: testWindowsVirtualMachine_dataDiskMultiple(data, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+			{
+				Config: testWindowsVirtualMachine_dataDiskRemoveFirst(data, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDiskUpdateWithDeleteDataDisk(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_dataDiskBasic(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+			{
+				Config: testWindowsVirtualMachine_dataDiskMultiple(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+			{
+				Config: testWindowsVirtualMachine_dataDiskRemoveFirst(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					checkVirtualMachineManagedDiskIsDeleted(fmt.Sprintf("acctestRG-%d", data.RandomInteger), "testdatadisk", fmt.Sprintf("acctestvm%s", data.RandomString)),
+				),
+			},
+			data.ImportStep("admin_password"),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_dataDiskBasic(data acceptance.TestData, deleteDataDisks bool) string {
 	template := testWindowsVirtualMachine_template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_data_disk_on_deletion = %t
+    }
+  }
+}
 
 resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
@@ -101,53 +183,21 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, template)
+`, template, deleteDataDisks)
 }
 
-func testWindowsVirtualMachine_dataDiskDeleteOnTermination(data acceptance.TestData) string {
+func testWindowsVirtualMachine_dataDiskMultiple(data acceptance.TestData, deleteDataDisk bool) string {
 	template := testWindowsVirtualMachine_template(data)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  data_disk {
-    name                  = "testdatadisk"
-    lun                   = 1
-    caching               = "None"
-    storage_account_type  = "Standard_LRS"
-    disk_size_gb          = 1
-    delete_on_termination = true
-  }
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_data_disk_on_deletion = %t
+    }
   }
 }
-`, template)
-}
-
-func testWindowsVirtualMachine_dataDiskMultiple(data acceptance.TestData) string {
-	template := testWindowsVirtualMachine_template(data)
-	return fmt.Sprintf(`
-%s
 
 resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
@@ -188,5 +238,68 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 }
-`, template)
+`, template, deleteDataDisk)
+}
+
+func testWindowsVirtualMachine_dataDiskRemoveFirst(data acceptance.TestData, deleteDataDisk bool) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_data_disk_on_deletion = %t
+    }
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                 = "testdatadisk2"
+    lun                  = 2
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 2
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, deleteDataDisk)
+}
+
+func testWindowsVirtualMachine_dataDiskVMRemoved(data acceptance.TestData, deleteDataDisks bool) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_data_disk_on_deletion = %t
+    }
+  }
+}
+
+`, template, deleteDataDisks)
 }

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
@@ -45,7 +45,6 @@ func TestAccWindowsVirtualMachine_dataDiskDeleteOnTermination(t *testing.T) {
 			{
 				Config: testWindowsVirtualMachine_dataDiskVMRemoved(data, true),
 				Check: resource.ComposeTestCheckFunc(
-					checkWindowsVirtualMachineExists(data.ResourceName),
 					checkVirtualMachineManagedDiskIsDeleted(fmt.Sprintf("acctestRG-%d", data.RandomInteger), "testdatadisk", fmt.Sprintf("acctestvm%s", data.RandomString)),
 				),
 			},

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
@@ -17,7 +17,7 @@ func TestAccWindowsVirtualMachine_dataDiskBasic(t *testing.T) {
 		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testWindowsVirtualMachine_dataDiskBasic(data, false),
+				Config: testWindowsVirtualMachine_dataDiskBasic(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					checkWindowsVirtualMachineExists(data.ResourceName),
 				),

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_data_disk_test.go
@@ -1,0 +1,192 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccWindowsVirtualMachine_dataDiskBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_dataDiskBasic(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDiskDeleteOnTermination(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_dataDiskDeleteOnTermination(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password", "data_disk.0.delete_on_termination"),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDiskMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_dataDiskMultiple(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password"),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_dataDiskBasic(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                 = "testdatadisk"
+    lun                  = 1
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 1
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_dataDiskDeleteOnTermination(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                  = "testdatadisk"
+    lun                   = 1
+    caching               = "None"
+    storage_account_type  = "Standard_LRS"
+    disk_size_gb          = 1
+    delete_on_termination = true
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_dataDiskMultiple(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disk {
+    name                 = "testdatadisk"
+    lun                  = 1
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 1
+  }
+
+  data_disk {
+    name                 = "testdatadisk2"
+    lun                  = 2
+    caching              = "None"
+    storage_account_type = "Standard_LRS"
+    disk_size_gb         = 2
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -288,7 +289,7 @@ func virtualMachineDataDiskSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
+		//Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"caching": {
@@ -536,18 +537,16 @@ func expandVirtualMachineDataDisks(d *schema.ResourceData, meta interface{}) (*[
 
 			existingDisk, err := disksClient.Get(ctx, dataDiskId.ResourceGroup, dataDiskId.Name)
 			if err != nil {
-				return nil, fmt.Errorf("failed to retreive Managed Disk information for Data Disk %q (resource group %q)", dataDiskId.Name, dataDiskId.ResourceGroup)
+				return nil, fmt.Errorf("failed to retrieve Managed Disk information for Data Disk %q (resource group %q)", dataDiskId.Name, dataDiskId.ResourceGroup)
 			}
 
 			dataDisk.ManagedDisk.ID = utils.String(managedDiskId)
 			dataDisk.DiskSizeGB = existingDisk.DiskSizeGB
 
-
 			// If this is the first pass through create option will be empty and the disk id must have been user specified so we set to `Attach`
 			if createOption, ok := disk["create_option"].(string); ok && createOption == "" {
 				dataDisk.CreateOption = compute.DiskCreateOptionTypesAttach
 			}
-
 		}
 
 		if diskEncryptionSet, encryptionSetOk := disk["disk_encryption_set_id"].(string); encryptionSetOk && diskEncryptionSet != "" {

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -310,7 +310,7 @@ func virtualMachineDataDiskSchema() *schema.Schema {
 
 				"name": {
 					Type:         schema.TypeString,
-					Optional:     true,
+					Required:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
@@ -336,6 +336,7 @@ func virtualMachineDataDiskSchema() *schema.Schema {
 				"disk_size_gb": {
 					Type:         schema.TypeInt,
 					Optional:     true,
+					Computed:     true,
 					ValidateFunc: validateManagedDiskSizeGB,
 				},
 

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -574,8 +574,18 @@ func flattenVirtualMachineDataDisks(input *[]compute.DataDisk) []interface{} {
 	result := make([]interface{}, 0)
 	for _, v := range *input {
 		dataDisk := make(map[string]interface{})
-		dataDisk["name"] = *v.Name
-		dataDisk["lun"] = int(*v.Lun)
+		name := ""
+		if v.Name != nil {
+			name = *v.Name
+		}
+		dataDisk["name"] = name
+
+		var lun int
+		if v.Lun != nil {
+			lun = int(*v.Lun)
+		}
+		dataDisk["lun"] = lun
+
 		dataDisk["caching"] = string(v.Caching)
 		storageAccountType := ""
 		managedDiskID := ""
@@ -592,7 +602,12 @@ func flattenVirtualMachineDataDisks(input *[]compute.DataDisk) []interface{} {
 		dataDisk["storage_account_type"] = storageAccountType
 		dataDisk["managed_disk_id"] = managedDiskID
 		dataDisk["disk_encryption_set_id"] = diskEncryptionSetID
-		dataDisk["disk_size_gb"] = int(*v.DiskSizeGB)
+		var diskSizeGB int
+		if v.DiskSizeGB != nil {
+			diskSizeGB = int(*v.DiskSizeGB)
+		}
+		dataDisk["disk_size_gb"] = diskSizeGB
+
 		dataDisk["create_option"] = v.CreateOption
 
 		writeAccelerator := false

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -597,9 +597,11 @@ func flattenVirtualMachineDataDisks(input *[]compute.DataDisk) []interface{} {
 				diskEncryptionSetID = *v.ManagedDisk.DiskEncryptionSet.ID
 			}
 		}
+
 		dataDisk["storage_account_type"] = storageAccountType
 		dataDisk["managed_disk_id"] = managedDiskID
 		dataDisk["disk_encryption_set_id"] = diskEncryptionSetID
+
 		var diskSizeGB int
 		if v.DiskSizeGB != nil {
 			diskSizeGB = int(*v.DiskSizeGB)
@@ -630,25 +632,4 @@ func flattenVirtualMachineDataDisks(input *[]compute.DataDisk) []interface{} {
 	}
 
 	return result
-}
-
-func rationaliseDataDiskForUpdate(existing, update *compute.DataDisk, vmName string) (*compute.DataDisk, error) {
-	// This has to be non nil to get here
-	name := *update.Name
-	if existing.ManagedDisk == nil || existing.ManagedDisk.ID == nil {
-		return nil, fmt.Errorf("existing Data Disk ID missing for %q, cannot update Data Disks for Virtual Machine %q", name, vmName)
-	} else {
-		if update.ManagedDisk != nil && update.ManagedDisk.ID != nil && *update.ManagedDisk.ID != *existing.ManagedDisk.ID {
-			return nil, fmt.Errorf("cannot update in place Managed Disk ID for %q, Virtual Machine %q", name, vmName)
-		}
-		if update.ManagedDisk.StorageAccountType != existing.ManagedDisk.StorageAccountType {
-			return nil, fmt.Errorf("changing Storage Account Type for %q, Virtual Machine %q is not allowed", name, vmName)
-		}
-		update.ManagedDisk = &compute.ManagedDiskParameters{
-			ID: existing.ManagedDisk.ID,
-		}
-		update.CreateOption = existing.CreateOption
-	}
-
-	return update, nil
 }

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -373,11 +373,7 @@ func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	// TODO - put beta env var flag here
 	if true {
-		dataDiskRaw := d.Get("data_disk").([]interface{})
-		dataDisks, err = expandVirtualMachineDataDisks(dataDiskRaw)
-		if err != nil {
-			return err
-		}
+		dataDisks = expandVirtualMachineDataDisks(d.Get("data_disk").([]interface{}))
 	}
 
 	secretsRaw := d.Get("secret").([]interface{})
@@ -672,6 +668,11 @@ func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{})
 
 		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference)); err != nil {
 			return fmt.Errorf("setting `source_image_reference`: %+v", err)
+		}
+
+		// TODO beta env var here
+		if true {
+			d.Set("data_disk", flattenVirtualMachineDataDisks(profile.DataDisks, d))
 		}
 	}
 

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1049,7 +1049,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
 	}
-	deleteRemovedDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+	deleteRemovedDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 	dataDisksToDeleted := make([]compute.DataDisk, 0)
 	// TODO Beta flag here
 	if true {
@@ -1249,7 +1249,7 @@ func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{
 
 	// TODO - put beta env var flag here
 	if true {
-		deleteDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+		deleteDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 		if deleteDataDisks {
 			if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.DataDisks != nil {
 				for _, v := range *props.StorageProfile.DataDisks {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -373,7 +373,7 @@ func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	// TODO - put beta env var flag here
 	if true {
-		dataDisks = expandVirtualMachineDataDisks(d.Get("data_disk").([]interface{}))
+		dataDisks, err = expandVirtualMachineDataDisks(d, meta)
 	}
 
 	secretsRaw := d.Get("secret").([]interface{})
@@ -1055,7 +1055,10 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	if true {
 		if d.HasChange("data_disk") {
 			shouldUpdate = true
-			updatedDataDisks := expandVirtualMachineDataDisks(d.Get("data_disk").([]interface{}))
+			updatedDataDisks, err := expandVirtualMachineDataDisks(d, meta)
+			if err != nil {
+				return err
+			}
 			dataDisks := make([]compute.DataDisk, 0)
 			// Reconcile the data disks if previously specified
 			if existing.VirtualMachineProperties.StorageProfile != nil && existing.VirtualMachineProperties.StorageProfile.DataDisks != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1085,6 +1085,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 
 func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VMClient
+	disksClient := meta.(*clients.Client).Compute.DisksClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -1135,7 +1136,6 @@ func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{
 	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
 	if deleteOSDisk {
 		log.Printf("[DEBUG] Deleting OS Disk from Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
-		disksClient := meta.(*clients.Client).Compute.DisksClient
 		managedDiskId := ""
 		if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
 			if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.ID != nil {
@@ -1168,6 +1168,37 @@ func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{
 	} else {
 		log.Printf("[DEBUG] Skipping Deleting OS Disk from Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	}
+
+	// TODO - put beta env var flag here
+	if true {
+		log.Printf("checking for data disks that should be deleted on termination for %q (resource group %q)", id.Name, id.ResourceGroup)
+		if dataDisks, ok := d.GetOk("data_disk"); ok {
+			for _, v := range dataDisks.([]interface{}) {
+				disk := v.(map[string]interface{})
+				if disk["delete_on_termination"].(bool) {
+					diskId, err := parse.ManagedDiskID(disk["managed_disk_id"].(string))
+					if err != nil {
+						return fmt.Errorf("failed to parse ID for data disk for deletion")
+					}
+					log.Printf("[DEBUG] Attempting to delete data disk %q (resource group %q)", diskId.Name, diskId.ResourceGroup)
+
+					diskDeleteFuture, err := disksClient.Delete(ctx, diskId.ResourceGroup, diskId.Name)
+					if err != nil {
+						// Should we just log and continue as OS Disk, since there may be more than one?
+						return fmt.Errorf("deleting Data Disk %q (Resource Group %q) for Linux Virtual Machine %q (Resource Group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+					}
+
+					if !response.WasNotFound(diskDeleteFuture.Response()) {
+						if err := diskDeleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
+							// Should we just log and continue as OS Disk, since there may be more than one?
+							return fmt.Errorf("failed waiting to delete Data Disk %q (Resource Group %q) for Linux Virtual Machine %q (Resource Group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+						}
+					}
+				}
+			}
+		}
+	}
+
 
 	// Need to add a get and a state wait to avoid bug in network API where the attached disk(s) are not actually deleted
 	// Service team indicated that we need to do a get after VM delete call returns to verify that the VM and all attached

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
@@ -371,8 +372,7 @@ func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	dataDisks := &[]compute.DataDisk{}
 
-	// TODO - put beta env var flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		dataDisks, err = expandVirtualMachineDataDisks(d, meta)
 		if err != nil {
 			return err
@@ -673,8 +673,7 @@ func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("setting `source_image_reference`: %+v", err)
 		}
 
-		// TODO beta env var here
-		if true {
+		if features.VMDataDiskBeta() {
 			d.Set("data_disk", flattenVirtualMachineDataDisks(profile.DataDisks))
 		}
 	}
@@ -1054,8 +1053,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	}
 	deleteRemovedDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 	dataDisksToDeleted := make([]compute.DataDisk, 0)
-	// TODO Beta flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		if d.HasChange("data_disk") {
 			shouldUpdate = true
 			updatedDataDisks, err := expandVirtualMachineDataDisks(d, meta)
@@ -1120,8 +1118,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 
 		log.Printf("[DEBUG] Updated Windows Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
 	}
-	// TODO Beta flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		if deleteRemovedDataDisks && len(dataDisksToDeleted) > 0 {
 			for _, v := range dataDisksToDeleted {
 				if v.ManagedDisk != nil && v.ManagedDisk.ID != nil {
@@ -1251,8 +1248,7 @@ func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{
 		log.Printf("[DEBUG] Skipping Deleting OS Disk from Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	}
 
-	// TODO - put beta env var flag here
-	if true {
+	if features.VMDataDiskBeta() {
 		deleteDataDisks := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 		if deleteDataDisks {
 			if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.DataDisks != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -136,6 +136,8 @@ func resourceWindowsVirtualMachine() *schema.Resource {
 
 			"custom_data": base64.OptionalSchema(true),
 
+			"data_disk": virtualMachineDataDiskSchema(),
+
 			"dedicated_host_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -367,6 +369,17 @@ func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{
 	osDiskRaw := d.Get("os_disk").([]interface{})
 	osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Windows)
 
+	dataDisks := &[]compute.DataDisk{}
+
+	// TODO - put beta env var flag here
+	if true {
+		dataDiskRaw := d.Get("data_disk").([]interface{})
+		dataDisks, err = expandVirtualMachineDataDisks(dataDiskRaw)
+		if err != nil {
+			return err
+		}
+	}
+
 	secretsRaw := d.Get("secret").([]interface{})
 	secrets := expandWindowsSecrets(secretsRaw)
 
@@ -408,10 +421,7 @@ func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{
 			StorageProfile: &compute.StorageProfile{
 				ImageReference: sourceImageReference,
 				OsDisk:         osDisk,
-
-				// Data Disks are instead handled via the Association resource - as such we can send an empty value here
-				// but for Updates this'll need to be nil, else any associations will be overwritten
-				DataDisks: &[]compute.DataDisk{},
+				DataDisks:      dataDisks,
 			},
 
 			// Optional

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1077,11 +1077,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 					found := false
 					for _, dataDisk := range *updatedDataDisks {
 						if existingDataDisk.Name != nil && *dataDisk.Name == *existingDataDisk.Name {
-							updateDisk, err := rationaliseDataDiskForUpdate(&existingDataDisk, &dataDisk, id.Name)
-							if err != nil {
-								return err
-							}
-							dataDisks = append(dataDisks, *updateDisk)
+							dataDisks = append(dataDisks, existingDataDisk)
 							found = true
 							break
 						}

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1068,7 +1068,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 				for _, existingDataDisk := range *existing.VirtualMachineProperties.StorageProfile.DataDisks {
 					found := false
 					for _, dataDisk := range *updatedDataDisks {
-						if *dataDisk.Name == *existingDataDisk.Name {
+						if existingDataDisk.Name != nil && *dataDisk.Name == *existingDataDisk.Name {
 							dataDisks = append(dataDisks, existingDataDisk)
 							found = true
 							break

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -109,6 +109,10 @@ The following arguments are supported:
 
 * `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
 
+* `data_diska` - (Optional) A `data_disk` block as defined below
+
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VM_DATADISK_BETA` is set to `true` to be used.
+
 ---
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
@@ -247,6 +251,32 @@ A `os_disk` block supports the following:
 * `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this OS Disk? Defaults to `false`.
 
 -> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
+
+---
+
+A `data_disk` block supports the following:
+
+* `name` - (Required) The name of the Managed Disk
+
+* `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.
+
+* `caching` - (Required) The type of Caching which should be used for this Data Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this Data Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS` and `UltraSSD_LRS`.
+
+* `disk_size_gb` -  (Required) The size of the Data Disk which should be created.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk.
+
+* `managed_disk_id` - (Optional) The ID of an existing managed disk to use.
+
+!> **NOTE:** If an existing managed disk is attached to a VM and the `delete_data_disks_on_termination` feature is not explicitly set to `false` it will be deleted along with the VM.
+
+* `vhd_uri` - 
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this Data Disk? Defaults to `false`.
+
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VM_DATADISK_BETA` is set to `true` to be used.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -109,10 +109,6 @@ The following arguments are supported:
 
 * `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
 
-* `data_diska` - (Optional) A `data_disk` block as defined below
-
-!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VM_DATADISK_BETA` is set to `true` to be used.
-
 ---
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
@@ -135,6 +131,10 @@ The following arguments are supported:
 * `computer_name` - (Optional) Specifies the Hostname which should be used for this Virtual Machine. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name`, then you must specify `computer_name`. Changing this forces a new resource to be created.
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
+
+* `data_disk` - (Optional) One or more `data_disk` block as defined below
+
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VM_DATADISK_BETA` is set to `true` to be used.
 
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Changing this forces a new resource to be created.
 
@@ -203,6 +203,32 @@ A `admin_ssh_key` block supports the following:
 A `boot_diagnostics` block supports the following:
 
 * `storage_account_uri` - (Required) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor.
+
+---
+
+A `data_disk` block supports the following:
+
+* `name` - (Required) The name of the Managed Disk. 
+
+* `lun` - (Required) The Logical Unit Number for the disk on the VM. (Must be unique)
+
+* `caching` - (Required) The caching mode for the managed disk. Possible values include: `None`, `ReadOnly`, and `ReadWrite`.  
+
+* `storage_account_type` - (Required) The storage account type. Possible values include: `Standard_LRS`, `Premium_LRS`, `StandardSSD_LRS`, and `UltraSSD_LRS`.  
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk. 
+
+-> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
+
+* `disk_size_gb` - (Optional) - The size of the disk in GB. Required if `managed_disk_id` not specified.
+
+* `managed_disk_id` - (Optional) - The ID of the existing Managed Disk to use.
+
+~> **NOTE:** If the `delete_data_disks_on_deletion` feature is enabled (which is the default) existing managed disks will be deleted with the VM.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be enabled for this Data Disk? Defaults to `false`.
+
+-> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -210,17 +210,23 @@ A `data_disk` block supports the following:
 
 * `name` - (Required) The name of the Managed Disk. 
 
+~> **NOTE:** Changing this value after creation is not supported.
+
 * `lun` - (Required) The Logical Unit Number for the disk on the VM. (Must be unique)
 
 * `caching` - (Required) The caching mode for the managed disk. Possible values include: `None`, `ReadOnly`, and `ReadWrite`.  
 
-* `storage_account_type` - (Required) The storage account type. Possible values include: `Standard_LRS`, `Premium_LRS`, `StandardSSD_LRS`, and `UltraSSD_LRS`.  
+* `storage_account_type` - (Required) The storage account type. Possible values include: `Standard_LRS`, `Premium_LRS`, `StandardSSD_LRS`, and `UltraSSD_LRS`.
+
+~> **NOTE:** Changing this value after creation is not supported.
 
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk. 
 
--> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
+-> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault.
 
 * `disk_size_gb` - (Optional) - The size of the disk in GB. Required if `managed_disk_id` not specified.
+
+~> **NOTE:** Changing this value after creation is not supported.
 
 * `managed_disk_id` - (Optional) - The ID of the existing Managed Disk to use.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -123,6 +123,10 @@ The following arguments are supported:
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
 
+* `data_disk` - (Optional) One or more `data_disk` block as defined below
+
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VM_DATADISK_BETA` is set to `true` to be used.
+
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Changing this forces a new resource to be created.
 
 * `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created.
@@ -190,6 +194,32 @@ A `additional_unattend_content` block supports the following:
 A `boot_diagnostics` block supports the following:
 
 * `storage_account_uri` - (Required) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor.
+
+---
+
+A `data_disk` block supports the following:
+
+* `name` - (Required) The name of the Managed Disk. 
+
+* `lun` - (Required) The Logical Unit Number for the disk on the VM. (Must be unique)
+
+* `caching` - (Required) The caching mode for the managed disk. Possible values include: `None`, `ReadOnly`, and `ReadWrite`.  
+
+* `storage_account_type` - (Required) The storage account type. Possible values include: `Standard_LRS`, `Premium_LRS`, `StandardSSD_LRS`, and `UltraSSD_LRS`.  
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk. 
+
+-> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
+
+* `disk_size_gb` - (Optional) - The size of the disk in GB. Required if `managed_disk_id` not specified.
+
+* `managed_disk_id` - (Optional) - The ID of the existing Managed Disk to use.
+
+~> **NOTE:** If the `delete_data_disks_on_deletion` feature is enabled (which is the default) existing managed disks will be deleted with the VM.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be enabled for this Data Disk? Defaults to `false`.
+
+-> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -201,17 +201,23 @@ A `data_disk` block supports the following:
 
 * `name` - (Required) The name of the Managed Disk. 
 
+~> **NOTE:** Changing this value after creation is not supported.
+
 * `lun` - (Required) The Logical Unit Number for the disk on the VM. (Must be unique)
 
 * `caching` - (Required) The caching mode for the managed disk. Possible values include: `None`, `ReadOnly`, and `ReadWrite`.  
 
 * `storage_account_type` - (Required) The storage account type. Possible values include: `Standard_LRS`, `Premium_LRS`, `StandardSSD_LRS`, and `UltraSSD_LRS`.  
 
+~> **NOTE:** Changing this value after creation is not supported.
+
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk. 
 
 -> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 
 * `disk_size_gb` - (Optional) - The size of the disk in GB. Required if `managed_disk_id` not specified.
+
+~> **NOTE:** Changing this value after creation is not supported.
 
 * `managed_disk_id` - (Optional) - The ID of the existing Managed Disk to use.
 


### PR DESCRIPTION
fixes #6117 

* `azurerm_linux_virtual_machine` - adds beta support for specifying `data_disk` blocks in-line in the resource
* `azurerm_windows_virtual_machine` - adds beta support for specifying `data_disk` blocks in-line in the resource

ToDo
- [x] More test coverage for data disk params
- [x] add env var flag / remove testing "short circuit"
- [x] Improve UX by collecting info from Managed Disk when `managed_disk_id` supplied
- [x] update docs
