### PR TITLE
r/vpn_site: fixing the build on 32 bit platforms

### DIFF
--- a/azurerm/internal/services/network/vpn_site_resource.go
+++ b/azurerm/internal/services/network/vpn_site_resource.go
@@ -123,7 +123,7 @@ func resourceArmVpnSite() *schema.Resource {
 									"asn": {
 										Type:         schema.TypeInt,
 										Required:     true,
-										ValidateFunc: validation.IntBetween(1, 4294967295),
+										ValidateFunc: validation.IntAtLeast(1),
 									},
 									"peering_address": {
 										Type:         schema.TypeString,


### PR DESCRIPTION
Currently this constant causes an overflow:

```
5 errors occurred:
--> linux/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network
azurerm/internal/services/network/vpn_site_resource.go:126:50: constant 4294967295 overflows int
--> freebsd/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network
azurerm/internal/services/network/vpn_site_resource.go:126:50: constant 4294967295 overflows int
--> freebsd/arm error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network
azurerm/internal/services/network/vpn_site_resource.go:126:50: constant 4294967295 overflows int
--> windows/386 error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network
azurerm/internal/services/network/vpn_site_resource.go:126:50: constant 4294967295 overflows int
--> linux/arm error: exit status 2
Stderr: # github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network
azurerm/internal/services/network/vpn_site_resource.go:126:50: constant 4294967295 overflows int
make: *** [compile] Error 1
```