### PR TITLE
[azurerm_function_app] App Settings should be Computed

### DIFF
--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -62,6 +62,7 @@ func resourceArmFunctionApp() *schema.Resource {
 			"app_settings": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/azurerm/internal/services/web/resource_arm_function_app_slot.go
+++ b/azurerm/internal/services/web/resource_arm_function_app_slot.go
@@ -91,6 +91,7 @@ func resourceArmFunctionAppSlot() *schema.Resource {
 			"app_settings": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
Function Apps should have computed App Settings just like App Services do, since they are effectively two different offshoots of the same resource type behind the scenes.

Also required as discussed in [this thread](https://github.com/hashicorp/terraform/issues/26401#issuecomment-700847694)