### PR TITLE
"azurerm_spring_cloud_service" - exporting `outbound_public_ip_addresses`

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -19,6 +19,9 @@ var runNightly = mapOf(
 
 // specifies a list of services which should be run with a custom test configuration
 var serviceTestConfigurationOverrides = mapOf(
+        // Spring Cloud only allows a max of 10 provisioned
+        "appplatform" to testConfiguration(5, defaultStartHour),
+
         // The AKS API has a low rate limit
         "containers" to testConfiguration(5, defaultStartHour),
 

--- a/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
+++ b/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
@@ -111,22 +111,6 @@ func resourceArmSpringCloudService() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
-
-						"outbound_ip": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"public_ips": {
-										Type:     schema.TypeList,
-										Computed: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-								},
-							},
-						},
 					},
 				},
 			},
@@ -220,6 +204,22 @@ func resourceArmSpringCloudService() *schema.Resource {
 						"instrumentation_key": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+					},
+				},
+			},
+
+			"outbound_ip": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"public_ips": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 					},
 				},
@@ -395,6 +395,11 @@ func resourceArmSpringCloudServiceRead(d *schema.ResourceData, meta interface{})
 		}
 		if err := d.Set("network", flattenArmSpringCloudNetwork(resp.Properties.NetworkProfile)); err != nil {
 			return fmt.Errorf("setting `network`: %+v", err)
+		}
+		if resp.Properties.NetworkProfile != nil {
+			if err := d.Set("outbound_ip", flattenArmSpringCloudNetworkOutboundIPs(resp.Properties.NetworkProfile.OutboundIPs)); err != nil {
+				return fmt.Errorf("setting `outbound_ip`: %+v", err)
+			}
 		}
 		if resp.Properties.ConfigServerProperties != nil && resp.Properties.ConfigServerProperties.ConfigServer != nil {
 			if props := resp.Properties.ConfigServerProperties.ConfigServer.GitProperty; props != nil {
@@ -821,7 +826,6 @@ func flattenArmSpringCloudNetwork(input *appplatform.NetworkProfile) []interface
 			"cidr_ranges":                            cidrRanges,
 			"app_network_resource_group":             appNetworkResourceGroup,
 			"service_runtime_network_resource_group": serviceRuntimeNetworkResourceGroup,
-			"outbound_ip":                            flattenArmSpringCloudNetworkOutboundIPs(input.OutboundIPs),
 		},
 	}
 }

--- a/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
+++ b/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
@@ -111,7 +111,7 @@ func resourceArmSpringCloudService() *schema.Resource {
 							ForceNew: true,
 						},
 
-						"outbound_ips": {
+						"outbound_ip": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Resource{
@@ -820,7 +820,7 @@ func flattenArmSpringCloudNetwork(input *appplatform.NetworkProfile) []interface
 			"cidr_ranges":                            cidrRanges,
 			"app_network_resource_group":             appNetworkResourceGroup,
 			"service_runtime_network_resource_group": serviceRuntimeNetworkResourceGroup,
-			"outbound_ips":                           flattenArmSpringCloudNetworkOutboundIPs(input.OutboundIPs),
+			"outbound_ip":                            flattenArmSpringCloudNetworkOutboundIPs(input.OutboundIPs),
 		},
 	}
 }

--- a/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
+++ b/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
@@ -69,6 +69,7 @@ func resourceArmSpringCloudService() *schema.Resource {
 			"network": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{

--- a/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
+++ b/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
@@ -69,7 +69,6 @@ func resourceArmSpringCloudService() *schema.Resource {
 			"network": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -817,6 +816,10 @@ func flattenArmSpringCloudNetwork(input *appplatform.NetworkProfile) []interface
 	}
 	if input.AppNetworkResourceGroup != nil {
 		appNetworkResourceGroup = *input.AppNetworkResourceGroup
+	}
+
+	if serviceRuntimeSubnetID == "" && appSubnetID == "" && serviceRuntimeNetworkResourceGroup == "" && appNetworkResourceGroup == "" && len(cidrRanges) == 0 {
+		return []interface{}{}
 	}
 
 	return []interface{}{

--- a/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
+++ b/azurerm/internal/services/appplatform/spring_cloud_service_resource.go
@@ -110,6 +110,22 @@ func resourceArmSpringCloudService() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+
+						"outbound_ips": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"public_ips": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -804,6 +820,18 @@ func flattenArmSpringCloudNetwork(input *appplatform.NetworkProfile) []interface
 			"cidr_ranges":                            cidrRanges,
 			"app_network_resource_group":             appNetworkResourceGroup,
 			"service_runtime_network_resource_group": serviceRuntimeNetworkResourceGroup,
+			"outbound_ips":                           flattenArmSpringCloudNetworkOutboundIPs(input.OutboundIPs),
+		},
+	}
+}
+
+func flattenArmSpringCloudNetworkOutboundIPs(input *appplatform.NetworkProfileOutboundIPs) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"public_ips": utils.FlattenStringSlice(input.PublicIPs),
 		},
 	}
 }

--- a/azurerm/internal/services/appplatform/tests/spring_cloud_service_data_source_test.go
+++ b/azurerm/internal/services/appplatform/tests/spring_cloud_service_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceAzureRMSpringCloudService_basic(t *testing.T) {
 				Config: testAccDataSourceSpringCloudService_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(data.ResourceName, "id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "outbound_public_ip_addresses.0"),
 				),
 			},
 		},

--- a/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
@@ -112,8 +112,8 @@ func TestAccAzureRMSpringCloudService_virtualNetwork(t *testing.T) {
 					testCheckAzureRMSpringCloudServiceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.service_runtime_network_resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.app_network_resource_group"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ips"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ips.0.public_ips"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ip"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ip.0.public_ips"),
 				),
 			},
 			data.ImportStep(

--- a/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
@@ -112,6 +112,8 @@ func TestAccAzureRMSpringCloudService_virtualNetwork(t *testing.T) {
 					testCheckAzureRMSpringCloudServiceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.service_runtime_network_resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.app_network_resource_group"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ips"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ips.0.public_ips"),
 				),
 			},
 			data.ImportStep(

--- a/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
@@ -112,7 +112,7 @@ func TestAccAzureRMSpringCloudService_virtualNetwork(t *testing.T) {
 					testCheckAzureRMSpringCloudServiceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.service_runtime_network_resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.app_network_resource_group"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ip.0.public_ips.0"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "outbound_ip.0.public_ips.0"),
 				),
 			},
 			data.ImportStep(

--- a/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
@@ -112,8 +112,7 @@ func TestAccAzureRMSpringCloudService_virtualNetwork(t *testing.T) {
 					testCheckAzureRMSpringCloudServiceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.service_runtime_network_resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.app_network_resource_group"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ip"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ip.0.public_ips"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.outbound_ip.0.public_ips.0"),
 				),
 			},
 			data.ImportStep(

--- a/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/appplatform/tests/spring_cloud_service_resource_test.go
@@ -112,7 +112,7 @@ func TestAccAzureRMSpringCloudService_virtualNetwork(t *testing.T) {
 					testCheckAzureRMSpringCloudServiceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.service_runtime_network_resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "network.0.app_network_resource_group"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "outbound_ip.0.public_ips.0"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "outbound_public_ip_addresses.0"),
 				),
 			},
 			data.ImportStep(

--- a/website/docs/d/spring_cloud_service.html.markdown
+++ b/website/docs/d/spring_cloud_service.html.markdown
@@ -41,9 +41,11 @@ The following attributes are exported:
 
 * `id` - The ID of Spring Cloud Service.
 
+* `config_server_git_setting` - A `config_server_git_setting` block as defined below.
+
 * `location` - The location of Spring Cloud Service.
 
-* `config_server_git_setting` - A `config_server_git_setting` block as defined below.
+* `outbound_public_ip_addresses` - A list of the outbound Public IP Addresses used by this Spring Cloud Service.
 
 * `tags` - A mapping of tags assigned to Spring Cloud Service.
 

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -153,6 +153,14 @@ The following attributes are exported:
 
 * `id` - The ID of the Spring Cloud Service.
 
+* `outbound_ips` - An `outbound_ips` block as defined below.
+
+---
+
+A `outbound_ips` block exports the following:
+
+* `public_ips` - A list of public IP addresses for Azure Spring Cloud instance.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -153,13 +153,7 @@ The following attributes are exported:
 
 * `id` - The ID of the Spring Cloud Service.
 
-* `outbound_ip` - An `outbound_ip` block as defined below.
-
----
-
-A `outbound_ip` block exports the following:
-
-* `public_ips` - A list of public IP addresses for Azure Spring Cloud instance.
+* `outbound_public_ip_addresses` - A list of the outbound Public IP Addresses used by this Spring Cloud Service.
 
 ## Timeouts
 

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -153,11 +153,11 @@ The following attributes are exported:
 
 * `id` - The ID of the Spring Cloud Service.
 
-* `outbound_ips` - An `outbound_ips` block as defined below.
+* `outbound_ip` - An `outbound_ip` block as defined below.
 
 ---
 
-A `outbound_ips` block exports the following:
+A `outbound_ip` block exports the following:
 
 * `public_ips` - A list of public IP addresses for Azure Spring Cloud instance.
 


### PR DESCRIPTION
this PR serves two purpose:
1. fix #9346 
2. exports "outbound_ip" block

the reason of issue 9346:
![image](https://user-images.githubusercontent.com/2786738/99376432-e5140c80-28ff-11eb-8f6f-c6ac0a87c6a3.png)
"outbound_ip" is a new field, and there is always a value for this field no matter spring cloud instance is in a virtual network.
so we could make "network" block computed to solve this issue.

![image](https://user-images.githubusercontent.com/2786738/99376054-64551080-28ff-11eb-9cab-9f3a3198121c.png)
