### PR TITLE
Update `address_space` attribute description

### DIFF
--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -121,7 +121,7 @@ The following attributes are exported:
 
 * `location` - The location/region where the virtual network is created.
 
-* `address_space` - The address space that is used the virtual network.
+* `address_space` - The list of address spaces used by the virtual network.
 
 * `guid` - The GUID of the virtual network.
 


### PR DESCRIPTION
The output of the `address_space` attribute is a list of strings as documented in its corresponding data block: https://www.terraform.io/docs/providers/azurerm/d/virtual_network.html#address_space.