### PR TITLE
make "kube_dashboard" Optional + Computed - azurerm_kubernetes_cluster

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -86,6 +86,7 @@ func schemaKubernetesAddOnProfiles() *schema.Schema {
 					Type:     schema.TypeList,
 					MaxItems: 1,
 					Optional: true,
+					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"enabled": {


### PR DESCRIPTION
fix #7716

it seems the service behaviour has changed and kube dashboard is enabled by default.
I have rerun all related acctest, all could succeed