### PR TITLE
Fix `azurerm_backup_protected_file_share`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -104,7 +104,7 @@ testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 acctests: fmtcheck
-	TF_ACC=1 go test -v ./azurerm/internal/services/$(SERVICE)/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
+	TF_ACC=1 go test -v ./azurerm/internal/services/$(SERVICE)/tests/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) --headless --listen=:2345 --api-version=2 -- -test.v $(TESTARGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -104,7 +104,7 @@ testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 acctests: fmtcheck
-	TF_ACC=1 go test -v ./azurerm/internal/services/$(SERVICE)/tests/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
+	TF_ACC=1 go test -v ./azurerm/internal/services/$(SERVICE)/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) --headless --listen=:2345 --api-version=2 -- -test.v $(TESTARGS)

--- a/azurerm/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
+++ b/azurerm/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
@@ -68,7 +68,7 @@ resource "azurerm_recovery_services_vault" "testvlt" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  soft_delete_enabled = false
+  soft_delete_enabled = true
 }
 
 resource "azurerm_storage_account" "test" {

--- a/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource.go
+++ b/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource.go
@@ -71,6 +71,7 @@ func resourceBackupProtectedFileShare() *schema.Resource {
 }
 
 func resourceBackupProtectedFileShareCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	protectedClient := meta.(*clients.Client).RecoveryServices.ProtectedItemsGroupClient
 	protectableClient := meta.(*clients.Client).RecoveryServices.ProtectableItemsClient
 	client := meta.(*clients.Client).RecoveryServices.ProtectedItemsClient
 	opClient := meta.(*clients.Client).RecoveryServices.BackupOperationStatusesClient

--- a/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
+++ b/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
@@ -163,6 +163,10 @@ resource "azurerm_recovery_services_vault" "test" {
   sku                 = "Standard"
 
   soft_delete_enabled = false
+
+  lifecycle {
+    ignore_changes = [soft_delete_enabled] // Ignore changes to prevent tests from flakiness
+  }
 }
 
 resource "azurerm_backup_policy_file_share" "test1" {
@@ -325,6 +329,10 @@ resource "azurerm_recovery_services_vault" "test" {
   sku                 = "Standard"
 
   soft_delete_enabled = false
+
+  lifecycle {
+    ignore_changes = [soft_delete_enabled] // Ignore changes to prevent tests from flakiness
+  }
 }
 
 resource "azurerm_backup_policy_file_share" "test" {

--- a/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
+++ b/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
@@ -162,11 +162,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
 
-  soft_delete_enabled = false
-
-  lifecycle {
-    ignore_changes = [soft_delete_enabled] // Ignore changes to prevent tests from flakiness
-  }
+  soft_delete_enabled = true
 }
 
 resource "azurerm_backup_policy_file_share" "test1" {
@@ -328,11 +324,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
 
-  soft_delete_enabled = false
-
-  lifecycle {
-    ignore_changes = [soft_delete_enabled] // Ignore changes to prevent tests from flakiness
-  }
+  soft_delete_enabled = true
 }
 
 resource "azurerm_backup_policy_file_share" "test" {

--- a/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
+++ b/azurerm/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
@@ -38,6 +38,26 @@ func TestAccBackupProtectedFileShare_basic(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectedFileShare_multiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_protected_file_share", "test")
+	r := BackupProtectedFileShareResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.multiple(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			// vault cannot be deleted unless we unregister all backups
+			Config: r.baseMultiple(data),
+		},
+	})
+}
+
 func TestAccBackupProtectedFileShare_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_backup_protected_file_share", "test")
 	r := BackupProtectedFileShareResource{}
@@ -162,6 +182,71 @@ resource "azurerm_backup_policy_file_share" "test1" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
+func (r BackupProtectedFileShareResource) baseMultiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-backup-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctest%[3]s"
+  location                 = "${azurerm_resource_group.test.location}"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "testshare1" {
+  name                 = "acctest-ss-%[1]d-1"
+  storage_account_name = "${azurerm_storage_account.test.name}"
+  metadata             = {}
+
+  lifecycle {
+    ignore_changes = [metadata] // Ignore changes Azure Backup makes to the metadata
+  }
+}
+
+resource "azurerm_storage_share" "testshare2" {
+	name                 = "acctest-ss-%[1]d-2"
+	storage_account_name = "${azurerm_storage_account.test.name}"
+	metadata             = {}
+  
+	lifecycle {
+	  ignore_changes = [metadata] // Ignore changes Azure Backup makes to the metadata
+	}
+  }
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-VAULT-%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+
+  soft_delete_enabled = false
+}
+
+resource "azurerm_backup_policy_file_share" "test1" {
+  name                = "acctest-PFS-%[1]d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  recovery_vault_name = "${azurerm_recovery_services_vault.test.name}"
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 10
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
 func (r BackupProtectedFileShareResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -180,6 +265,26 @@ resource "azurerm_backup_protected_file_share" "test" {
   backup_policy_id          = azurerm_backup_policy_file_share.test1.id
 }
 `, r.base(data))
+}
+
+func (r BackupProtectedFileShareResource) multiple(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_backup_container_storage_account" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+  storage_account_id  = azurerm_storage_account.test.id
+}
+
+resource "azurerm_backup_protected_file_share" "test" {
+  resource_group_name       = azurerm_resource_group.test.name
+  recovery_vault_name       = azurerm_recovery_services_vault.test.name
+  source_storage_account_id = azurerm_backup_container_storage_account.test.storage_account_id
+  source_file_share_name    = azurerm_storage_share.testshare2.name
+  backup_policy_id          = azurerm_backup_policy_file_share.test1.id
+}
+`, r.baseMultiple(data))
 }
 
 func (r BackupProtectedFileShareResource) updatePolicy(data acceptance.TestData) string {

--- a/azurerm/internal/services/recoveryservices/client/client.go
+++ b/azurerm/internal/services/recoveryservices/client/client.go
@@ -8,7 +8,9 @@ import (
 )
 
 type Client struct {
+	ProtectableItemsClient           *backup.ProtectableItemsClient
 	ProtectedItemsClient             *backup.ProtectedItemsClient
+	ProtectedItemsGroupClient        *backup.ProtectedItemsGroupClient
 	ProtectionPoliciesClient         *backup.ProtectionPoliciesClient
 	BackupProtectionContainersClient *backup.ProtectionContainersClient
 	BackupOperationStatusesClient    *backup.OperationStatusesClient
@@ -29,8 +31,14 @@ func NewClient(o *common.ClientOptions) *Client {
 	vaultsClient := recoveryservices.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
 
+	protectableItemsClient := backup.NewProtectableItemsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&protectableItemsClient.Client, o.ResourceManagerAuthorizer)
+
 	protectedItemsClient := backup.NewProtectedItemsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&protectedItemsClient.Client, o.ResourceManagerAuthorizer)
+
+	protectedItemsGroupClient := backup.NewProtectedItemsGroupClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&protectedItemsGroupClient.Client, o.ResourceManagerAuthorizer)
 
 	protectionPoliciesClient := backup.NewProtectionPoliciesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&protectionPoliciesClient.Client, o.ResourceManagerAuthorizer)
@@ -78,7 +86,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	}
 
 	return &Client{
+		ProtectableItemsClient:           &protectableItemsClient,
 		ProtectedItemsClient:             &protectedItemsClient,
+		ProtectedItemsGroupClient:        &protectedItemsGroupClient,
 		ProtectionPoliciesClient:         &protectionPoliciesClient,
 		BackupProtectionContainersClient: &backupProtectionContainersClient,
 		BackupOperationStatusesClient:    &backupOperationStatusesClient,

--- a/website/docs/r/backup_protected_file_share.markdown
+++ b/website/docs/r/backup_protected_file_share.markdown
@@ -10,10 +10,6 @@ description: |-
 
 Manages an Azure Backup Protected File Share to enable backups for file shares within an Azure Storage Account
 
--> **NOTE:** Azure Backup for Azure File Shares is currently in public preview. During the preview, the service is subject to additional limitations and unsupported backup scenarios. [Read More](https://docs.microsoft.com/en-us/azure/backup/backup-azure-files#limitations-for-azure-file-share-backup-during-preview)
-
--> **NOTE** Azure Backup for Azure File Shares does not support Soft Delete at this time. Deleting this resource will also delete all associated backup data. Please exercise caution. Consider using [`prevent_destroy`](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy) to guard against accidental deletion.
-
 ## Example Usage
 
 ```hcl
@@ -108,7 +104,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Azure Backup Protected File Shares can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_backup_protected_file_share.item1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.RecoveryServices/vaults/example-recovery-vault/backupFabrics/Azure/protectionContainers/StorageContainer;storage;group2;example-storage-account/protectedItems/AzureFileShare;example-share"
+terraform import azurerm_backup_protected_file_share.item1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.RecoveryServices/vaults/example-recovery-vault/backupFabrics/Azure/protectionContainers/StorageContainer;storage;group2;example-storage-account/protectedItems/AzureFileShare;3f6e3108a45793581bcbd1c61c87a3b2ceeb4ff4bc02a95ce9d1022b23722935"
 ```
 
-Note the ID requires quoting as there are semicolons
+-> **NOTE** The ID requires quoting as there are semicolons. This user unfriendly ID can be found in the Deployments of the used resourcegroup, look for an Deployment which starts with `ConfigureAFSProtection-`, click then `Go to resource`.


### PR DESCRIPTION
## Context
`azurerm_backup_protected_file_share` was broken due to a backward incompatible change of the Azure Backup backend, using system names instead of user defined names.

Fixes #9368

## Solution
The solution is implemented based on [Azure Docs](https://docs.microsoft.com/en-us/azure/backup/backup-azure-file-share-rest-api) for the REST API, where protectable (and in our case also protected) fileshares' system names can be fetched.

## Acceptance Tests
```bash
--- PASS: TestAccAzureRMBackupProtectedFileShare_basic (435.24s)
--- PASS: TestAccAzureRMBackupProtectedFileShare_requiresImport (450.48s)
--- PASS: TestAccAzureRMBackupProtectedFileShare_updateBackupPolicyId (534.66s)
```

## Done
- [x] Resource `azurerm_backup_protected_file_share` fixed
- [x] Update documentation
  - [x] Explain where the user unfriendly id/Azure Backup fileshare system name can be found
  - [x] Resource is GA
  - [x] Resource is locked when it contains backups

