### PR TITLE
log_analytics_workspace: support for the `daily_quota_gb` property

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_data_source.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_data_source.go
@@ -41,6 +41,11 @@ func dataSourceLogAnalyticsWorkspace() *schema.Resource {
 				Computed: true,
 			},
 
+			"daily_quota_gb": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+
 			"workspace_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -100,6 +105,12 @@ func dataSourceLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface{
 		d.Set("sku", sku.Name)
 	}
 	d.Set("retention_in_days", resp.RetentionInDays)
+
+	if workspaceCapping := resp.WorkspaceCapping; workspaceCapping != nil {
+		d.Set("daily_quota_gb", resp.WorkspaceCapping.DailyQuotaGb)
+	} else {
+		d.Set("daily_quota_gb", utils.Float(-1))
+	}
 
 	sharedKeys, err := sharedKeysClient.GetSharedKeys(ctx, resGroup, name)
 	if err != nil {

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -137,7 +137,7 @@ func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta i
 	}
 
 	retentionInDays := int32(d.Get("retention_in_days").(int))
-	dailyQuotaGb := float64(d.Get("daily_quota_gb").(float64))
+	dailyQuotaGb := d.Get("daily_quota_gb").(float64)
 
 	t := d.Get("tags").(map[string]interface{})
 

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -73,6 +73,13 @@ func resourceArmLogAnalyticsWorkspace() *schema.Resource {
 				ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
 			},
 
+			"daily_quota_gb": {
+				Type:         schema.TypeFloat,
+				Optional:     true,
+				Default:      float64(-1),
+				ValidateFunc: validation.Any(validation.FloatBetween(-1, -1), validation.FloatAtLeast(0)),
+			},
+
 			"workspace_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -130,6 +137,7 @@ func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta i
 	}
 
 	retentionInDays := int32(d.Get("retention_in_days").(int))
+	dailyQuotaGb := float64(d.Get("daily_quota_gb").(float64))
 
 	t := d.Get("tags").(map[string]interface{})
 
@@ -140,6 +148,9 @@ func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta i
 		WorkspaceProperties: &operationalinsights.WorkspaceProperties{
 			Sku:             sku,
 			RetentionInDays: &retentionInDays,
+			WorkspaceCapping: &operationalinsights.WorkspaceCapping{
+				DailyQuotaGb: &dailyQuotaGb,
+			},
 		},
 	}
 
@@ -197,6 +208,11 @@ func resourceArmLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface
 		d.Set("sku", sku.Name)
 	}
 	d.Set("retention_in_days", resp.RetentionInDays)
+	if workspaceCapping := resp.WorkspaceCapping; workspaceCapping != nil {
+		d.Set("daily_quota_gb", resp.WorkspaceCapping.DailyQuotaGb)
+	} else {
+		d.Set("daily_quota_gb", utils.Float(-1))
+	}
 
 	sharedKeys, err := sharedKeysClient.GetSharedKeys(ctx, id.ResourceGroup, id.Name)
 	if err != nil {

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -76,7 +76,7 @@ func resourceArmLogAnalyticsWorkspace() *schema.Resource {
 			"daily_quota_gb": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				Default:      float64(-1),
+				Default:      -1.0,
 				ValidateFunc: validation.Any(validation.FloatBetween(-1, -1), validation.FloatAtLeast(0)),
 			},
 

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_data_source_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_data_source_test.go
@@ -21,6 +21,27 @@ func TestAccDataSourceAzureRMLogAnalyticsWorkspace_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "sku", "pergb2018"),
 					resource.TestCheckResourceAttr(data.ResourceName, "retention_in_days", "30"),
+					resource.TestCheckResourceAttr(data.ResourceName, "daily_quota_gb", "-1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMLogAnalyticsWorkspace_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_log_analytics_workspace", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMLogAnalyticsWorkspace_volumeCapWithDataSource(data, 4.5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "sku", "pergb2018"),
+					resource.TestCheckResourceAttr(data.ResourceName, "retention_in_days", "30"),
+					resource.TestCheckResourceAttr(data.ResourceName, "daily_quota_gb", "4.5"),
 				),
 			},
 		},
@@ -29,6 +50,18 @@ func TestAccDataSourceAzureRMLogAnalyticsWorkspace_basic(t *testing.T) {
 
 func testAccDataSourceAzureRMLogAnalyticsWorkspace_basicWithDataSource(data acceptance.TestData) string {
 	config := testAccAzureRMLogAnalyticsWorkspace_complete(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_log_analytics_workspace" "test" {
+  name                = azurerm_log_analytics_workspace.test.name
+  resource_group_name = azurerm_log_analytics_workspace.test.resource_group_name
+}
+`, config)
+}
+
+func testAccDataSourceAzureRMLogAnalyticsWorkspace_volumeCapWithDataSource(data acceptance.TestData) string {
+	config := testAccAzureRMLogAnalyticsWorkspace_withVolumeCap(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_data_source_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccDataSourceAzureRMLogAnalyticsWorkspace_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAzureRMLogAnalyticsWorkspace_basic(t *testing.T) {
+func TestAccDataSourceAzureRMLogAnalyticsWorkspace_volumeCapWithDataSource(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_log_analytics_workspace", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_data_source_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_data_source_test.go
@@ -60,8 +60,8 @@ data "azurerm_log_analytics_workspace" "test" {
 `, config)
 }
 
-func testAccDataSourceAzureRMLogAnalyticsWorkspace_volumeCapWithDataSource(data acceptance.TestData) string {
-	config := testAccAzureRMLogAnalyticsWorkspace_withVolumeCap(data)
+func testAccDataSourceAzureRMLogAnalyticsWorkspace_volumeCapWithDataSource(data acceptance.TestData, volumeCapGb float64) string {
+	config := testAccAzureRMLogAnalyticsWorkspace_withVolumeCap(data, volumeCapGb)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
@@ -146,7 +146,6 @@ func TestAccAzureRMLogAnalyticsWorkspace_withDefaultSku(t *testing.T) {
 				Config: testAccAzureRMLogAnalyticsWorkspace_withDefaultSku(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogAnalyticsWorkspaceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "daily_quota_gb", "-1"),
 				),
 			},
 			data.ImportStep(),
@@ -166,7 +165,6 @@ func TestAccAzureRMLogAnalyticsWorkspace_withVolumeCap(t *testing.T) {
 				Config: testAccAzureRMLogAnalyticsWorkspace_withVolumeCap(data, 4.5),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogAnalyticsWorkspaceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "daily_quota_gb", "4.5"),
 				),
 			},
 			data.ImportStep(),
@@ -346,7 +344,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
-  daily_quota_gb    = %d
+  daily_quota_gb      = %d
 
   tags = {
     Environment = "Test"

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
@@ -346,7 +346,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
-  daily_volume_cap    = %d
+  daily_quota_gb    = %d
 
   tags = {
     Environment = "Test"

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
@@ -344,7 +344,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
-  daily_quota_gb      = %d
+  daily_quota_gb      = %f
 
   tags = {
     Environment = "Test"

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
@@ -332,7 +332,7 @@ func testAccAzureRMLogAnalyticsWorkspace_withVolumeCap(data acceptance.TestData,
 provider "azurerm" {
   features {}
 }
-	
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -46,7 +46,7 @@ The following attributes are exported:
 
 * `retention_in_days` - The workspace data retention in days.
 
-* `daily_quota_gb` - The workspace of the volume cap in gb.  Defaults to -1 (unlimited).
+* `daily_quota_gb` - The workspace daily quota for ingestion in GB.
 
 * `tags` - A mapping of tags assigned to the resource.
 

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -46,6 +46,8 @@ The following attributes are exported:
 
 * `retention_in_days` - The workspace data retention in days.
 
+* `daily_quota_gb` - The workspace of the volume cap in gb.  Defaults to -1 (unlimited).
+
 * `tags` - A mapping of tags assigned to the resource.
 
 ## Timeouts

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `retention_in_days` - (Optional) The workspace data retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 
+* `daily_quota_gb` - (Optional) The workspace of the volume cap in gb.  Defaults to -1 (unlimited).
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `retention_in_days` - (Optional) The workspace data retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 
-* `daily_quota_gb` - (Optional) The workspace of the volume cap in gb.  Defaults to -1 (unlimited).
+* `daily_quota_gb` - (Optional) The workspace daily quota for ingestion in GB.  Defaults to -1 (unlimited).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/3288

The daily volume cap is off by default as per [the docs](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/manage-cost-storage#daily-cap), so I've set the default value to -1 which means unlimited (no cap).  Validation is set to either be -1 or some non-negative value.

One new test per resource/data source added, and one old test updated to confirm default value.