### PR TITLE
added avset name validation

### DIFF
--- a/azurerm/internal/services/compute/availability_set_resource.go
+++ b/azurerm/internal/services/compute/availability_set_resource.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,6 +42,10 @@ func resourceArmAvailabilitySet() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[a-zA-Z0-9]([-._a-zA-Z0-9]{0,78}[a-zA-Z0-9_])?$"),
+					"The Availability set name can contain only letters, numbers, periods (.), hyphens (-),and underscores (_), up to 80 characters, and it must begin a letter or number and end with a letter, number or underscore.",
+				),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),


### PR DESCRIPTION
Name validation for compute avset resource was missing. added it.

TF_ACC=1 go test -v ./azurerm/internal/services/compute/tests/ -run=TestAccAzureRMAvailabilitySet -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMAvailabilitySet_basic
=== PAUSE TestAccAzureRMAvailabilitySet_basic
=== RUN   TestAccAzureRMAvailabilitySet_requiresImport
=== PAUSE TestAccAzureRMAvailabilitySet_requiresImport
=== RUN   TestAccAzureRMAvailabilitySet_disappears
=== PAUSE TestAccAzureRMAvailabilitySet_disappears
=== RUN   TestAccAzureRMAvailabilitySet_withTags
=== PAUSE TestAccAzureRMAvailabilitySet_withTags
=== RUN   TestAccAzureRMAvailabilitySet_withPPG
=== PAUSE TestAccAzureRMAvailabilitySet_withPPG
=== RUN   TestAccAzureRMAvailabilitySet_withDomainCounts
=== PAUSE TestAccAzureRMAvailabilitySet_withDomainCounts
=== RUN   TestAccAzureRMAvailabilitySet_unmanaged
=== PAUSE TestAccAzureRMAvailabilitySet_unmanaged
=== CONT  TestAccAzureRMAvailabilitySet_basic
=== CONT  TestAccAzureRMAvailabilitySet_withPPG
=== CONT  TestAccAzureRMAvailabilitySet_withDomainCounts
=== CONT  TestAccAzureRMAvailabilitySet_requiresImport
=== CONT  TestAccAzureRMAvailabilitySet_disappears
=== CONT  TestAccAzureRMAvailabilitySet_withTags
=== CONT  TestAccAzureRMAvailabilitySet_unmanaged
--- PASS: TestAccAzureRMAvailabilitySet_disappears (84.74s)
--- PASS: TestAccAzureRMAvailabilitySet_withDomainCounts (88.39s)
--- PASS: TestAccAzureRMAvailabilitySet_basic (89.28s)
--- PASS: TestAccAzureRMAvailabilitySet_unmanaged (90.43s)
--- PASS: TestAccAzureRMAvailabilitySet_withPPG (95.31s)
--- PASS: TestAccAzureRMAvailabilitySet_requiresImport (96.65s)
--- PASS: TestAccAzureRMAvailabilitySet_withTags (114.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/tests	114.717s