### PR TITLE
Add support for SecurityProviderName property of Virtual Hub

### DIFF
--- a/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
@@ -130,6 +130,25 @@ func TestAccAzureRMVPNGateway_tags(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVPNGateway_withSecurityProviderName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_gateway", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMVPNGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVPNGateway_withSecurityProviderName(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVPNGatewayExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMVPNGatewayExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.VpnGatewaysClient
@@ -313,4 +332,19 @@ resource "azurerm_virtual_hub" "test" {
   virtual_wan_id      = azurerm_virtual_wan.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMVPNGateway_withSecurityProviderName(data acceptance.TestData) string {
+	template := testAccAzureRMVPNGateway_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_vpn_gateway" "test" {
+  name                   = "acctestVPNG-%d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  virtual_hub_id         = azurerm_virtual_hub.test.id
+  security_provider_name = "ZScaler"
+}
+`, template, data.RandomInteger)
 }

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 * `scale_unit` - (Optional) The Scale Unit for this VPN Gateway. Defaults to `1`.
 
+* `security_provider_name` - (Optional) The Security Provider name.
+
 * `tags` - (Optional) A mapping of tags to assign to the VPN Gateway.
 
 ---


### PR DESCRIPTION
Although the [SecurityProviderName](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/network/resource-manager/Microsoft.Network/stable/2020-05-01/virtualWan.json#L4850) property belongs to Virtual Hub. But this property cannot be implemented at azurerm_virtual_hub since this property only can be set after vpn gateway is attached to virtual hub according by the instruction of below api returned error message. However, vpn gateway (azurerm_vpn_gateway) is a separate resource and it depends on virtual hub, which means azurerm_virtual_hub would be created before azurerm_vpn_gateway is created. So this property has to been implemented at azurerm_vpn_gateway.

Error message:
```
network.VirtualHubsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="VirtualHubSecurityProviderNotSupportedWithoutVPNGw" Message="SecurityProviderName 'xxxxxx' is not supported without VPN Gateway in the Hub." Details=[]
```