### PR TITLE
Added Redis Cache firewall resource start and end IP address validations

### DIFF
--- a/azurerm/internal/services/mysql/mysql_firewall_rule_resource.go
+++ b/azurerm/internal/services/mysql/mysql_firewall_rule_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mysql/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -50,13 +51,15 @@ func resourceArmMySqlFirewallRule() *schema.Resource {
 			},
 
 			"start_ip_address": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azValidate.IPv4Address,
 			},
 
 			"end_ip_address": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azValidate.IPv4Address,
 			},
 		},
 	}

--- a/azurerm/internal/services/redis/resource_arm_redis_firewall_rule.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_firewall_rule.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -52,11 +53,19 @@ func resourceArmRedisFirewallRule() *schema.Resource {
 			"start_ip": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.All(
+					validation.IsIPAddress,
+					validation.StringIsNotEmpty,
+				),
 			},
 
 			"end_ip": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: validation.All(
+					validation.IsIPAddress,
+					validation.StringIsNotEmpty,
+				),
 			},
 		},
 	}


### PR DESCRIPTION
Added Redis Cache firewall resource start and end IP address validations such that the request fails at plan level rather than apply. The validations will provide feedback for invalid ip addresses during plan itself.

Details of acceptance tests

riteshmodi@MININT-3FOKASG terraform-provider-azurerm % make acctests SERVICE=redis TESTARGS='-run=TestAccAzureRMRedisFirewallRule' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/redis/tests/ -run=TestAccAzureRMRedisFirewallRule -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMRedisFirewallRule_basic
=== PAUSE TestAccAzureRMRedisFirewallRule_basic
=== RUN   TestAccAzureRMRedisFirewallRule_multi
=== PAUSE TestAccAzureRMRedisFirewallRule_multi
=== RUN   TestAccAzureRMRedisFirewallRule_requiresImport
=== PAUSE TestAccAzureRMRedisFirewallRule_requiresImport
=== RUN   TestAccAzureRMRedisFirewallRule_update
=== PAUSE TestAccAzureRMRedisFirewallRule_update
=== CONT  TestAccAzureRMRedisFirewallRule_basic
=== CONT  TestAccAzureRMRedisFirewallRule_update
=== CONT  TestAccAzureRMRedisFirewallRule_requiresImport
=== CONT  TestAccAzureRMRedisFirewallRule_multi
--- PASS: TestAccAzureRMRedisFirewallRule_requiresImport (1324.42s)
--- PASS: TestAccAzureRMRedisFirewallRule_update (1395.16s)
--- PASS: TestAccAzureRMRedisFirewallRule_multi (1432.15s)
--- PASS: TestAccAzureRMRedisFirewallRule_basic (1491.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/redis/tests	1491.109s
