### PR TITLE
Update role definition docs to include `role_definition_resource_id`

### DIFF
--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -67,7 +67,9 @@ The following attributes are exported:
 
 * `id` - The Role Definition ID.
 
-* `role_definition_id` - The Azure Resource Manager ID for the resource
+* `role_definition_id` - This ID is specific to Terraform - and is of the format `{roleDefinitionId}|{scope}`.
+
+* `role_definition_resource_id` - The Azure Resource Manager ID for the resource.
 
 ## Timeouts
 


### PR DESCRIPTION
Reference to `role_definition_resource_id` was previously removed from the website documentation. This updates the `role_definition_id` summary to match the import note.

There's a disconnect for `role_definition_id` as an argument vs. as an attribute, which is potentially a bug. As an argument `role_definition_id` takes a UUID compared to the computed attribute which concatenates `roleDefinitionId|scope`.