### PR TITLE
`azurerm_key_vault_certificate_issuer` - `org_id` is now optional

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource.go
@@ -49,19 +49,22 @@ func resourceArmKeyVaultCertificateIssuer() *schema.Resource {
 				ValidateFunc: validate.KeyVaultCertificateIssuerName,
 			},
 
-			"org_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
 			"provider_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"DigiCert",
 					"GlobalSign",
+					"OneCertV2-PrivateCA",
+					"OneCertV2-PublicCA",
+					"SslAdminV2",
 				}, false),
+			},
+
+			"org_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"account_id": {
@@ -131,18 +134,17 @@ func resourceArmKeyVaultCertificateIssuerCreateOrUpdate(d *schema.ResourceData, 
 	}
 
 	parameter := keyvault.CertificateIssuerSetParameters{
-		Provider: utils.String(d.Get("provider_name").(string)),
+		Provider:            utils.String(d.Get("provider_name").(string)),
+		OrganizationDetails: &keyvault.OrganizationDetails{},
 	}
 
-	orgDetails := &keyvault.OrganizationDetails{
-		ID: utils.String(d.Get("org_id").(string)),
+	if orgIdRaw, ok := d.GetOk("org_id"); ok {
+		parameter.OrganizationDetails.ID = utils.String(orgIdRaw.(string))
 	}
 
 	if adminsRaw, ok := d.GetOk("admin"); ok {
-		orgDetails.AdminDetails = expandKeyVaultCertificateIssuerOrganizationDetailsAdminDetails(adminsRaw.([]interface{}))
+		parameter.OrganizationDetails.AdminDetails = expandKeyVaultCertificateIssuerOrganizationDetailsAdminDetails(adminsRaw.([]interface{}))
 	}
-
-	parameter.OrganizationDetails = orgDetails
 
 	accountId, gotAccountId := d.GetOk("account_id")
 	password, gotPassword := d.GetOk("password")

--- a/azurerm/internal/services/keyvault/tests/key_vault_certificate_issuer_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_certificate_issuer_resource_test.go
@@ -307,10 +307,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_certificate_issuer" "test" {
   name          = "acctestKVCI-%d"
   key_vault_id  = azurerm_key_vault.test.id
-  org_id        = "accTestOrg"
-  account_id    = "test-account"
-  password      = "test"
-  provider_name = "DigiCert"
+  provider_name = "OneCertV2-PrivateCA"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }

--- a/website/docs/r/key_vault_certificate_issuer.html.markdown
+++ b/website/docs/r/key_vault_certificate_issuer.html.markdown
@@ -46,13 +46,13 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Key Vault Certificate Issuer. Changing this forces a new Key Vault Certificate Issuer to be created.
 
-* `org_id` - (Required) The ID of the organization as provided to the issuer. 
+* `provider_name` - (Required) The name of the third-party Certificate Issuer. Possible values are: `DigiCert`, `GlobalSign`, `OneCertV2-PrivateCA`, `OneCertV2-PublicCA` and `SslAdminV2`.
+
+* `org_id` - (Optional) The ID of the organization as provided to the issuer. 
 
 * `account_id` - (Optional) The account number with the third-party Certificate Issuer.
 
 * `admin` - (Optional) One or more `admin` blocks as defined below.
-
-* `provider_name` - (Required) The name of the third-party Certificate Issuer. Possible values are: `DigiCert`, `GlobalSign`.
 
 * `password` - (Optional) The password associated with the account and organization ID at the third-party Certificate Issuer. If not specified, will not overwrite any previous value.
 
@@ -73,8 +73,6 @@ An `admin` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported: 
 
 * `id` - The ID of the Key Vault Certificate Issuer.
-
-
 
 ## Import
 


### PR DESCRIPTION
fix #8431 

![image](https://user-images.githubusercontent.com/2786738/94639086-fed8a080-030d-11eb-96ca-95f09fdb3b50.png)
