### PR TITLE
`azurerm_role_definition` - expose `role_definition_resource_id` 

### DIFF
--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -5,15 +5,13 @@ import (
 	"log"
 	"time"
 
-	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/authorization/parse"
-
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/authorization/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -119,7 +117,7 @@ func resourceArmRoleDefinition() *schema.Resource {
 				},
 			},
 
-			"resource_manager_id": {
+			"role_definition_resource_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -201,6 +199,7 @@ func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("scope", roleDefinitionId.Scope)
 	d.Set("role_definition_id", roleDefinitionId.RoleID)
+	d.Set("role_definition_resource_id", roleDefinitionId.ResourceID)
 
 	resp, err := client.Get(ctx, roleDefinitionId.Scope, roleDefinitionId.RoleID)
 	if err != nil {
@@ -227,12 +226,6 @@ func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) err
 			return err
 		}
 	}
-
-	resourceManagerID := ""
-	if resp.ID != nil && *resp.ID == "" {
-		resourceManagerID = *resp.ID
-	}
-	d.Set("resource_manager_id", resourceManagerID)
 
 	return nil
 }

--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -118,6 +118,11 @@ func resourceArmRoleDefinition() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
+			"resource_manager_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -222,6 +227,12 @@ func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) err
 			return err
 		}
 	}
+
+	resourceManagerID := ""
+	if resp.ID != nil && *resp.ID == "" {
+		resourceManagerID = *resp.ID
+	}
+	d.Set("resource_manager_id", resourceManagerID)
 
 	return nil
 }

--- a/azurerm/internal/services/authorization/tests/role_assignment_resource_test.go
+++ b/azurerm/internal/services/authorization/tests/role_assignment_resource_test.go
@@ -459,7 +459,7 @@ resource "azurerm_role_definition" "test" {
 resource "azurerm_role_assignment" "test" {
   name               = "%s"
   scope              = data.azurerm_subscription.primary.id
-  role_definition_id = azurerm_role_definition.test.id
+  role_definition_id = azurerm_role_definition.test.role_definition_resource_id
   principal_id       = data.azurerm_client_config.test.object_id
 }
 `, roleDefinitionId, rInt, roleAssignmentId)

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -67,7 +67,7 @@ The following attributes are exported:
 
 * `id` - The Role Definition ID.
 
-* `resource_manager_id` - The Azure Resource Manager ID for the resource
+* `role_definition_resource_id` - The Azure Resource Manager ID for the resource
 
 ## Timeouts
 

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -67,6 +67,8 @@ The following attributes are exported:
 
 * `id` - The Role Definition ID.
 
+* `resource_manager_id` - The Azure Resource Manager ID for the resource
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
Addresses breaking change in #6107 
Exposes new attribute `role_definition_resource_id` which can be used to reference the resource where required. 

closes #8426