### PR TITLE
added new data source azurerm_servicebus_subscription

### DIFF
--- a/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
+++ b/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
@@ -131,7 +131,6 @@ func dataSourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interf
 		}
 
 		d.Set("max_delivery_count", maxDeliveryCount)
-
 	}
 
 	return nil

--- a/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
+++ b/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
@@ -127,7 +127,6 @@ func dataSourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interf
 		if count := props.MaxDeliveryCount; count != nil {
 			d.Set("max_delivery_count", int(*count))
 		}
-
 	}
 
 	return nil

--- a/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
+++ b/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
@@ -124,9 +124,14 @@ func dataSourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interf
 		d.Set("requires_session", props.RequiresSession)
 		d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
 		d.Set("forward_to", props.ForwardTo)
-		if count := props.MaxDeliveryCount; count != nil {
-			d.Set("max_delivery_count", int(*count))
+
+		maxDeliveryCount := 0
+		if props.MaxDeliveryCount != nil {
+			maxDeliveryCount = int(*props.MaxDeliveryCount)
 		}
+
+		d.Set("max_delivery_count", maxDeliveryCount)
+
 	}
 
 	return nil

--- a/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
+++ b/azurerm/internal/services/servicebus/data_source_servicebus_subscription.go
@@ -1,0 +1,134 @@
+package servicebus
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmServiceBusSubscription() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmServiceBusSubscriptionRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"namespace_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.ServiceBusNamespaceName,
+			},
+
+			"topic_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azure.ValidateServiceBusTopicName(),
+			},
+
+			"auto_delete_on_idle": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_message_ttl": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"lock_duration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"dead_lettering_on_message_expiration": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"dead_lettering_on_filter_evaluation_error": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"enable_batched_operations": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"max_delivery_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"requires_session": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"forward_to": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"forward_dead_lettered_messages_to": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ServiceBus.SubscriptionsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	topicName := d.Get("topic_name").(string)
+
+	existing, err := client.Get(ctx, resourceGroup, namespaceName, topicName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("ServiceBus Subscription %q was not found in Namespace %q in Resource Group %q", name, namespaceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving ServiceBus Subscription %q (Namespace %q, Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	}
+
+	d.SetId(*existing.ID)
+
+	if props := existing.SBSubscriptionProperties; props != nil {
+		d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)
+		d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
+		d.Set("lock_duration", props.LockDuration)
+		d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
+		d.Set("dead_lettering_on_filter_evaluation_error", props.DeadLetteringOnFilterEvaluationExceptions)
+		d.Set("enable_batched_operations", props.EnableBatchedOperations)
+		d.Set("requires_session", props.RequiresSession)
+		d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
+		d.Set("forward_to", props.ForwardTo)
+		if count := props.MaxDeliveryCount; count != nil {
+			d.Set("max_delivery_count", int(*count))
+		}
+
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/servicebus/registration.go
+++ b/azurerm/internal/services/servicebus/registration.go
@@ -26,6 +26,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 		"azurerm_servicebus_namespace_authorization_rule": dataSourceArmServiceBusNamespaceAuthorizationRule(),
 		"azurerm_servicebus_topic_authorization_rule":     dataSourceArmServiceBusTopicAuthorizationRule(),
 		"azurerm_servicebus_queue_authorization_rule":     dataSourceArmServiceBusQueueAuthorizationRule(),
+		"azurerm_servicebus_subscription":                 dataSourceArmServiceBusSubscription(),
 	}
 }
 

--- a/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
+++ b/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
@@ -28,41 +28,34 @@ func TestAccDataSourceAzureRMServiceBusSubscription_basic(t *testing.T) {
 }
 
 func testAccDataSourceAzureRMServiceBusSubscription_basic(data acceptance.TestData) string {
-	return fmt.Sprintf(testAccDataSourceAzureRMServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, "")
-}
-
-const testAccDataSourceAzureRMServiceBusSubscription_tfTemplate = `
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name     = "acctestRG-%d"
-    location = "%s"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
-
 resource "azurerm_servicebus_namespace" "test" {
-    name                = "acctestservicebusnamespace-%d"
-    location            = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku                 = "Standard"
+  name                = "acctestservicebusnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
 }
-
 resource "azurerm_servicebus_topic" "test" {
-    name                = "acctestservicebustopic-%d"
-    namespace_name      = "${azurerm_servicebus_namespace.test.name}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestservicebustopic-%d"
+  namespace_name      = "${azurerm_servicebus_namespace.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
-
 resource "azurerm_servicebus_subscription" "test" {
-    name                = "acctestservicebussubscription-%d"
-    namespace_name      = "${azurerm_servicebus_namespace.test.name}"
-    topic_name          = "${azurerm_servicebus_topic.test.name}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    max_delivery_count  = 10
-	%s
+  name                = "acctestservicebussubscription-%d"
+  namespace_name      = "${azurerm_servicebus_namespace.test.name}"
+  topic_name          = "${azurerm_servicebus_topic.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  max_delivery_count  = 10
 }
-
 data "azurerm_servicebus_subscription" "test" {
-	name                = azurerm_servicebus_subscription.test.name
-	resource_group_name = azurerm_resource_group.test.name
-	namespace_name      = azurerm_servicebus_namespace.test.name
-	topic_name          = azurerm_servicebus_topic.test.name
-  }
-`
+  name                = azurerm_servicebus_subscription.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+}
+	`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
+++ b/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
@@ -2,9 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"testing"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"testing"
 )
 
 func TestAccDataSourceAzureRMServiceBusSubscription_basic(t *testing.T) {

--- a/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
+++ b/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"fmt"
 	"testing"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 )
@@ -31,7 +30,6 @@ func testAccDataSourceAzureRMServiceBusSubscription_basic(data acceptance.TestDa
 	return fmt.Sprintf(testAccDataSourceAzureRMServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, "")
 }
 
-////////TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR
 const testAccDataSourceAzureRMServiceBusSubscription_tfTemplate = `
 resource "azurerm_resource_group" "test" {
     name     = "acctestRG-%d"
@@ -63,7 +61,7 @@ resource "azurerm_servicebus_subscription" "test" {
 data "azurerm_servicebus_subscription" "test" {
 	name                = azurerm_servicebus_subscription.test.name
 	resource_group_name = azurerm_resource_group.test.name
-	namespace_name      = azurerm_servicebus_namespace.test.name 
+	namespace_name      = azurerm_servicebus_namespace.test.name
 	topic_name          = azurerm_servicebus_topic.test.name
   }
 `

--- a/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
+++ b/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
@@ -2,9 +2,10 @@ package tests
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
-	"testing"
 )
 
 func TestAccDataSourceAzureRMServiceBusSubscription_basic(t *testing.T) {

--- a/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
+++ b/azurerm/internal/services/servicebus/tests/data_source_servicebus_subscription_test.go
@@ -1,0 +1,69 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMServiceBusSubscription_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_servicebus_subscription", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMServiceBusSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMServiceBusSubscription_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusSubscriptionExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "max_delivery_count"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMServiceBusSubscription_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(testAccDataSourceAzureRMServiceBusSubscription_tfTemplate, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, "")
+}
+
+////////TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR
+const testAccDataSourceAzureRMServiceBusSubscription_tfTemplate = `
+resource "azurerm_resource_group" "test" {
+    name     = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name                = "acctestservicebusnamespace-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+    name                = "acctestservicebustopic-%d"
+    namespace_name      = "${azurerm_servicebus_namespace.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_servicebus_subscription" "test" {
+    name                = "acctestservicebussubscription-%d"
+    namespace_name      = "${azurerm_servicebus_namespace.test.name}"
+    topic_name          = "${azurerm_servicebus_topic.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    max_delivery_count  = 10
+	%s
+}
+
+data "azurerm_servicebus_subscription" "test" {
+	name                = azurerm_servicebus_subscription.test.name
+	resource_group_name = azurerm_resource_group.test.name
+	namespace_name      = azurerm_servicebus_namespace.test.name 
+	topic_name          = azurerm_servicebus_topic.test.name
+  }
+`

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -570,11 +570,11 @@
                 </li>
 
                 <li>
-                <a href="/docs/providers/azurerm/d/servicebus_namespace_authorization_rule.html">azurerm_servicebus_namespace_authorization_rule</a>
+                    <a href="/docs/providers/azurerm/d/servicebus_namespace_authorization_rule.html">azurerm_servicebus_namespace_authorization_rule</a>
                 </li>
 
                 <li>
-                <a href="/docs/providers/azurerm/d/servicebus_subscription.html">azurerm_servicebus_subscription</a>
+                    <a href="/docs/providers/azurerm/d/servicebus_subscription.html">azurerm_servicebus_subscription</a>
                 </li>
 
                 <li>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -570,7 +570,11 @@
                 </li>
 
                 <li>
-                    <a href="/docs/providers/azurerm/d/servicebus_namespace_authorization_rule.html">azurerm_servicebus_namespace_authorization_rule</a>
+                <a href="/docs/providers/azurerm/d/servicebus_namespace_authorization_rule.html">azurerm_servicebus_namespace_authorization_rule</a>
+                </li>
+
+                <li>
+                <a href="/docs/providers/azurerm/d/servicebus_subscription.html">azurerm_servicebus_subscription</a>
                 </li>
 
                 <li>

--- a/website/docs/d/servicebus_subscription.html.markdown
+++ b/website/docs/d/servicebus_subscription.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing ServiceBus Namespac
 
 ```hcl
 data "azurerm_servicebus_subscription" "example" {
-  name                = "examplesubscription'
+  name                = "examplesubscription"
   resource_group_name = "exampleresources"
   namespace_name      = "examplenamespace"
   topic_name          = "exampletopic"

--- a/website/docs/d/servicebus_subscription.html.markdown
+++ b/website/docs/d/servicebus_subscription.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: azurerm_servicebus_subscription
 
-Use this data source to access information about an existing ServiceBus Namespace.
+Use this data source to access information about an existing ServiceBus Subscription.
 
 ## Example Usage
 
@@ -61,4 +61,4 @@ output "servicebus_subscription" {
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace.
+* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Subscription.

--- a/website/docs/d/servicebus_subscription.html.markdown
+++ b/website/docs/d/servicebus_subscription.html.markdown
@@ -45,15 +45,15 @@ output "servicebus_subscription" {
 
 * `lock_duration` - The lock duration for the subscription.
 
-* `dead_lettering_on_message_expiration` - Boolean flag which controls whether the Subscription has dead letter support when a message expires.
+* `dead_lettering_on_message_expiration` - Does the Service Bus Subscription have dead letter support when a message expires?
 
-* `dead_lettering_on_filter_evaluation_error` - Boolean flag which controls whether the Subscription has dead letter support on filter evaluation exceptions.
+* `dead_lettering_on_filter_evaluation_error` - Does the ServiceBus Subscription have dead letter support on filter evaluation exceptions?
 
-* `enable_batched_operations` - Boolean flag which controls whether the Subscription supports batched operations.
+* `enable_batched_operations` - Are batched operations enabled on this ServiceBus Subscription?
 
-* `requires_session` - Boolean flag which controls whether this Subscription supports the concept of a session.
+* `requires_session` - Whether or not this ServiceBus Subscription supports session.
 
-* `forward_to` - The name of a Queue or Topic to automatically forward messages to.
+* `forward_to` - The name of a ServiceBus Queue or ServiceBus Topic where messages are automatically forwarded.
 
 * `forward_dead_lettered_messages_to` - The name of a Queue or Topic to automatically forward Dead Letter messages to.
 

--- a/website/docs/d/servicebus_subscription.html.markdown
+++ b/website/docs/d/servicebus_subscription.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_subscription"
+description: |-
+  Gets information about an existing ServiceBus Subscription.
+---
+
+# Data Source: azurerm_servicebus_subscription
+
+Use this data source to access information about an existing ServiceBus Namespace.
+
+## Example Usage
+
+```hcl
+data "azurerm_servicebus_subscription" "example" {
+  name                = "examplesubscription'
+  resource_group_name = "exampleresources"
+  namespace_name      = "examplenamespace"
+  topic_name          = "exampletopic"
+}
+
+output "servicebus_subscription" {
+  value = data.azurerm_servicebus_namespace.example
+}
+```
+
+## Argument Reference
+
+* `name` - Specifies the name of the ServiceBus Subscription.
+
+* `resource_group_name` - Specifies the name of the Resource Group where the ServiceBus Namespace exists.
+
+* `namespace_name` - The name of the ServiceBus Namespace.
+
+* `topic_name` - The name of the ServiceBus Topic.
+
+## Attributes Reference
+
+* `max_delivery_count` - The maximum number of deliveries.
+
+* `auto_delete_on_idle` - The idle interval after which the topic is automatically deleted.
+
+* `default_message_ttl` - The Default message timespan to live. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
+
+* `lock_duration` - The lock duration for the subscription.
+
+* `dead_lettering_on_message_expiration` - Boolean flag which controls whether the Subscription has dead letter support when a message expires.
+
+* `dead_lettering_on_filter_evaluation_error` - Boolean flag which controls whether the Subscription has dead letter support on filter evaluation exceptions.
+
+* `enable_batched_operations` - Boolean flag which controls whether the Subscription supports batched operations.
+
+* `requires_session` - Boolean flag which controls whether this Subscription supports the concept of a session.
+
+* `forward_to` - The name of a Queue or Topic to automatically forward messages to.
+
+* `forward_dead_lettered_messages_to` - The name of a Queue or Topic to automatically forward Dead Letter messages to.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace.


### PR DESCRIPTION
Added a new Data source azurerm_servicebus_subscription
added test files and modified the website documentation.

```
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make build
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
go generate ./azurerm/internal/provider/
go install
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE='servicebus' TESTARGS='-run=TestAccDataSourceAzureRMServiceBusSubscription' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/servicebus/tests/ -run=TestAccDataSourceAzureRMServiceBusSubscription -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMServiceBusSubscription_basic
=== PAUSE TestAccDataSourceAzureRMServiceBusSubscription_basic
=== CONT  TestAccDataSourceAzureRMServiceBusSubscription_basic
--- PASS: TestAccDataSourceAzureRMServiceBusSubscription_basic (307.70s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/tests	(cached)
```

Fixes #9278