### PR TITLE
Doc Fix: `azurerm_private_endpoint` Updating documentation for `private_ip_address`

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -153,8 +153,6 @@ See the product [documentation](https://docs.microsoft.com/en-us/azure/private-l
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The request message can be a maximum of `140` characters in length. Only valid if `is_manual_connection` is set to `true`.
 
-* `private_ip_address` - (Computed) The private IP address associated with the private endpoint, note that you will have a private IP address assigned to the private endpoint even if the connection request was `Rejected`.
-
 ## Attributes Reference
 
 The following attributes are exported:
@@ -191,9 +189,9 @@ A `private_dns_zone_configs` block exports:
 
 ---
 
-A list of `private_serivce_connection` blocks that exports:
+A `private_serivce_connection` block exports:
 
-* `private_ip_address` - a Private IP address associated to the private endpoint
+* `private_ip_address` - (Computed) The private IP address associated with the private endpoint, note that you will have a private IP address assigned to the private endpoint even if the connection request was `Rejected`.
 
 ---
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -191,6 +191,12 @@ A `private_dns_zone_configs` block exports:
 
 ---
 
+A list of `private_serivce_connection` blocks that exports:
+
+* `private_ip_address` - a Private IP address associated to the private endpoint
+
+---
+
 A `record_sets` block exports:
 
 * `name` - The name of the Private DNS Zone that the config belongs to.


### PR DESCRIPTION
Based on the syntax for getting the ```private_ip_address``` for a private endpoint from issue #6146 

Also includes the syntax for ACR which creates multiple private ip address for updating/creating Private DNS Zone A Records