### PR TITLE
Update data_factory_integration_runtime_managed.html.markdown - pricing tier from required to optional

### DIFF
--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -72,7 +72,7 @@ A `catalog_info` block supports the following:
 
 * `administrator_password` - (Required) Administrator login password for the SQL Server.
 
-* `pricing_tier` - (Required) Pricing tier for the database that will be created for the SSIS catalog. Valid values are: `Basic`, `Standard`, `Premium` and `PremiumRS`.
+* `pricing_tier` - (Optional) Pricing tier for the database that will be created for the SSIS catalog. Valid values are: `Basic`, `Standard`, `Premium` and `PremiumRS`.
 
 ---
 


### PR DESCRIPTION
Updated the `pricing_tier` from required to optional. 
The Azure documentation that supports the update can be found here: https://docs.microsoft.com/en-us/azure/data-factory/create-azure-ssis-integration-runtime and https://github.com/Azure/azure-resource-manager-schemas/blob/master/schemas/2018-06-01/Microsoft.DataFactory.json 
This change was prompted from the issue reported in https://hashicorp.zendesk.com/agent/tickets/28435