### PR TITLE
azurerm_firewall: supports `dns_setting`

### DIFF
--- a/azurerm/internal/services/network/firewall_network_rule_collection_resource.go
+++ b/azurerm/internal/services/network/firewall_network_rule_collection_resource.go
@@ -463,30 +463,40 @@ func flattenFirewallNetworkRuleCollectionRules(rules *[]network.AzureFirewallNet
 	}
 
 	for _, rule := range *rules {
-		output := make(map[string]interface{})
+		var (
+			name            string
+			description     string
+			sourceAddresses *schema.Set
+			sourceIPGroups  *schema.Set
+			destAddresses   *schema.Set
+			destIPGroups    *schema.Set
+			destPorts       *schema.Set
+			destFqdns       *schema.Set
+		)
+
 		if rule.Name != nil {
-			output["name"] = *rule.Name
+			name = *rule.Name
 		}
 		if rule.Description != nil {
-			output["description"] = *rule.Description
+			description = *rule.Description
 		}
 		if rule.SourceAddresses != nil {
-			output["source_addresses"] = set.FromStringSlice(*rule.SourceAddresses)
+			sourceAddresses = set.FromStringSlice(*rule.SourceAddresses)
 		}
 		if rule.SourceIPGroups != nil {
-			output["source_ip_groups"] = set.FromStringSlice(*rule.SourceIPGroups)
+			sourceIPGroups = set.FromStringSlice(*rule.SourceIPGroups)
 		}
 		if rule.DestinationAddresses != nil {
-			output["destination_addresses"] = set.FromStringSlice(*rule.DestinationAddresses)
+			destAddresses = set.FromStringSlice(*rule.DestinationAddresses)
 		}
 		if rule.DestinationIPGroups != nil {
-			output["destination_ip_groups"] = set.FromStringSlice(*rule.DestinationIPGroups)
+			destIPGroups = set.FromStringSlice(*rule.DestinationIPGroups)
 		}
 		if rule.DestinationPorts != nil {
-			output["destination_ports"] = set.FromStringSlice(*rule.DestinationPorts)
+			destPorts = set.FromStringSlice(*rule.DestinationPorts)
 		}
 		if rule.DestinationFqdns != nil {
-			output["destination_fqdns"] = set.FromStringSlice(*rule.DestinationFqdns)
+			destFqdns = set.FromStringSlice(*rule.DestinationFqdns)
 		}
 		protocols := make([]string, 0)
 		if rule.Protocols != nil {
@@ -494,8 +504,17 @@ func flattenFirewallNetworkRuleCollectionRules(rules *[]network.AzureFirewallNet
 				protocols = append(protocols, string(protocol))
 			}
 		}
-		output["protocols"] = set.FromStringSlice(protocols)
-		outputs = append(outputs, output)
+		outputs = append(outputs, map[string]interface{}{
+			"name":                  name,
+			"description":           description,
+			"source_addresses":      sourceAddresses,
+			"source_ip_groups":      sourceIPGroups,
+			"destination_addresses": destAddresses,
+			"destination_ip_groups": destIPGroups,
+			"destination_ports":     destPorts,
+			"destination_fqdns":     destFqdns,
+			"protocols":             set.FromStringSlice(protocols),
+		})
 	}
 	return outputs
 }

--- a/azurerm/internal/services/network/firewall_resource.go
+++ b/azurerm/internal/services/network/firewall_resource.go
@@ -509,6 +509,7 @@ func expandArmFirewallDNSSetting(input []interface{}) map[string]*string {
 		servers = append(servers, server.(string))
 	}
 
+	// Swagger issue asking finalize these properties: https://github.com/Azure/azure-rest-api-specs/issues/11278
 	return map[string]*string{
 		"Network.DNS.EnableProxy": utils.String(fmt.Sprintf("%t", v["enabled"].(bool))),
 		"Network.DNS.Servers":     utils.String(strings.Join(servers, ",")),

--- a/azurerm/internal/services/network/tests/firewall_resource_test.go
+++ b/azurerm/internal/services/network/tests/firewall_resource_test.go
@@ -70,6 +70,25 @@ func TestAccAzureRMFirewall_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFirewall_enableDNS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMFirewall_enableDNS(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFirewallExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMFirewall_withManagementIp(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
 
@@ -369,6 +388,59 @@ resource "azurerm_firewall" "test" {
     public_ip_address_id = azurerm_public_ip.test.id
   }
   threat_intel_mode = "Deny"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMFirewall_enableDNS(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+  threat_intel_mode = "Deny"
+
+  dns_setting {
+    enabled = true
+    servers = ["8.8.8.8", "1.1.1.1"]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `ip_configuration` - (Required) An `ip_configuration` block as documented below.
 
-* `dns_setting` - (Optional) A `dns_setting` block as documented below.
+* `dns_servers` - (Optional) A list of DNS servers that the Azure Firewall will direct DNS traffic to the for name resolution.
 
 * `management_ip_configuration` - (Optional) A `management_ip_configuration` block as documented below, which allows force-tunnelling of traffic to be performed by the firewall. Adding or removing this block or changing the `subnet_id` in an existing block forces a new resource to be created.
 
@@ -77,14 +77,6 @@ The following arguments are supported:
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
-
----
-
-A `dns_setting` block supports the following:
-
-* `enabled` - (Optional) Whether enable the DNS proxy on the Azure Firewall. Defaults to `true`.
-
-* `servers` - (Optional) A list of DNS servers that the Azure Firewall will direct DNS traffic to the for name resolution.
 
 ---
 

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `ip_configuration` - (Required) An `ip_configuration` block as documented below.
 
+* `dns_setting` - (Optional) A `dns_setting` block as documented below.
+
 * `management_ip_configuration` - (Optional) A `management_ip_configuration` block as documented below, which allows force-tunnelling of traffic to be performed by the firewall. Adding or removing this block or changing the `subnet_id` in an existing block forces a new resource to be created.
 
 * `threat_intel_mode` - (Optional) The operation mode for threat intelligence-based filtering. Possible values are: `Off`, `Alert` and `Deny`. Defaults to `Alert`
@@ -75,6 +77,14 @@ The following arguments are supported:
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `dns_setting` block supports the following:
+
+* `enabled` - (Optional) Whether enable the DNS proxy on the Azure Firewall. Defaults to `true`.
+
+* `servers` - (Optional) A list of DNS servers that the Azure Firewall will direct DNS traffic to the for name resolution.
 
 ---
 

--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -118,7 +118,11 @@ A `rule` block supports the following:
 
 * `destination_ip_groups` - (Optional) A list of destination IP Group IDs for the rule.
 
--> **NOTE** At least one of `destination_addresses` and `destination_ip_groups` must be specified for a rule.
+* `destination_fqdns` - (Optional) A list of destination FQDNS for the rule.
+
+-> **NOTE** [You must enable DNS Proxy to use FQDNs in your network rules](https://docs.microsoft.com/en-us/azure/firewall/fqdn-filtering-network-rules).
+
+-> **NOTE** At least one of `destination_addresses`, `destination_ip_groups` and `destination_fqdns` must be specified for a rule.
 
 * `destination_ports` - (Required) A list of destination ports.
 


### PR DESCRIPTION
`azurerm_firewall` supports `dns_setting` and `azurerm_firewall_network_rule_collection` supports `destination_fqdns`.

## Test Result

```bash
💢 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run "TestAccAzureRMFirewallNetworkRuleCollection_fqdns|TestAccAzureRMFirewallNetworkRuleCollection_noDestination|TestAccAzureRMFirewall_enableDNS"'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run "TestAccAzureRMFirewallNetworkRuleCollection_fqdns|TestAccAzureRMFirewallNetworkRuleCollection_noDestination|TestAccAzureRMFirewall_enableDNS" -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMFirewallNetworkRuleCollection_fqdns
=== PAUSE TestAccAzureRMFirewallNetworkRuleCollection_fqdns
=== RUN   TestAccAzureRMFirewallNetworkRuleCollection_noDestination
=== PAUSE TestAccAzureRMFirewallNetworkRuleCollection_noDestination
=== RUN   TestAccAzureRMFirewall_enableDNS
=== PAUSE TestAccAzureRMFirewall_enableDNS
=== CONT  TestAccAzureRMFirewallNetworkRuleCollection_fqdns
=== CONT  TestAccAzureRMFirewall_enableDNS
=== CONT  TestAccAzureRMFirewallNetworkRuleCollection_noDestination
--- PASS: TestAccAzureRMFirewallNetworkRuleCollection_fqdns (2213.69s)
--- PASS: TestAccAzureRMFirewall_enableDNS (2222.99s)
--- PASS: TestAccAzureRMFirewallNetworkRuleCollection_noDestination (2234.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       2234.580s
```

Fixes #8312, fixes #7743.