### PR TITLE
`azurerm_mssql_server` - update doc and test for sql server min tls

### DIFF
--- a/azurerm/internal/services/mssql/mssql_server_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_resource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	uuid "github.com/satori/go.uuid"
-
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -170,6 +169,7 @@ func resourceArmMsSqlServer() *schema.Resource {
 
 			"tags": tags.Schema(),
 		},
+		CustomizeDiff: mssqlMinimumTLSVersionDiff,
 	}
 }
 
@@ -492,4 +492,12 @@ func flattenAzureRmSqlServerRestorableDatabases(resp sql.RestorableDroppedDataba
 		res = append(res, id)
 	}
 	return res
+}
+
+func mssqlMinimumTLSVersionDiff(d *schema.ResourceDiff, _ interface{}) (err error) {
+	old, new := d.GetChange("minimum_tls_version")
+	if old != "" && new == "" {
+		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
+	}
+	return
 }

--- a/azurerm/internal/services/mssql/tests/mssql_server_resource_test.go
+++ b/azurerm/internal/services/mssql/tests/mssql_server_resource_test.go
@@ -478,6 +478,7 @@ resource "azurerm_mssql_server" "test" {
   version                      = "12.0"
   administrator_login          = "missadministrator"
   administrator_login_password = "thisIsKat11"
+  minimum_tls_version          = "1.0"
 
   public_network_access_enabled = false
 

--- a/azurerm/internal/services/mssql/tests/mssql_server_resource_test.go
+++ b/azurerm/internal/services/mssql/tests/mssql_server_resource_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -221,6 +222,33 @@ func TestAccAzureRMMsSqlServer_blobAuditingPolicies_withFirewall(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMMsSqlServer_customDiff(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlServer_basicWithMinimumTLSVersion(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("administrator_login_password"),
+			{
+				Config: testAccAzureRMMsSqlServer_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlServerExists(data.ResourceName),
+				),
+				ExpectError: regexp.MustCompile("`minimum_tls_version` cannot be removed once set, please set a valid value for this property"),
+			},
+			data.ImportStep("administrator_login_password"),
+		},
+	})
+}
+
 func testCheckAzureRMMsSqlServerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acceptance.AzureProvider.Meta().(*clients.Client).Sql.ServersClient
@@ -319,6 +347,29 @@ resource "azurerm_mssql_server" "test" {
   version                      = "12.0"
   administrator_login          = "missadministrator"
   administrator_login_password = "thisIsKat11"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMMsSqlServer_basicWithMinimumTLSVersion(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%d"
+  location = "%s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctestsqlserver%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "thisIsKat11"
+  minimum_tls_version          = "1.2"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `minimum_tls_version` - (Optional) The Minimum TLS Version for all SQL Database and SQL Data Warehouse databases associated with the server. Valid values are: `1.0`, `1.1` and `1.2`.
 
+~> **NOTE:** Once `minimum_tls_version` is set it is not possible to remove this setting and must be given a valid value for any further updates to the resource.
+
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this server. Defaults to `true`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
`minimum_tls_version` setting cannot be removed once set, updates testing config for this and adds note to docs.