### PR TITLE
UPDATE azurerm_subnet documentation example

### DIFF
--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_subnet" "example" {
   name                 = "acctsub"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -30,14 +30,14 @@ resource "azurerm_subnet" "ase" {
   name                 = "asesubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_subnet" "gateway" {
   name                 = "gatewaysubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_app_service_environment" "example" {

--- a/website/docs/r/app_service_slot_virtual_network_swift_connection.html.markdown
+++ b/website/docs/r/app_service_slot_virtual_network_swift_connection.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 
   delegation {
     name = "example-delegation"

--- a/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
+++ b/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 
   delegation {
     name = "example-delegation"

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "example" {
   name                 = "AzureBastionSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "192.168.1.224/27"
+  address_prefixes     = ["192.168.1.224/27"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/database_migration_project.html.markdown
+++ b/website/docs/r/database_migration_project.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_database_migration_service" "example" {

--- a/website/docs/r/database_migration_service.html.markdown
+++ b/website/docs/r/database_migration_service.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_database_migration_service" "example" {

--- a/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
+++ b/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                 = "sample-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "AzureFirewallSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/firewall_application_rule_collection.html.markdown
+++ b/website/docs/r/firewall_application_rule_collection.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "AzureFirewallSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/firewall_nat_rule_collection.html.markdown
+++ b/website/docs/r/firewall_nat_rule_collection.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "AzureFirewallSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "AzureFirewallSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_subnet" "example" {
   name                 = "examplesubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_hpc_cache" "example" {

--- a/website/docs/r/hpc_cache_blob_target.html.markdown
+++ b/website/docs/r/hpc_cache_blob_target.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                 = "examplesubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_hpc_cache" "example" {

--- a/website/docs/r/hpc_cache_nfs_target.html.markdown
+++ b/website/docs/r/hpc_cache_nfs_target.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example_hpc" {
   name                 = "examplesubnethpc"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_hpc_cache" "example" {
@@ -47,7 +47,7 @@ resource "azurerm_subnet" "example_vm" {
   name                 = "examplesubnetvm"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "example" {

--- a/website/docs/r/maintenance_assignment_virtual_machine.html.markdown
+++ b/website/docs/r/maintenance_assignment_virtual_machine.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/mariadb_virtual_network_rule.html.markdown
+++ b/website/docs/r/mariadb_virtual_network_rule.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.7.29.0/29"
+  address_prefixes     = ["10.7.29.0/29"]
   service_endpoints    = ["Microsoft.Sql"]
 }
 

--- a/website/docs/r/netapp_snapshot.html.markdown
+++ b/website/docs/r/netapp_snapshot.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 
   delegation {
     name = "netapp"

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 
   delegation {
     name = "netapp"

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
@@ -30,14 +30,14 @@ resource "azurerm_subnet" "frontend" {
   name                 = "frontend"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_subnet" "backend" {
   name                 = "backend"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_application_security_group" "example" {

--- a/website/docs/r/network_interface_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_backend_address_pool_association.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/network_interface_nat_rule_association.html.markdown
+++ b/website/docs/r/network_interface_nat_rule_association.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/network_interface_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_security_group_association.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_security_group" "example" {

--- a/website/docs/r/network_packet_capture.html.markdown
+++ b/website/docs/r/network_packet_capture.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/network_profile.html.markdown
+++ b/website/docs/r/network_profile.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "examplesubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.1.0.0/24"
+  address_prefixes     = ["10.1.0.0/24"]
 
   delegation {
     name = "delegation"

--- a/website/docs/r/packet_capture.html.markdown
+++ b/website/docs/r/packet_capture.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/postgresql_virtual_network_rule.html.markdown
+++ b/website/docs/r/postgresql_virtual_network_rule.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.7.29.0/29"
+  address_prefixes     = ["10.7.29.0/29"]
   service_endpoints    = ["Microsoft.Sql"]
 }
 

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                                          = "example-subnet"
   resource_group_name                           = azurerm_resource_group.example.name
   virtual_network_name                          = azurerm_virtual_network.example.name
-  address_prefix                                = "10.5.1.0/24"
+  address_prefixes                              = ["10.5.1.0/24"]
   enforce_private_link_service_network_policies = true
 }
 

--- a/website/docs/r/servicebus_namespace_network_rule_set.html.markdown
+++ b/website/docs/r/servicebus_namespace_network_rule_set.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_subnet" "example" {
   name                 = "default"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "172.17.0.0/24"
+  address_prefixes     = ["172.17.0.0/24"]
 
   service_endpoints = ["Microsoft.ServiceBus"]
 }

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -128,7 +128,7 @@ resource "azurerm_subnet" "primary" {
   name                 = "network1-subnet"
   resource_group_name  = azurerm_resource_group.primary.name
   virtual_network_name = azurerm_virtual_network.primary.name
-  address_prefix       = "192.168.1.0/24"
+  address_prefixes     = ["192.168.1.0/24"]
 }
 
 resource "azurerm_network_interface" "vm" {

--- a/website/docs/r/sql_virtual_network_rule.html.markdown
+++ b/website/docs/r/sql_virtual_network_rule.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "subnet" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.vnet.name
-  address_prefix       = "10.7.29.0/29"
+  address_prefixes     = ["10.7.29.0/29"]
   service_endpoints    = ["Microsoft.Sql"]
 }
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_subnet" "example" {
   name                 = "subnetname"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
   service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
 }
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
   service_endpoints    = ["Microsoft.Storage"]
 }
 

--- a/website/docs/r/subnet_network_security_group_association.html.markdown
+++ b/website/docs/r/subnet_network_security_group_association.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "frontend"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_security_group" "example" {

--- a/website/docs/r/subnet_route_table_association.html.markdown
+++ b/website/docs/r/subnet_route_table_association.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_subnet" "example" {
   name                 = "frontend"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_route_table" "example" {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "main" {

--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "main" {

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_subnet" "example" {
   name                 = "acctsub"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -185,7 +185,7 @@ resource "azurerm_subnet" "example" {
   name                 = "acctsub"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes   = ["10.0.2.0/24"]
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_storage_account" "example" {

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_subnet" "example" {
   name                 = "acctsub"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {
@@ -185,7 +185,7 @@ resource "azurerm_subnet" "example" {
   name                 = "acctsub"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes   = ["10.0.2.0/24"]
 }
 
 resource "azurerm_storage_account" "example" {

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "example" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "example" {

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "example" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_local_network_gateway" "onpremise" {
@@ -106,7 +106,7 @@ resource "azurerm_subnet" "us_gateway" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.us.name
   virtual_network_name = azurerm_virtual_network.us.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_public_ip" "us" {
@@ -148,7 +148,7 @@ resource "azurerm_subnet" "europe_gateway" {
   name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.europe.name
   virtual_network_name = azurerm_virtual_network.europe.name
-  address_prefix       = "10.1.1.0/24"
+  address_prefixes     = ["10.1.1.0/24"]
 }
 
 resource "azurerm_public_ip" "europe" {

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_subnet" "example" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_network_interface" "example" {

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "example" {


### PR DESCRIPTION
Hi,

just a small PR but if anyone will read the documentation and the examples, they will always use the deprecated property.

All examples should be changed to the new property 
`address_prefix` to `adress_prefixed` 

Br
Tobi 