### PR TITLE
add gateway_resource_id property

### DIFF
--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
@@ -72,6 +72,12 @@ func resourceArmAnalysisServicesServer() *schema.Resource {
 				}, false),
 			},
 
+			"gateway_resource_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
 			"admin_users": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -241,6 +247,10 @@ func resourceArmAnalysisServicesServerRead(d *schema.ResourceData, meta interfac
 		if containerUri, ok := d.GetOk("backup_blob_container_uri"); ok {
 			d.Set("backup_blob_container_uri", containerUri)
 		}
+
+		if gatewayDetails := serverProps.GatewayDetails; gatewayDetails != nil {
+			d.Set("gateway_resource_id", gatewayDetails.GatewayResourceID)
+		}
 	}
 
 	return tags.FlattenAndSet(d, server.Tags)
@@ -363,6 +373,12 @@ func expandAnalysisServicesServerProperties(d *schema.ResourceData) *analysisser
 
 	if querypoolConnectionMode, ok := d.GetOk("querypool_connection_mode"); ok {
 		serverProperties.QuerypoolConnectionMode = analysisservices.ConnectionMode(querypoolConnectionMode.(string))
+	}
+
+	if gatewayResourceID, ok := d.GetOk("gateway_resource_id"); ok {
+		serverProperties.GatewayDetails = &analysisservices.GatewayDetails{
+			GatewayResourceID: utils.String(gatewayResourceID.(string)),
+		}
 	}
 
 	if containerUri, ok := d.GetOk("backup_blob_container_uri"); ok {

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `ipv4_firewall_rule` - (Optional) One or more `ipv4_firewall_rule` block(s) as defined below.
 
+* `gateway_resource_id` - (Optional) The resource ID of the on-premise gateway.
+
 ---
 
 A `ipv4_firewall_rule` block supports the following:


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/8537

The resource ID is of an on premises data gateway, which apparently there is no Terraform resource for, so acceptance testing wise, I don't think it's possible to write one for this property.  I'm open to any advice on handling this.