### PR TITLE
Add fields for App Service and App Service Slot

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1346,10 +1346,10 @@ func flattenAppServiceLogs(input *web.SiteLogsConfigProperties) []interface{} {
 	}
 	result["http_logs"] = httpLogs
 
-	if input.DetailedErrorMessages.Enabled != nil {
+	if input.DetailedErrorMessages != nil && input.DetailedErrorMessages.Enabled != nil {
 		result["detailed_error_messages_enabled"] = *input.DetailedErrorMessages.Enabled
 	}
-	if input.FailedRequestsTracing.Enabled != nil {
+	if input.FailedRequestsTracing != nil && input.FailedRequestsTracing.Enabled != nil {
 		result["failed_request_tracing_enabled"] = *input.FailedRequestsTracing.Enabled
 	}
 
@@ -1435,11 +1435,15 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 	}
 
 	if v, ok := config["detailed_error_messages_enabled"]; ok {
-		logs.DetailedErrorMessages = &web.EnabledConfig{Enabled: utils.Bool(v.(bool))}
+		logs.DetailedErrorMessages = &web.EnabledConfig{
+			Enabled: utils.Bool(v.(bool)),
+		}
 	}
 
 	if v, ok := config["failed_request_tracing_enabled"]; ok {
-		logs.FailedRequestsTracing = &web.EnabledConfig{Enabled: utils.Bool(v.(bool))}
+		logs.FailedRequestsTracing = &web.EnabledConfig{
+			Enabled: utils.Bool(v.(bool)),
+		}
 	}
 
 	return logs

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -598,6 +598,16 @@ func schemaAppServiceLogsConfig() *schema.Schema {
 						},
 					},
 				},
+				"detailed_error_messages_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"failed_request_tracing_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 			},
 		},
 	}
@@ -1336,6 +1346,13 @@ func flattenAppServiceLogs(input *web.SiteLogsConfigProperties) []interface{} {
 	}
 	result["http_logs"] = httpLogs
 
+	if input.DetailedErrorMessages.Enabled != nil {
+		result["detailed_error_messages_enabled"] = *input.DetailedErrorMessages.Enabled
+	}
+	if input.FailedRequestsTracing.Enabled != nil {
+		result["failed_request_tracing_enabled"] = *input.FailedRequestsTracing.Enabled
+	}
+
 	return append(results, result)
 }
 
@@ -1415,6 +1432,14 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 				}
 			}
 		}
+	}
+
+	if v, ok := config["detailed_error_messages_enabled"]; ok {
+		logs.DetailedErrorMessages = &web.EnabledConfig{Enabled: utils.Bool(v.(bool))}
+	}
+
+	if v, ok := config["failed_request_tracing_enabled"]; ok {
+		logs.FailedRequestsTracing = &web.EnabledConfig{Enabled: utils.Bool(v.(bool))}
 	}
 
 	return logs

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -866,55 +866,49 @@ func TestAccAppService_managedPipelineMode(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppService_detailedErrorMessagesLogs(t *testing.T) {
+func TestAccAppService_detailedErrorMessagesLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMAppService_detailedErrorMessagesEnabled(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "true"),
-				),
-			},
-			{
-				Config: testAccAzureRMAppService_detailedErrorMessagesDisabled(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "false"),
-				),
-			},
-			data.ImportStep(),
+	r := AppServiceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.detailedErrorMessages(data, true),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("logs.0.detailed_error_messages_enabled").HasValue("true"),
+			),
 		},
+		{
+			Config: r.detailedErrorMessages(data, false),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "false"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
 func TestAccAzureRMAppService_failedRequestTracingLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMAppService_failedRequestTracingEnabled(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "true"),
-				),
-			},
-			{
-				Config: testAccAzureRMAppService_failedRequestTracingDisabled(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "false"),
-				),
-			},
-			data.ImportStep(),
+	r := AppServiceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.failedRequestTracing(data, true),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("logs.0.failed_request_tracing_enabled").HasValue("true"),
+			),
 		},
+		{
+			Config: r.failedRequestTracing(data, false),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("logs.0.failed_request_tracing_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -3534,7 +3528,7 @@ resource "azurerm_app_service" "test" {
 `, template, data.RandomInteger)
 }
 
-func testAccAzureRMAppService_detailedErrorMessages(data acceptance.TestData, detailedErrorEnabled bool) string {
+func (r AppServiceResource) detailedErrorMessages(data acceptance.TestData, detailedErrorEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3569,7 +3563,7 @@ resource "azurerm_app_service" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, detailedErrorEnabled)
 }
 
-func testAccAzureRMAppService_failedRequestTracing(data acceptance.TestData, failedRequestEnabled bool) string {
+func (r AppServiceResource) failedRequestTracing(data acceptance.TestData, failedRequestEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -3534,7 +3534,7 @@ resource "azurerm_app_service" "test" {
 `, template, data.RandomInteger)
 }
 
-func testAccAzureRMAppService_detailedErrorMessagesEnabled(data acceptance.TestData) string {
+func testAccAzureRMAppService_detailedErrorMessages(data acceptance.TestData, detailedErrorEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3563,13 +3563,13 @@ resource "azurerm_app_service" "test" {
   app_service_plan_id = azurerm_app_service_plan.test.id
 
   logs {
-    detailed_error_messages_enabled = true
+    detailed_error_messages_enabled = %t
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, detailedErrorEnabled)
 }
 
-func testAccAzureRMAppService_detailedErrorMessagesDisabled(data acceptance.TestData) string {
+func testAccAzureRMAppService_failedRequestTracing(data acceptance.TestData, failedRequestEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3598,80 +3598,10 @@ resource "azurerm_app_service" "test" {
   app_service_plan_id = azurerm_app_service_plan.test.id
 
   logs {
-    detailed_error_messages_enabled = false
+    failed_request_tracing_enabled = %t
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func testAccAzureRMAppService_failedRequestTracingEnabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-
-  logs {
-    failed_request_tracing_enabled = true
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func testAccAzureRMAppService_failedRequestTracingDisabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-
-  logs {
-    failed_request_tracing_enabled = false
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, failedRequestEnabled)
 }
 
 func (r AppServiceResource) managedPipelineMode(data acceptance.TestData) string {

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -866,6 +866,58 @@ func TestAccAppService_managedPipelineMode(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_detailedErrorMessagesLogs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppService_detailedErrorMessagesEnabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppService_detailedErrorMessagesDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMAppService_failedRequestTracingLogs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppService_failedRequestTracingEnabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppService_failedRequestTracingDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAppService_tagsUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
@@ -3480,6 +3532,146 @@ resource "azurerm_app_service" "test" {
   }
 }
 `, template, data.RandomInteger)
+}
+
+func testAccAzureRMAppService_detailedErrorMessagesEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  logs {
+    detailed_error_messages_enabled = true
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppService_detailedErrorMessagesDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  logs {
+    detailed_error_messages_enabled = false
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppService_failedRequestTracingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  logs {
+    failed_request_tracing_enabled = true
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppService_failedRequestTracingDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  logs {
+    failed_request_tracing_enabled = false
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (r AppServiceResource) managedPipelineMode(data acceptance.TestData) string {

--- a/azurerm/internal/services/web/app_service_slot_resource_test.go
+++ b/azurerm/internal/services/web/app_service_slot_resource_test.go
@@ -1112,6 +1112,58 @@ func TestAccAppServiceSlot_httpBlobStorageLogs(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceSlot_detailedErrorMessagesEnabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppServiceSlot_detailedErrorMessagesDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceSlot_failedRequestTracingEnabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "true"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppServiceSlot_failedRequestTracingDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAppServiceSlot_autoSwap(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
@@ -3491,6 +3543,178 @@ resource "azurerm_app_service_slot" "test" {
         retention_in_days = 3
       }
     }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceSlot_detailedErrorMessagesEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+  app_service_name    = azurerm_app_service.test.name
+
+  logs {
+    detailed_error_messages_enabled = true
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceSlot_detailedErrorMessagesDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+  app_service_name    = azurerm_app_service.test.name
+
+  logs {
+    detailed_error_messages_enabled = false
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceSlot_failedRequestTracingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+  app_service_name    = azurerm_app_service.test.name
+
+  logs {
+    failed_request_tracing_enabled = true
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceSlot_failedRequestTracingDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+  app_service_name    = azurerm_app_service.test.name
+
+  logs {
+    failed_request_tracing_enabled = false
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/web/app_service_slot_resource_test.go
+++ b/azurerm/internal/services/web/app_service_slot_resource_test.go
@@ -1114,51 +1114,44 @@ func TestAccAppServiceSlot_httpBlobStorageLogs(t *testing.T) {
 
 func TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMAppServiceSlot_detailedErrorMessages(data, true),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: testAccAzureRMAppServiceSlot_detailedErrorMessages(data, false),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
+	r := AppServiceSlotResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.detailedErrorMessages(data, true),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
+		data.ImportStep(),
+		{
+			Config: r.detailedErrorMessages(data, false),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
 func TestAccAzureRMAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMAppServiceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMAppServiceSlot_failedRequestTracing(data, true),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: testAccAzureRMAppServiceSlot_failedRequestTracing(data, false),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
+	r := AppServiceSlotResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.failedRequestTracing(data, true),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
 		},
+		data.ImportStep(),
+		{
+			Config: r.failedRequestTracing(data, false),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -3546,7 +3539,7 @@ resource "azurerm_app_service_slot" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAppServiceSlot_detailedErrorMessages(data acceptance.TestData, detailedErrorEnabled bool) string {
+func (r AppServiceSlotResource) detailedErrorMessages(data acceptance.TestData, detailedErrorEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3589,7 +3582,7 @@ resource "azurerm_app_service_slot" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, detailedErrorEnabled)
 }
 
-func testAccAzureRMAppServiceSlot_failedRequestTracing(data acceptance.TestData, failedRequestEnabled bool) string {
+func (r AppServiceSlotResource) failedRequestTracing(data acceptance.TestData, failedRequestEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/web/app_service_slot_resource_test.go
+++ b/azurerm/internal/services/web/app_service_slot_resource_test.go
@@ -1112,7 +1112,7 @@ func TestAccAppServiceSlot_httpBlobStorageLogs(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
+func TestAccAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
@@ -1133,7 +1133,7 @@ func TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
+func TestAccAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 

--- a/azurerm/internal/services/web/app_service_slot_resource_test.go
+++ b/azurerm/internal/services/web/app_service_slot_resource_test.go
@@ -1120,17 +1120,16 @@ func TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAppServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAppServiceSlot_detailedErrorMessagesEnabled(data),
+				Config: testAccAzureRMAppServiceSlot_detailedErrorMessages(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "true"),
 				),
 			},
+			data.ImportStep(),
 			{
-				Config: testAccAzureRMAppServiceSlot_detailedErrorMessagesDisabled(data),
+				Config: testAccAzureRMAppServiceSlot_detailedErrorMessages(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.detailed_error_messages_enabled", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -1146,17 +1145,16 @@ func TestAccAzureRMAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAppServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAppServiceSlot_failedRequestTracingEnabled(data),
+				Config: testAccAzureRMAppServiceSlot_failedRequestTracing(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "true"),
 				),
 			},
+			data.ImportStep(),
 			{
-				Config: testAccAzureRMAppServiceSlot_failedRequestTracingDisabled(data),
+				Config: testAccAzureRMAppServiceSlot_failedRequestTracing(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.0.failed_request_tracing_enabled", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -3548,7 +3546,7 @@ resource "azurerm_app_service_slot" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMAppServiceSlot_detailedErrorMessagesEnabled(data acceptance.TestData) string {
+func testAccAzureRMAppServiceSlot_detailedErrorMessages(data acceptance.TestData, detailedErrorEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3585,13 +3583,13 @@ resource "azurerm_app_service_slot" "test" {
   app_service_name    = azurerm_app_service.test.name
 
   logs {
-    detailed_error_messages_enabled = true
+    detailed_error_messages_enabled = %t
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, detailedErrorEnabled)
 }
 
-func testAccAzureRMAppServiceSlot_detailedErrorMessagesDisabled(data acceptance.TestData) string {
+func testAccAzureRMAppServiceSlot_failedRequestTracing(data acceptance.TestData, failedRequestEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3628,96 +3626,10 @@ resource "azurerm_app_service_slot" "test" {
   app_service_name    = azurerm_app_service.test.name
 
   logs {
-    detailed_error_messages_enabled = false
+    failed_request_tracing_enabled = %t
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func testAccAzureRMAppServiceSlot_failedRequestTracingEnabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-}
-
-resource "azurerm_app_service_slot" "test" {
-  name                = "acctestASSlot-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-  app_service_name    = azurerm_app_service.test.name
-
-  logs {
-    failed_request_tracing_enabled = true
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func testAccAzureRMAppServiceSlot_failedRequestTracingDisabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-}
-
-resource "azurerm_app_service_slot" "test" {
-  name                = "acctestASSlot-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  app_service_plan_id = azurerm_app_service_plan.test.id
-  app_service_name    = azurerm_app_service.test.name
-
-  logs {
-    failed_request_tracing_enabled = false
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, failedRequestEnabled)
 }
 
 func (r AppServiceSlotResource) autoSwap(data acceptance.TestData) string {

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -141,6 +141,10 @@ A `logs` block supports the following:
 
 * `http_logs` - (Optional) An `http_logs` block as defined below.
 
+* `detailed_error_messages_enabled` - (Optional) Is `Detailed error messages` enabled on this App Service? Defaults to false.
+
+* `failed_request_tracing_enabled` - (Optional) Is `Failed request tracing` enabled on this App Service? Defaults to false.
+
 ---
 
 An `application_logs` block supports the following:

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -141,9 +141,9 @@ A `logs` block supports the following:
 
 * `http_logs` - (Optional) An `http_logs` block as defined below.
 
-* `detailed_error_messages_enabled` - (Optional) Is `Detailed error messages` enabled on this App Service? Defaults to false.
+* `detailed_error_messages_enabled` - (Optional) Are `Detailed error messages` enabled on this App Service? Defaults to false.
 
-* `failed_request_tracing_enabled` - (Optional) Is `Failed request tracing` enabled on this App Service? Defaults to false.
+* `failed_request_tracing_enabled` - (Optional) Are `Failed request tracing` enabled on this App Service? Defaults to false.
 
 ---
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -141,9 +141,9 @@ A `logs` block supports the following:
 
 * `http_logs` - (Optional) An `http_logs` block as defined below.
 
-* `detailed_error_messages_enabled` - (Optional) Are `Detailed error messages` enabled on this App Service? Defaults to false.
+* `detailed_error_messages_enabled` - (Optional) Should `Detailed error messages` be enabled on this App Service? Defaults to `false`.
 
-* `failed_request_tracing_enabled` - (Optional) Are `Failed request tracing` enabled on this App Service? Defaults to false.
+* `failed_request_tracing_enabled` - (Optional) Should `Failed request tracing` be enabled on this App Service? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -352,9 +352,9 @@ A `logs` block supports the following:
 
 * `http_logs` - (Optional) An `http_logs` block as defined below.
 
-* `detailed_error_messages_enabled` - (Optional) Is `Detailed error messages` enabled on this App Service slot? Defaults to false.
+* `detailed_error_messages_enabled` - (Optional) Are `Detailed error messages` enabled on this App Service slot? Defaults to false.
 
-* `failed_request_tracing_enabled` - (Optional) Is `Failed request tracing` enabled on this App Service slot? Defaults to false.
+* `failed_request_tracing_enabled` - (Optional) Are `Failed request tracing` enabled on this App Service slot? Defaults to false.
 
 ---
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -352,9 +352,9 @@ A `logs` block supports the following:
 
 * `http_logs` - (Optional) An `http_logs` block as defined below.
 
-* `detailed_error_messages_enabled` - (Optional) Are `Detailed error messages` enabled on this App Service slot? Defaults to false.
+* `detailed_error_messages_enabled` - (Optional) Should `Detailed error messages` be enabled on this App Service slot? Defaults to `false`.
 
-* `failed_request_tracing_enabled` - (Optional) Are `Failed request tracing` enabled on this App Service slot? Defaults to false.
+* `failed_request_tracing_enabled` - (Optional) Should `Failed request tracing` be enabled on this App Service slot? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -168,6 +168,8 @@ The following arguments are supported:
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
+* `logs` - (Optional) A `logs` block as defined below.
+
 * `identity` - (Optional) A Managed Service Identity block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -349,6 +351,10 @@ A `logs` block supports the following:
 * `application_logs` - (Optional) An `application_logs` block as defined below.
 
 * `http_logs` - (Optional) An `http_logs` block as defined below.
+
+* `detailed_error_messages_enabled` - (Optional) Is `Detailed error messages` enabled on this App Service slot? Defaults to false.
+
+* `failed_request_tracing_enabled` - (Optional) Is `Failed request tracing` enabled on this App Service slot? Defaults to false.
 
 ---
 


### PR DESCRIPTION
## Background
This PR adds `detailed_error_mesage_enabled` and `failed_request_tracing_enabled` properties to the `App Service` and `App Service Slot` resources's `log` argument reference.

Both fields are `optional` and have a default value of `false`.

This is a fix for this issue: #7050 

## Usage
### azurerm_app_service
```
resource "azurerm_app_service" "example" {
  # Other settings here
  logs {
    detailed_error_messages_enabled = true
    failed_request_tracing_enabled  = true
  }
}
```
### azurerm_app_service_slot
```
resource "azurerm_app_service_slot" "example" {
  # Other settings here
  logs {
    detailed_error_messages_enabled = true
    failed_request_tracing_enabled  = true
  }
}
```

## Test Result
```
❯ make acctests SERVICE='web' TESTARGS='-run=TestAccAzureRMAppService.*Log' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/web/tests/ -run=TestAccAzureRMAppService.*Log -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMAppServiceSlot_authSettingsAdditionalLoginParams
=== PAUSE TestAccAzureRMAppServiceSlot_authSettingsAdditionalLoginParams
=== RUN   TestAccAzureRMAppServiceSlot_applicationBlobStorageLogs
=== PAUSE TestAccAzureRMAppServiceSlot_applicationBlobStorageLogs
=== RUN   TestAccAzureRMAppServiceSlot_httpFileSystemLogs
=== PAUSE TestAccAzureRMAppServiceSlot_httpFileSystemLogs
=== RUN   TestAccAzureRMAppServiceSlot_httpBlobStorageLogs
=== PAUSE TestAccAzureRMAppServiceSlot_httpBlobStorageLogs
=== RUN   TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs
=== PAUSE TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs
=== RUN   TestAccAzureRMAppServiceSlot_failedRequestTracingLogs
=== PAUSE TestAccAzureRMAppServiceSlot_failedRequestTracingLogs
=== RUN   TestAccAzureRMAppService_applicationBlobStorageLogs
=== PAUSE TestAccAzureRMAppService_applicationBlobStorageLogs
=== RUN   TestAccAzureRMAppService_httpFileSystemLogs
=== PAUSE TestAccAzureRMAppService_httpFileSystemLogs
=== RUN   TestAccAzureRMAppService_httpBlobStorageLogs
=== PAUSE TestAccAzureRMAppService_httpBlobStorageLogs
=== RUN   TestAccAzureRMAppService_httpFileSystemAndStorageBlobLogs
=== PAUSE TestAccAzureRMAppService_httpFileSystemAndStorageBlobLogs
=== RUN   TestAccAzureRMAppService_detailedErrorMessagesLogs
=== PAUSE TestAccAzureRMAppService_detailedErrorMessagesLogs
=== RUN   TestAccAzureRMAppService_failedRequestTracingLogs
=== PAUSE TestAccAzureRMAppService_failedRequestTracingLogs
=== RUN   TestAccAzureRMAppService_authSettingsAdditionalLoginParams
=== PAUSE TestAccAzureRMAppService_authSettingsAdditionalLoginParams
=== CONT  TestAccAzureRMAppServiceSlot_authSettingsAdditionalLoginParams
=== CONT  TestAccAzureRMAppService_httpFileSystemLogs
=== CONT  TestAccAzureRMAppServiceSlot_failedRequestTracingLogs
=== CONT  TestAccAzureRMAppService_authSettingsAdditionalLoginParams
=== CONT  TestAccAzureRMAppServiceSlot_httpBlobStorageLogs
=== CONT  TestAccAzureRMAppService_detailedErrorMessagesLogs
=== CONT  TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs
=== CONT  TestAccAzureRMAppService_applicationBlobStorageLogs
=== CONT  TestAccAzureRMAppService_failedRequestTracingLogs
=== CONT  TestAccAzureRMAppServiceSlot_httpFileSystemLogs
=== CONT  TestAccAzureRMAppService_httpFileSystemAndStorageBlobLogs
=== CONT  TestAccAzureRMAppServiceSlot_applicationBlobStorageLogs
=== CONT  TestAccAzureRMAppService_httpBlobStorageLogs
--- PASS: TestAccAzureRMAppService_authSettingsAdditionalLoginParams (135.71s)
--- PASS: TestAccAzureRMAppService_httpFileSystemAndStorageBlobLogs (141.66s)
--- PASS: TestAccAzureRMAppService_httpFileSystemLogs (142.56s)
--- PASS: TestAccAzureRMAppService_detailedErrorMessagesLogs (143.23s)
--- PASS: TestAccAzureRMAppService_failedRequestTracingLogs (143.60s)
--- PASS: TestAccAzureRMAppService_applicationBlobStorageLogs (145.94s)
--- PASS: TestAccAzureRMAppServiceSlot_applicationBlobStorageLogs (148.38s)
--- PASS: TestAccAzureRMAppServiceSlot_httpFileSystemLogs (151.73s)
--- PASS: TestAccAzureRMAppServiceSlot_httpBlobStorageLogs (152.07s)
--- PASS: TestAccAzureRMAppService_httpBlobStorageLogs (170.66s)
--- PASS: TestAccAzureRMAppServiceSlot_authSettingsAdditionalLoginParams (181.56s)
--- PASS: TestAccAzureRMAppServiceSlot_failedRequestTracingLogs (183.22s)
--- PASS: TestAccAzureRMAppServiceSlot_detailedErrorMessagesLogs (185.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web/tests	(cached)```
