### PR TITLE
`azurerm_log_analytics_solution` - add support of `tags`

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/operationsmanagement/mgmt/2015-11-01-preview/operationsmanagement"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -89,6 +91,8 @@ func resourceArmLogAnalyticsSolution() *schema.Resource {
 					},
 				},
 			},
+
+			"tags": tags.Schema(),
 		},
 	}
 }
@@ -130,6 +134,7 @@ func resourceArmLogAnalyticsSolutionCreateUpdate(d *schema.ResourceData, meta in
 		Properties: &operationsmanagement.SolutionProperties{
 			WorkspaceResourceID: utils.String(workspaceID),
 		},
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, parameters)
@@ -207,7 +212,7 @@ func resourceArmLogAnalyticsSolutionRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting `plan`: %+v", err)
 	}
 
-	return nil
+	return tags.FlattenAndSet(d, resp.Tags)
 }
 
 func resourceArmLogAnalyticsSolutionDelete(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_solution_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_solution_resource_test.go
@@ -153,6 +153,10 @@ resource "azurerm_log_analytics_solution" "test" {
     publisher = "Microsoft"
     product   = "OMSGallery/ContainerInsights"
   }
+
+  tags = {
+    environment = "Test"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_solution_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_solution_resource_test.go
@@ -155,7 +155,7 @@ resource "azurerm_log_analytics_solution" "test" {
   }
 
   tags = {
-    environment = "Test"
+    Environment = "Test"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -64,6 +64,8 @@ The following arguments are supported:
 
 * `plan` - (Required) A `plan` block as documented below.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 A `plan` block includes:


### PR DESCRIPTION
Fixes #8751

```bash
💤 make testacc TEST=./azurerm/internal/services/loganalytics/tests TESTARGS='-run TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/loganalytics/tests -v -run TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring
=== PAUSE TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring
=== CONT  TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring
--- PASS: TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring (177.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/tests  177.550s
```