### PR TITLE
`azurerm_postgresql_firewall_rule` - add validation for `start_ip_address` and `end_ip_address`

### DIFF
--- a/azurerm/internal/services/postgres/postgresql_firewall_rule_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_firewall_rule_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -49,15 +50,17 @@ func resourceArmPostgreSQLFirewallRule() *schema.Resource {
 			},
 
 			"start_ip_address": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azValidate.IPv4Address,
 			},
 
 			"end_ip_address": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azValidate.IPv4Address,
 			},
 		},
 	}

--- a/azurerm/internal/services/postgres/postgresql_firewall_rule_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_firewall_rule_resource.go
@@ -8,9 +8,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2020-01-01/postgresql"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -53,14 +53,14 @@ func resourceArmPostgreSQLFirewallRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: azValidate.IPv4Address,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 
 			"end_ip_address": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: azValidate.IPv4Address,
+				ValidateFunc: validation.IsIPv4Address,
 			},
 		},
 	}


### PR DESCRIPTION
Added postgres firewall start and end IP address validation

Acceptance tests details
===================================

riteshmodi@MININT-3FOKASG terraform-provider-azurerm % make acctests SERVICE=postgres TESTARGS='-run=TestAccAzureRMPostgreSQLFirewallRule' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/postgres/tests/ -run=TestAccAzureRMPostgreSQLFirewallRule -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMPostgreSQLFirewallRule_basic
=== PAUSE TestAccAzureRMPostgreSQLFirewallRule_basic
=== RUN   TestAccAzureRMPostgreSQLFirewallRule_requiresImport
=== PAUSE TestAccAzureRMPostgreSQLFirewallRule_requiresImport
=== CONT  TestAccAzureRMPostgreSQLFirewallRule_basic
=== CONT  TestAccAzureRMPostgreSQLFirewallRule_requiresImport
--- PASS: TestAccAzureRMPostgreSQLFirewallRule_basic (264.14s)
--- PASS: TestAccAzureRMPostgreSQLFirewallRule_requiresImport (269.61s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/tests	269.659s