### PR TITLE
`azurerm_appplication_insights` - Add support for `connection_string`

### DIFF
--- a/azurerm/internal/services/applicationinsights/application_insights_data_source.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_data_source.go
@@ -35,6 +35,12 @@ func dataSourceArmApplicationInsights() *schema.Resource {
 				Computed: true,
 			},
 
+			"connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"location": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -85,6 +91,7 @@ func dataSourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface
 
 	d.SetId(*resp.ID)
 	d.Set("instrumentation_key", resp.InstrumentationKey)
+	d.Set("connection_string", resp.ConnectionString)
 	d.Set("location", resp.Location)
 	d.Set("app_id", resp.AppID)
 	d.Set("application_type", resp.ApplicationType)

--- a/azurerm/internal/services/applicationinsights/application_insights_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_resource.go
@@ -116,6 +116,12 @@ func resourceArmApplicationInsights() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -252,6 +258,7 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 		d.Set("instrumentation_key", props.InstrumentationKey)
 		d.Set("sampling_percentage", props.SamplingPercentage)
 		d.Set("disable_ip_masking", props.DisableIPMasking)
+		d.Set("connection_string", props.ConnectionString)
 		if v := props.RetentionInDays; v != nil {
 			d.Set("retention_in_days", v)
 		}

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -34,6 +34,7 @@ output "application_insights_instrumentation_key" {
 * `app_id` - The App ID associated with this Application Insights component.
 * `application_type` - The type of the component.
 * `instrumentation_key` - The instrumentation key of the Application Insights component.
+* `connection_string` - The connection string of the Application Insights component. (Sensitive)
 * `location` - The Azure location where the component exists.
 * `retention_in_days` - The retention period in days.
 * `tags` - Tags applied to the component.

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -70,6 +70,8 @@ The following attributes are exported:
 
 * `instrumentation_key` - The Instrumentation Key for this Application Insights component.
 
+* `connection_string` - The Connection String for this Application Insights component. (Sensitive)
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
I've added support for connection_string property to the application_insight resource. This fixes #8669 and #1303.

The connection string value is generated on the Azure side, this should just surface the value in the outputs for the resource. Tested this change with new, existing resources, and imported resources. 

I've added the value into the documentation markup too but let me know if I missed any references. 