### PR TITLE
docs: add ip_address property to data.azurerm_public_ips.public_ips

### DIFF
--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -36,6 +36,7 @@ A `public_ips` block contains:
 * `domain_name_label` - The Domain Name Label of the Public IP Address
 * `fqdn` - The FQDN of the Public IP Address
 * `name` - The Name of the Public IP Address
+* `ip_address` - The IP address of the Public IP Address
 
 ## Timeouts
 


### PR DESCRIPTION
The property was missing in the documentation:

https://github.com/terraform-providers/terraform-provider-azurerm/blob/a5e728dc62e832e74d7bb0f40a79af0ae5a79e1e/azurerm/internal/services/network/public_ips_data_source.go#L68-L71