### PR TITLE
Adding user defined properties to service bus correlation filters

### DIFF
--- a/azurerm/internal/services/servicebus/resource_arm_servicebus_subscription_rule.go
+++ b/azurerm/internal/services/servicebus/resource_arm_servicebus_subscription_rule.go
@@ -126,6 +126,13 @@ func resourceArmServiceBusSubscriptionRule() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"properties": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},
@@ -295,8 +302,9 @@ func expandAzureRmServiceBusCorrelationFilter(d *schema.ResourceData) (*serviceb
 	replyToSessionID := config["reply_to_session_id"].(string)
 	sessionID := config["session_id"].(string)
 	to := config["to"].(string)
+	properties := utils.ExpandMapStringPtrString(config["properties"].(map[string]interface{}))
 
-	if contentType == "" && correlationID == "" && label == "" && messageID == "" && replyTo == "" && replyToSessionID == "" && sessionID == "" && to == "" {
+	if contentType == "" && correlationID == "" && label == "" && messageID == "" && replyTo == "" && replyToSessionID == "" && sessionID == "" && to == "" && len(properties) == 0 {
 		return nil, fmt.Errorf("At least one property must be set in the `correlation_filter` block")
 	}
 
@@ -332,6 +340,10 @@ func expandAzureRmServiceBusCorrelationFilter(d *schema.ResourceData) (*serviceb
 
 	if contentType != "" {
 		correlationFilter.ContentType = utils.String(contentType)
+	}
+
+	if len(properties) > 0 {
+		correlationFilter.Properties = properties
 	}
 
 	return &correlationFilter, nil
@@ -374,6 +386,10 @@ func flattenAzureRmServiceBusCorrelationFilter(input *servicebus.CorrelationFilt
 
 	if input.ContentType != nil {
 		filter["content_type"] = *input.ContentType
+	}
+
+	if input.Properties != nil {
+		filter["properties"] = utils.FlattenMapStringPtrString(input.Properties)
 	}
 
 	return []interface{}{filter}

--- a/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_subscription_rule_test.go
+++ b/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_subscription_rule_test.go
@@ -300,7 +300,10 @@ resource "azurerm_servicebus_subscription_rule" "test" {
     label               = "test_label"
     session_id          = "test_session_id"
     reply_to_session_id = "test_reply_to_session_id"
-    content_type        = "test_content_type"
+		content_type        = "test_content_type"
+		properties 					= {
+			test_key = "test_value"
+		}
   }
 }
 `, template, data.RandomInteger)
@@ -321,7 +324,10 @@ resource "azurerm_servicebus_subscription_rule" "test" {
 
   correlation_filter {
     correlation_id = "test_correlation_id"
-    message_id     = "test_message_id"
+		message_id     = "test_message_id"
+		properties 		 = {
+			test_key	   = "test_value"
+		}
   }
 }
 `, template, data.RandomInteger)
@@ -343,7 +349,10 @@ resource "azurerm_servicebus_subscription_rule" "test" {
   correlation_filter {
     correlation_id = "test_correlation_id"
     message_id     = "test_message_id_updated"
-    reply_to       = "test_reply_to_added"
+		reply_to       = "test_reply_to_added"
+		properties		 = {
+			test_key     = "test_value_updated"
+		}
   }
 }
 `, template, data.RandomInteger)

--- a/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_subscription_rule_test.go
+++ b/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_subscription_rule_test.go
@@ -300,10 +300,10 @@ resource "azurerm_servicebus_subscription_rule" "test" {
     label               = "test_label"
     session_id          = "test_session_id"
     reply_to_session_id = "test_reply_to_session_id"
-		content_type        = "test_content_type"
-		properties 					= {
-			test_key = "test_value"
-		}
+    content_type        = "test_content_type"
+    properties = {
+      test_key = "test_value"
+    }
   }
 }
 `, template, data.RandomInteger)
@@ -324,10 +324,10 @@ resource "azurerm_servicebus_subscription_rule" "test" {
 
   correlation_filter {
     correlation_id = "test_correlation_id"
-		message_id     = "test_message_id"
-		properties 		 = {
-			test_key	   = "test_value"
-		}
+    message_id     = "test_message_id"
+    properties = {
+      test_key = "test_value"
+    }
   }
 }
 `, template, data.RandomInteger)
@@ -349,10 +349,10 @@ resource "azurerm_servicebus_subscription_rule" "test" {
   correlation_filter {
     correlation_id = "test_correlation_id"
     message_id     = "test_message_id_updated"
-		reply_to       = "test_reply_to_added"
-		properties		 = {
-			test_key     = "test_value_updated"
-		}
+    reply_to       = "test_reply_to_added"
+    properties = {
+      test_key = "test_value_updated"
+    }
   }
 }
 `, template, data.RandomInteger)

--- a/website/docs/r/servicebus_subscription_rule.html.markdown
+++ b/website/docs/r/servicebus_subscription_rule.html.markdown
@@ -101,7 +101,10 @@ resource "azurerm_servicebus_subscription_rule" "example" {
 
   correlation_filter {
     correlation_id = "high"
-    label          = "red"
+    label          = "red",
+    properties     = {
+      customProperty = "value"
+    }
   }
 }
 ```
@@ -145,6 +148,8 @@ The following arguments are supported:
 * `session_id` - (Optional) Session identifier.
 
 * `to` - (Optional) Address to send to.
+
+* `properties` - (Optional) A list of user defined properties to be included in the filter. Specified as a map of name/value pairs.
 
 ~> **NOTE:** When creating a subscription rule of type `CorrelationFilter` at least one property must be set in the `correlation_filter` block.
 


### PR DESCRIPTION
Fix #8350 