### PR TITLE
`azurerm_cosmosdb_mongo_collection` - correctly read the `_id` index back when mongo 3.6

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -322,9 +322,11 @@ func resourceArmCosmosDbMongoCollectionRead(d *schema.ResourceData, meta interfa
 			}
 			accountIsVersion36 := false
 			if accProps := accResp.DatabaseAccountGetProperties; accProps != nil {
-				for _, v := range *accProps.Capabilities {
-					if *v.Name == "EnableMongo" {
-						accountIsVersion36 = true
+				if capabilities := accProps.Capabilities; capabilities != nil {
+					for _, v := range *capabilities {
+						if v.Name != nil && *v.Name == "EnableMongo" {
+							accountIsVersion36 = true
+						}
 					}
 				}
 			}

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -441,8 +441,9 @@ func flattenCosmosMongoCollectionIndex(input *[]documentdb.MongoIndex, accountIs
 				if accountIsVersion36 {
 					index["keys"] = utils.FlattenStringSlice(v.Key.Keys)
 					index["unique"] = true
+					indexes = append(indexes, index)
 				}
-				indexes = append(indexes, index)
+
 			case "DocumentDBDefaultIndex":
 				// Updating system index `DocumentDBDefaultIndex` is not a supported scenario.
 				systemIndex["keys"] = utils.FlattenStringSlice(v.Key.Keys)

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -421,8 +421,9 @@ func flattenCosmosMongoCollectionIndex(input *[]documentdb.MongoIndex, d *schema
 	}
 
 	for _, v := range *input {
-		systemIndex := map[string]interface{}{}
 		index := map[string]interface{}{}
+		systemIndex := map[string]interface{}{}
+
 		if v.Key != nil && v.Key.Keys != nil && len(*v.Key.Keys) > 0 {
 			key := (*v.Key.Keys)[0]
 

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -320,16 +320,16 @@ func resourceArmCosmosDbMongoCollectionRead(d *schema.ResourceData, meta interfa
 			for k := range res.ShardKey {
 				d.Set("shard_key", k)
 			}
-			version36 := false
+			accountIsVersion36 := false
 			if accProps := accResp.DatabaseAccountGetProperties; accProps != nil {
 				for _, v := range *accProps.Capabilities {
 					if *v.Name == "EnableMongo" {
-						version36 = true
+						accountIsVersion36 = true
 					}
 				}
 			}
 
-			indexes, systemIndexes, ttl := flattenCosmosMongoCollectionIndex(res.Indexes, version36)
+			indexes, systemIndexes, ttl := flattenCosmosMongoCollectionIndex(res.Indexes, accountIsVersion36)
 			if err := d.Set("default_ttl_seconds", ttl); err != nil {
 				return fmt.Errorf("failed to set `default_ttl_seconds`: %+v", err)
 			}
@@ -414,7 +414,7 @@ func expandCosmosMongoCollectionIndex(indexes []interface{}, defaultTtl *int) *[
 	return &results
 }
 
-func flattenCosmosMongoCollectionIndex(input *[]documentdb.MongoIndex, version36 bool) (*[]map[string]interface{}, *[]map[string]interface{}, *int32) {
+func flattenCosmosMongoCollectionIndex(input *[]documentdb.MongoIndex, accountIsVersion36 bool) (*[]map[string]interface{}, *[]map[string]interface{}, *int32) {
 	indexes := make([]map[string]interface{}, 0)
 	systemIndexes := make([]map[string]interface{}, 0)
 	var ttl *int32
@@ -438,7 +438,7 @@ func flattenCosmosMongoCollectionIndex(input *[]documentdb.MongoIndex, version36
 
 				systemIndexes = append(systemIndexes, systemIndex)
 
-				if version36 {
+				if accountIsVersion36 {
 					index["keys"] = utils.FlattenStringSlice(v.Key.Keys)
 					index["unique"] = true
 				}

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -307,7 +307,6 @@ func resourceArmCosmosDbMongoCollectionRead(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return fmt.Errorf("reading Cosmos Account %q : %+v", id.DatabaseAccountName, err)
 	}
-	d.Set("database_name", id.MongodbDatabaseName)
 	if props := resp.MongoDBCollectionGetProperties; props != nil {
 		if res := props.Resource; res != nil {
 			d.Set("name", res.ID)

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
@@ -2,10 +2,10 @@ package cosmos_test
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
@@ -194,7 +194,7 @@ func TestAccAzureRMCosmosDbMongoCollection_ver36(t *testing.T) {
 					testCheckAzureRMCosmosDbMongoCollectionExists(data.ResourceName),
 				),
 			},
-			data.ImportStep("index.#", "index.1997105887.keys.#", "index.1997105887.keys.0", "index.1997105887.unique"),
+			data.ImportStep(),
 		},
 	})
 }
@@ -382,8 +382,8 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
 
   index {
     keys   = ["_id"]
-    unique = false
+    unique = true
   }
 }
-`, testAccAzureRMCosmosDBAccount_basic(data, documentdb.MongoDB, documentdb.Strong), data.RandomInteger)
+`, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.MongoDB, []string{"EnableMongo"}), data.RandomInteger)
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
+	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/8660

=== RUN   TestAccAzureRMCosmosDbMongoCollection_basic
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_basic
=== CONT  TestAccAzureRMCosmosDbMongoCollection_basic
--- PASS: TestAccAzureRMCosmosDbMongoCollection_basic (1811.27s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_complete
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_complete
=== CONT  TestAccAzureRMCosmosDbMongoCollection_complete
--- PASS: TestAccAzureRMCosmosDbMongoCollection_complete (1819.16s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_update
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_update
=== CONT  TestAccAzureRMCosmosDbMongoCollection_update
--- PASS: TestAccAzureRMCosmosDbMongoCollection_update (2097.46s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_throughput
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_throughput
=== CONT  TestAccAzureRMCosmosDbMongoCollection_throughput
--- PASS: TestAccAzureRMCosmosDbMongoCollection_throughput (2052.64s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_withIndex
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_withIndex
=== CONT  TestAccAzureRMCosmosDbMongoCollection_withIndex
--- PASS: TestAccAzureRMCosmosDbMongoCollection_withIndex (1824.25s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_autoscale
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_autoscale
=== CONT  TestAccAzureRMCosmosDbMongoCollection_autoscale
--- PASS: TestAccAzureRMCosmosDbMongoCollection_autoscale (2234.07s)
=== RUN   TestAccAzureRMCosmosDbMongoCollection_ver36
=== PAUSE TestAccAzureRMCosmosDbMongoCollection_ver36
=== CONT  TestAccAzureRMCosmosDbMongoCollection_ver36
--- PASS: TestAccAzureRMCosmosDbMongoCollection_ver36 (1685.88s)