### PR TITLE
test framework: introducing a shim layer for Binary Testing

### DIFF
--- a/azurerm/internal/acceptance/check/that.go
+++ b/azurerm/internal/acceptance/check/that.go
@@ -1,0 +1,74 @@
+package check
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+)
+
+type thatType struct {
+	// resourceName being the full resource name e.g. azurerm_foo.bar
+	resourceName string
+}
+
+// Key returns a type which can be used for more fluent assertions for a given Resource
+func That(resourceName string) thatType {
+	return thatType{
+		resourceName: resourceName,
+	}
+}
+
+// ExistsInAzure validates that the specified resource exists within Azure
+func (t thatType) ExistsInAzure(testResource types.TestResource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client)
+		return helpers.ExistsInAzure(client, testResource, t.resourceName)(s)
+	}
+}
+
+// Key returns a type which can be used for more fluent assertions for a given Resource & Key combination
+func (t thatType) Key(key string) thatWithKeyType {
+	return thatWithKeyType{
+		resourceName: t.resourceName,
+		key:          key,
+	}
+}
+
+type thatWithKeyType struct {
+	// resourceName being the full resource name e.g. azurerm_foo.bar
+	resourceName string
+
+	// key being the specific field we're querying e.g. bar or a nested object ala foo.0.bar
+	key string
+}
+
+// DoesNotExist returns a TestCheckFunc which validates that the specific key
+// does not exist on the resource
+func (t thatWithKeyType) DoesNotExist() resource.TestCheckFunc {
+	return resource.TestCheckNoResourceAttr(t.resourceName, t.key)
+}
+
+// Exists returns a TestCheckFunc which validates that the specific key exists on the resource
+func (t thatWithKeyType) Exists() resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrSet(t.resourceName, t.key)
+}
+
+// IsEmpty returns a TestCheckFunc which validates that the specific key is empty on the resource
+func (t thatWithKeyType) IsEmpty() resource.TestCheckFunc {
+	return resource.TestCheckResourceAttr(t.resourceName, t.key, "")
+}
+
+// HasValue returns a TestCheckFunc which validates that the specific key has the
+// specified value on the resource
+func (t thatWithKeyType) HasValue(value string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttr(t.resourceName, t.key, value)
+}
+
+// MatchesOtherKey returns a TestCheckFunc which validates that the key on this resource
+// matches another other key on another resource
+func (t thatWithKeyType) MatchesOtherKey(other thatWithKeyType) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrPair(t.resourceName, t.key, other.resourceName, other.key)
+}

--- a/azurerm/internal/acceptance/helpers/check_destroyed.go
+++ b/azurerm/internal/acceptance/helpers/check_destroyed.go
@@ -1,0 +1,36 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+)
+
+// CheckDestroyedFunc returns a TestCheckFunc which validates the resource no longer exists
+func CheckDestroyedFunc(client *clients.Client, testResource types.TestResource, resourceType, resourceLabel string) func(state *terraform.State) error {
+	return func(state *terraform.State) error {
+		ctx := client.StopContext
+
+		for label, resourceState := range state.RootModule().Resources {
+			if resourceState.Type != resourceType {
+				continue
+			}
+			if label != resourceLabel {
+				continue
+			}
+
+			// Destroy is unconcerned with an error checking the status, since this is going to be "not found"
+			result, err := testResource.Exists(ctx, client, resourceState.Primary)
+			if result == nil && err != nil {
+				return fmt.Errorf("should have either an error or a result when checking if \"%s.%s\" has been destroyed", resourceType, resourceLabel)
+			}
+			if result != nil && *result {
+				return fmt.Errorf("\"%s.%s\" still exists", resourceType, resourceLabel)
+			}
+		}
+
+		return nil
+	}
+}

--- a/azurerm/internal/acceptance/helpers/delete.go
+++ b/azurerm/internal/acceptance/helpers/delete.go
@@ -1,0 +1,36 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+)
+
+// DeleteResourceFunc returns a TestCheckFunc which deletes the resource within Azure
+// this is only used within the Internal
+func DeleteResourceFunc(client *clients.Client, testResource types.TestResourceVerifyingRemoved, resourceName string) func(state *terraform.State) error {
+	return func(state *terraform.State) error {
+		ctx := client.StopContext
+
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%q was not found in the state", resourceName)
+		}
+
+		result, err := testResource.Destroy(ctx, client, rs.Primary)
+		if err != nil {
+			return fmt.Errorf("running destroy func for %q: %+v", resourceName, err)
+		}
+		if result == nil {
+			return fmt.Errorf("received nil for destroy result for %q", resourceName)
+		}
+
+		if !*result {
+			return fmt.Errorf("error deleting %q but no error", resourceName)
+		}
+
+		return nil
+	}
+}

--- a/azurerm/internal/acceptance/helpers/exists.go
+++ b/azurerm/internal/acceptance/helpers/exists.go
@@ -1,0 +1,35 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+)
+
+func ExistsInAzure(client *clients.Client, testResource types.TestResource, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ctx := client.StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%q was not found in the state", resourceName)
+		}
+
+		result, err := testResource.Exists(ctx, client, rs.Primary)
+		if err != nil {
+			return fmt.Errorf("running exists func for %q: %+v", resourceName, err)
+		}
+		if result == nil {
+			return fmt.Errorf("received nil for exists for %q", resourceName)
+		}
+
+		if !*result {
+			return fmt.Errorf("%q did not exist", resourceName)
+		}
+
+		return nil
+	}
+}

--- a/azurerm/internal/acceptance/providers.go
+++ b/azurerm/internal/acceptance/providers.go
@@ -13,8 +13,10 @@ import (
 var once sync.Once
 
 func EnsureProvidersAreInitialised() {
-	// NOTE: (@tombuildsstuff) - opting-out of Binary Testing for the moment
-	os.Setenv("TF_DISABLE_BINARY_TESTING", "true")
+	if !enableBinaryTesting {
+		// NOTE: (@tombuildsstuff) - opting-out of Binary Testing for the moment
+		os.Setenv("TF_DISABLE_BINARY_TESTING", "true")
+	}
 
 	once.Do(func() {
 		azureProvider := provider.TestAzureProvider().(*schema.Provider)

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -48,10 +48,9 @@ func buildClient() *clients.Client {
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 	if enableBinaryTesting {
 		testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
-			// TODO: switch this out for dynamic initialization
+			// TODO: switch this out for dynamic initialization?
 			"azurerm": terraform.ResourceProviderFactoryFixed(AzureProvider),
 		}
-		//} else {
 	}
 	testCase.Providers = SupportedProviders
 

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -38,9 +38,11 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 }
 
 func buildClient() *clients.Client {
-	if enableBinaryTesting {
-		// TODO: we can likely cache the built up auth object and return a new client instance
-	}
+	//if enableBinaryTesting {
+	// TODO: build up a client on demand
+	// NOTE: this'll want caching/a singleton, and likely RP registration etc disabled, since otherwise this'll become
+	// 		 extremely expensive - and this doesn't need access to the provider feature toggles
+	//}
 
 	return AzureProvider.Meta().(*clients.Client)
 }

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -16,6 +16,9 @@ import (
 var enableBinaryTesting = false
 
 func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {
+	// DataSources don't need a check destroy - however since this is a wrapper function
+	// and not matching the ignore pattern `XXX_data_source_test.go`, this needs to be explicitly opted out
+	//lintignore:AT001
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },
 		Steps:    steps,
@@ -38,11 +41,11 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 }
 
 func buildClient() *clients.Client {
-	//if enableBinaryTesting {
-	// TODO: build up a client on demand
-	// NOTE: this'll want caching/a singleton, and likely RP registration etc disabled, since otherwise this'll become
-	// 		 extremely expensive - and this doesn't need access to the provider feature toggles
-	//}
+	// if enableBinaryTesting {
+	//   TODO: build up a client on demand
+	//   NOTE: this'll want caching/a singleton, and likely RP registration etc disabled, since otherwise this'll become
+	//   		 extremely expensive - and this doesn't need access to the provider feature toggles
+	// }
 
 	return AzureProvider.Meta().(*clients.Client)
 }

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -1,0 +1,59 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+)
+
+// NOTE: when Binary Testing is enabled the Check functions will need to build a client rather than relying on the
+// shared one. For the moment we init the shared client when Binary Testing is Enabled & Disabled - but this needs
+// fixing when we move to Binary Testing so that we can test across provider instances
+var enableBinaryTesting = false
+
+func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {
+	testCase := resource.TestCase{
+		PreCheck: func() { PreCheck(t) },
+		Steps:    steps,
+	}
+
+	td.runAcceptanceTest(t, testCase)
+}
+
+func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []resource.TestStep) {
+	testCase := resource.TestCase{
+		PreCheck: func() { PreCheck(t) },
+		CheckDestroy: func(s *terraform.State) error {
+			client := buildClient()
+			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.resourceLabel)(s)
+		},
+		Steps: steps,
+	}
+
+	td.runAcceptanceTest(t, testCase)
+}
+
+func buildClient() *clients.Client {
+	if enableBinaryTesting {
+		// TODO: we can likely cache the built up auth object and return a new client instance
+	}
+
+	return AzureProvider.Meta().(*clients.Client)
+}
+
+func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
+	if enableBinaryTesting {
+		testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
+			// TODO: switch this out for dynamic initialization
+			"azurerm": terraform.ResourceProviderFactoryFixed(AzureProvider),
+		}
+		//} else {
+	}
+	testCase.Providers = SupportedProviders
+
+	resource.ParallelTest(t, testCase)
+}

--- a/azurerm/internal/acceptance/types/resource.go
+++ b/azurerm/internal/acceptance/types/resource.go
@@ -1,0 +1,17 @@
+package types
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+)
+
+type TestResource interface {
+	Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error)
+}
+
+type TestResourceVerifyingRemoved interface {
+	TestResource
+	Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error)
+}

--- a/azurerm/internal/services/advisor/tests/data_source_advisor_recommendations_test.go
+++ b/azurerm/internal/services/advisor/tests/data_source_advisor_recommendations_test.go
@@ -6,80 +6,68 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 )
 
-func TestAccDataSourceAzureRMAdvisorRecommendations_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_advisor_recommendations", "test")
+type AdvisorRecommendationsDataSourceTests struct{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.PreCheck(t) },
-		Providers: acceptance.SupportedProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckArmAdvisorRecommendations_basic,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.#"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.category"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.description"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.impact"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.recommendation_name"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.recommendation_type_id"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.resource_name"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.resource_type"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.0.updated_time"),
-				),
-			},
+func TestAdvisorRecommendationsDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_advisor_recommendations", "test")
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: AdvisorRecommendationsDataSourceTests{}.basicConfig(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("recommendations.#").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.category").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.description").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.impact").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.recommendation_name").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.recommendation_type_id").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.resource_name").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.resource_type").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.updated_time").Exists(),
+			),
 		},
 	})
 }
 
-func TestAccDataSourceAzureRMAdvisorRecommendations_complete(t *testing.T) {
+func TestAdvisorRecommendationsDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_advisor_recommendations", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.PreCheck(t) },
-		Providers: acceptance.SupportedProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckArmAdvisorRecommendations_complete(data),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.#"),
-				),
-			},
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: AdvisorRecommendationsDataSourceTests{}.completeConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("recommendations.#").Exists(),
+			),
 		},
 	})
 }
 
-func TestAccDataSourceAzureRMAdvisorRecommendations_categoriesFilter(t *testing.T) {
+func TestAdvisorRecommendationsDataSource_categoriesFilter(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_advisor_recommendations", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { acceptance.PreCheck(t) },
-		Providers: acceptance.SupportedProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckArmAdvisorRecommendations_categoriesFilter,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(data.ResourceName, "recommendations.#"),
-					resource.TestCheckResourceAttr(data.ResourceName, "recommendations.0.category", "Cost"),
-				),
-			},
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: AdvisorRecommendationsDataSourceTests{}.categoriesFilterConfig(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("recommendations.#").Exists(),
+				check.That(data.ResourceName).Key("recommendations.0.category").HasValue("Cost"),
+			),
 		},
 	})
 }
 
-const testAccCheckArmAdvisorRecommendations_basic = `
-provider "azurerm" {
+func (AdvisorRecommendationsDataSourceTests) basicConfig() string {
+	return `provider "azurerm" {
   features {}
 }
 
-data "azurerm_advisor_recommendations" "test" { }
-`
+data "azurerm_advisor_recommendations" "test" {}`
+}
 
-// Advisor genereate recommendations needs long time to take effects, sometimes up to one day or more,
+// Advisor generated recommendations needs long time to take effects, sometimes up to one day or more,
 // Please refer to the issue https://github.com/Azure/azure-rest-api-specs/issues/9284
 // So here we get an empty list of recommendations
-func testAccCheckArmAdvisorRecommendations_complete(data acceptance.TestData) string {
+func (AdvisorRecommendationsDataSourceTests) completeConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -106,12 +94,13 @@ data "azurerm_advisor_recommendations" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-const testAccCheckArmAdvisorRecommendations_categoriesFilter = `
+func (AdvisorRecommendationsDataSourceTests) categoriesFilterConfig() string {
+	return `
 provider "azurerm" {
   features {}
 }
 
 data "azurerm_advisor_recommendations" "test" {
-  filter_by_category           = ["cost"]
+  filter_by_category = ["cost"]
+}`
 }
-`


### PR DESCRIPTION
This PR introduces a shim layer, which allows us to gradually migrate over to Plugin SDKv2 without introducing a gradual breaking change all at once.

Going forward this allows us to define a struct for the test resource:

```
type ResourceGroupResource struct {
}

func (t ResourceGroupResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
  // ..
}
```

.. which contains a single method (with Azure-typed specific params) for "does this resource exist" - which is used for both Exists (where this should) and the Destroy func (and where it shouldn't). This is intentionally implemented to avoid large amounts of breaking changes from today, meaning we can go through and switch over gradually.

Longer term we can look to flip on Binary Testing, which can be done via the feature toggle and initializing the clients as necessary prior to passing them in in the Exists/Destroy funcs.

---

Tests pass for both of these resources:

```
$ TF_ACC=1 envchain azurerm go test -v ./azurerm/internal/services/advisor/tests/ -run=TestAdvisorRecommendationsDataSource_
=== RUN   TestAdvisorRecommendationsDataSource_basic
=== PAUSE TestAdvisorRecommendationsDataSource_basic
=== RUN   TestAdvisorRecommendationsDataSource_complete
=== PAUSE TestAdvisorRecommendationsDataSource_complete
=== RUN   TestAdvisorRecommendationsDataSource_categoriesFilter
=== PAUSE TestAdvisorRecommendationsDataSource_categoriesFilter
=== CONT  TestAdvisorRecommendationsDataSource_basic
=== CONT  TestAdvisorRecommendationsDataSource_categoriesFilter
=== CONT  TestAdvisorRecommendationsDataSource_complete
--- PASS: TestAdvisorRecommendationsDataSource_basic (34.62s)
--- PASS: TestAdvisorRecommendationsDataSource_categoriesFilter (34.72s)
--- PASS: TestAdvisorRecommendationsDataSource_complete (112.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/advisor/tests	112.350s
```

```
$ TF_ACC=1 envchain azurerm go test -v ./azurerm/internal/services/resource/tests/ -run=TestAccResourceGroup_
=== RUN   TestAccResourceGroup_basic
=== PAUSE TestAccResourceGroup_basic
=== RUN   TestAccResourceGroup_requiresImport
=== PAUSE TestAccResourceGroup_requiresImport
=== RUN   TestAccResourceGroup_disappears
=== PAUSE TestAccResourceGroup_disappears
=== RUN   TestAccResourceGroup_withTags
=== PAUSE TestAccResourceGroup_withTags
=== CONT  TestAccResourceGroup_basic
=== CONT  TestAccResourceGroup_withTags
=== CONT  TestAccResourceGroup_disappears
=== CONT  TestAccResourceGroup_requiresImport
--- PASS: TestAccResourceGroup_disappears (69.65s)
--- PASS: TestAccResourceGroup_basic (81.90s)
--- PASS: TestAccResourceGroup_requiresImport (85.99s)
--- PASS: TestAccResourceGroup_withTags (101.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/tests	101.929s
```
