### PR TITLE
azurerm_firewall_policy - deprecate `dns.network_rule_fqdn_enabled`

### DIFF
--- a/azurerm/internal/services/network/firewall_policy_data_source.go
+++ b/azurerm/internal/services/network/firewall_policy_data_source.go
@@ -63,10 +63,6 @@ func dataSourceArmFirewallPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
-						"network_rule_fqdn_enabled": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
 					},
 				},
 			},

--- a/azurerm/internal/services/network/firewall_policy_data_source.go
+++ b/azurerm/internal/services/network/firewall_policy_data_source.go
@@ -63,6 +63,10 @@ func dataSourceArmFirewallPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"network_rule_fqdn_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/azurerm/internal/services/network/firewall_policy_resource.go
+++ b/azurerm/internal/services/network/firewall_policy_resource.go
@@ -83,10 +83,12 @@ func resourceArmFirewallPolicy() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						// TODO 3.0 - remove this property
 						"network_rule_fqdn_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							Type:       schema.TypeBool,
+							Optional:   true,
+							Computed:   true,
+							Deprecated: "This property is deprecated since service no longer support it since Nov.2020",
 						},
 					},
 				},
@@ -319,9 +321,8 @@ func expandFirewallPolicyDNSSetting(input []interface{}) *network.DNSSettings {
 
 	raw := input[0].(map[string]interface{})
 	output := &network.DNSSettings{
-		Servers:                     utils.ExpandStringSlice(raw["servers"].(*schema.Set).List()),
-		EnableProxy:                 utils.Bool(raw["proxy_enabled"].(bool)),
-		RequireProxyForNetworkRules: utils.Bool(raw["network_rule_fqdn_enabled"].(bool)),
+		Servers:     utils.ExpandStringSlice(raw["servers"].(*schema.Set).List()),
+		EnableProxy: utils.Bool(raw["proxy_enabled"].(bool)),
 	}
 
 	return output
@@ -350,16 +351,10 @@ func flattenFirewallPolicyDNSSetting(input *network.DNSSettings) []interface{} {
 		proxyEnabled = *input.EnableProxy
 	}
 
-	networkRulesFqdnEnabled := false
-	if input.RequireProxyForNetworkRules != nil {
-		networkRulesFqdnEnabled = *input.RequireProxyForNetworkRules
-	}
-
 	return []interface{}{
 		map[string]interface{}{
-			"servers":                   utils.FlattenStringSlice(input.Servers),
-			"proxy_enabled":             proxyEnabled,
-			"network_rule_fqdn_enabled": networkRulesFqdnEnabled,
+			"servers":       utils.FlattenStringSlice(input.Servers),
+			"proxy_enabled": proxyEnabled,
 		},
 	}
 }

--- a/azurerm/internal/services/network/firewall_policy_resource.go
+++ b/azurerm/internal/services/network/firewall_policy_resource.go
@@ -88,7 +88,7 @@ func resourceArmFirewallPolicy() *schema.Resource {
 							Type:       schema.TypeBool,
 							Optional:   true,
 							Computed:   true,
-							Deprecated: "This property is deprecated since service no longer support it since Nov.2020",
+							Deprecated: "This property has been deprecated as the service team has removed it from all API versions and is no longer supported by Azure. It will be removed in v3.0 of the provider.",
 						},
 					},
 				},
@@ -355,6 +355,8 @@ func flattenFirewallPolicyDNSSetting(input *network.DNSSettings) []interface{} {
 		map[string]interface{}{
 			"servers":       utils.FlattenStringSlice(input.Servers),
 			"proxy_enabled": proxyEnabled,
+			// TODO 3.0: remove the setting zero value for property below.
+			"network_rule_fqdn_enabled": false,
 		},
 	}
 }

--- a/azurerm/internal/services/network/tests/firewall_policy_data_source_test.go
+++ b/azurerm/internal/services/network/tests/firewall_policy_data_source_test.go
@@ -29,7 +29,6 @@ func TestAccDataSourceFirewallPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(data.ResourceName, "base_policy_id"),
 					resource.TestCheckResourceAttr(dataParent.ResourceName, "child_policies.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "dns.0.proxy_enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "dns.0.network_rule_fqdn_enabled", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "dns.0.servers.#", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "threat_intelligence_mode", string(network.AzureFirewallThreatIntelModeAlert)),
 					resource.TestCheckResourceAttr(data.ResourceName, "threat_intelligence_allowlist.0.ip_addresses.#", "2"),

--- a/azurerm/internal/services/network/tests/firewall_policy_resource_test.go
+++ b/azurerm/internal/services/network/tests/firewall_policy_resource_test.go
@@ -203,8 +203,8 @@ resource "azurerm_firewall_policy" "test" {
     fqdns        = ["foo.com", "bar.com"]
   }
   dns {
-    servers                   = ["1.1.1.1", "2.2.2.2"]
-    proxy_enabled             = true
+    servers       = ["1.1.1.1", "2.2.2.2"]
+    proxy_enabled = true
   }
   tags = {
     env = "Test"
@@ -247,8 +247,8 @@ resource "azurerm_firewall_policy" "test" {
     fqdns        = ["foo.com", "bar.com"]
   }
   dns {
-    servers                   = ["1.1.1.1", "2.2.2.2"]
-    proxy_enabled             = true
+    servers       = ["1.1.1.1", "2.2.2.2"]
+    proxy_enabled = true
   }
   tags = {
     env = "Test"

--- a/azurerm/internal/services/network/tests/firewall_policy_resource_test.go
+++ b/azurerm/internal/services/network/tests/firewall_policy_resource_test.go
@@ -205,7 +205,6 @@ resource "azurerm_firewall_policy" "test" {
   dns {
     servers                   = ["1.1.1.1", "2.2.2.2"]
     proxy_enabled             = true
-    network_rule_fqdn_enabled = true
   }
   tags = {
     env = "Test"
@@ -250,7 +249,6 @@ resource "azurerm_firewall_policy" "test" {
   dns {
     servers                   = ["1.1.1.1", "2.2.2.2"]
     proxy_enabled             = true
-    network_rule_fqdn_enabled = true
   }
   tags = {
     env = "Test"

--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -50,8 +50,6 @@ A `dns` block supports the following:
 
 * `proxy_enabled` - (Optional) Whether to enable DNS proxy on Firewalls attached to this Firewall Policy? Defaults to `false`.
 
-* `network_rule_fqdn_enabled` - (Optional) Whether FQDNS in Network Rules belongs to this Firewall Policy are supported? Defaults to `false`.
-
 ---
 
 A `threat_intelligence_allowlist` block supports the following:


### PR DESCRIPTION
This is due to service deprecate this property in all API versions.

Fixes: #9312

## Test Result

```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run "TestAccAzureRMFirewallPolicy_|TestAccDataSourceFirewallPolicy_"'                                                                                                      
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...  
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run "TestAccAzureRMFirewallPolicy_|TestAccDataSourceFirewallPolicy_" -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceFirewallPolicy_basic
=== PAUSE TestAccDataSourceFirewallPolicy_basic
=== RUN   TestAccAzureRMFirewallPolicy_basic 
=== PAUSE TestAccAzureRMFirewallPolicy_basic 
=== RUN   TestAccAzureRMFirewallPolicy_complete      
=== PAUSE TestAccAzureRMFirewallPolicy_complete      
=== RUN   TestAccAzureRMFirewallPolicy_update 
=== PAUSE TestAccAzureRMFirewallPolicy_update 
=== RUN   TestAccAzureRMFirewallPolicy_requiresImport
=== PAUSE TestAccAzureRMFirewallPolicy_requiresImport
=== RUN   TestAccAzureRMFirewallPolicy_inherit 
=== PAUSE TestAccAzureRMFirewallPolicy_inherit
=== CONT  TestAccDataSourceFirewallPolicy_basic
=== CONT  TestAccAzureRMFirewallPolicy_requiresImport
=== CONT  TestAccAzureRMFirewallPolicy_complete          
=== CONT  TestAccAzureRMFirewallPolicy_basic          
=== CONT  TestAccAzureRMFirewallPolicy_inherit                 
=== CONT  TestAccAzureRMFirewallPolicy_update           
--- PASS: TestAccAzureRMFirewallPolicy_complete (130.11s)
--- PASS: TestAccAzureRMFirewallPolicy_basic (130.35s) 
--- PASS: TestAccAzureRMFirewallPolicy_requiresImport (143.74s)
--- PASS: TestAccAzureRMFirewallPolicy_inherit (146.51s)                                                                                     
--- PASS: TestAccDataSourceFirewallPolicy_basic (154.37s)
--- PASS: TestAccAzureRMFirewallPolicy_update (238.21s)                                                                                      
PASS  
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       238.269s
```