### PR TITLE
`azurerm_api_management_custom_domain` - Add exception for R001 lint rule

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -189,6 +189,7 @@ func apiManagementCustomDomainRead(d *schema.ResourceData, meta interface{}) err
 		configs := flattenApiManagementHostnameConfiguration(resp.ServiceProperties.HostnameConfigurations, d)
 		for _, config := range configs {
 			for key, v := range config.(map[string]interface{}) {
+				// nolint R001: ResourceData.Set() key argument should be string literal
 				if err := d.Set(key, v); err != nil {
 					return fmt.Errorf("setting `hostname_configuration` %q: %+v", key, err)
 				}


### PR DESCRIPTION
Adding a nolint declaration for lint rule `R001: ResourceData.Set() key argument should be string literal` as this is causing the lint checks to fail for all open PR's.

Related: #8946 