### PR TITLE
storage_management_policy - support appendBlob for blob_types

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_management_policy.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_management_policy.go
@@ -73,8 +73,11 @@ func resourceArmStorageManagementPolicy() *schema.Resource {
 										Type:     schema.TypeSet,
 										Optional: true,
 										Elem: &schema.Schema{
-											Type:         schema.TypeString,
-											ValidateFunc: validation.StringInSlice([]string{"blockBlob"}, false),
+											Type: schema.TypeString,
+											ValidateFunc: validation.StringInSlice([]string{
+												"blockBlob",
+												"appendBlob",
+											}, false),
 										},
 										Set: schema.HashString,
 									},

--- a/azurerm/internal/services/storage/tests/data_source_storage_management_policy_test.go
+++ b/azurerm/internal/services/storage/tests/data_source_storage_management_policy_test.go
@@ -39,6 +39,36 @@ func TestAccDataSourceAzureRMStorageManagementPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMStorageManagementPolicy_blobTypes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_management_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMStorageManagementPolicy_blobTypes(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.filters.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.filters.0.prefix_match.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.filters.0.prefix_match.3439697764", "container1/prefix1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.filters.0.blob_types.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.filters.0.blob_types.1068358194", "blockBlob"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.filters.0.blob_types.932666486", "appendBlob"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.actions.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.actions.0.base_blob.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.actions.0.base_blob.0.delete_after_days_since_modification_greater_than", "100"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.actions.0.snapshot.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "rule.0.actions.0.snapshot.0.delete_after_days_since_creation_greater_than", "30"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAzureRMStorageManagementPolicy_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -75,6 +105,54 @@ resource "azurerm_storage_management_policy" "test" {
         tier_to_cool_after_days_since_modification_greater_than    = 10
         tier_to_archive_after_days_since_modification_greater_than = 50
         delete_after_days_since_modification_greater_than          = 100
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = 30
+      }
+    }
+  }
+}
+
+data "azurerm_storage_management_policy" "test" {
+  storage_account_id = azurerm_storage_management_policy.test.storage_account_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccDataSourceAzureRMStorageManagementPolicy_blobTypes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "BlobStorage"
+}
+
+resource "azurerm_storage_management_policy" "test" {
+  storage_account_id = azurerm_storage_account.test.id
+
+  rule {
+    name    = "rule1"
+    enabled = true
+    filters {
+      prefix_match = ["container1/prefix1"]
+      blob_types   = ["blockBlob", "appendBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 100
       }
       snapshot {
         delete_after_days_since_creation_greater_than = 30

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 `filters` supports the following:
 
 * `prefix_match` - An array of strings for prefixes to be matched.
-* `blob_types` - An array of predefined values. Only `blockBlob` is supported.
+* `blob_types` - An array of predefined values. Valid options are `blockBlob` and `appendBlob`.
 
 ---
 

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 `filters` supports the following:
 
 * `prefix_match` - An array of strings for prefixes to be matched.
-* `blob_types` - An array of predefined values. Only `blockBlob` is supported.
+* `blob_types` - An array of predefined values. Valid options are `blockBlob` and `appendBlob`.
 
 ---
 


### PR DESCRIPTION
Append Blob now supports Blob Lifecycle Management and will be added to the validation.
https://azure.microsoft.com/en-us/updates/azure-blob-storage-lifecycle-management-now-supports-append-blobs/

Docs:
https://docs.microsoft.com/en-us/azure/storage/blobs/storage-lifecycle-management-concepts?tabs=azure-portal#rule-filters