### PR TITLE
Validate policy mode value

### DIFF
--- a/azurerm/internal/services/policy/policy_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_definition_resource.go
@@ -63,6 +63,20 @@ func resourceArmPolicyDefinition() *schema.Resource {
 			"mode": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						"All",
+						"Indexed",
+						"Microsoft.ContainerService.Data",
+						"Microsoft.CustomerLockbox.Data",
+						"Microsoft.DataCatalog.Data",
+						"Microsoft.KeyVault.Data",
+						"Microsoft.Kubernetes.Data",
+						"Microsoft.MachineLearningServices.Data",
+						"Microsoft.Network.Data",
+						"Microsoft.Synapse.Data",
+					}, false,
+				),
 			},
 
 			"management_group_id": {

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -70,8 +70,7 @@ The following arguments are supported:
 * `policy_type` - (Required) The policy type. Possible values are `BuiltIn`, `Custom` and `NotSpecified`. Changing this forces a new resource to be created.
 
 * `mode` - (Required) The policy mode that allows you to specify which resource
-    types will be evaluated.  The value can be "All", "Indexed" or
-    "NotSpecified".
+    types will be evaluated. Possible values are `All`, `Indexed`, `Microsoft.ContainerService.Data`, `Microsoft.CustomerLockbox.Data`, `Microsoft.DataCatalog.Data`, `Microsoft.KeyVault.Data`, `Microsoft.Kubernetes.Data`, `Microsoft.MachineLearningServices.Data`, `Microsoft.Network.Data` and `Microsoft.Synapse.Data`.
 
 * `display_name` - (Required) The display name of the policy definition.
 


### PR DESCRIPTION
Policy creation succeeds even if the policy mode in the request is
not capitalized, however, when fetching the policy mode value from
Azure, the correct capitalized version is returned, which causes
the Terraform state and configuration to be different.

Ideally, there should be an enum with a set of allowed values, but
thi is not the case in the latest version of the Azure Rest API specs.
However, the supported mode values are returned in the create error
response when an invalid mode is requested.

Fixes #8748