### PR TITLE
standardize ID Formatter usage

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -236,7 +236,11 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if existing.ID != nil && *existing.ID != "" {
-		return tf.ImportAsExistsError("azurerm_cdn_endpoint", *existing.ID)
+		id, err := parse.CdnEndpointID(*existing.ID)
+		if err != nil {
+			return err
+		}
+		return tf.ImportAsExistsError("azurerm_cdn_endpoint", id.ID(subscriptionId))
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint.go
@@ -12,6 +12,11 @@ type CdnEndpointId struct {
 	Name          string
 }
 
+func (id CdnEndpointId) ID(subscriptionId string) string {
+	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscriptionId)
+	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
+}
+
 func NewCdnEndpointID(id CdnProfileId, name string) CdnEndpointId {
 	return CdnEndpointId{
 		ResourceGroup: id.ResourceGroup,
@@ -43,9 +48,4 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	}
 
 	return &endpoint, nil
-}
-
-func (id CdnEndpointId) ID(subscriptionId string) string {
-	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscriptionId)
-	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_profile.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile.go
@@ -11,6 +11,11 @@ type CdnProfileId struct {
 	Name          string
 }
 
+func (id CdnProfileId) ID(subscriptionId string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s",
+		subscriptionId, id.ResourceGroup, id.Name)
+}
+
 func NewCdnProfileID(resourceGroup, name string) CdnProfileId {
 	return CdnProfileId{
 		ResourceGroup: resourceGroup,
@@ -37,9 +42,4 @@ func CdnProfileID(input string) (*CdnProfileId, error) {
 	}
 
 	return &profile, nil
-}
-
-func (id CdnProfileId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s",
-		subscriptionId, id.ResourceGroup, id.Name)
 }

--- a/azurerm/internal/services/compute/dedicated_host_group_data_source.go
+++ b/azurerm/internal/services/compute/dedicated_host_group_data_source.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -54,6 +56,7 @@ func dataSourceArmDedicatedHostGroup() *schema.Resource {
 }
 
 func dataSourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -69,7 +72,11 @@ func dataSourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error reading Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
 	}
 
-	d.SetId(*resp.ID)
+	id, err := parse.DedicatedHostGroupID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroupName)

--- a/azurerm/internal/services/compute/dedicated_host_group_resource.go
+++ b/azurerm/internal/services/compute/dedicated_host_group_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -67,6 +69,7 @@ func resourceArmDedicatedHostGroup() *schema.Resource {
 }
 
 func resourceArmDedicatedHostGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -82,7 +85,11 @@ func resourceArmDedicatedHostGroupCreate(d *schema.ResourceData, meta interface{
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_dedicated_host_group", *existing.ID)
+			id, err := parse.DedicatedHostGroupID(*existing.ID)
+			if err != nil {
+				return err
+			}
+			return tf.ImportAsExistsError("azurerm_dedicated_host_group", id.ID(subscriptionId))
 		}
 	}
 
@@ -112,7 +119,12 @@ func resourceArmDedicatedHostGroupCreate(d *schema.ResourceData, meta interface{
 	if resp.ID == nil {
 		return fmt.Errorf("Cannot read Dedicated Host Group %q (Resource Group %q) ID", name, resourceGroupName)
 	}
-	d.SetId(*resp.ID)
+
+	id, err := parse.DedicatedHostGroupID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	return resourceArmDedicatedHostGroupRead(d, meta)
 }
@@ -122,12 +134,12 @@ func resourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.DedicatedHostGroupID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroupName := id.ResourceGroup
-	name := id.Path["hostGroups"]
+	name := id.Name
 
 	resp, err := client.Get(ctx, resourceGroupName, name, "")
 	if err != nil {
@@ -181,12 +193,12 @@ func resourceArmDedicatedHostGroupDelete(d *schema.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.DedicatedHostGroupID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	name := id.Path["hostGroups"]
+	name := id.Name
 
 	if _, err := client.Delete(ctx, resourceGroup, name); err != nil {
 		return fmt.Errorf("Error deleting Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/internal/services/compute/disk_encryption_set_data_source.go
+++ b/azurerm/internal/services/compute/disk_encryption_set_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -38,6 +40,7 @@ func dataSourceArmDiskEncryptionSet() *schema.Resource {
 }
 
 func dataSourceArmDiskEncryptionSetRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -53,7 +56,11 @@ func dataSourceArmDiskEncryptionSetRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error reading Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(*resp.ID)
+	id, err := parse.DiskEncryptionSetID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)

--- a/azurerm/internal/services/compute/managed_disk_data_source.go
+++ b/azurerm/internal/services/compute/managed_disk_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -92,6 +94,7 @@ func dataSourceArmManagedDisk() *schema.Resource {
 }
 
 func dataSourceArmManagedDiskRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Compute.DisksClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -107,7 +110,11 @@ func dataSourceArmManagedDiskRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("[ERROR] Error making Read request on Azure Managed Disk %q (Resource Group %q): %s", name, resGroup, err)
 	}
 
-	d.SetId(*resp.ID)
+	id, err := parse.ManagedDiskID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)

--- a/azurerm/internal/services/compute/proximity_placement_group_data_source.go
+++ b/azurerm/internal/services/compute/proximity_placement_group_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -38,6 +40,7 @@ func dataSourceArmProximityPlacementGroup() *schema.Resource {
 }
 
 func dataSourceArmProximityPlacementGroupRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Compute.ProximityPlacementGroupsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -54,7 +57,11 @@ func dataSourceArmProximityPlacementGroupRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error making Read request on Proximity Placement Group %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(*resp.ID)
+	id, err := parse.ProximityPlacementGroupID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))

--- a/azurerm/internal/services/compute/shared_image_version_data_source.go
+++ b/azurerm/internal/services/compute/shared_image_version_data_source.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -90,6 +92,7 @@ func dataSourceArmSharedImageVersion() *schema.Resource {
 }
 
 func dataSourceArmSharedImageVersionRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Compute.GalleryImageVersionsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -104,7 +107,11 @@ func dataSourceArmSharedImageVersionRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	d.SetId(*image.ID)
+	id, err := parse.SharedImageVersionID(*image.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 	d.Set("name", image.Name)
 	d.Set("image_name", imageName)
 	d.Set("gallery_name", galleryName)

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_data_source.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_data_source.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -70,6 +72,7 @@ func dataSourceLogAnalyticsWorkspace() *schema.Resource {
 }
 
 func dataSourceLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).LogAnalytics.WorkspacesClient
 	sharedKeysClient := meta.(*clients.Client).LogAnalytics.SharedKeysClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
@@ -86,7 +89,11 @@ func dataSourceLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error making Read request on AzureRM Log Analytics workspaces '%s': %+v", name, err)
 	}
 
-	d.SetId(*resp.ID)
+	id, err := parse.LogAnalyticsWorkspaceID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resGroup)

--- a/azurerm/internal/services/network/lb_backend_address_pool_data_source.go
+++ b/azurerm/internal/services/network/lb_backend_address_pool_data_source.go
@@ -49,6 +49,7 @@ func dataSourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 }
 
 func dataSourceArmLoadBalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Network.LoadBalancersClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -72,7 +73,11 @@ func dataSourceArmLoadBalancerBackendAddressPoolRead(d *schema.ResourceData, met
 		return fmt.Errorf("Backend Address Pool %q was not found in Load Balancer %q (Resource Group %q)", name, loadBalancerId.Name, loadBalancerId.ResourceGroup)
 	}
 
-	d.SetId(*bap.ID)
+	id, err := parse.LoadBalancerBackendAddressPoolID(*bap.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	backendIPConfigurations := make([]interface{}, 0)
 	if props := bap.BackendAddressPoolPropertiesFormat; props != nil {

--- a/azurerm/internal/services/network/lb_backend_address_pool_resource.go
+++ b/azurerm/internal/services/network/lb_backend_address_pool_resource.go
@@ -114,7 +114,11 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 	if exists {
 		if name == *existingPool.Name {
 			if d.IsNewResource() {
-				return tf.ImportAsExistsError("azurerm_lb_backend_address_pool", *existingPool.ID)
+				id, err := parse.LoadBalancerBackendAddressPoolID(*existingPool.ID)
+				if err != nil {
+					return err
+				}
+				return tf.ImportAsExistsError("azurerm_lb_backend_address_pool", id.ID(subscriptionId))
 			}
 
 			// this pool is being updated/reapplied remove old copy from the slice
@@ -152,7 +156,11 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 		return fmt.Errorf("Cannot find created Load Balancer Backend Address Pool ID %q", poolId)
 	}
 
-	d.SetId(poolId)
+	id, err := parse.LoadBalancerBackendAddressPoolID(poolId)
+	if err != nil {
+		return err
+	}
+	d.SetId(id.ID(subscriptionId))
 
 	return resourceArmLoadBalancerBackendAddressPoolRead(d, meta)
 }


### PR DESCRIPTION
The ID formatter should be used exclusively. If a resource opt in using
the ID formatter, it should use it in below places at the same time:

- when setting the resource id in create callback (resource) or read
  callback (data source)
- when formatting the import error message
- when setting another resource's id as some property

fixes: #8593