### PR TITLE
azurerm_security_center_contact - override SDK creation function to handle `201` response code

### DIFF
--- a/azurerm/internal/services/securitycenter/azuresdkhacks/security_center_contact.go
+++ b/azurerm/internal/services/securitycenter/azuresdkhacks/security_center_contact.go
@@ -1,0 +1,56 @@
+package azuresdkhacks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+)
+
+func CreateSecurityCenterContact(client *security.ContactsClient, ctx context.Context, securityContactName string, securityContact security.Contact) (result security.Contact, err error) {
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: client.SubscriptionID,
+			Constraints: []validation.Constraint{{Target: "client.SubscriptionID", Name: validation.Pattern, Rule: `^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`, Chain: nil}}},
+		{TargetValue: securityContact,
+			Constraints: []validation.Constraint{{Target: "securityContact.ContactProperties", Name: validation.Null, Rule: false,
+				Chain: []validation.Constraint{{Target: "securityContact.ContactProperties.Email", Name: validation.Null, Rule: true, Chain: nil}}}}}}); err != nil {
+		return result, validation.NewError("security.ContactsClient", "Create", err.Error())
+	}
+
+	req, err := client.CreatePreparer(ctx, securityContactName, securityContact)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.ContactsClient", "Create", nil, "Failure preparing request")
+		return result, err
+	}
+
+	resp, err := client.CreateSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "security.ContactsClient", "Create", resp, "Failure sending request")
+		return result, err
+	}
+
+	result, err = createResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.ContactsClient", "Create", resp, "Failure responding to request")
+		return result, err
+	}
+
+	return result, nil
+}
+
+func createResponder(resp *http.Response) (result security.Contact, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	if err != nil {
+		return result, err
+	}
+	result.Response = autorest.Response{Response: resp}
+	return result, nil
+}

--- a/azurerm/internal/services/securitycenter/resource_arm_security_center_contact.go
+++ b/azurerm/internal/services/securitycenter/resource_arm_security_center_contact.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/azuresdkhacks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -104,7 +105,9 @@ func resourceArmSecurityCenterContactCreateUpdate(d *schema.ResourceData, meta i
 	}
 
 	if d.IsNewResource() {
-		if _, err := client.Create(ctx, name, contact); err != nil {
+		// TODO: switch back when the Swagger/API bug has been fixed:
+		// https://github.com/Azure/azure-rest-api-specs/issues/10717 (an undefined 201)
+		if _, err := azuresdkhacks.CreateSecurityCenterContact(client, ctx, name, contact); err != nil {
 			return fmt.Errorf("Creating Security Center Contact: %+v", err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v46.4.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.10
 	github.com/Azure/go-autorest/autorest/date v0.3.0
+	github.com/Azure/go-autorest/autorest/validation v0.3.0
 	github.com/btubbs/datetime v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/uuid v1.1.1


### PR DESCRIPTION
This allows to create a new security center contact.

The current issue is that the Azure Rest API may return a 201 upon resource
creation, however, the API specs don't include this status code as
successful, which causes the corresponding method from the Azure Go SDK
to return an error.

Fixes #8317 