### PR TITLE
tooling: switching to `go install`ing the tooling

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,10 +13,10 @@ default: build
 tools:
 	@echo "==> installing required tooling..."
 	@sh "$(CURDIR)/scripts/gogetcookie.sh"
-	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
-	GO111MODULE=off go get -u github.com/bflad/tfproviderlint/cmd/tfproviderlint
-	GO111MODULE=off go get -u github.com/bflad/tfproviderdocs
-	GO111MODULE=off go get -u github.com/katbyte/terrafmt
+	GO111MODULE=off go install github.com/client9/misspell/cmd/misspell
+	GO111MODULE=off go install github.com/bflad/tfproviderlint/cmd/tfproviderlint
+	GO111MODULE=off go install github.com/bflad/tfproviderdocs
+	GO111MODULE=off go install github.com/katbyte/terrafmt
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$GOPATH/bin v1.24.0
 
 build: fmtcheck generate

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ tools:
 	GO111MODULE=off go install github.com/bflad/tfproviderlint/cmd/tfproviderlint
 	GO111MODULE=off go install github.com/bflad/tfproviderdocs
 	GO111MODULE=off go install github.com/katbyte/terrafmt
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$GOPATH/bin v1.24.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v1.24.0
 
 build: fmtcheck generate
 	go install


### PR DESCRIPTION
This forces the tooling to be installed into the `bin` directory