### PR TITLE
Add v5.0 dotnet_framework_version to app_service validation

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -299,6 +299,7 @@ func schemaAppServiceSiteConfig() *schema.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						"v2.0",
 						"v4.0",
+						"v5.0",
 					}, true),
 					DiffSuppressFunc: suppress.CaseDifference,
 				},

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -1069,6 +1069,25 @@ func TestAccAzureRMAppService_windowsDotNet4(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_windowsDotNet5(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppService_windowsDotNet(data, "v5.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.dotnet_framework_version", "v5.0"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMAppService_windowsDotNetUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	resource.ParallelTest(t, resource.TestCase{
@@ -1088,6 +1107,13 @@ func TestAccAzureRMAppService_windowsDotNetUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppService_windowsDotNet(data, "v5.0"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.dotnet_framework_version", "v5.0"),
 				),
 			},
 		},

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -185,7 +185,7 @@ A `site_config` block supports the following:
 
 * `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
 
-* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targeting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
+* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`), `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`) and `v5.0`. [For more information on which .net CLR version to use based on the .net framework you're targeting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
 
 * `ftps_state` - (Optional) State of FTP / FTPS service for this App Service. Possible values include: `AllAllowed`, `FtpsOnly` and `Disabled`.
 


### PR DESCRIPTION
Fixes #9241

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/web/tests -timeout=1000m -run TestAccAzureRMAppService_windowsDotNet5
=== RUN   TestAccAzureRMAppService_windowsDotNet5
=== PAUSE TestAccAzureRMAppService_windowsDotNet5
=== CONT  TestAccAzureRMAppService_windowsDotNet5
--- PASS: TestAccAzureRMAppService_windowsDotNet5 (147.85s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web/tests	149.388s
```

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/web/tests -timeout=1000m -run TestAccAzureRMAppService_windowsDotNetUpdate
=== RUN   TestAccAzureRMAppService_windowsDotNetUpdate
=== PAUSE TestAccAzureRMAppService_windowsDotNetUpdate
=== CONT  TestAccAzureRMAppService_windowsDotNetUpdate
--- PASS: TestAccAzureRMAppService_windowsDotNetUpdate (233.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web/tests	234.396s
```