### PR TITLE
added validation for eventgrid resources

### DIFF
--- a/azurerm/internal/services/eventgrid/eventgrid_domain_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_domain_resource.go
@@ -3,6 +3,7 @@ package eventgrid
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventgrid/mgmt/2020-04-01-preview/eventgrid"
@@ -43,6 +44,13 @@ func resourceArmEventGridDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,50}$"),
+						"EventGrid domain name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/internal/services/eventgrid/eventgrid_domain_topic_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_domain_topic_resource.go
@@ -3,10 +3,12 @@ package eventgrid
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -38,12 +40,26 @@ func resourceArmEventGridDomainTopic() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,50}$"),
+						"EventGrid domain name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,50}$"),
+						"EventGrid domain name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -3,6 +3,7 @@ package eventgrid
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventgrid/mgmt/2020-04-01-preview/eventgrid"
@@ -54,10 +55,16 @@ func resourceArmEventGridEventSubscription() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,50}$"),
+						"EventGrid subscription name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"scope": {

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_resource.go
@@ -3,6 +3,7 @@ package eventgrid
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventgrid/mgmt/2020-04-01-preview/eventgrid"
@@ -40,10 +41,16 @@ func resourceArmEventGridSystemTopic() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,128}$"),
+						"EventGrid Topics name must be 3 - 128 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/internal/services/eventgrid/eventgrid_topic_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_topic_resource.go
@@ -3,6 +3,7 @@ package eventgrid
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventgrid/mgmt/2020-04-01-preview/eventgrid"
@@ -40,10 +41,16 @@ func resourceArmEventGridTopic() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,50}$"),
+						"EventGrid topic name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
 			},
 
 			"location": azure.SchemaLocation(),


### PR DESCRIPTION
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE=eventgrid TESTARGS='-run=TestAccAzureRMEventGridTopic' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid/tests/ -run=TestAccAzureRMEventGridTopic -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMEventGridTopic_basic
=== PAUSE TestAccAzureRMEventGridTopic_basic
=== RUN   TestAccAzureRMEventGridTopic_requiresImport
=== PAUSE TestAccAzureRMEventGridTopic_requiresImport
=== RUN   TestAccAzureRMEventGridTopic_mapping
=== PAUSE TestAccAzureRMEventGridTopic_mapping
=== RUN   TestAccAzureRMEventGridTopic_basicWithTags
=== PAUSE TestAccAzureRMEventGridTopic_basicWithTags
=== CONT  TestAccAzureRMEventGridTopic_basic
=== CONT  TestAccAzureRMEventGridTopic_basicWithTags
=== CONT  TestAccAzureRMEventGridTopic_mapping
=== CONT  TestAccAzureRMEventGridTopic_requiresImport
--- PASS: TestAccAzureRMEventGridTopic_mapping (115.51s)
--- PASS: TestAccAzureRMEventGridTopic_basicWithTags (129.53s)
--- PASS: TestAccAzureRMEventGridTopic_basic (161.45s)
--- PASS: TestAccAzureRMEventGridTopic_requiresImport (166.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventgrid/tests	(cached)
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE=eventgrid TESTARGS='-run=TestAccAzureRMEventGridEventSubscription' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid/tests/ -run=TestAccAzureRMEventGridEventSubscription -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMEventGridEventSubscription_basic
=== PAUSE TestAccAzureRMEventGridEventSubscription_basic
=== RUN   TestAccAzureRMEventGridEventSubscription_requiresImport
=== PAUSE TestAccAzureRMEventGridEventSubscription_requiresImport
=== RUN   TestAccAzureRMEventGridEventSubscription_eventHubID
=== PAUSE TestAccAzureRMEventGridEventSubscription_eventHubID
=== RUN   TestAccAzureRMEventGridEventSubscription_serviceBusQueueID
=== PAUSE TestAccAzureRMEventGridEventSubscription_serviceBusQueueID
=== RUN   TestAccAzureRMEventGridEventSubscription_serviceBusTopicID
=== PAUSE TestAccAzureRMEventGridEventSubscription_serviceBusTopicID
=== RUN   TestAccAzureRMEventGridEventSubscription_update
=== PAUSE TestAccAzureRMEventGridEventSubscription_update
=== RUN   TestAccAzureRMEventGridEventSubscription_filter
=== PAUSE TestAccAzureRMEventGridEventSubscription_filter
=== RUN   TestAccAzureRMEventGridEventSubscription_advancedFilter
=== PAUSE TestAccAzureRMEventGridEventSubscription_advancedFilter
=== CONT  TestAccAzureRMEventGridEventSubscription_basic
=== CONT  TestAccAzureRMEventGridEventSubscription_update
=== CONT  TestAccAzureRMEventGridEventSubscription_serviceBusQueueID
=== CONT  TestAccAzureRMEventGridEventSubscription_eventHubID
=== CONT  TestAccAzureRMEventGridEventSubscription_serviceBusTopicID
=== CONT  TestAccAzureRMEventGridEventSubscription_requiresImport
=== CONT  TestAccAzureRMEventGridEventSubscription_advancedFilter
=== CONT  TestAccAzureRMEventGridEventSubscription_filter
--- PASS: TestAccAzureRMEventGridEventSubscription_advancedFilter (159.32s)
--- PASS: TestAccAzureRMEventGridEventSubscription_filter (160.66s)
--- PASS: TestAccAzureRMEventGridEventSubscription_basic (221.81s)
--- PASS: TestAccAzureRMEventGridEventSubscription_requiresImport (234.13s)
--- PASS: TestAccAzureRMEventGridEventSubscription_serviceBusQueueID (284.66s)
--- PASS: TestAccAzureRMEventGridEventSubscription_serviceBusTopicID (317.90s)
--- PASS: TestAccAzureRMEventGridEventSubscription_update (343.11s)
--- PASS: TestAccAzureRMEventGridEventSubscription_eventHubID (371.25s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventgrid/tests	371.310s
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE=eventgrid TESTARGS='-run=TestAccAzureRMEventGridTopic' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid/tests/ -run=TestAccAzureRMEventGridTopic -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMEventGridTopic_basic
=== PAUSE TestAccAzureRMEventGridTopic_basic
=== RUN   TestAccAzureRMEventGridTopic_requiresImport
=== PAUSE TestAccAzureRMEventGridTopic_requiresImport
=== RUN   TestAccAzureRMEventGridTopic_mapping
=== PAUSE TestAccAzureRMEventGridTopic_mapping
=== RUN   TestAccAzureRMEventGridTopic_basicWithTags
=== PAUSE TestAccAzureRMEventGridTopic_basicWithTags
=== CONT  TestAccAzureRMEventGridTopic_basic
=== CONT  TestAccAzureRMEventGridTopic_basicWithTags
=== CONT  TestAccAzureRMEventGridTopic_mapping
=== CONT  TestAccAzureRMEventGridTopic_requiresImport
--- PASS: TestAccAzureRMEventGridTopic_mapping (115.51s)
--- PASS: TestAccAzureRMEventGridTopic_basicWithTags (129.53s)
--- PASS: TestAccAzureRMEventGridTopic_basic (161.45s)
--- PASS: TestAccAzureRMEventGridTopic_requiresImport (166.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventgrid/tests	(cached)
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE=eventgrid TESTARGS='-run=TestAccAzureRMEventGridDomain' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid/tests/ -run=TestAccAzureRMEventGridDomain -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMEventGridDomain_basic
=== PAUSE TestAccAzureRMEventGridDomain_basic
=== RUN   TestAccAzureRMEventGridDomain_requiresImport
=== PAUSE TestAccAzureRMEventGridDomain_requiresImport
=== RUN   TestAccAzureRMEventGridDomain_mapping
=== PAUSE TestAccAzureRMEventGridDomain_mapping
=== RUN   TestAccAzureRMEventGridDomain_basicWithTags
=== PAUSE TestAccAzureRMEventGridDomain_basicWithTags
=== RUN   TestAccAzureRMEventGridDomainTopic_basic
=== PAUSE TestAccAzureRMEventGridDomainTopic_basic
=== RUN   TestAccAzureRMEventGridDomainTopic_requiresImport
=== PAUSE TestAccAzureRMEventGridDomainTopic_requiresImport
=== CONT  TestAccAzureRMEventGridDomain_basic
=== CONT  TestAccAzureRMEventGridDomainTopic_basic
=== CONT  TestAccAzureRMEventGridDomain_requiresImport
=== CONT  TestAccAzureRMEventGridDomain_mapping
=== CONT  TestAccAzureRMEventGridDomain_basicWithTags
=== CONT  TestAccAzureRMEventGridDomainTopic_requiresImport
--- PASS: TestAccAzureRMEventGridDomain_basicWithTags (109.87s)
--- PASS: TestAccAzureRMEventGridDomain_basic (109.87s)
--- PASS: TestAccAzureRMEventGridDomain_mapping (109.88s)
--- PASS: TestAccAzureRMEventGridDomain_requiresImport (116.55s)
--- PASS: TestAccAzureRMEventGridDomainTopic_basic (198.40s)
--- PASS: TestAccAzureRMEventGridDomainTopic_requiresImport (205.41s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventgrid/tests	205.467s
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE=eventgrid TESTARGS='-run=TestAccAzureRMEventGridDomainTopic' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid/tests/ -run=TestAccAzureRMEventGridDomainTopic -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMEventGridDomainTopic_basic
=== PAUSE TestAccAzureRMEventGridDomainTopic_basic
=== RUN   TestAccAzureRMEventGridDomainTopic_requiresImport
=== PAUSE TestAccAzureRMEventGridDomainTopic_requiresImport
=== CONT  TestAccAzureRMEventGridDomainTopic_basic
=== CONT  TestAccAzureRMEventGridDomainTopic_requiresImport
--- PASS: TestAccAzureRMEventGridDomainTopic_basic (139.16s)
--- PASS: TestAccAzureRMEventGridDomainTopic_requiresImport (150.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventgrid/tests	150.415s
riteshmodi@MININT-57VL578 terraform-provider-azurerm % make acctests SERVICE=eventgrid TESTARGS='-run=TestAccAzureRMEventGridSystemTopic' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/eventgrid/tests/ -run=TestAccAzureRMEventGridSystemTopic -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMEventGridSystemTopic_basic
=== PAUSE TestAccAzureRMEventGridSystemTopic_basic
=== RUN   TestAccAzureRMEventGridSystemTopic_requiresImport
=== PAUSE TestAccAzureRMEventGridSystemTopic_requiresImport
=== RUN   TestAccAzureRMEventGridSystemTopic_complete
=== PAUSE TestAccAzureRMEventGridSystemTopic_complete
=== CONT  TestAccAzureRMEventGridSystemTopic_basic
=== CONT  TestAccAzureRMEventGridSystemTopic_complete
=== CONT  TestAccAzureRMEventGridSystemTopic_requiresImport
--- PASS: TestAccAzureRMEventGridSystemTopic_complete (158.83s)
--- PASS: TestAccAzureRMEventGridSystemTopic_requiresImport (163.93s)
--- PASS: TestAccAzureRMEventGridSystemTopic_basic (164.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventgrid/tests	164.423s
riteshmodi@MININT-57VL578 terraform-provider-azurerm % 