### PR TITLE
Docs: Replace Basic with GeneralPurpose for sku_name

### DIFF
--- a/website/docs/r/postgresql_virtual_network_rule.html.markdown
+++ b/website/docs/r/postgresql_virtual_network_rule.html.markdown
@@ -40,7 +40,7 @@ resource "azurerm_postgresql_server" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
-  sku_name = "B_Gen5_2"
+  sku_name = "GP_Gen5_2"
 
   storage_profile {
     storage_mb            = 5120


### PR DESCRIPTION
For consistency, since PostgreSQL Virtual Network Rules can only be used
with SKU Tiers of GeneralPurpose or MemoryOptimized.

