### PR TITLE
[WIP] Added JitNetworkAccessPolicy basic implementation

### DIFF
--- a/azurerm/internal/services/securitycenter/client/client.go
+++ b/azurerm/internal/services/securitycenter/client/client.go
@@ -10,6 +10,7 @@ type Client struct {
 	PricingClient                  *security.PricingsClient
 	WorkspaceClient                *security.WorkspaceSettingsClient
 	AdvancedThreatProtectionClient *security.AdvancedThreatProtectionClient
+	JitNetworkAccessPoliciesClient *CustomJitNetworkAccessPoliciesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -27,10 +28,14 @@ func NewClient(o *common.ClientOptions) *Client {
 	AdvancedThreatProtectionClient := security.NewAdvancedThreatProtectionClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
 	o.ConfigureClient(&AdvancedThreatProtectionClient.Client, o.ResourceManagerAuthorizer)
 
+	JitNetworkAccessPoliciesClient := NewCustomJitNetworkAccessPoliciesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
+	o.ConfigureClient(&JitNetworkAccessPoliciesClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		ContactsClient:                 &ContactsClient,
 		PricingClient:                  &PricingClient,
 		WorkspaceClient:                &WorkspaceClient,
 		AdvancedThreatProtectionClient: &AdvancedThreatProtectionClient,
+		JitNetworkAccessPoliciesClient: &JitNetworkAccessPoliciesClient,
 	}
 }

--- a/azurerm/internal/services/securitycenter/client/jit_network_access_policies_client.go
+++ b/azurerm/internal/services/securitycenter/client/jit_network_access_policies_client.go
@@ -1,0 +1,176 @@
+package client
+
+import (
+	"context"
+
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/Azure/go-autorest/tracing"
+)
+
+const fqdn = "github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
+
+type CustomJitNetworkAccessPoliciesClient struct {
+	security.JitNetworkAccessPoliciesClient
+}
+
+func NewCustomJitNetworkAccessPoliciesClientWithBaseURI(baseURI string, subscriptionID string, ascLocation string) CustomJitNetworkAccessPoliciesClient {
+	return CustomJitNetworkAccessPoliciesClient{security.NewJitNetworkAccessPoliciesClientWithBaseURI(baseURI, subscriptionID, ascLocation)}
+}
+
+func (client CustomJitNetworkAccessPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, jitNetworkAccessPolicyName string, ascLocation string, body security.JitNetworkAccessPolicy) (result security.JitNetworkAccessPolicy, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/JitNetworkAccessPoliciesClient.CreateOrUpdate")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: client.SubscriptionID,
+			Constraints: []validation.Constraint{{Target: "client.SubscriptionID", Name: validation.Pattern, Rule: `^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`, Chain: nil}}},
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `^[-\w\._\(\)]+$`, Chain: nil}}},
+		{TargetValue: body,
+			Constraints: []validation.Constraint{{Target: "body.JitNetworkAccessPolicyProperties", Name: validation.Null, Rule: true,
+				Chain: []validation.Constraint{{Target: "body.JitNetworkAccessPolicyProperties.VirtualMachines", Name: validation.Null, Rule: true, Chain: nil}}}}}}); err != nil {
+		return result, validation.NewError("security.JitNetworkAccessPoliciesClient", "CreateOrUpdate", err.Error())
+	}
+
+	req, err := client.RequestPreparer(autorest.AsPut(), ctx, resourceGroupName, jitNetworkAccessPolicyName, ascLocation, &body)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateOrUpdateSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "CreateOrUpdate", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "CreateOrUpdate", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client CustomJitNetworkAccessPoliciesClient) Delete(ctx context.Context, resourceGroupName string, jitNetworkAccessPolicyName string, ascLocation string) (result autorest.Response, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/JitNetworkAccessPoliciesClient.Delete")
+		defer func() {
+			sc := -1
+			if result.Response != nil {
+				sc = result.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: client.SubscriptionID,
+			Constraints: []validation.Constraint{{Target: "client.SubscriptionID", Name: validation.Pattern, Rule: `^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`, Chain: nil}}},
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `^[-\w\._\(\)]+$`, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("security.JitNetworkAccessPoliciesClient", "Delete", err.Error())
+	}
+
+	req, err := client.RequestPreparer(autorest.AsDelete(), ctx, resourceGroupName, jitNetworkAccessPolicyName, ascLocation, nil)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteSender(req)
+	if err != nil {
+		result.Response = resp
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "Delete", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "Delete", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client CustomJitNetworkAccessPoliciesClient) Get(ctx context.Context, resourceGroupName string, jitNetworkAccessPolicyName string, ascLocation string) (result security.JitNetworkAccessPolicy, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/JitNetworkAccessPoliciesClient.Get")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: client.SubscriptionID,
+			Constraints: []validation.Constraint{{Target: "client.SubscriptionID", Name: validation.Pattern, Rule: `^[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$`, Chain: nil}}},
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `^[-\w\._\(\)]+$`, Chain: nil}}}}); err != nil {
+		return result, validation.NewError("security.JitNetworkAccessPoliciesClient", "Get", err.Error())
+	}
+
+	req, err := client.RequestPreparer(autorest.AsGet(), ctx, resourceGroupName, jitNetworkAccessPolicyName, ascLocation, nil)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "Get", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "security.JitNetworkAccessPoliciesClient", "Get", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+func (client CustomJitNetworkAccessPoliciesClient) RequestPreparer(method autorest.PrepareDecorator, ctx context.Context, resourceGroupName string, jitNetworkAccessPolicyName string, ascLocation string, body *security.JitNetworkAccessPolicy) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"ascLocation":                autorest.Encode("path", ascLocation),
+		"jitNetworkAccessPolicyName": autorest.Encode("path", jitNetworkAccessPolicyName),
+		"resourceGroupName":          autorest.Encode("path", resourceGroupName),
+		"subscriptionId":             autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2015-06-01-preview"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		method,
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Security/locations/{ascLocation}/jitNetworkAccessPolicies/{jitNetworkAccessPolicyName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	if body != nil {
+		preparer = autorest.DecoratePreparer(preparer, autorest.WithJSON(*body))
+	}
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}

--- a/azurerm/internal/services/securitycenter/parse/jit_network_access_policy.go
+++ b/azurerm/internal/services/securitycenter/parse/jit_network_access_policy.go
@@ -1,0 +1,50 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type JitNetworkAccessPolicyId struct {
+	ResourceGroup string
+	Name          string
+	Location      string
+}
+
+func NewJitNetworkAccessPolicyId(resourceGroup, name, location string) JitNetworkAccessPolicyId {
+	return JitNetworkAccessPolicyId{
+		ResourceGroup: resourceGroup,
+		Name:          name,
+		Location:      location,
+	}
+}
+
+func (id JitNetworkAccessPolicyId) ID(subscriptionId string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Security/locations/%s/jitNetworkAccessPolicies/%s", subscriptionId, id.ResourceGroup, id.Location, id.Name)
+}
+
+func JitNetworkAccessPolicyID(input string) (*JitNetworkAccessPolicyId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse Jit Network Access Policy ID %q: %+v", input, err)
+	}
+
+	jnp := JitNetworkAccessPolicyId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if jnp.Name, err = id.PopSegment("jitNetworkAccessPolicies"); err != nil {
+		return nil, err
+	}
+
+	if jnp.Location, err = id.PopSegment("locations"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &jnp, nil
+}

--- a/azurerm/internal/services/securitycenter/registration.go
+++ b/azurerm/internal/services/securitycenter/registration.go
@@ -30,5 +30,6 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_security_center_contact":              resourceArmSecurityCenterContact(),
 		"azurerm_security_center_subscription_pricing": resourceArmSecurityCenterSubscriptionPricing(),
 		"azurerm_security_center_workspace":            resourceArmSecurityCenterWorkspace(),
+		"azurerm_jit_network_access_policies":          resourceArmJitNetworkAccessPolicies(),
 	}
 }

--- a/azurerm/internal/services/securitycenter/resource_arm_jit_network_access_policies.go
+++ b/azurerm/internal/services/securitycenter/resource_arm_jit_network_access_policies.go
@@ -1,0 +1,353 @@
+package securitycenter
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmJitNetworkAccessPolicies() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmJitNetworkAccessPoliciesCreateOrUpdate,
+		Read:   resourceArmJitNetworkAccessPoliciesRead,
+		Update: resourceArmJitNetworkAccessPoliciesCreateOrUpdate,
+		Delete: resourceArmJitNetworkAccessPoliciesDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"asc_location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"kind": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"virtual_machines": virtualMachinesPolicySchema(),
+		},
+	}
+}
+
+func flattenPorts(input *[]security.JitNetworkAccessPortRule) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+	result := make([]interface{}, 0)
+	for _, port := range *input {
+		result = append(result, map[string]interface{}{
+			"port":                          port.Number,
+			"protocol":                      port.Protocol,
+			"allowed_source_address_prefix": port.AllowedSourceAddressPrefix,
+			// "allowed_source_address_prefixes":
+			"max_request_access_duration": port.MaxRequestAccessDuration,
+		})
+	}
+	return result
+}
+
+func extractVirtualMachineName(id *string) string {
+	subStrings := strings.Split(*id, "/")
+	name := subStrings[len(subStrings)-1]
+	if len(name) > 0 {
+		fmt.Printf("Virtual Machine Name: %s\n", name)
+		return name
+	}
+	return ""
+}
+
+func flattenVirtualMachines(input *[]security.JitNetworkAccessPolicyVirtualMachine) []map[string]interface{} {
+	if input == nil {
+		return []map[string]interface{}{}
+	}
+
+	result := make([]map[string]interface{}, 0)
+
+	for _, virtualMachine := range *input {
+		result = append(result, map[string]interface{}{
+			"name":  extractVirtualMachineName(virtualMachine.ID),
+			"ports": flattenPorts(virtualMachine.Ports),
+		})
+	}
+
+	//fmt.Printf("Virtual Machines result: %s\n", spew.Sdump(result))
+	return result
+}
+
+func virtualMachinesPolicySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"ports": portsPolicySchema(),
+			},
+		},
+	}
+}
+
+func portsPolicySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"port": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validate.PortNumber,
+				},
+				"protocol": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Default:  string(security.TCP),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(security.All),
+						string(security.TCP),
+						string(security.UDP),
+					}, false),
+				},
+				"allowed_source_address_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"max_request_access_duration": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validate.ISO8601Duration,
+				},
+			},
+		},
+	}
+}
+
+func expandJitNetworkAccessPortRules(portData map[string]interface{}) *[]security.JitNetworkAccessPortRule {
+	ports := make([]security.JitNetworkAccessPortRule, 0)
+
+	if v, ok := portData["ports"].([]interface{}); ok {
+		for _, portConfig := range v {
+			data := portConfig.(map[string]interface{})
+			number := int32(data["port"].(int))
+			protocol := security.Protocol(data["protocol"].(string))
+			allowed_source_address_prefix := data["allowed_source_address_prefix"].(string)
+			max_request_access_duration := data["max_request_access_duration"].(string)
+			port := security.JitNetworkAccessPortRule{
+				Number:                     &number,
+				Protocol:                   protocol,
+				AllowedSourceAddressPrefix: &allowed_source_address_prefix,
+				MaxRequestAccessDuration:   &max_request_access_duration,
+			}
+			ports = append(ports, port)
+		}
+	}
+
+	return &ports
+}
+
+func resourceArmJitNetworkAccessPoliciesCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).SecurityCenter.JitNetworkAccessPoliciesClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	virtualMachinesConfig := d.Get("virtual_machines").([]interface{})
+	virtualMachines := make([]security.JitNetworkAccessPolicyVirtualMachine, 0)
+
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
+	for _, virtualMachineConfig := range virtualMachinesConfig {
+		data := virtualMachineConfig.(map[string]interface{})
+		var virtualMachineID string = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}"
+
+		vmIdReplacer := strings.NewReplacer("{subscriptionId}", subscriptionId,
+			"{resourceGroupName}", d.Get("resource_group_name").(string),
+			"{virtualMachineName}", data["name"].(string))
+		vmID := vmIdReplacer.Replace(virtualMachineID)
+
+		virtualMachine := security.JitNetworkAccessPolicyVirtualMachine{
+			ID:    &vmID,
+			Ports: expandJitNetworkAccessPortRules(data),
+		}
+		virtualMachines = append(virtualMachines, virtualMachine)
+	}
+
+	accessRequests := make([]security.JitNetworkAccessRequest, 0)
+	// TODO: build access request
+	jitNetworkAccessPolicyProperties := security.JitNetworkAccessPolicyProperties{
+		VirtualMachines: &virtualMachines,
+		Requests:        &accessRequests,
+	}
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	kind := d.Get("kind").(string)
+	location := d.Get("asc_location").(string)
+	name := d.Get("name").(string)
+
+	policyId := fmt.Sprintf(
+		"/subscriptions/%v/resourceGroups/%v/providers/Microsoft.Security/locations/%v/jitNetworkAccessPolicies/%v",
+		subscriptionId, resourceGroup, location, name,
+	)
+
+	policyType := "Microsoft.Security/locations/jitNetworkAccessPolicies"
+
+	jitNetworkAccessPolicy := security.JitNetworkAccessPolicy{
+		ID:                               &policyId,
+		Name:                             &name,
+		Type:                             &policyType,
+		Kind:                             &kind,
+		Location:                         &location,
+		JitNetworkAccessPolicyProperties: &jitNetworkAccessPolicyProperties,
+	}
+
+	ascLocation := d.Get("asc_location").(string)
+
+	resp, err := client.CreateOrUpdate(ctx, resourceGroup, name, ascLocation, jitNetworkAccessPolicy)
+	if err != nil {
+		return fmt.Errorf("Error creating/updating Security Center Subscription pricing: %+v", err)
+	}
+
+	// the API returns 'done' but it's not actually finished provisioning yet
+	// Updating and Succeeded are the only states discovered so far, and may not be complete list
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{
+			string("Updating"),
+		},
+		Target: []string{
+			string("Succeeded"),
+		},
+		MinTimeout: 30 * time.Second,
+		Refresh: func() (interface{}, string, error) {
+			resp, err2 := client.Get(ctx, resourceGroup, name, ascLocation)
+			if err2 != nil {
+				return resp, "Error", fmt.Errorf("Error retrieving JIT Network Access  Policy %q (Location %q / Resource Group %q): %+v", name, ascLocation, resourceGroup, err2)
+			}
+
+			if properties := resp.JitNetworkAccessPolicyProperties; properties != nil {
+				return resp, string(*properties.ProvisioningState), nil
+			}
+
+			return resp, "Unknown", nil
+		},
+	}
+	if d.IsNewResource() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+	} else {
+		stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+	}
+
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for JIT Network Access  Policy %q (Location %q / Resource Group %q) to finish provisioning: %+v", name, ascLocation, resourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, resourceGroup, name, ascLocation)
+	if err != nil {
+		return err
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read JIT Network Access Policy %q (resource group %q) ID", name, resourceGroup)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmJitNetworkAccessPoliciesRead(d, meta)
+}
+
+func resourceArmJitNetworkAccessPoliciesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).SecurityCenter.JitNetworkAccessPoliciesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.JitNetworkAccessPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, id.Location)
+
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] JIT Network Access Policy %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving JIT Network Access Policy %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("asc_location", azure.NormalizeLocation(*location))
+	} else {
+		d.Set("asc_location", id.Location)
+	}
+	d.Set("kind", "Basic")
+
+	// flatten JitNetworkAccessPolicyProperties to create the virtualmachines struct for tf state
+	if resp.JitNetworkAccessPolicyProperties == nil {
+		return fmt.Errorf("retrieving Jit Network Access Policy %q (Resource Group %q): `JitNetworkAccessPolicyProperties` was nil", id.Name, id.ResourceGroup)
+	}
+
+	if err := d.Set("virtual_machines", flattenVirtualMachines(resp.JitNetworkAccessPolicyProperties.VirtualMachines)); err != nil {
+		return fmt.Errorf("settings 'JitNetworkAccessPolicyProperties': %+v", err)
+	}
+
+	return nil
+}
+
+func resourceArmJitNetworkAccessPoliciesDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).SecurityCenter.JitNetworkAccessPoliciesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[DEBUG] Security Center Subscription JIT Network Access Deletion invocation")
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	location := d.Get("asc_location").(string)
+
+	resp, err := client.Delete(ctx, resGroup, name, location)
+
+	if err != nil {
+		return fmt.Errorf("Error deleting JIT Network Access Policy %q (Resource Group %q): %s", name, resGroup, err)
+	} else {
+		fmt.Printf("Delete Succeeded %d\n", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/securitycenter/tests/resource_arm_security_jit_network_access_policies_test.go
+++ b/azurerm/internal/services/securitycenter/tests/resource_arm_security_jit_network_access_policies_test.go
@@ -1,0 +1,208 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccJitNetworkAccessPolicy_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_jit_network_access_policies", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMJitNetworkPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJitNetworkAccessPolicy_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckJitNetworkAccessPolicyExists(data),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testCheckJitNetworkAccessPolicyExists(data acceptance.TestData) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).SecurityCenter.JitNetworkAccessPoliciesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		jitNetworkAccessPolicyName := fmt.Sprintf("default_%d", data.RandomInteger)
+		jitRGName := fmt.Sprintf("acctestJIT_RG_%d", data.RandomInteger)
+		location := data.Locations.Primary
+		resp, err := client.Get(ctx, jitRGName, jitNetworkAccessPolicyName, location)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("[DEBUG EXISTS] Security Center Subscription Virtual Machine Jit Network Access Policy %q was not found: %+v", jitNetworkAccessPolicyName, err)
+			}
+
+			return fmt.Errorf("Bad: Get: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccJitNetworkAccessPolicy_basic(data acceptance.TestData) string {
+	template := testAccAzureRMJIT_Network_Access_Policy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_jit_network_access_policies" "jit" {
+	name = "default_%d"
+	asc_location = azurerm_resource_group.rg.location
+	resource_group_name = azurerm_resource_group.rg.name
+	kind = "Basic"
+	virtual_machines {
+		name = azurerm_virtual_machine.main.name
+		ports {
+			port = 22
+			protocol = "*"
+			allowed_source_address_prefix = "*"
+			max_request_access_duration = "PT3H"
+		}
+		
+	}
+	
+  }
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMJIT_Network_Access_Policy_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+	provider "azurerm" {
+		features {}
+	  }
+	  
+	  resource "azurerm_resource_group" "rg" {
+		name     = "acctestJIT_RG_%[1]d"
+		location = "%s"
+	  }
+	  
+	  # create vm
+	  resource "azurerm_virtual_network" "vnet" {
+		name                = "acctestJIT_network_%[1]d"
+		address_space       = ["10.0.0.0/16"]
+		location            = azurerm_resource_group.rg.location
+		resource_group_name = azurerm_resource_group.rg.name
+	  }
+	  
+	  resource "azurerm_subnet" "subnet" {
+		name                 = "subnet__%[1]d"
+		resource_group_name  = azurerm_resource_group.rg.name
+		virtual_network_name = azurerm_virtual_network.vnet.name
+		address_prefixes     = ["10.0.2.0/24"]
+	  }
+	  
+	  resource "azurerm_network_interface" "inet" {
+		name                = "nic__%[1]d"
+		location            = azurerm_resource_group.rg.location
+		resource_group_name = azurerm_resource_group.rg.name
+	  
+		ip_configuration {
+		  name                          = "testconfiguration1"
+		  subnet_id                     = azurerm_subnet.subnet.id
+		  private_ip_address_allocation = "Dynamic"
+		}
+	  }
+
+	  resource "azurerm_subnet_network_security_group_association" "nsg_subnet_association" {
+		subnet_id                 = azurerm_subnet.subnet.id
+		network_security_group_id = azurerm_network_security_group.vmnsg.id
+	  }
+
+	  resource "azurerm_network_security_group" "vmnsg"{
+		name = "nsg_%[1]d"
+		location            = azurerm_resource_group.rg.location
+		resource_group_name = azurerm_resource_group.rg.name
+		security_rule {
+		name						="acctest_secrule"
+		priority                   = 1000
+		direction                  = "Inbound"
+		access                     = "Deny"
+		protocol                   = "Tcp"
+		source_port_range          = "*"
+		destination_port_range     = "*"
+		source_address_prefix      = "*"
+		destination_address_prefix = "*"
+		}
+	
+	}
+
+	resource "azurerm_public_ip" "public_vm_ip" {
+		name                = "vm_ip_%[1]d"
+		resource_group_name = azurerm_resource_group.rg.name
+		location            = azurerm_resource_group.rg.location
+		allocation_method   = "Dynamic"
+	  
+	  }
+
+	  resource "azurerm_virtual_machine" "main" {
+		name                             = "vm_%[1]d"
+		location                         = azurerm_resource_group.rg.location
+		resource_group_name              = azurerm_resource_group.rg.name
+		network_interface_ids            = [azurerm_network_interface.inet.id]
+		vm_size                          = "Standard_A1_v2"
+		delete_os_disk_on_termination    = true
+		delete_data_disks_on_termination = true
+	  
+		storage_image_reference {
+		  publisher = "Canonical"
+		  offer     = "UbuntuServer"
+		  sku       = "16.04-LTS"
+		  version   = "latest"
+		}
+		storage_os_disk {
+		  name              = "disk1"
+		  caching           = "ReadWrite"
+		  create_option     = "FromImage"
+		  managed_disk_type = "Standard_LRS"
+		}
+		os_profile {
+		  computer_name  = "hostname"
+		  admin_username = "tester"
+		  admin_password = "12345&tester"
+		}
+		os_profile_linux_config {
+		  disable_password_authentication = false
+		}
+	  }
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testCheckAzureRMJitNetworkPolicyDestroy(s *terraform.State) error {
+	conn := acceptance.AzureProvider.Meta().(*clients.Client).SecurityCenter.JitNetworkAccessPoliciesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_jit_network_access_policies" {
+			continue
+		}
+
+		jitPolicyName := rs.Primary.Attributes["name"] //"default" // rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		location := rs.Primary.Attributes["asc_location"]
+
+		resp, err := conn.Get(ctx, resourceGroup, jitPolicyName, location)
+
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return fmt.Errorf("Bad: Get Server: %+v", err)
+		}
+
+		return fmt.Errorf("JIT Network Access Policy %s still exists", jitPolicyName)
+	}
+
+	return nil
+}

--- a/examples/security/securitycenter-jitnetworkacesspolicy/main.tf
+++ b/examples/security/securitycenter-jitnetworkacesspolicy/main.tf
@@ -1,0 +1,117 @@
+	provider "azurerm" {
+		features {}
+	  }
+	  
+	  resource "azurerm_resource_group" "rg" {
+		name     = "acctestJIT_RG-4"
+		location = "NorthEurope"
+	  }
+	  
+	  # create vm
+	  resource "azurerm_virtual_network" "vnet" {
+		name                = "acctestJIT_network"
+		address_space       = ["10.0.0.0/16"]
+		location            = azurerm_resource_group.rg.location
+		resource_group_name = azurerm_resource_group.rg.name
+	  }
+	  
+	  resource "azurerm_subnet" "subnet" {
+		name                 = "internal"
+		resource_group_name  = azurerm_resource_group.rg.name
+		virtual_network_name = azurerm_virtual_network.vnet.name
+		address_prefixes     = ["10.0.2.0/24"]
+	  }
+	  
+	  resource "azurerm_subnet_network_security_group_association" "example" {
+  		subnet_id                 = azurerm_subnet.subnet.id
+  		network_security_group_id = azurerm_network_security_group.vmnsg.id
+		}
+
+	  resource "azurerm_network_interface" "inet" {
+		name                = "acctestJIT-nic"
+		location            = azurerm_resource_group.rg.location
+		resource_group_name = azurerm_resource_group.rg.name
+	  
+		ip_configuration {
+		  name                          = "testconfiguration1"
+		  subnet_id                     = azurerm_subnet.subnet.id
+		  private_ip_address_allocation = "Dynamic"
+      public_ip_address_id          = azurerm_public_ip.public_vm_ip.id
+
+		}
+	  }
+	  
+	  resource "azurerm_virtual_machine" "main" {
+		name                             = "acctestJIT-vm1"
+		location                         = azurerm_resource_group.rg.location
+		resource_group_name              = azurerm_resource_group.rg.name
+		network_interface_ids            = [azurerm_network_interface.inet.id]
+		vm_size                          = "Standard_A1_v2"
+		delete_os_disk_on_termination    = true
+		delete_data_disks_on_termination = true
+
+		storage_image_reference {
+		  publisher = "Canonical"
+		  offer     = "UbuntuServer"
+		  sku       = "16.04-LTS"
+		  version   = "latest"
+		}
+		storage_os_disk {
+		  name              = "disk1"
+		  caching           = "ReadWrite"
+		  create_option     = "FromImage"
+		  managed_disk_type = "Standard_LRS"
+		}
+		os_profile {
+		  computer_name  = "hostname"
+		  admin_username = "tester"
+		  admin_password = "12345&tester"
+		}
+		os_profile_linux_config {
+		  disable_password_authentication = false
+		}
+	  }
+
+resource "azurerm_network_security_group" "vmnsg"{
+	name = "acctestnsg"
+	location            = azurerm_resource_group.rg.location
+	resource_group_name = azurerm_resource_group.rg.name
+    security_rule {
+	name						="acctest_secrule"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+    }
+
+}
+
+resource "azurerm_public_ip" "public_vm_ip" {
+  name                = "acctest_vm_ip"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  allocation_method   = "Dynamic"
+
+}
+
+resource "azurerm_jit_network_access_policies" "jit-4" {
+	name = "default-4"
+	asc_location = azurerm_resource_group.rg.location
+	resource_group_name = azurerm_resource_group.rg.name
+	kind = "Basic"
+	virtual_machines {
+		name = azurerm_virtual_machine.main.name
+		ports {
+			port = 22
+			protocol = "*"
+			allowed_source_address_prefix = "*"
+			max_request_access_duration = "PT3H"
+		}
+		
+	}
+	depends_on = [azurerm_resource_group.rg,azurerm_network_security_group.vmnsg]
+  }


### PR DESCRIPTION
Adds the Azure just-in-time network access policy setting capability for virtual machine ports documented in issue [#3661 ](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3661)

Implemented as part of the Security Center resources. The acceptance test demonstrates the implementation of the JIT network access policies on the required Network Security Group (NSG) associated with a subnet used by the target virtual machine.  The JIT Network Access Policy REST API creates a new security rule on the NSG which currently trips up Terraform state management. 

Expert guidance would be appreciated on how to best resolve this. E,G, Make functionality part of the NSG resource provider

Implemented in this draft PR for the JIT Network Access Policy:
1. Custom client to accommodate the passing of a location parameter (default client is hardcoded to Global)
2. Parse functionality
3. Basic acceptance test
4. Example Terraform including the *required* virtual machine, subnet, network security group dependency
5. Resource implementation using simple schema:

```
resource "azurerm_jit_network_access_policies" "test-jit-network-access" {
	name = "default-test"
	asc_location = "northeurope"
	resource_group_name = "test-jit"
	kind = "Basic"
	virtual_machines {
		name = "test-jit-vm-1"
		ports {
			port = 22
			protocol = "*"
			allowed_source_address_prefix = "*"
			max_request_access_duration = "PT3H"
		}	
	}
  }
