### PR TITLE
azurerm_key_vault - supports "contact" block

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -7,9 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
-
+	dataPlaneKeyVault "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -21,6 +19,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -182,6 +182,27 @@ func resourceArmKeyVault() *schema.Resource {
 				ValidateFunc: validation.IntBetween(7, 90),
 			},
 
+			"contact": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"phone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
 			"tags": tags.Schema(),
 
 			// Computed
@@ -195,6 +216,7 @@ func resourceArmKeyVault() *schema.Resource {
 
 func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).KeyVault.VaultsClient
+	dataPlaneClient := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -343,11 +365,25 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if v, ok := d.GetOk("contact"); ok {
+		contacts := dataPlaneKeyVault.Contacts{
+			ContactList: expandKeyVaultCertificateContactList(v.(*schema.Set).List()),
+		}
+		if read.Properties == nil || read.Properties.VaultURI == nil {
+			return fmt.Errorf("failed to get vault base url Key Vault %q (Resource Group %q) to become available: %s", name, resourceGroup, err)
+		}
+		_, err := dataPlaneClient.SetCertificateContacts(ctx, *read.Properties.VaultURI, contacts)
+		if err != nil {
+			return fmt.Errorf("failed to set Contacts for Key Vault %q (Resource Group %q): %s", name, resourceGroup, err)
+		}
+	}
+
 	return resourceArmKeyVaultRead(d, meta)
 }
 
 func resourceArmKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).KeyVault.VaultsClient
+	dataPlaneClient := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -534,6 +570,24 @@ func resourceArmKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error updating Key Vault %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
+	if d.HasChange("contact") {
+		contacts := dataPlaneKeyVault.Contacts{
+			ContactList: expandKeyVaultCertificateContactList(d.Get("contact").(*schema.Set).List()),
+		}
+		if existing.Properties == nil || existing.Properties.VaultURI == nil {
+			return fmt.Errorf("failed to get vault base url Key Vault %q (Resource Group %q) to become available: %s", name, resourceGroup, err)
+		}
+		var err error
+		if len(*contacts.ContactList) == 0 {
+			_, err = dataPlaneClient.DeleteCertificateContacts(ctx, *existing.Properties.VaultURI)
+		} else {
+			_, err = dataPlaneClient.SetCertificateContacts(ctx, *existing.Properties.VaultURI, contacts)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to set Contacts for Key Vault %q (Resource Group %q): %s", name, resourceGroup, err)
+		}
+	}
+
 	d.Partial(false)
 
 	return resourceArmKeyVaultRead(d, meta)
@@ -541,6 +595,7 @@ func resourceArmKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceArmKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).KeyVault.VaultsClient
+	dataPlaneClient := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -592,6 +647,16 @@ func resourceArmKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 		flattenedPolicies := azure.FlattenKeyVaultAccessPolicies(props.AccessPolicies)
 		if err := d.Set("access_policy", flattenedPolicies); err != nil {
 			return fmt.Errorf("Error setting `access_policy` for KeyVault %q: %+v", *resp.Name, err)
+		}
+
+		if resp, err := dataPlaneClient.GetCertificateContacts(ctx, *props.VaultURI); err != nil {
+			if !utils.ResponseWasForbidden(resp.Response) && !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("retrieving `contact` for KeyVault: %+v", err)
+			}
+		} else {
+			if err := d.Set("contact", flattenKeyVaultCertificateContactList(resp.ContactList)); err != nil {
+				return fmt.Errorf("setting `contact` for KeyVault: %+v", err)
+			}
 		}
 	}
 
@@ -771,6 +836,24 @@ func expandKeyVaultNetworkAcls(input []interface{}) (*keyvault.NetworkRuleSet, [
 	return &ruleSet, subnetIds
 }
 
+func expandKeyVaultCertificateContactList(input []interface{}) *[]dataPlaneKeyVault.Contact {
+	results := make([]dataPlaneKeyVault.Contact, 0)
+	if len(input) == 0 || input[0] == nil {
+		return &results
+	}
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		results = append(results, dataPlaneKeyVault.Contact{
+			Name:         utils.String(v["name"].(string)),
+			EmailAddress: utils.String(v["email"].(string)),
+			Phone:        utils.String(v["phone"].(string)),
+		})
+	}
+
+	return &results
+}
+
 func flattenKeyVaultNetworkAcls(input *keyvault.NetworkRuleSet) []interface{} {
 	if input == nil {
 		return []interface{}{
@@ -813,6 +896,38 @@ func flattenKeyVaultNetworkAcls(input *keyvault.NetworkRuleSet) []interface{} {
 	output["virtual_network_subnet_ids"] = schema.NewSet(schema.HashString, virtualNetworkRules)
 
 	return []interface{}{output}
+}
+
+func flattenKeyVaultCertificateContactList(input *[]dataPlaneKeyVault.Contact) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, contact := range *input {
+		emailAddress := ""
+		if contact.EmailAddress != nil {
+			emailAddress = *contact.EmailAddress
+		}
+
+		name := ""
+		if contact.Name != nil {
+			name = *contact.Name
+		}
+
+		phone := ""
+		if contact.Phone != nil {
+			phone = *contact.Phone
+		}
+
+		results = append(results, map[string]interface{}{
+			"email": emailAddress,
+			"name":  name,
+			"phone": phone,
+		})
+	}
+
+	return results
 }
 
 func optedOutOfRecoveringSoftDeletedKeyVaultErrorFmt(name, location string) string {

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -372,8 +372,7 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 		if read.Properties == nil || read.Properties.VaultURI == nil {
 			return fmt.Errorf("failed to get vault base url Key Vault %q (Resource Group %q) to become available: %s", name, resourceGroup, err)
 		}
-		_, err := dataPlaneClient.SetCertificateContacts(ctx, *read.Properties.VaultURI, contacts)
-		if err != nil {
+		if _, err := dataPlaneClient.SetCertificateContacts(ctx, *read.Properties.VaultURI, contacts); err != nil {
 			return fmt.Errorf("failed to set Contacts for Key Vault %q (Resource Group %q): %s", name, resourceGroup, err)
 		}
 	}

--- a/azurerm/internal/services/keyvault/tests/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_resource_test.go
@@ -209,6 +209,39 @@ func TestAccAzureRMKeyVault_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKeyVault_updateContacts(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKeyVault_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMKeyVault_updateContacts(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMKeyVault_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMKeyVault_justCert(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
 
@@ -606,7 +639,11 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    certificate_permissions = [
+      "ManageContacts",
+    ]
 
     key_permissions = [
       "create",
@@ -635,7 +672,7 @@ resource "azurerm_key_vault" "import" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",
@@ -703,7 +740,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",
@@ -738,7 +775,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",
@@ -774,7 +811,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",
@@ -817,7 +854,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "get",
@@ -931,7 +968,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id      = data.azurerm_client_config.current.tenant_id
-    object_id      = data.azurerm_client_config.current.client_id
+    object_id      = data.azurerm_client_config.current.object_id
     application_id = data.azurerm_client_config.current.client_id
 
     certificate_permissions = [
@@ -978,7 +1015,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.client_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "get",
@@ -1214,6 +1251,54 @@ resource "azurerm_key_vault" "test" {
   sku_name = "premium"
 
   access_policy = []
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMKeyVault_updateContacts(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "vault%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    certificate_permissions = [
+      "ManageContacts",
+    ]
+
+    key_permissions = [
+      "create",
+    ]
+
+    secret_permissions = [
+      "set",
+    ]
+  }
+
+  contact {
+    email = "example@example.com"
+    name  = "example"
+    phone = "01234567890"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/keyvault/tests/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_resource_test.go
@@ -1265,7 +1265,7 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-kv-%d"
   location = "%s"
 }
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -52,6 +52,7 @@ resource "azurerm_key_vault" "example" {
 
     key_permissions = [
       "get",
+      "ManageContacts",
     ]
 
     secret_permissions = [
@@ -66,6 +67,12 @@ resource "azurerm_key_vault" "example" {
   network_acls {
     default_action = "Deny"
     bypass         = "AzureServices"
+  }
+
+  contact {
+    email = "example@example.com"
+    name  = "example"
+    phone = "0123456789"
   }
 
   tags = {
@@ -116,6 +123,10 @@ The following arguments are supported:
 
 ~> **Note:** This field can only be set once Soft Delete is Enabled and cannot be updated.
 
+* `contact` - (Optional) One or more `contact` block as defined below.
+
+~> **Note:** This field can only be set once user has `ManageContacts` permission.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -147,6 +158,16 @@ A `network_acls` block supports the following:
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Key Vault.
 
 * `virtual_network_subnet_ids` - (Optional) One or more Subnet ID's which should be able to access this Key Vault.
+
+---
+
+A `contact` block supports the following:
+
+* `email` - (Required) E-mail address of the contact.
+
+* `name` - (Optional) Name of the contact.
+
+* `phone` - (Optional) Phone number of the contact.
 
 ## Attributes Reference
 


### PR DESCRIPTION
fix #1301

making certificate contact as a standalone resource is pushed back. submit this PR to make it as a embeded field in "key_vault" resource

![image](https://user-images.githubusercontent.com/2786738/96420374-03ff8000-1228-11eb-8994-64c8f7363a47.png)
