### PR TITLE
`azurerm_cosmosdb_sql_database` doesn't call get throughput api when cosmos account is serverless

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
@@ -192,6 +192,7 @@ func resourceArmCosmosDbSQLDatabaseUpdate(d *schema.ResourceData, meta interface
 
 func resourceArmCosmosDbSQLDatabaseRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Cosmos.SqlClient
+	accountClient := meta.(*clients.Client).Cosmos.DatabaseClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -219,16 +220,36 @@ func resourceArmCosmosDbSQLDatabaseRead(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	throughputResp, err := client.GetSQLDatabaseThroughput(ctx, id.ResourceGroup, id.Account, id.Name)
+	accResp, err := accountClient.Get(ctx, id.ResourceGroup, id.Account)
 	if err != nil {
-		if !utils.ResponseWasNotFound(throughputResp.Response) {
-			return fmt.Errorf("Error reading Throughput on Cosmos SQL Database %q (Account: %q) ID: %v", id.Name, id.Account, err)
-		} else {
-			d.Set("throughput", nil)
-			d.Set("autoscale_settings", nil)
+		return fmt.Errorf("reading CosmosDB Account %q (Resource Group %q): %+v", id.Account, id.ResourceGroup, err)
+	}
+
+	if accResp.ID == nil || *accResp.ID == "" {
+		return fmt.Errorf("cosmosDB Account %q (Resource Group %q) ID is empty or nil", id.Account, id.ResourceGroup)
+	}
+
+	if props := accResp.DatabaseAccountGetProperties; props != nil && props.Capabilities != nil {
+		serverless := false
+		for _, v := range *props.Capabilities {
+			if *v.Name == "EnableServerless" {
+				serverless = true
+			}
 		}
-	} else {
-		common.SetResourceDataThroughputFromResponse(throughputResp, d)
+
+		if !serverless {
+			throughputResp, err := client.GetSQLDatabaseThroughput(ctx, id.ResourceGroup, id.Account, id.Name)
+			if err != nil {
+				if !utils.ResponseWasNotFound(throughputResp.Response) {
+					return fmt.Errorf("Error reading Throughput on Cosmos SQL Database %q (Account: %q) ID: %v", id.Name, id.Account, err)
+				} else {
+					d.Set("throughput", nil)
+					d.Set("autoscale_settings", nil)
+				}
+			} else {
+				common.SetResourceDataThroughputFromResponse(throughputResp, d)
+			}
+		}
 	}
 
 	return nil

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource_test.go
@@ -100,6 +100,25 @@ func TestAccAzureRMCosmosDbSqlDatabase_autoscale(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbSqlDatabase_serverless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_database", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbSqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbSqlDatabase_serverless(data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlDatabaseExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbSqlDatabaseDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.SqlClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -194,4 +213,15 @@ resource "azurerm_cosmosdb_sql_database" "test" {
   }
 }
 `, testAccAzureRMCosmosDBAccount_basic(data, documentdb.GlobalDocumentDB, documentdb.Strong), data.RandomInteger, maxThroughput)
+}
+
+func testAccAzureRMCosmosDbSqlDatabase_serverless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+`, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableServerless"}), data.RandomInteger)
 }


### PR DESCRIPTION
Fixes #8175

This is based on #8673 /cc @yupwei68 
```
make testacc TEST=./azurerm/internal/services/cosmos TESTARGS='-run=TestAccAzureRMCosmosDbSqlDatabase' TESTTIMEOUT='60m'

=== RUN   TestAccAzureRMCosmosDbSqlDatabase_basic
=== PAUSE TestAccAzureRMCosmosDbSqlDatabase_basic
=== RUN   TestAccAzureRMCosmosDbSqlDatabase_update
=== PAUSE TestAccAzureRMCosmosDbSqlDatabase_update
=== RUN   TestAccAzureRMCosmosDbSqlDatabase_autoscale
=== PAUSE TestAccAzureRMCosmosDbSqlDatabase_autoscale
=== RUN   TestAccAzureRMCosmosDbSqlDatabase_serverless
=== PAUSE TestAccAzureRMCosmosDbSqlDatabase_serverless
=== CONT  TestAccAzureRMCosmosDbSqlDatabase_basic
=== CONT  TestAccAzureRMCosmosDbSqlDatabase_serverless
=== CONT  TestAccAzureRMCosmosDbSqlDatabase_autoscale
=== CONT  TestAccAzureRMCosmosDbSqlDatabase_update
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_basic (1454.09s)
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_serverless (1515.23s)
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_autoscale (1697.47s)
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_update (1721.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos      1722.021s
```