### PR TITLE
azurerm_private_endpoint subresource_names parameter should be marked as required instead of optional

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -135,7 +135,7 @@ A `private_service_connection` supports the following:
 
 * `private_connection_resource_id` - (Required) The ID of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. Changing this forces a new resource to be created.
 
-* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Changing this forces a new resource to be created.
+* `subresource_names` - (Required) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Changing this forces a new resource to be created.
 
 -> Several possible values for this field are shown below, however this is not extensive:
 


### PR DESCRIPTION
I tried to create a private endpoint and get the following message:
Error: Error creating Private Endpoint "xxxxxxxt"  due to missing 'group Id', ensure that the 'subresource_names' type is populated: network.PrivateEndpointsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="MissingParameterOnPrivateLinkServiceConnection" Message="Private link service connection /subscriptions/xxxxxxx/resourceGroups/xxxxxxxxxxxxxxx/providers/Microsoft.Network/privateEndpoints/xxxxxxxxxxxxxxxx/privateLinkServiceConnections/xxxxx-privateserviceconnection is missing required parameter 'group Id'." Details=[]

So the subresource_names parameter should be marked as required instead of optional