### PR TITLE
Remove cosmosdb autoscale upper cap

### DIFF
--- a/azurerm/helpers/validate/cosmos.go
+++ b/azurerm/helpers/validate/cosmos.go
@@ -55,11 +55,6 @@ func CosmosMaxThroughput(i interface{}, k string) (warnings []string, errors []e
 			"%s must be a minimum of 4000", k))
 	}
 
-	if v > 1000000 {
-		errors = append(errors, fmt.Errorf(
-			"%s must be a maximum of 1000000", k))
-	}
-
 	if v%1000 != 0 {
 		errors = append(errors, fmt.Errorf(
 			"%q must be set in increments of 1000", k))

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -133,6 +133,10 @@ func TestCosmosMaxThroughput(t *testing.T) {
 			Errors: 0,
 		},
 		{
+			Value:  1100000,
+			Errors: 0,
+		},
+		{
 			Value:  "400",
 			Errors: 1,
 		},

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -133,10 +133,6 @@ func TestCosmosMaxThroughput(t *testing.T) {
 			Errors: 0,
 		},
 		{
-			Value:  1100000,
-			Errors: 1,
-		},
-		{
 			Value:  "400",
 			Errors: 1,
 		},

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of Cassandra KeySpace (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support
+
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of the Gremlin database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support
+
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of the MongoDB database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support.
+
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of SQL database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support
+
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of Table (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support
+
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 


### PR DESCRIPTION
MSFT support can scale accounts and containers to the skies (largest
we've heard was around 30M RUs), so capping this in terraform breaks
custom accounts and containers scaled to large ~~wallets~~ volumes.