### PR TITLE
feat: CDN endpoint disable default value for compression

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -437,7 +437,6 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 
 	if props := resp.EndpointProperties; props != nil {
 		d.Set("host_name", props.HostName)
-		d.Set("is_compression_enabled", props.IsCompressionEnabled)
 		d.Set("is_http_allowed", props.IsHTTPAllowed)
 		d.Set("is_https_allowed", props.IsHTTPSAllowed)
 		d.Set("querystring_caching_behaviour", props.QueryStringCachingBehavior)
@@ -445,6 +444,10 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("origin_path", props.OriginPath)
 		d.Set("probe_path", props.ProbePath)
 		d.Set("optimization_type", string(props.OptimizationType))
+		
+		if is_compression_enabled := props.IsCompressionEnabled; is_compression_enabled != nil {
+			d.Set("is_compression_enabled", *is_compression_enabled)
+		}
 
 		contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)
 		if err := d.Set("content_types_to_compress", contentTypes); err != nil {

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -141,7 +141,6 @@ func resourceArmCdnEndpoint() *schema.Resource {
 			"is_compression_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"probe_path": {

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -241,7 +241,6 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
-	compressionEnabled := d.Get("is_compression_enabled").(bool)
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
 	originHostHeader := d.Get("origin_host_header").(string)
 	originPath := d.Get("origin_path").(string)
@@ -258,11 +257,14 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			GeoFilters:                 geoFilters,
 			IsHTTPAllowed:              &httpAllowed,
 			IsHTTPSAllowed:             &httpsAllowed,
-			IsCompressionEnabled:       &compressionEnabled,
 			QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(cachingBehaviour),
 			OriginHostHeader:           utils.String(originHostHeader),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("is_compression_enabled"); ok {
+		endpoint.EndpointProperties.IsCompressionEnabled = utils.Bool(v.(bool))
 	}
 
 	if optimizationType != "" {
@@ -336,7 +338,6 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
-	compressionEnabled := d.Get("is_compression_enabled").(bool)
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
 	hostHeader := d.Get("origin_host_header").(string)
 	originPath := d.Get("origin_path").(string)
@@ -352,13 +353,15 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 			GeoFilters:                 geoFilters,
 			IsHTTPAllowed:              utils.Bool(httpAllowed),
 			IsHTTPSAllowed:             utils.Bool(httpsAllowed),
-			IsCompressionEnabled:       utils.Bool(compressionEnabled),
 			QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(cachingBehaviour),
 			OriginHostHeader:           utils.String(hostHeader),
 		},
 		Tags: tags.Expand(t),
 	}
 
+	if v, ok := d.GetOk("is_compression_enabled"); ok {
+		endpoint.EndpointPropertiesUpdateParameters.IsCompressionEnabled = utils.Bool(v.(bool))
+	}
 	if optimizationType != "" {
 		endpoint.EndpointPropertiesUpdateParameters.OptimizationType = cdn.OptimizationType(optimizationType)
 	}

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -448,8 +448,10 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("probe_path", props.ProbePath)
 		d.Set("optimization_type", string(props.OptimizationType))
 
-		if is_compression_enabled := props.IsCompressionEnabled; is_compression_enabled != nil {
-			d.Set("is_compression_enabled", *is_compression_enabled)
+		if _, ok := d.GetOk("is_compression_enabled"); ok {
+			if compressionEnabled := props.IsCompressionEnabled; compressionEnabled != nil {
+				d.Set("is_compression_enabled", *compressionEnabled)
+			}
 		}
 
 		contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -444,7 +444,7 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("origin_path", props.OriginPath)
 		d.Set("probe_path", props.ProbePath)
 		d.Set("optimization_type", string(props.OptimizationType))
-		
+
 		if is_compression_enabled := props.IsCompressionEnabled; is_compression_enabled != nil {
 			d.Set("is_compression_enabled", *is_compression_enabled)
 		}

--- a/azurerm/internal/services/cdn/migration/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint.go
@@ -118,7 +118,6 @@ func CdnEndpointV0Schema() *schema.Resource {
 			"is_compression_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"probe_path": {

--- a/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
@@ -136,6 +136,24 @@ func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCdnEndpoint_withoutCompression(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_endpoint", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCdnEndpoint_withoutCompression(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists(data.ResourceName),
+					resource.TestCheckNoResourceAttr(data.ResourceName, "is_compression_enabled"),
+				),
+			}, data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMCdnEndpoint_optimized(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_endpoint", "test")
 
@@ -674,6 +692,43 @@ resource "azurerm_cdn_endpoint" "test" {
 }
 
 func testAccAzureRMCdnEndpoint_optimized(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard_Verizon"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+  name                = "acctestcdnend%d"
+  profile_name        = azurerm_cdn_profile.test.name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  is_http_allowed     = false
+  is_https_allowed    = true
+  optimization_type   = "GeneralWebDelivery"
+
+  origin {
+    name       = "acceptanceTestCdnOrigin1"
+    host_name  = "www.contoso.com"
+    https_port = 443
+    http_port  = 80
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMCdnEndpoint_withoutCompression(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `geo_filter` - (Optional) A set of Geo Filters for this CDN Endpoint. Each `geo_filter` block supports fields documented below.
 
-* `is_compression_enabled` - (Optional) Indicates whether compression is to be enabled. Defaults to false.
+* `is_compression_enabled` - (Optional) Indicates whether compression is to be enabled.
 
 * `querystring_caching_behaviour` - (Optional) Sets query string caching behavior. Allowed values are `IgnoreQueryString`, `BypassCaching` and `UseQueryString`. `NotSet` value can be used for `Premium Verizon` CDN profile. Defaults to `IgnoreQueryString`.
 


### PR DESCRIPTION
fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/1109

Regarding this issue, this PR fixes it but it will forces people to set the attribute if they have not set `is_compression_allowed` attribute in their terraform template.

Currently this is a blocking issue for people willing to use Premium Verizon