### PR TITLE
ISSUE Fixed: azurerm_virtual_desktop_application_group name allowed length is 3-31, should be 1-260 #8980

### DIFF
--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -3,6 +3,7 @@ package desktopvirtualization
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/desktopvirtualization/mgmt/2019-12-10-preview/desktopvirtualization"
@@ -10,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -40,10 +40,16 @@ func resourceArmVirtualDesktopApplicationGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.DevSpaceName(),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{1,260}$"),
+						"Virtual desktop application group name must be 1 - 260 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"location": azure.SchemaLocation(),


### PR DESCRIPTION
Acceptance tests results

TF_PROVIDER_SPLIT_COMBINED_TESTS=1 TF_ACC=1 go test -v ./azurerm/internal/services/containers/tests/ -timeout=60m -run=TestAccAzureRMKubernetesCluster_sameSize
TF_ACC=1 go test -v ./azurerm/internal/services/desktopvirtualization -timeout=60m -run=TestAccAzureRMVirtualDesktopApplicationGroup_basic
=== RUN   TestAccAzureRMVirtualDesktopApplicationGroup_basic
=== PAUSE TestAccAzureRMVirtualDesktopApplicationGroup_basic
=== CONT  TestAccAzureRMVirtualDesktopApplicationGroup_basic
--- PASS: TestAccAzureRMVirtualDesktopApplicationGroup_basic (185.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization	185.749s


TF_ACC=1 go test -v ./azurerm/internal/services/desktopvirtualization -timeout=60m -run=TestAccAzureRMVirtualDesktopApplicationGroup_complete
=== RUN   TestAccAzureRMVirtualDesktopApplicationGroup_complete
=== PAUSE TestAccAzureRMVirtualDesktopApplicationGroup_complete
=== CONT  TestAccAzureRMVirtualDesktopApplicationGroup_complete
--- PASS: TestAccAzureRMVirtualDesktopApplicationGroup_complete (177.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization	177.591s

TF_ACC=1 go test -v ./azurerm/internal/services/desktopvirtualization -timeout=60m -run=TestAccAzureRMVirtualDesktopApplicationGroup_update

=== RUN   TestAccAzureRMVirtualDesktopApplicationGroup_update
=== PAUSE TestAccAzureRMVirtualDesktopApplicationGroup_update
=== CONT  TestAccAzureRMVirtualDesktopApplicationGroup_update
--- PASS: TestAccAzureRMVirtualDesktopApplicationGroup_update (314.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization	314.068s

TF_ACC=1 go test -v ./azurerm/internal/services/desktopvirtualization -timeout=60m -run=TestAccAzureRMVirtualDesktopApplicationGroup_requiresImport
=== RUN   TestAccAzureRMVirtualDesktopApplicationGroup_requiresImport
=== PAUSE TestAccAzureRMVirtualDesktopApplicationGroup_requiresImport
=== CONT  TestAccAzureRMVirtualDesktopApplicationGroup_requiresImport
--- PASS: TestAccAzureRMVirtualDesktopApplicationGroup_requiresImport (193.34s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization	193.410s

(fixes #8980)