### PR TITLE
azurerm_kubernetes_cluster, azurerm_kubernetes_cluster_node_pool - make "availability_zones" force new

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -76,6 +76,7 @@ func resourceArmKubernetesClusterNodePool() *schema.Resource {
 			"availability_zones": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -49,6 +49,7 @@ func SchemaDefaultNodePool() *schema.Schema {
 				"availability_zones": {
 					Type:     schema.TypeList,
 					Optional: true,
+					ForceNew: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -223,7 +223,7 @@ A `default_node_pool` block supports the following:
 
 * `vm_size` - (Required) The size of the Virtual Machine, such as `Standard_DS2_v2`.
 
-* `availability_zones` - (Optional) A list of Availability Zones across which the Node Pool should be spread.
+* `availability_zones` - (Optional) A list of Availability Zones across which the Node Pool should be spread. Changing this forces a new resource to be created.
 
 -> **NOTE:** This requires that the `type` is set to `VirtualMachineScaleSets` and that `load_balancer_sku` is set to `Standard`.
 
@@ -487,8 +487,6 @@ provider "kubernetes" {
 ```
 
 ## Timeouts
-
-
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 ---
 
-* `availability_zones` - (Optional) A list of Availability Zones where the Nodes in this Node Pool should be created in.
+* `availability_zones` - (Optional) A list of Availability Zones where the Nodes in this Node Pool should be created in. Changing this forces a new resource to be created.
 
 * `enable_auto_scaling` - (Optional) Whether to enable [auto-scaler](https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler). Defaults to `false`.
 


### PR DESCRIPTION
fix #7780

based on https://docs.microsoft.com/en-us/azure/aks/availability-zones#limitations-and-region-availability
zone could not be updated