### PR TITLE
`azurerm_policy_definition` resource and datasource can now look up builtin policy by name

### DIFF
--- a/azurerm/internal/services/policy/policy.go
+++ b/azurerm/internal/services/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-09-01/policy"
+	"github.com/Azure/go-autorest/autorest"
 )
 
 func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.DefinitionsClient, displayName, managementGroupName string) (policy.Definition, error) {
@@ -50,6 +51,9 @@ func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.Defini
 func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsClient, name string, managementGroupName string) (res policy.Definition, err error) {
 	if managementGroupName == "" {
 		res, err = client.Get(ctx, name)
+		if aerr, ok := err.(autorest.DetailedError); ok && aerr.StatusCode == 404 {
+			res, err = client.GetBuiltIn(ctx, name)
+		}
 	} else {
 		res, err = client.GetAtManagementGroup(ctx, name, managementGroupName)
 	}
@@ -60,6 +64,9 @@ func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsCl
 func getPolicySetDefinitionByName(ctx context.Context, client *policy.SetDefinitionsClient, name string, managementGroupID string) (res policy.SetDefinition, err error) {
 	if managementGroupID == "" {
 		res, err = client.Get(ctx, name)
+		if aerr, ok := err.(autorest.DetailedError); ok && aerr.StatusCode == 404 {
+			res, err = client.GetBuiltIn(ctx, name)
+		}
 	} else {
 		res, err = client.GetAtManagementGroup(ctx, name, managementGroupID)
 	}

--- a/azurerm/internal/services/policy/policy.go
+++ b/azurerm/internal/services/policy/policy.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-09-01/policy"
-	"github.com/Azure/go-autorest/autorest"
 )
 
 func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.DefinitionsClient, displayName, managementGroupName string) (policy.Definition, error) {
@@ -51,7 +52,7 @@ func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.Defini
 func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsClient, name string, managementGroupName string) (res policy.Definition, err error) {
 	if managementGroupName == "" {
 		res, err = client.Get(ctx, name)
-		if aerr, ok := err.(autorest.DetailedError); ok && aerr.StatusCode == 404 {
+		if utils.ResponseWasNotFound(res.Response) {
 			res, err = client.GetBuiltIn(ctx, name)
 		}
 	} else {
@@ -64,7 +65,7 @@ func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsCl
 func getPolicySetDefinitionByName(ctx context.Context, client *policy.SetDefinitionsClient, name string, managementGroupID string) (res policy.SetDefinition, err error) {
 	if managementGroupID == "" {
 		res, err = client.Get(ctx, name)
-		if aerr, ok := err.(autorest.DetailedError); ok && aerr.StatusCode == 404 {
+		if utils.ResponseWasNotFound(res.Response) {
 			res, err = client.GetBuiltIn(ctx, name)
 		}
 	} else {

--- a/azurerm/internal/services/policy/tests/policy_definition_data_source_test.go
+++ b/azurerm/internal/services/policy/tests/policy_definition_data_source_test.go
@@ -29,6 +29,27 @@ func TestAccDataSourceAzureRMPolicyDefinition_builtIn(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMPolicyDefinition_builtIn_byName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBuiltInPolicyDefinitionByName("a08ec900-254a-4555-9bf5-e42af04b5c5c"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "id", "/providers/Microsoft.Authorization/policyDefinitions/a08ec900-254a-4555-9bf5-e42af04b5c5c"),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", "a08ec900-254a-4555-9bf5-e42af04b5c5c"),
+					resource.TestCheckResourceAttr(data.ResourceName, "display_name", "Allowed resource types"),
+					resource.TestCheckResourceAttr(data.ResourceName, "type", "Microsoft.Authorization/policyDefinitions"),
+					resource.TestCheckResourceAttr(data.ResourceName, "description", "This policy enables you to specify the resource types that your organization can deploy. Only resource types that support 'tags' and 'location' will be affected by this policy. To restrict all resources please duplicate this policy and change the 'mode' to 'All'."),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
 
@@ -100,6 +121,18 @@ provider "azurerm" {
 
 data "azurerm_policy_definition" "test" {
   display_name = "%s"
+}
+`, name)
+}
+
+func testAccDataSourceBuiltInPolicyDefinitionByName(name string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_policy_definition" "test" {
+  name = "%s"
 }
 `, name)
 }


### PR DESCRIPTION
Fixes #9074 

Added the search by name into built in since it actually uses a different api so if the policy it is not found in the local ones get it from the built in ones.