### PR TITLE
Fix typo in azurerm_redis_linked_server docs

### DIFF
--- a/website/docs/r/redis_linked_server.html.markdown
+++ b/website/docs/r/redis_linked_server.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported: 
+In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Redis.
 
@@ -97,7 +97,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Rediss can be imported using the `resource id`, e.g.
+Redis can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_redis_linked_server.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/Redis/cache1/linkedServers/cache2


### PR DESCRIPTION
Minor typo `Rediss` -> `Redis`