### PR TITLE
[WIP] Fix example where infrastructure_encryption_enabled is not supported

### DIFF
--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -33,9 +33,9 @@ resource "azurerm_mysql_server" "example" {
 
   auto_grow_enabled                 = true
   backup_retention_days             = 7
-  geo_redundant_backup_enabled      = true
-  infrastructure_encryption_enabled = true
-  public_network_access_enabled     = false
+  geo_redundant_backup_enabled      = false
+  infrastructure_encryption_enabled = false
+  public_network_access_enabled     = true
   ssl_enforcement_enabled           = true
   ssl_minimal_tls_version_enforced  = "TLS1_2"
 }


### PR DESCRIPTION
I tried the example provided in the docs and got an error that:

- `infrastructure_encryption_enabled` is not supported for sku Tier `Basic`
- Geo-Redundant Backup is not supported

Therefore I propose to disable it in the example.

