### PR TITLE
This line can be removed now that the service is GA as of 14/02/20

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages a Private Endpoint.
 
--> **NOTE** Private Endpoint is currently in Public Preview.
-
 Azure Private Endpoint is a network interface that connects you privately and securely to a service powered by Azure Private Link. Private Endpoint uses a private IP address from your VNet, effectively bringing the service into your VNet. The service could be an Azure service such as Azure Storage, SQL, etc. or your own Private Link Service.
 
 ## Example Usage


### PR DESCRIPTION
Removed line about the service being in public preview as it went GA earlier in the year.

Source: https://azure.microsoft.com/en-gb/updates/private-link-now-available-in-ga/