### PR TITLE
Do not recreate ASE when changing tags

### DIFF
--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -119,7 +119,7 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 			// TODO in 3.0 Make it "Required"
 			"resource_group_name": azure.SchemaResourceGroupNameOptionalComputed(),
 
-			"tags": tags.ForceNewSchema(),
+			"tags": tags.Schema(),
 
 			// Computed
 			"location": {

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -71,7 +71,7 @@ resource "azurerm_app_service_environment" "example" {
 
 * `resource_group_name` - (Optional) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`).
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created. 
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 ## Attribute Reference
 


### PR DESCRIPTION
Currently changing ASE tags force creation of a new resource, which is completely uncalled for.