### PR TITLE
Container configuration batch pool

### DIFF
--- a/azurerm/internal/services/batch/batch_pool.go
+++ b/azurerm/internal/services/batch/batch_pool.go
@@ -567,7 +567,7 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 		WaitForSuccess:    &waitForSuccess,
 		UserIdentity:      &userIdentity,
 		ResourceFiles:     &resourceFiles,
-		ContainerSettings: &containerSettings,
+		ContainerSettings: &containerConfiguration,
 	}
 
 	// populate environment settings, if defined

--- a/azurerm/internal/services/batch/batch_pool.go
+++ b/azurerm/internal/services/batch/batch_pool.go
@@ -133,16 +133,16 @@ func flattenBatchPoolStartTask(startTask *batch.StartTask) []interface{} {
 		if startTask.ContainerSettings.ContainerRunOptions != nil {
 			containerSettings["container_run_settings"] = *startTask.ContainerSettings.ContainerRunOptions
 		}
-	
+
 		if startTask.ContainerSettings.ImageName != nil {
 			containerSettings["image_name"] = *startTask.ContainerSettings.ImageName
 		}
-	
+
 		containerSettings["working_directory"] = string(startTask.ContainerSettings.WorkingDirectory)
-	
+
 		if startTask.ContainerSettings.Registry != nil {
 			registry := make(map[string]interface{})
-	
+
 			if startTask.ContainerSettings.Registry.UserName != nil {
 				registry["user_name"] = startTask.ContainerSettings.Registry.UserName
 			}
@@ -513,8 +513,6 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 			}
 		}
 	}
-
-
 
 	resourceFileList := startTaskValue["resource_file"].([]interface{})
 	resourceFiles := make([]batch.ResourceFile, 0)

--- a/azurerm/internal/services/batch/batch_pool.go
+++ b/azurerm/internal/services/batch/batch_pool.go
@@ -131,7 +131,7 @@ func flattenBatchPoolStartTask(startTask *batch.StartTask) []interface{} {
 		containerSettings := make(map[string]interface{})
 
 		if startTask.ContainerSettings.ContainerRunOptions != nil {
-			containerSettings["container_run_settings"] = *startTask.ContainerSettings.ContainerRunOptions
+			containerSettings["container_run_options"] = *startTask.ContainerSettings.ContainerRunOptions
 		}
 
 		if startTask.ContainerSettings.ImageName != nil {
@@ -479,8 +479,11 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 		}
 	}
 
-	if v, ok := containerConfigurationValue["container_run_settings"]; ok {
-		containerConfiguration.ContainerRunOptions = utils.String(v.(string))
+	if v, ok := containerConfigurationValue["container_run_options"]; ok {
+		containerRunOptions := v.(string)
+		if containerRunOptions != "" {
+			containerConfiguration.ContainerRunOptions = utils.String(containerRunOptions)
+		}
 	}
 
 	if v, ok := containerConfigurationValue["working_directory"]; ok {

--- a/azurerm/internal/services/batch/batch_pool.go
+++ b/azurerm/internal/services/batch/batch_pool.go
@@ -490,7 +490,7 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 		containerConfiguration.WorkingDirectory = batch.ContainerWorkingDirectory(v.(string))
 	}
 
-	if v, ok := containerConfigurationValue["registry"]; ok {
+	if _, ok := containerConfigurationValue["registry"]; ok {
 		registryList := containerConfigurationValue["registry"].([]interface{})
 		registryValue := registryList[0].(map[string]interface{})
 		registry := batch.ContainerRegistry{}

--- a/azurerm/internal/services/batch/batch_pool_data_source.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source.go
@@ -289,7 +289,7 @@ func dataSourceArmBatchPool() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"container_run_settings": {
+									"container_run_options": {
 										Type:     schema.TypeString,
 										Computed: true,
 									},

--- a/azurerm/internal/services/batch/batch_pool_data_source.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source.go
@@ -283,6 +283,47 @@ func dataSourceArmBatchPool() *schema.Resource {
 								},
 							},
 						},
+
+						"container_configuration": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"container_run_settings": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"image_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"working_directory": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"registry": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"registry_server": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"user_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"password": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/azurerm/internal/services/batch/batch_pool_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source_test.go
@@ -40,6 +40,13 @@ func TestAccBatchPoolDataSource_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.scope", "Task"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.elevation_level", "NonAdmin"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--testflag"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.image_name", "testimage"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.working_directory", "ContainerImageDefault"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.0.registry_server", "myContainerRegistry"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.0.user_name", "myUserName"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "certificate.0.id"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.store_location", "CurrentUser"),
@@ -148,6 +155,17 @@ resource "azurerm_batch_pool" "test" {
       auto_user {
         elevation_level = "NonAdmin"
         scope           = "Task"
+      }
+    }
+
+    container_configuration {
+      container_run_settings = "--testflag"
+      image_name             = "testimage"
+      working_directory      = "ContainerImageDefault"
+      registry {
+        registry_server = "myContainerRegistry.azurecr.io"
+        user_name       = "myUserName"
+        password        = "myPassword"
       }
     }
   }

--- a/azurerm/internal/services/batch/batch_pool_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source_test.go
@@ -41,7 +41,7 @@ func TestAccBatchPoolDataSource_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.scope", "Task"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.elevation_level", "NonAdmin"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--workdir /app"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_options", "--workdir /app"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.image_name", "testimage"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.working_directory", "ContainerImageDefault"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.#", "1"),
@@ -159,7 +159,7 @@ resource "azurerm_batch_pool" "test" {
     }
 
     container_configuration {
-      container_run_settings = "--workdir /app"
+      container_run_options = "--workdir /app"
       image_name             = "testimage"
       working_directory      = "ContainerImageDefault"
       registry {

--- a/azurerm/internal/services/batch/batch_pool_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source_test.go
@@ -160,8 +160,8 @@ resource "azurerm_batch_pool" "test" {
 
     container_configuration {
       container_run_options = "--workdir /app"
-      image_name             = "testimage"
-      working_directory      = "ContainerImageDefault"
+      image_name            = "testimage"
+      working_directory     = "ContainerImageDefault"
       registry {
         registry_server = "myContainerRegistry.azurecr.io"
         user_name       = "myUserName"

--- a/azurerm/internal/services/batch/batch_pool_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source_test.go
@@ -41,7 +41,7 @@ func TestAccBatchPoolDataSource_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.scope", "Task"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.elevation_level", "NonAdmin"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--testflag"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--workdir /app"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.image_name", "testimage"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.working_directory", "ContainerImageDefault"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.#", "1"),
@@ -159,7 +159,7 @@ resource "azurerm_batch_pool" "test" {
     }
 
     container_configuration {
-      container_run_settings = "--testflag"
+      container_run_settings = "--workdir /app"
       image_name             = "testimage"
       working_directory      = "ContainerImageDefault"
       registry {

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -380,6 +380,67 @@ func resourceArmBatchPool() *schema.Resource {
 								},
 							},
 						},
+
+						"container_configuration": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"container_run_settings": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:   true,
+									},
+									"image_name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:   true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"working_directory": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:   true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(batch.ContainerWorkingDirectory.ContainerImageDefault),
+											string(batch.ContainerWorkingDirectory.ContainerWorkingDirectory),
+										}),
+									},
+									"registry": {
+										Type:       schema.TypeList,
+										Required:   true,
+										ForceNew:   true,
+										MinItems: 1,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"registry_server": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+												"user_name": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+												"password": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ForceNew:     true,
+													Sensitive:    true,
+													ValidateFunc: validation.StringIsNotEmpty,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -389,9 +389,9 @@ func resourceArmBatchPool() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"container_run_options": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"image_name": {
@@ -405,8 +405,8 @@ func resourceArmBatchPool() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
-											string(batch.ContainerWorkingDirectory.ContainerImageDefault),
-											string(batch.ContainerWorkingDirectory.ContainerWorkingDirectory),
+											string(batch.ContainerImageDefault),
+											string(batch.ContainerWorkingDirectory),
 										}, false),
 									},
 									"registry": {

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -407,7 +407,7 @@ func resourceArmBatchPool() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											string(batch.ContainerWorkingDirectory.ContainerImageDefault),
 											string(batch.ContainerWorkingDirectory.ContainerWorkingDirectory),
-										}),
+										}, false),
 									},
 									"registry": {
 										Type:     schema.TypeList,

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -389,29 +389,29 @@ func resourceArmBatchPool() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"container_run_settings": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:   true,
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
 									},
 									"image_name": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ForceNew:   true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"working_directory": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:   true,
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											string(batch.ContainerWorkingDirectory.ContainerImageDefault),
 											string(batch.ContainerWorkingDirectory.ContainerWorkingDirectory),
 										}),
 									},
 									"registry": {
-										Type:       schema.TypeList,
-										Required:   true,
-										ForceNew:   true,
+										Type:     schema.TypeList,
+										Required: true,
+										ForceNew: true,
 										MinItems: 1,
 										MaxItems: 1,
 										Elem: &schema.Resource{

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -406,7 +406,7 @@ func resourceArmBatchPool() *schema.Resource {
 										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											string(batch.ContainerImageDefault),
-											string(batch.ContainerWorkingDirectory),
+											string(batch.TaskWorkingDirectory),
 										}, false),
 									},
 									"registry": {

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -388,10 +388,11 @@ func resourceArmBatchPool() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"container_run_settings": {
+									"container_run_options": {
 										Type:     schema.TypeString,
 										Optional: true,
 										ForceNew: true,
+										ValidateFunc: validation.StringIsNotEmpty,
 									},
 									"image_name": {
 										Type:         schema.TypeString,

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -264,7 +264,7 @@ func TestAccBatchPoolStartTask_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.elevation_level", "NonAdmin"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.working_directory", "TaskWorkingDirectory"),
-					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--testflag"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--workdir /app"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.image_name", "centos7"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.0.registry_server", "myContainerRegistry.azurecr.io"),
@@ -1509,7 +1509,7 @@ resource "azurerm_batch_pool" "test" {
     }
 
     container_configuration {
-      container_run_settings = "--testflag"
+      container_run_settings = "--workdir /app"
       image_name             = "centos7"
       working_directory      = "TaskWorkingDirectory"
       registry {

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -229,7 +229,7 @@ func TestAccBatchPoolStartTask_basic(t *testing.T) {
 	})
 }
 
-func TestAccBatchPoolStartTask_basic(t *testing.T) {
+func TestAccBatchPoolStartTask_withContainerConfiguration(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -238,7 +238,7 @@ func TestAccBatchPoolStartTask_basic(t *testing.T) {
 		CheckDestroy: testCheckBatchPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBatchPoolStartTask_basic(data),
+				Config: testAccBatchPoolStartTask_basicWithContainerConfiguration(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckBatchPoolExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "vm_size", "STANDARD_A1"),

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -264,7 +264,7 @@ func TestAccBatchPoolStartTask_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.user_identity.0.auto_user.0.elevation_level", "NonAdmin"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.working_directory", "TaskWorkingDirectory"),
-					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_settings", "--workdir /app"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.container_run_options", "--workdir /app"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.image_name", "centos7"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start_task.0.container_configuration.0.registry.0.registry_server", "myContainerRegistry.azurecr.io"),
@@ -1509,7 +1509,7 @@ resource "azurerm_batch_pool" "test" {
     }
 
     container_configuration {
-      container_run_settings = "--workdir /app"
+      container_run_options = "--workdir /app"
       image_name             = "centos7"
       working_directory      = "TaskWorkingDirectory"
       registry {

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -1510,8 +1510,8 @@ resource "azurerm_batch_pool" "test" {
 
     container_configuration {
       container_run_options = "--workdir /app"
-      image_name             = "centos7"
-      working_directory      = "TaskWorkingDirectory"
+      image_name            = "centos7"
+      working_directory     = "TaskWorkingDirectory"
       registry {
         registry_server = "myContainerRegistry.azurecr.io"
         user_name       = "myUserName"

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -97,7 +97,7 @@ A `container_configuration` block within a `start_task` block supports the follo
 
 ~> **Please Note:** If `working_directory` is set to `ContainerImageDefault`, this directory will not contain the resource files downloaded by Batch.
 
-* `container_run_settings` - Run settings for the container
+* `container_run_options` - Run options for the container
 
 ---
 

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -83,6 +83,32 @@ A `start_task` block exports the following:
 
 * `resource_file` - One or more `resource_file` blocks that describe the files to be downloaded to a compute node.
 
+* `container_configuration` - A `container_configuration` block that describes the container settings for the start task.
+
+---
+
+A `container_configuration` block within a `start_task` block supports the following:
+
+* `image_name` - The image name of the container. Changing this forces a new resource to be created.
+
+* `registry` - A `registry` block for the container registry. Changing this forces a new resource to be created.
+
+* `working_directory` - The working directory for the container.  Can be set to `ContainerImageDefault` or `TaskWorkingDirectory`. 
+
+~> **Please Note:** If `working_directory` is set to `ContainerImageDefault`, this directory will not contain the resource files downloaded by Batch.
+
+* `container_run_settings` - Run settings for the container
+
+---
+
+A `registry` block supports the following:
+
+* `registry_server` - The container registry URL. The default is "docker.io". Changing this forces a new resource to be created.
+
+* `user_name` - The user name to log into the registry server. Changing this forces a new resource to be created.
+
+* `password` - The password to log into the registry server. Changing this forces a new resource to be created.
+
 ---
 
 A `user_identity` block exports the following:

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -215,7 +215,7 @@ A `container_configuration` block within a `start_task` block supports the follo
 
 ~> **Please Note:** If `working_directory` is set to `ContainerImageDefault`, this directory will not contain the resource files downloaded by Batch.
 
-* `container_run_settings` - (Optional) Run settings for the container
+* `container_run_options` - (Optional) Run options for the container
 
 ---
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -201,6 +201,34 @@ A `start_task` block supports the following:
 
 * `resource_file` - (Optional) One or more `resource_file` blocks that describe the files to be downloaded to a compute node.
 
+* `container_configuration` - (Optional) A `container_configuration` block that describes the container settings for the start task.
+
+---
+
+A `container_configuration` block within a `start_task` block supports the following:
+
+* `image_name` - (Required) The image name of the container. Changing this forces a new resource to be created.
+
+* `registry` - (Required) A `registry` block for the container registry. Changing this forces a new resource to be created.
+
+* `working_directory` - (Required) The working directory for the container.  Can be set to `ContainerImageDefault` or `TaskWorkingDirectory`. 
+
+~> **Please Note:** If `working_directory` is set to `ContainerImageDefault`, this directory will not contain the resource files downloaded by Batch.
+
+* `container_run_settings` - (Optional) Run settings for the container
+
+
+---
+
+A `registry` block supports the followin:
+
+* `registry_server` - (Optional) The container registry URL. The default is "docker.io". Changing this forces a new resource to be created.
+
+* `user_name` - (Optional) The user name to log into the registry server. Changing this forces a new resource to be created.
+
+* `password` - (Optional) The password to log into the registry server. Changing this forces a new resource to be created.
+
+
 ---
 
 A `user_identity` block supports the following:

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -217,17 +217,15 @@ A `container_configuration` block within a `start_task` block supports the follo
 
 * `container_run_settings` - (Optional) Run settings for the container
 
-
 ---
 
-A `registry` block supports the followin:
+A `registry` block supports the following:
 
 * `registry_server` - (Optional) The container registry URL. The default is "docker.io". Changing this forces a new resource to be created.
 
 * `user_name` - (Optional) The user name to log into the registry server. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The password to log into the registry server. Changing this forces a new resource to be created.
-
 
 ---
 


### PR DESCRIPTION
This resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/7001, modifying both the resource and data source to include the `container_configuration` setting for the start task.

There is a root level `container_configuration` block as well, so the documentation tries to make clear that the `container_configuration` block inside the `start_task` has some different configuration properties and the two should not be confused.

If there are additional restrictions (rules around when `container_configuration` can be specified for a start task) let me know and I can alter this PR.  I did not find any in the documentation.
