### PR TITLE
`azurerm_cosmosdb_mongo_collection` order of  compound `keys` in `index` matters

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -101,7 +101,7 @@ func resourceArmCosmosDbMongoCollection() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"keys": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -376,7 +376,7 @@ func expandCosmosMongoCollectionIndex(indexes []interface{}, defaultTtl *int) *[
 
 			results = append(results, documentdb.MongoIndex{
 				Key: &documentdb.MongoIndexKeys{
-					Keys: utils.ExpandStringSlice(index["keys"].(*schema.Set).List()),
+					Keys: utils.ExpandStringSlice(index["keys"].([]interface{})),
 				},
 				Options: &documentdb.MongoIndexOptions{
 					Unique: utils.Bool(index["unique"].(bool)),


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/8572.
Confirmed from service team: https://github.com/Azure/azure-rest-api-specs/issues/10909

=== RUN   TestAccAzureRMCosmosDbMongoCollection_basic
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_basic
=== CONT  TestAccAzureRMCosmosDbMongoCollection_basic
--- PASS: TestAccAzureRMCosmosDbMongoCollection_basic (1859.98s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_complete
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_complete
=== CONT  TestAccAzureRMCosmosDbMongoCollection_complete
--- PASS: TestAccAzureRMCosmosDbMongoCollection_complete (1919.78s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_update
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_update
=== CONT  TestAccAzureRMCosmosDbMongoCollection_update
--- PASS: TestAccAzureRMCosmosDbMongoCollection_update (2197.21s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_throughput
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_throughput
=== CONT  TestAccAzureRMCosmosDbMongoCollection_throughput
--- PASS: TestAccAzureRMCosmosDbMongoCollection_throughput (2137.38s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_withIndex
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_withIndex
=== CONT  TestAccAzureRMCosmosDbMongoCollection_withIndex
--- PASS: TestAccAzureRMCosmosDbMongoCollection_withIndex (1926.99s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_autoscale
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_autoscale
=== CONT  TestAccAzureRMCosmosDbMongoCollection_autoscale
--- PASS: TestAccAzureRMCosmosDbMongoCollection_autoscale (2244.46s)
