### PR TITLE
MSSQL: working around a breaking change in the MSSQL API

### DIFF
--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -108,6 +108,10 @@ func ExpandAzureRmMsSqlDBBlobAuditingPolicies(input []interface{}) *sql.Extended
 	if len(input) == 0 || input[0] == nil {
 		return &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	dbBlobAuditingPolicies := input[0].(map[string]interface{})

--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -49,6 +49,10 @@ func ExpandAzureRmSqlServerBlobAuditingPolicies(input []interface{}) *sql.Extend
 	if len(input) == 0 || input[0] == nil {
 		return &sql.ExtendedServerBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	serverBlobAuditingPolicies := input[0].(map[string]interface{})

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -183,6 +183,10 @@ func resourceArmMsSqlDatabaseExtendedAuditingPolicyDelete(d *schema.ResourceData
 	params := sql.ExtendedDatabaseBlobAuditingPolicy{
 		ExtendedDatabaseBlobAuditingPolicyProperties: &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		},
 	}
 

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -105,6 +105,10 @@ func resourceArmMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *schema.Resour
 			StorageEndpoint:            utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse: utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:              utils.Int32(int32(d.Get("retention_in_days").(int))),
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		},
 	}
 

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -105,6 +105,10 @@ func resourceArmMsSqlServerExtendedAuditingPolicyCreateUpdate(d *schema.Resource
 			StorageEndpoint:            utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse: utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:              utils.Int32(int32(d.Get("retention_in_days").(int))),
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		},
 	}
 

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -188,6 +188,10 @@ func resourceArmMsSqlServerExtendedAuditingPolicyDelete(d *schema.ResourceData, 
 	params := sql.ExtendedServerBlobAuditingPolicy{
 		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		},
 	}
 

--- a/azurerm/internal/services/sql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/sql/helper/sql_extended_auditing.go
@@ -49,6 +49,10 @@ func ExpandAzureRmSqlServerBlobAuditingPolicies(input []interface{}) *sql.Extend
 	if len(input) == 0 {
 		return &sql.ExtendedServerBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	serverBlobAuditingPolicies := input[0].(map[string]interface{})

--- a/azurerm/internal/services/sql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/sql/helper/sql_extended_auditing.go
@@ -108,6 +108,10 @@ func ExpandAzureRmSqlDBBlobAuditingPolicies(input []interface{}) *sql.ExtendedDa
 	if len(input) == 0 {
 		return &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
+
+			// NOTE: this works around a regression in the Azure API detailed here:
+			// https://github.com/Azure/azure-rest-api-specs/issues/11271
+			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	dbBlobAuditingPolicies := input[0].(map[string]interface{})


### PR DESCRIPTION
This PR works around #8915 - which describes a breaking upstream API change tracked in https://github.com/Azure/azure-rest-api-specs/issues/11271

Whilst we've got a Microsoft Support and an ICM Ticket tracking this, unfortunately this'll be several days until the breaking API change is resolved, as the Service Team have opted to release the current API version to all regions, then fix the bug, rather than reverting this change.

The Service Team have confirmed that it's possible to workaround this by sending an additional field in the request - setting `isAzureMonitorTargetEnabled` to `true` - as such this PR forces this on at this time, exposing this as a user configurable field is left as a future exercise (since we believe this should only be temporary until the API is fixed and can ultimately be reverted).

Tests pass for the Legacy SQL Resources (ignoring an unrelated/known issue):

<img width="457" alt="Screenshot 2020-10-21 at 19 57 43" src="https://user-images.githubusercontent.com/666005/96758910-b0339900-13d7-11eb-9495-5dedec79f7ca.png">

Tests are in progress for the MSSQL Resources:

[TODO: screenshot when done]

Fixes #8915