### PR TITLE
Allow OS disks up to 4095GB

### DIFF
--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -263,7 +263,7 @@ func virtualMachineOSDiskSchema() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 2048),
+					ValidateFunc: validation.IntBetween(0, 4095),
 				},
 
 				"name": {

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -922,7 +922,7 @@ func VirtualMachineScaleSetOSDiskSchema() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 2048),
+					ValidateFunc: validation.IntBetween(0, 4095),
 				},
 
 				"write_accelerator_enabled": {


### PR DESCRIPTION
A virtual machine or virtual machine scale set can have an OS disk size up to 4095GB. Currently, the `azurerm` provider limits the OS disk size to 2048GB. This pull request raises that value to 4095GB.

Unfortunately, at the time of this writing the [Azure API documentation](https://docs.microsoft.com/en-us/rest/api/compute/virtualmachinescalesets/createorupdate#virtualmachinescalesetosdisk) for `osDisk.diskSizeGB` states the following.

> Specifies the size of the operating system disk in gigabytes. This element can be used to overwrite the size of the disk in a virtual machine image.
>
> This value cannot be larger than 1023 GB

However, I was able to use the `az` CLI to create both a virtual machine and a virtual machine scale set with an OS disk up to 4095GB in size.

Here's the `az` command I used to create the virtual machine.

```
az vm create --name ${NAME} --resource-group ${RG} --image UbuntuLTS --size Standard_D32as_v4 --admin-username ${USER} --ssh-key-values "${SSH_PUB}" --vnet-name ${VNET} --subnet ${SUBNET} --os-disk-size-gb 4095 --os-disk-caching None
```

Here's the `az` command I used to create the virtual machine scale set.

```
az vmss create --name ${NAME} --resource-group ${RG} --image UbuntuLTS --instance-count 1 --vm-sku Standard_D32as_v4 --admin-username ${USER} --ssh-key-values "${SSH_PUB}" --vnet-name ${VNET} --subnet ${SUBNET} --os-disk-size-gb 4095 --os-disk-caching None
```

Whenever I attempted to create a virtual machine or a virtual machine scale set with an OS disk over 4095GB in size, I received the following error.

```
ValidationError: Deployment failed. Correlation ID: redacted. {
  "error": {
    "code": "InvalidParameter",
    "message": "The value 4096 of parameter 'osDisk.diskSizeGB' is out of range. The value must be between '1' and '4095', inclusive.",
    "target": "osDisk.diskSizeGB"
  }
}
```