### PR TITLE
Add `plan` block argument to scale set

### DIFF
--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -164,6 +164,10 @@ The following arguments are supported:
 
 * `overprovision` - (Optional) Should Azure over-provision Virtual Machines in this Scale Set? This means that multiple Virtual Machines will be provisioned and Azure will keep the instances which become available first - which improves provisioning success rates and improves deployment time. You're not billed for these over-provisioned VM's and they don't count towards the Subscription Quota. Defaults to `true`.
 
+* `plan` - (Optional) A plan block as documented below.
+
+-> **NOTE:** When using an image from Azure Marketplace a `plan` must be specified.
+
 * `priority` - (Optional) The Priority of this Virtual Machine Scale Set. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this value forces a new resource.
 
 -> **NOTE:** When `priority` is set to `Spot` an `eviction_policy` must be specified.
@@ -403,6 +407,16 @@ A `os_disk` block supports the following:
 * `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this OS Disk? Defaults to `false`.
 
 -> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
+
+---
+
+`plan` supports the following:
+
+* `name` - (Required) Specifies the name of the image from the marketplace.
+
+* `publisher` - (Required) Specifies the publisher of the image.
+
+* `product` - (Required) Specifies the product of the image from the marketplace.
 
 ---
 


### PR DESCRIPTION
When using a marketplace image, Azure requires plan details provided, which may be similar to the `source_image_reference` information.

I based the information off of the documentation for `azurerm_virtual_machine_scale_set`