### PR TITLE
azurerm_vpn_gateway - support block "bgp_peering_addresses"

### DIFF
--- a/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
@@ -225,14 +225,12 @@ resource "azurerm_vpn_gateway" "test" {
     asn         = 65515
     peer_weight = 0
 
-    bgp_peering_addresses {
-      ip_configuration_id     = "Instance0"
-      custom_bgp_ip_addresses = ["169.254.21.5"]
+    instance_bgp_peering_address {
+      custom_ips = ["169.254.21.5"]
     }
 
-    bgp_peering_addresses {
-      ip_configuration_id     = "Instance1"
-      custom_bgp_ip_addresses = ["169.254.21.10"]
+    instance_bgp_peering_address {
+      custom_ips = ["169.254.21.10"]
     }
   }
 }

--- a/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
@@ -225,11 +225,11 @@ resource "azurerm_vpn_gateway" "test" {
     asn         = 65515
     peer_weight = 0
 
-    instance_bgp_peering_address {
+    instance_0_bgp_peering_address {
       custom_ips = ["169.254.21.5"]
     }
 
-    instance_bgp_peering_address {
+    instance_1_bgp_peering_address {
       custom_ips = ["169.254.21.10"]
     }
   }

--- a/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/vpn_gateway_resource_test.go
@@ -224,6 +224,16 @@ resource "azurerm_vpn_gateway" "test" {
   bgp_settings {
     asn         = 65515
     peer_weight = 0
+
+    bgp_peering_addresses {
+      ip_configuration_id     = "Instance0"
+      custom_bgp_ip_addresses = ["169.254.21.5"]
+    }
+
+    bgp_peering_addresses {
+      ip_configuration_id     = "Instance1"
+      custom_bgp_ip_addresses = ["169.254.21.10"]
+    }
   }
 }
 `, template, data.RandomInteger)

--- a/azurerm/internal/services/network/vpn_gateway_resource.go
+++ b/azurerm/internal/services/network/vpn_gateway_resource.go
@@ -194,7 +194,9 @@ func resourceArmVPNGatewayCreate(d *schema.ResourceData, meta interface{}) error
 		val := bgpSettingsRaw[0].(map[string]interface{})
 		input := val["instance_bgp_peering_address"].([]interface{})
 		if len(input) > 0 {
-			expandVPNGatewayIPConfigurationBgpPeeringAddress(resp.VpnGatewayProperties.BgpSettings.BgpPeeringAddresses, input)
+			if err := expandVPNGatewayIPConfigurationBgpPeeringAddress(resp.VpnGatewayProperties.BgpSettings.BgpPeeringAddresses, input); err != nil {
+				return err
+			}
 			if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, resp); err != nil {
 				return fmt.Errorf("creating VPN Gateway %q (Resource Group %q): %+v", name, resourceGroup, err)
 			}
@@ -229,7 +231,9 @@ func resourceArmVPNGatewayUpdate(d *schema.ResourceData, meta interface{}) error
 		bgpSettingsRaw := d.Get("bgp_settings").([]interface{})
 		if len(bgpSettingsRaw) > 0 {
 			val := bgpSettingsRaw[0].(map[string]interface{})
-			expandVPNGatewayIPConfigurationBgpPeeringAddress(existing.VpnGatewayProperties.BgpSettings.BgpPeeringAddresses, val["instance_bgp_peering_address"].([]interface{}))
+			if err := expandVPNGatewayIPConfigurationBgpPeeringAddress(existing.VpnGatewayProperties.BgpSettings.BgpPeeringAddresses, val["instance_bgp_peering_address"].([]interface{})); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -75,6 +75,16 @@ A `bgp_settings` block supports the following:
 
 * `peer_weight` - (Required) The weight added to Routes learned from this BGP Speaker. Changing this forces a new resource to be created.
 
+* `bgp_peering_addresses` - (Optional) One or more `bgp_peering_addresses` block as defined below.
+
+---
+
+A `bgp_peering_addresses` block supports the following:
+
+* `ip_configuration_id` - (Required) The ID of IP configuration which belongs to gateway.
+
+* `custom_bgp_ip_addresses` - (Required) The list of custom BGP peering addresses which belong to IP configuration.
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:
@@ -88,6 +98,16 @@ In addition to the arguments above, the following attributes are exported:
 A `bgp_settings` block exports the following:
 
 * `bgp_peering_address` - The Address which should be used for the BGP Peering.
+
+* `bgp_peering_addresses` - One or more `bgp_peering_addresses` block as defined below.
+
+---
+
+A `bgp_peering_addresses` block exports the following:
+
+* `default_bgp_ip_addresses` - The list of default BGP peering addresses which belong to IP configuration.
+
+* `tunnel_ip_addresses` - The list of tunnel public IP addresses which belong to IP configuration.
 
 ## Timeouts
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -75,13 +75,15 @@ A `bgp_settings` block supports the following:
 
 * `peer_weight` - (Required) The weight added to Routes learned from this BGP Speaker. Changing this forces a new resource to be created.
 
-* `instance_bgp_peering_address` - (Optional) One or more `instance_bgp_peering_address` block as defined below.
+* `instance_0_bgp_peering_address` - (Optional) An `instance_bgp_peering_address` block as defined below.
+
+* `instance_1_bgp_peering_address` - (Optional) An `instance_bgp_peering_address` block as defined below.
 
 ---
 
 A `instance_bgp_peering_address` block supports the following:
 
-* `custom_ips` - (Required) The list of custom BGP peering addresses which belong to pre-defined IP configuration.
+* `custom_ips` - (Required) A list of custom BGP peering addresses to assign to this instance.
 
 ## Attributes Reference
 
@@ -97,7 +99,9 @@ A `bgp_settings` block exports the following:
 
 * `bgp_peering_address` - The Address which should be used for the BGP Peering.
 
-* `instance_bgp_peering_address` - One or more `instance_bgp_peering_address` block as defined below.
+* `instance_0_bgp_peering_address` - an `instance_bgp_peering_address` block as defined below.
+
+* `instance_1_bgp_peering_address` - an `instance_bgp_peering_address` block as defined below.
 
 ---
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -75,15 +75,13 @@ A `bgp_settings` block supports the following:
 
 * `peer_weight` - (Required) The weight added to Routes learned from this BGP Speaker. Changing this forces a new resource to be created.
 
-* `bgp_peering_addresses` - (Optional) One or more `bgp_peering_addresses` block as defined below.
+* `instance_bgp_peering_address` - (Optional) One or more `instance_bgp_peering_address` block as defined below.
 
 ---
 
-A `bgp_peering_addresses` block supports the following:
+A `instance_bgp_peering_address` block supports the following:
 
-* `ip_configuration_id` - (Required) The ID of IP configuration which belongs to gateway.
-
-* `custom_bgp_ip_addresses` - (Required) The list of custom BGP peering addresses which belong to IP configuration.
+* `custom_ips` - (Required) The list of custom BGP peering addresses which belong to pre-defined IP configuration.
 
 ## Attributes Reference
 
@@ -99,15 +97,17 @@ A `bgp_settings` block exports the following:
 
 * `bgp_peering_address` - The Address which should be used for the BGP Peering.
 
-* `bgp_peering_addresses` - One or more `bgp_peering_addresses` block as defined below.
+* `instance_bgp_peering_address` - One or more `instance_bgp_peering_address` block as defined below.
 
 ---
 
-A `bgp_peering_addresses` block exports the following:
+A `instance_bgp_peering_address` block exports the following:
 
-* `default_bgp_ip_addresses` - The list of default BGP peering addresses which belong to IP configuration.
+* `ip_configuration_id` - The pre-defined id of VPN Gateway Ip Configuration.
 
-* `tunnel_ip_addresses` - The list of tunnel public IP addresses which belong to IP configuration.
+* `default_ips` - The list of default BGP peering addresses which belong to the pre-defined VPN Gateway IP configuration.
+
+* `tunnel_ips` - The list of tunnel public IP addresses which belong to the pre-defined VPN Gateway IP configuration.
 
 ## Timeouts
 


### PR DESCRIPTION
After confirmed with service team, this field "bgp_peering_addresses" could not be set when creating, otherwise the rest api will report error. It could only be updated.

![image](https://user-images.githubusercontent.com/2786738/97273857-d1c8d080-186e-11eb-9183-97289dfe4ff5.png)
