### PR TITLE
key_vault_certificate: fixing a crash when serializing the certificate policy block

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -288,6 +288,10 @@ func dataSourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface
 }
 
 func flattenKeyVaultCertificatePolicyForDataSource(input *keyvault.CertificatePolicy) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
 	policy := make(map[string]interface{})
 
 	if params := input.IssuerParameters; params != nil {

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -722,6 +722,10 @@ func expandKeyVaultCertificatePolicy(d *schema.ResourceData) keyvault.Certificat
 }
 
 func flattenKeyVaultCertificatePolicy(input *keyvault.CertificatePolicy) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
 	policy := make(map[string]interface{})
 
 	if params := input.IssuerParameters; params != nil {


### PR DESCRIPTION
This PR fixes a crash which occurred when the certificate block was returned as nil from the API

Fixes #9352