### PR TITLE
Scaffold azurerm_data_factory data documentation

### DIFF
--- a/website/docs/d/data_factory.html.markdown
+++ b/website/docs/d/data_factory.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Data Factory"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_data_factory"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_factory"
 description: |-
   Gets information about an existing Azure Data Factory (Version 2).
 ---
@@ -14,80 +14,81 @@ Use this data source to access information about an existing Azure Data Factory 
 
 ```hcl
 data "azurerm_data_factory" "example" {
-  name                = azurerm_data_factory.example.name
-  resource_group_name = azurerm_data_factory.example.resource_group_name
+  name                = "existing-adf"
+  resource_group_name = "existing-rg"
 }
 
-output "data_factory_id" {
-  value = azurerm_data_factory.example.id
+output "id" {
+  value = data.azurerm_data_factory.example.id
 }
 ```
 
-## Argument Reference
+## Arguments Reference
 
 The following arguments are supported:
 
-* `name` - Specifies the name of the Data Factory to retrieve information about. 
+- `name` - (Required) The name of this Azure Data Factory.
 
-* `resource_group_name` - The name of the resource group where the Data Factory exists.
+- `resource_group_name` - (Required) The name of the Resource Group where the Azure Data Factory exists.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The Data Factory ID.
+- `id` - The ID of the Azure Data Factory.
 
-* `location` - The Azure location where the resource exists.
+- `github_configuration` - A `github_configuration` block as defined below.
 
-* `github_configuration` - A `github_configuration` block as defined below.
+- `identity` - An `identity` block as defined below.
 
-* `identity` - An `identity` block as defined below.
+- `location` - The Azure Region where the Azure Data Factory exists.
 
-* `vsts_configuration` - A `vsts_configuration` block as defined below.
+- `tags` - A mapping of tags assigned to the Azure Data Factory.
 
-* `tags` - A mapping of tags assigned to the resource.
+- `vsts_configuration` - A `vsts_configuration` block as defined below.
+
 ---
 
 A `github_configuration` block exports the following:
 
-* `account_name` - The GitHub account name.
+- `account_name` - The GitHub account name.
 
-* `branch_name` - The branch of the repository to get code from.
+- `branch_name` - The branch of the repository to get code from.
 
-* `git_url` - The GitHub Enterprise host name. 
+- `git_url` - The GitHub Enterprise host name.
 
-* `repository_name` - The name of the git repository.
+- `repository_name` - The name of the git repository.
 
-* `root_folder` - The root folder within the repository.
+- `root_folder` - The root folder within the repository.
 
 ---
 
 An `identity` block exports the following:
 
-* `principal_id` - The ID of the Principal (Client) in Azure Active Directory.
+- `principal_id` - The ID of the Principal (Client) in Azure Active Directory.
 
-* `tenant_id` - The ID of the Azure Active Directory Tenant.
+- `tenant_id` - The ID of the Azure Active Directory Tenant.
 
-* `type` - The identity type of the Data Factory.
+- `type` - The identity type of the Data Factory.
 
 ---
 
 A `vsts_configuration` block exports the following:
 
-* `account_name` - The VSTS account name.
+- `account_name` - The VSTS account name.
 
-* `branch_name` - The branch of the repository to get code from.
+- `branch_name` - The branch of the repository to get code from.
 
-* `project_name` - The name of the VSTS project.
+- `project_name` - The name of the VSTS project.
 
-* `repository_name` - The name of the git repository.
+- `repository_name` - The name of the git repository.
 
-* `root_folder` - The root folder within the repository.
+- `root_folder` - The root folder within the repository.
 
-* `tenant_id` - The Tenant ID associated with the VSTS account.
+- `tenant_id` - The Tenant ID associated with the VSTS account.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Azure Data Factory.


### PR DESCRIPTION
Noticed a non-functioning example on the azurerm_data_factory data documentation as well, and a malformed attribute list. 

This PR has a new scaffold of the documentation and added back most of the existing documentation for attributes, where those are not auto-generated.