### PR TITLE
`log_analytics_workspace` - exclude `Free` from `daily_quota_gb` settings

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -164,7 +164,7 @@ func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta i
 	dailyQuotaGb, ok := d.GetOk("daily_quota_gb")
 	if ok && skuName == "Free" {
 		return fmt.Errorf("`Free` tier SKU quota is not configurable and is hard set to 0.5GB")
-	} else {
+	} else if skuName != "Free" {
 		parameters.WorkspaceProperties.WorkspaceCapping = &operationalinsights.WorkspaceCapping{
 			DailyQuotaGb: utils.Float(dailyQuotaGb.(float64)),
 		}

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_workspace_resource_test.go
@@ -172,6 +172,33 @@ func TestAccAzureRMLogAnalyticsWorkspace_withVolumeCap(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLogAnalyticsWorkspace_removeVolumeCap(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsWorkspace_withVolumeCap(data, 5.5),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsWorkspaceExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMLogAnalyticsWorkspace_removeVolumeCap(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsWorkspaceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "daily_quota_gb", "-1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMLogAnalyticsWorkspaceDestroy(s *terraform.State) error {
 	conn := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.WorkspacesClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -351,4 +378,29 @@ resource "azurerm_log_analytics_workspace" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, volumeCapGb)
+}
+
+func testAccAzureRMLogAnalyticsWorkspace_removeVolumeCap(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+
+  tags = {
+    Environment = "Test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -43,7 +43,9 @@ The following arguments are supported:
 
 * `retention_in_days` - (Optional) The workspace data retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 
-* `daily_quota_gb` - (Optional) The workspace daily quota for ingestion in GB.  Defaults to -1 (unlimited).
+* `daily_quota_gb` - (Optional) The workspace daily quota for ingestion in GB.  Defaults to -1 (unlimited) if omitted.
+
+~> **NOTE:** The `Free` tier SKU does not accept any value for this argument, and is always configured as `0.5` GB. 
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -41,11 +41,13 @@ The following arguments are supported:
 
 ~> **NOTE:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you're provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKU's defined above. More information about [the Pricing SKU's is available at the following URI](http://aka.ms/PricingTierWarning).
 
+~> **NOTE:** The `Free` SKU has a default `daily_quota_gb` value of `0.5` (GB).
+
 * `retention_in_days` - (Optional) The workspace data retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 
 * `daily_quota_gb` - (Optional) The workspace daily quota for ingestion in GB.  Defaults to -1 (unlimited) if omitted.
 
-~> **NOTE:** The `Free` tier SKU does not accept any value for this argument, and is always configured as `0.5` GB. 
+~> **NOTE:** When `sku_name` is set to `Free` this field can be set to a maximum of `0.5` (GB), and has a default value of `0.5`. 
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
The `Free` tier SKU does not accept changes for the Quota value, and is always set to `0.5` GB.

Upgrade Notes:
Previously the `daily_quota_gb` argument on the `log_analytics_workspace` resource required setting to `-1` to disable. This is no longer a valid value and the argument should be removed to set to the default of `Unlimited`.

fixes #9150 