### PR TITLE
azurerm_local_network_gateway: support for `gateway_fqdn`

### DIFF
--- a/azurerm/internal/services/network/local_network_gateway_resource.go
+++ b/azurerm/internal/services/network/local_network_gateway_resource.go
@@ -44,8 +44,15 @@ func resourceArmLocalNetworkGateway() *schema.Resource {
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"gateway_address": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"gateway_address", "gateway_fqdn"},
+			},
+
+			"gateway_fqdn": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"gateway_address", "gateway_fqdn"},
 			},
 
 			"address_space": {
@@ -108,8 +115,6 @@ func resourceArmLocalNetworkGatewayCreateUpdate(d *schema.ResourceData, meta int
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	ipAddress := d.Get("gateway_address").(string)
-
 	t := d.Get("tags").(map[string]interface{})
 
 	gateway := network.LocalNetworkGateway{
@@ -117,10 +122,17 @@ func resourceArmLocalNetworkGatewayCreateUpdate(d *schema.ResourceData, meta int
 		Location: &location,
 		LocalNetworkGatewayPropertiesFormat: &network.LocalNetworkGatewayPropertiesFormat{
 			LocalNetworkAddressSpace: &network.AddressSpace{},
-			GatewayIPAddress:         &ipAddress,
 			BgpSettings:              expandLocalNetworkGatewayBGPSettings(d),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	ipAddress := d.Get("gateway_address").(string)
+	fqdn := d.Get("gateway_fqdn").(string)
+	if ipAddress != "" {
+		gateway.LocalNetworkGatewayPropertiesFormat.GatewayIPAddress = &ipAddress
+	} else {
+		gateway.LocalNetworkGatewayPropertiesFormat.Fqdn = &fqdn
 	}
 
 	// There is a bug in the provider where the address space ordering doesn't change as expected.
@@ -187,6 +199,7 @@ func resourceArmLocalNetworkGatewayRead(d *schema.ResourceData, meta interface{}
 
 	if props := resp.LocalNetworkGatewayPropertiesFormat; props != nil {
 		d.Set("gateway_address", props.GatewayIPAddress)
+		d.Set("gateway_fqdn", props.Fqdn)
 
 		if lnas := props.LocalNetworkAddressSpace; lnas != nil {
 			d.Set("address_space", lnas.AddressPrefixes)

--- a/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
@@ -245,7 +245,14 @@ func TestAccAzureRMLocalNetworkGateway_fqdn(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLocalNetworkGatewayConfig_fqdn(data),
+				Config: testAccAzureRMLocalNetworkGatewayConfig_fqdn(data, "www.foo.com"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_fqdn(data, "www.bar.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLocalNetworkGatewayExists(data.ResourceName),
 				),
@@ -515,7 +522,7 @@ resource "azurerm_local_network_gateway" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMLocalNetworkGatewayConfig_fqdn(data acceptance.TestData) string {
+func testAccAzureRMLocalNetworkGatewayConfig_fqdn(data acceptance.TestData, fqdn string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -530,8 +537,8 @@ resource "azurerm_local_network_gateway" "test" {
   name                = "acctestlng-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  gateway_fqdn        = "www.foobar.com"
+  gateway_fqdn        = %q
   address_space       = ["127.0.0.0/8"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, fqdn)
 }

--- a/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
@@ -236,6 +236,25 @@ func TestAccAzureRMLocalNetworkGateway_updateAddressSpace(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLocalNetworkGateway_fqdn(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_local_network_gateway", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_fqdn(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 // testCheckAzureRMLocalNetworkGatewayExists returns the resource.TestCheckFunc
 // which checks whether or not the expected local network gateway exists both
 // in the schema, and on Azure.
@@ -492,6 +511,27 @@ resource "azurerm_local_network_gateway" "test" {
   resource_group_name = azurerm_resource_group.test.name
   gateway_address     = "127.0.0.1"
   address_space       = ["127.0.1.0/24", "127.0.0.0/24"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMLocalNetworkGatewayConfig_fqdn(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-%d"
+  location = "%s"
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  gateway_fqdn        = "www.foobar.com"
+  address_space       = ["127.0.0.0/8"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
@@ -529,7 +529,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctest-%d"
+  name     = "acctestRG-network-%d"
   location = "%s"
 }
 

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -48,8 +48,7 @@ The following arguments are supported:
     
 * `gateway_address` - (Optional) The gateway IP address to connect with.
     
-* `gateway_fqdn` - (Optional) The FQDN of the gateway to which to
-    connect.
+* `gateway_fqdn` - (Optional) The gateway FQDN to connect with.
 
 -> **NOTE**: Either `gateway_address` or `gateway_fqdn` should be specified.
 

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -40,14 +40,19 @@ The following arguments are supported:
 * `location` - (Required) The location/region where the local network gateway is
     created. Changing this forces a new resource to be created.
 
-* `gateway_address` - (Required) The IP address of the gateway to which to
-    connect.
-
 * `address_space` - (Required) The list of string CIDRs representing the
     address spaces the gateway exposes.
 
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below containing the
     Local Network Gateway's BGP speaker settings.
+    
+* `gateway_address` - (Optional) The IP address of the gateway to which to
+    connect.
+    
+* `gateway_fqdn` - (Optional) The FQDN of the gateway to which to
+    connect.
+
+-> **NOTE**: Either `gateway_address` or `gateway_fqdn` should be specified.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -46,8 +46,7 @@ The following arguments are supported:
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below containing the
     Local Network Gateway's BGP speaker settings.
     
-* `gateway_address` - (Optional) The IP address of the gateway to which to
-    connect.
+* `gateway_address` - (Optional) The gateway IP address to connect with.
     
 * `gateway_fqdn` - (Optional) The FQDN of the gateway to which to
     connect.


### PR DESCRIPTION
## Test Result

```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMLocalNetworkGateway_fqdn'    
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMLocalNetworkGateway_fqdn -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLocalNetworkGateway_fqdn
=== PAUSE TestAccAzureRMLocalNetworkGateway_fqdn
=== CONT  TestAccAzureRMLocalNetworkGateway_fqdn
--- PASS: TestAccAzureRMLocalNetworkGateway_fqdn (127.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       127.406s
```