### PR TITLE
azurerm_management_group_subscription_association fixes #3555

### DIFF
--- a/azurerm/internal/services/managementgroup/management_group_subscription_association_resource.go
+++ b/azurerm/internal/services/managementgroup/management_group_subscription_association_resource.go
@@ -1,0 +1,189 @@
+package managementgroup
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/managementgroups"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmManagementGroupSubscriptionAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmManagementGroupSubscriptionAssociationCreate,
+		Read:   resourceArmManagementGroupSubscriptionAssociationRead,
+		Delete: resourceArmManagementGroupSubscriptionAssociationDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.ManagementGroupID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"management_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.ManagementGroupID,
+			},
+
+			"subscription_guid": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.SubscriptionGUID,
+			},
+		},
+	}
+}
+
+func resourceArmManagementGroupSubscriptionAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ManagementGroups.SubscriptionClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	managementGroupId := d.Get("management_group_id").(string)
+	subscriptionGuid := d.Get("subscription_guid").(string)
+	subscriptionId := "/subscriptions/" + subscriptionGuid
+
+	parsedManagementGroupId, err := parse.ManagementGroupID(managementGroupId)
+	if err != nil {
+		return fmt.Errorf("Error parsing management group name '%s': %+v", managementGroupId, err)
+	}
+
+	managementGroupName := parsedManagementGroupId.Name
+
+	log.Printf("[INFO] management group %q <-> subscription %q association creation.", managementGroupName, subscriptionGuid)
+
+	locks.ByID(managementGroupId)
+	defer locks.UnlockByID(managementGroupId)
+	locks.ByID(subscriptionId)
+	defer locks.UnlockByID(subscriptionId)
+
+	result, err := client.Create(ctx, managementGroupName, subscriptionGuid, managementGroupCacheControl)
+	if err != nil {
+		return fmt.Errorf("Error creating association for subscription %q to management group %q: %+v", subscriptionGuid, managementGroupName, err)
+	}
+
+	log.Printf("[INFO] management group %q <-> subscription %q association created: %+v", managementGroupName, subscriptionGuid, result)
+
+	id := fmt.Sprintf("%s|%s", managementGroupId, subscriptionGuid)
+
+	d.SetId(id)
+
+	d.Set("management_group_id", managementGroupId)
+	d.Set("subscription_guid", subscriptionGuid)
+
+	return resourceArmManagementGroupRead(d, meta)
+}
+
+func resourceArmManagementGroupSubscriptionAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ManagementGroups.GroupsClient // No GET on SubscriptionsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	managementGroupId := d.Get("management_group_id").(string)
+	subscriptionGuid := d.Get("subscription_guid").(string)
+
+	parsedManagementGroupId, err := parse.ManagementGroupID(managementGroupId)
+	if err != nil {
+		return fmt.Errorf("Error parsing management group name '%s': %+v", managementGroupId, err)
+	}
+
+	managementGroupName := parsedManagementGroupId.Name
+
+	recurse := false // Only want immediate children
+	resp, err := client.Get(ctx, managementGroupName, "children", &recurse, "", managementGroupCacheControl)
+	if err != nil {
+		if utils.ResponseWasForbidden(resp.Response) || utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Management Group %q doesn't exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("unable to read Management Group %q: %+v", d.Id(), err)
+	}
+
+	if props := resp.Properties; props != nil {
+		// subscriptionIds, err := flattenArmManagementGroupSubscriptionIds(props.Children)
+		err := checkArmSubscriptionGuidInManagementGroupSubscriptionIds(subscriptionGuid, props.Children)
+		if err != nil {
+			log.Printf("[INFO] Management Group %q doesn't exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+	}
+
+	log.Printf("[INFO] Management Group Subscription association %q is not found - removing from state", d.Id())
+	d.SetId("")
+	return nil
+}
+
+func resourceArmManagementGroupSubscriptionAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ManagementGroups.SubscriptionClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	managementGroupId := d.Get("management_group_id").(string)
+	subscriptionGuid := d.Get("subscription_guid").(string)
+	subscriptionId := "/subscriptions/" + subscriptionGuid
+
+	parsedManagementGroupId, err := parse.ManagementGroupID(managementGroupId)
+	if err != nil {
+		return fmt.Errorf("Error parsing management group name '%s': %+v", managementGroupId, err)
+	}
+
+	managementGroupName := parsedManagementGroupId.Name
+
+	log.Printf("[INFO] management group %q <-> subscription %q association deletion.", managementGroupName, subscriptionGuid)
+
+	locks.ByID(managementGroupId)
+	defer locks.UnlockByID(managementGroupId)
+	locks.ByID(subscriptionId)
+	defer locks.UnlockByID(subscriptionId)
+
+	result, err := client.Delete(ctx, managementGroupId, subscriptionGuid, managementGroupCacheControl)
+	if err != nil {
+		return fmt.Errorf("Error deleting association for subscription %q to management group %q: %+v", subscriptionGuid, managementGroupName, err)
+	}
+
+	log.Printf("[INFO] management group %q <-> subscription %q association deleted: %+v", managementGroupName, subscriptionGuid, result)
+
+	return resourceArmManagementGroupRead(d, meta)
+}
+
+func checkArmSubscriptionGuidInManagementGroupSubscriptionIds(subscriptionGuid string, input *[]managementgroups.ChildInfo) error {
+	if input == nil {
+		return fmt.Errorf("no children")
+	}
+
+	for _, child := range *input {
+		if child.ID == nil {
+			continue
+		}
+
+		_, err := parseManagementGroupSubscriptionID(*child.ID)
+		if err != nil {
+			return fmt.Errorf("unable to parse child Subscription GUID %+v", err)
+		}
+
+		if *child.ID == subscriptionGuid {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%q was not found in children", subscriptionGuid)
+}

--- a/azurerm/internal/services/managementgroup/parse/management_group_subscription_association.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group_subscription_association.go
@@ -1,0 +1,48 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ManagementGroupSubscriptionAssociationId struct {
+	ManagementGroupID   string
+	ManagementGroupName string
+	SubscriptionScopeID string
+	SubscriptionID      string
+}
+
+func ManagementGroupSubscriptionAssociationID(input string) (*ManagementGroupSubscriptionAssociationId, error) {
+	segments := strings.Split(input, "|")
+	if len(segments) != 2 {
+		return nil, fmt.Errorf("Expected an ID in the format `{managementGroupId}|{subscriptionId} but got %q", input)
+	}
+
+	managementGroupId := segments[0]
+	subscriptionScopeId := segments[1]
+
+	parsedManagementGroupID, err := ManagementGroupID(managementGroupId)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Management Group ID %q: %+v", managementGroupId, err)
+	}
+	managementGroupName := parsedManagementGroupID.Name
+
+	// The subscriptionId is the full scope form, i.e. '/subscriptions/{subscriptionGuid}'
+	if subscriptionScopeSegments := strings.Split(subscriptionScopeId, "/"); len(subscriptionScopeSegments) != 3 {
+		return nil, fmt.Errorf("unable to parse subscription scope ID %q - has %d segments", subscriptionScopeId, len(subscriptionScopeSegments))
+	}
+
+	subscriptionId := strings.TrimPrefix(subscriptionScopeId, "/subscriptions/")
+	if subscriptionId == subscriptionScopeId {
+		return nil, fmt.Errorf("expected subscription scope ID %q  in `/subscriptions/00000000-0000-0000-0000-000000000000` format", subscriptionScopeId)
+	}
+
+	id := ManagementGroupSubscriptionAssociationId{
+		ManagementGroupID:   managementGroupId,
+		ManagementGroupName: managementGroupName, // strings.Split(managementGroupId, "/")[-1],
+		SubscriptionScopeID: subscriptionScopeId,
+		SubscriptionID:      subscriptionId,
+	}
+
+	return &id, nil
+}

--- a/azurerm/internal/services/managementgroup/parse/management_group_subscription_association_test.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group_subscription_association_test.go
@@ -1,0 +1,86 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestManagementGroupSubscriptionAssociationID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *ManagementGroupSubscriptionAssociationId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "One Segment",
+			Input: "hello",
+			Error: true,
+		},
+		{
+			Name:  "Two Segments Invalid ID's",
+			Input: "hello|world",
+			Error: true,
+		},
+		{
+			Name:  "Bad Management Group",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup|/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "Subscription GUID, not scope",
+			Input: "/providers/Microsoft.Management/managementGroups/myManagementGroup|00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "Bad GUID",
+			Input: "/providers/Microsoft.Management/managementGroups/myManagementGroup|/subscriptions/mySubscriptionAlias",
+			Error: true,
+		},
+		{
+			Name:  "Nat Gateway / Public IP Association ID",
+			Input: "/providers/Microsoft.Management/managementGroups/myManagementGroup|/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: false,
+			Expect: &ManagementGroupSubscriptionAssociationId{
+				ManagementGroupID:   "/providers/Microsoft.Management/managementGroups/myManagementGroup",
+				ManagementGroupName: "myManagementGroup",
+				SubscriptionScopeID: "/subscriptions/00000000-0000-0000-0000-000000000000",
+				SubscriptionID:      "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ManagementGroupSubscriptionAssociationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.ManagementGroupID != v.Expect.ManagementGroupID {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.ManagementGroupID, actual.ManagementGroupID)
+		}
+
+		if actual.ManagementGroupName != v.Expect.ManagementGroupName {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.ManagementGroupName, actual.ManagementGroupName)
+		}
+
+		if actual.SubscriptionScopeID != v.Expect.SubscriptionScopeID {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.SubscriptionScopeID, actual.SubscriptionScopeID)
+		}
+
+		if actual.SubscriptionID != v.Expect.SubscriptionID {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.SubscriptionID, actual.SubscriptionID)
+		}
+
+	}
+}

--- a/azurerm/internal/services/managementgroup/registration.go
+++ b/azurerm/internal/services/managementgroup/registration.go
@@ -28,6 +28,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_management_group": resourceArmManagementGroup(),
+		"azurerm_management_group":                          resourceArmManagementGroup(),
+		"azurerm_management_group_subscription_association": resourceArmManagementGroupSubscriptionAssociation(),
 	}
 }

--- a/azurerm/internal/services/managementgroup/tests/management_group_subscription_association_resource_test.go
+++ b/azurerm/internal/services/managementgroup/tests/management_group_subscription_association_resource_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccAzureRMManagementGroupSubscriptionAssociation(t *testing.T) {
+	managementGroupData := acceptance.BuildTestData(t, "azurerm_management_group", "test")
+	managementGroupSubscriptionAssociationData := acceptance.BuildTestData(t, "azurerm_management_group_subscription_association", "test")
+	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMManagementGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMManagementGroup_managementGroupOnly(),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMManagementGroupExists(managementGroupData.ResourceName),
+					testCheckAzureRMManagementGroupSubscriptionAssociationDoesNotExist(managementGroupSubscriptionAssociationData.ResourceName),
+					resource.TestCheckResourceAttr(managementGroupData.ResourceName, "subscription_ids.#", "0"),
+				),
+			},
+			{
+				Config: testAzureRMManagementGroup_associatedSubscription(subscriptionId),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMManagementGroupExists(managementGroupData.ResourceName),
+					testCheckAzureRMManagementGroupSubscriptionAssociationExists(managementGroupSubscriptionAssociationData.ResourceName),
+					resource.TestCheckResourceAttr(managementGroupData.ResourceName, "subscription_ids.#", "1"),
+				),
+			},
+			{
+				Config: testAzureRMManagementGroup_managementGroupOnly(),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMManagementGroupExists(managementGroupData.ResourceName),
+					testCheckAzureRMManagementGroupSubscriptionAssociationDoesNotExist(managementGroupSubscriptionAssociationData.ResourceName),
+					resource.TestCheckResourceAttr(managementGroupData.ResourceName, "subscription_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMManagementGroupSubscriptionAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// No GET for (*clients.Client).ManagementGroups.GroupsClient so just check Terraform state plus subscription_ids.# increment / decrement
+
+		_, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMManagementGroupSubscriptionAssociationDoesNotExist(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// No GET for (*clients.Client).ManagementGroups.GroupsClient so just check Terraform state plus subscription_ids.# increment / decrement
+
+		_, ok := s.RootModule().Resources[resourceName]
+		if ok {
+			return fmt.Errorf("unexpectedly found: %s", resourceName)
+		}
+
+		return nil
+	}
+}
+
+func testAzureRMManagementGroup_managementGroupOnly() string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_management_group" "test" {}
+
+`)
+}
+
+func testAzureRMManagementGroup_associatedSubscription(subscriptionId string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_management_group" "test" {}
+
+resource "azurerm_management_group_subscription_association" "test" {
+  management_group_id = azurerm_management_group.test.id
+  subscription_id     = "%s"
+}
+
+`, subscriptionId)
+}

--- a/azurerm/internal/services/managementgroup/validate/management_group.go
+++ b/azurerm/internal/services/managementgroup/validate/management_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
 )
 
@@ -33,5 +34,18 @@ func ManagementGroupID(i interface{}, k string) (warnings []string, errors []err
 		return
 	}
 
+	return
+}
+
+func SubscriptionGUID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := uuid.ParseUUID(v); err != nil {
+		errors = append(errors, fmt.Errorf("expected subscription_guid value to be a valid UUID, got %v", v))
+	}
 	return
 }

--- a/azurerm/internal/services/managementgroup/validate/management_group_test.go
+++ b/azurerm/internal/services/managementgroup/validate/management_group_test.go
@@ -75,3 +75,53 @@ func TestManagementGroupName(t *testing.T) {
 		}
 	}
 }
+
+func TestSubscriptionGUID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+			Valid: false,
+		},
+		{
+			Input: "NotASubscriptionID",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+		{
+			Input: "00000000-0000-0000-0000-000000000000",
+			Valid: true,
+		},
+		{
+			Input: "/subscriptions/StillNotAValidSubscription",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1",
+			Valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := SubscriptionGUID(tc.Input, "")
+
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t for %q", tc.Valid, valid, tc.Input)
+		}
+	}
+}

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -26,7 +26,7 @@ Data Share
 Database
 Database Migration
 Databricks
-Desktop Virtualization
+DesktopVirtualization
 Dev Test
 DevSpace
 HDInsight

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -26,7 +26,7 @@ Data Share
 Database
 Database Migration
 Databricks
-DesktopVirtualization
+Desktop Virtualization
 Dev Test
 DevSpace
 HDInsight

--- a/website/docs/r/management_group_subscription_association.html.markdown
+++ b/website/docs/r/management_group_subscription_association.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_management_group_subscription_association"
+description: |-
+  Associates a Subscription ID to a Management Group
+---
+
+# azurerm_management_group_subscription_association
+
+Associates a Subscription ID to a Management Group.
+
+## Example Usage
+
+```hcl
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_management_group" "example" {
+  name = "example"
+
+  lifecycle {
+    ignore_changes = [subscription_ids, ]
+  }
+}
+
+resource "azurerm_management_group_subscription_association" "example" {
+  management_group_id = azurerm_management_group.example.id
+  subscription_id     = data.azurerm_subscription.current.subscription_id
+}
+```
+
+~> **NOTE:** When using azurerm_management_group_subscription_association you **must** use `lifecycle.ignore_changes = [subscription_ids,]` on the associated azurerm_management_group to avoid conflicts and unexpected plan outputs.
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `management_group_id` - (Required) The ID of the Management Group. Changing this forces a new resource to be created.
+
+* `subscription_id` - (Required) The subscription GUID to associate to the Management Group. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The (Terraform specific) ID of the Association between the Management Group and the Subscription.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Management Group Subscription Association.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Management Group Subscription Association.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Management Group Subscription Association.
+
+## Import
+
+Associations between Management Groups and Subscriptions can be imported using the association `resource id`, e.g.
+
+```shell
+terraform import azurerm_management_group_subscription_association.example /providers/Microsoft.Management/managementGroups/example|/subscriptions/00000000-0000-0000-0000-000000000000
+```
+
+-> **NOTE:** This ID is specific to Terraform - and is of the format `{managementGroupId}|{subscriptionId}`.


### PR DESCRIPTION
Fixes #3555. New azurerm_management_group_subscription_association resource. 

Example HCL:

```terraform
terraform {
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "~> 2.32"
    }
  }
}

provider "azurerm" {
  features {}
}

data "azurerm_subscription" "current" {}

resource "azurerm_management_group" "example" {
  name = "example"

  lifecycle {
    ignore_changes = [subscription_ids, ]
  }
}

resource "azurerm_management_group_subscription_association" "example" {
  management_group_id = azurerm_management_group.example.id
  subscription_id     = data.azurerm_subscription.current.subscription_id
}
```

My first full resource, and I have all of the resource, parse, test and docs in here but let me know if I need to change anything.