### PR TITLE
`azurerm_data_factory_linked_service_data_lake_storage_gen2` - Supports managed identity auth through `use_managed_identity `

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
@@ -147,16 +147,15 @@ func resourceArmDataFactoryLinkedServiceDataLakeStorageGen2CreateUpdate(d *schem
 
 	if d.Get("use_managed_identity").(bool) {
 		for _, k := range []string{"service_principal_key", "service_principal_name"} {
-
 			if _, ok := d.GetOk(k); ok {
 				return fmt.Errorf("Error %s cannont be defined when use_managed_identity = true", k)
 			}
 		}
+
 		datalakeStorageGen2Properties = &datafactory.AzureBlobFSLinkedServiceTypeProperties{
 			URL:    utils.String(d.Get("url").(string)),
 			Tenant: utils.String(d.Get("tenant").(string)),
 		}
-
 	} else {
 		_, key_ok := d.GetOk("service_principal_key")
 		_, id_ok := d.GetOk("service_principal_id")

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
@@ -31,6 +31,25 @@ func TestAccAzureRMDataFactoryLinkedServiceDataLakeStorageGen2_basic(t *testing.
 	})
 }
 
+func TestAccAzureRMDataFactoryLinkedServiceDataLakeStorageGen2_managed_id(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_data_lake_storage_gen2", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceDataLakeStorageGen2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataFactoryLinkedServiceDataLakeStorageGen2_managed_id(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataFactoryLinkedServiceDataLakeStorageGen2Exists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMDataFactoryLinkedServiceDataLakeStorageGen2_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_data_lake_storage_gen2", "test")
 
@@ -149,6 +168,39 @@ resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "test" {
   service_principal_id  = data.azurerm_client_config.current.client_id
   service_principal_key = "testkey"
   tenant                = "11111111-1111-1111-1111-111111111111"
+  url                   = "https://test.azure.com"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMDataFactoryLinkedServiceDataLakeStorageGen2_managed_id(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "test" {
+  name                  = "acctestDataLake%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  data_factory_name     = azurerm_data_factory.test.name
+  use_managed_identity  = true
   url                   = "https://test.azure.com"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
@@ -197,11 +197,11 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "test" {
-  name                  = "acctestDataLake%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  data_factory_name     = azurerm_data_factory.test.name
-  use_managed_identity  = true
-  url                   = "https://test.azure.com"
+  name                 = "acctestDataLake%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  data_factory_name    = azurerm_data_factory.test.name
+  use_managed_identity = true
+  url                  = "https://test.azure.com"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
+++ b/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
@@ -42,33 +42,36 @@ resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "example" 
 
 ## Argument Reference
 
-The following arguments are supported:
+The following supported arguments are common across all Azure Data Factory Linked Services:
 
-* `name` - (Required) Specifies the name of the Data Factory Linked Service MySQL. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service MySQL. Changing this forces a new resource
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service. Changing this forces a new resource
 
 * `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
 
+* `description` - (Optional) The description for the Data Factory Linked Service.
+
+* `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service.
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service.
+
+The following supported arguments are specific to Data Lake Storage Gen2 Linked Service:
+
 * `url` - (Required) The endpoint for the Azure Data Lake Storage Gen2 service.
 
-* `service_principal_id` - (Required) The service principal id in which to authenticate against the Azure Data Lake Storage Gen2 account.
+* `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure Data Lake Storage Gen2 account. Incompatible with `service_principal_id` and `service_principal_key`  
 
-* `service_principal_key` - (Required) The service principal key in which to authenticate against the Azure Data Lake Storage Gen2 account.
+* `service_principal_id` - (Optional) The service principal id in which to authenticate against the Azure Data Lake Storage Gen2 account. Required if `use_managed_identity` is true.
+
+* `service_principal_key` - (Optional) The service principal key in which to authenticate against the Azure Data Lake Storage Gen2 account.  Required if `use_managed_identity` is true.
+## Attributes Reference
 
 * `tenant` - (Required) The tenant id or name in which to authenticate against the Azure Data Lake Storage Gen2 account.
-
-* `description` - (Optional) The description for the Data Factory Linked Service MySQL.
-
-* `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service MySQL.
-
-* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service MySQL.
-
-* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service MySQL.
-
-* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service MySQL.
-
-## Attributes Reference
 
 The following attributes are exported:
 
@@ -88,5 +91,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Data Factory Data Lake Storage Gen2 Linked Services can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_data_factory_linked_service_mysql.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+terraform import azurerm_data_factory_linked_service_data_lake_storage_gen2.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
 ```


### PR DESCRIPTION
Closes  #6501

Adds a use_managed_identity flag to azurerm_data_factory_linked_service_data_lake_storage_gen2.

If both use_managed_identity=true and service_principal_key or service_principal_id are specified raises an error.

First contribution so feel free to add feedback