### PR TITLE
origin_host_header changed to required, else TF apply fails

### DIFF
--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `origin` - (Required) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options. Each `origin` block supports fields documented below.
 
-* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
+* `origin_host_header` - (Required) The host header CDN provider will send along with content requests to origins. Set to the host name of the origin.
 
 * `origin_path` - (Optional) The path used at for origin requests.
 


### PR DESCRIPTION
origin_host_header is required else the TF apply fails with 
to finish creating: Code="BadRequest" Message="{\"ErrorMessage\":\"Errors found in Model: OriginHostHeader must match the regex '(^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])$)|((?:[:0-9A-Fa-f]+))'.\"}"[0m

REF: https://stackoverflow.com/questions/61402470/terraform-script-error-while-deploying-app-service-cdn-endpoint