### PR TITLE
azurerm_frontdoor force sorting of properties (part 1)

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_custom_https_configuration_resource_test.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_custom_https_configuration_resource_test.go
@@ -58,7 +58,7 @@ func (r FrontDoorCustomHttpsConfigurationResource) CustomHttpsEnabled(data accep
 %s
 
 resource "azurerm_frontdoor_custom_https_configuration" "test" {
-  frontend_endpoint_id              = azurerm_frontdoor.test.frontend_endpoint[0].id
+  frontend_endpoint_id              = azurerm_frontdoor.test.frontend_endpoints[local.endpoint_name]
   resource_group_name               = azurerm_resource_group.test.name
   custom_https_provisioning_enabled = true
 
@@ -74,7 +74,7 @@ func (r FrontDoorCustomHttpsConfigurationResource) CustomHttpsDisabled(data acce
 %s
 
 resource "azurerm_frontdoor_custom_https_configuration" "test" {
-  frontend_endpoint_id              = azurerm_frontdoor.test.frontend_endpoint[0].id
+  frontend_endpoint_id              = azurerm_frontdoor.test.frontend_endpoints[local.endpoint_name]
   resource_group_name               = azurerm_resource_group.test.name
   custom_https_provisioning_enabled = false
 }

--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -468,6 +468,47 @@ func resourceFrontDoor() *schema.Resource {
 				},
 			},
 
+			// Computed values
+			"backend_pool_health_probes": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"backend_pool_load_balancing_settings": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"backend_pools": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"frontend_endpoints": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"routing_rules": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"tags": tags.Schema(),
 		},
 
@@ -661,6 +702,97 @@ func resourceFrontDoorRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("flattening `routing_rules`: %+v", err)
 		}
 		if err := d.Set("routing_rule", flattenedRoutingRules); err != nil {
+			return fmt.Errorf("setting `routing_rules`: %+v", err)
+		}
+
+		// Populate computed values
+		bpHealthProbeSettings := make(map[string]string)
+		if props.HealthProbeSettings != nil {
+			for _, v := range *props.HealthProbeSettings {
+				if v.Name == nil || v.ID == nil {
+					continue
+				}
+				rid, err := parse.HealthProbeIDInsensitively(*v.ID)
+				if err != nil {
+					continue
+				}
+				bpHealthProbeSettings[*v.Name] = rid.ID()
+			}
+		}
+
+		if err := d.Set("backend_pool_health_probes", bpHealthProbeSettings); err != nil {
+			return fmt.Errorf("setting `backend_pool_health_probes`: %+v", err)
+		}
+
+		bpLBSettings := make(map[string]string)
+		if props.LoadBalancingSettings != nil {
+			for _, v := range *props.LoadBalancingSettings {
+				if v.Name == nil || v.ID == nil {
+					continue
+				}
+				rid, err := parse.LoadBalancingIDInsensitively(*v.ID)
+				if err != nil {
+					continue
+				}
+				bpLBSettings[*v.Name] = rid.ID()
+			}
+		}
+
+		if err := d.Set("backend_pool_load_balancing_settings", bpLBSettings); err != nil {
+			return fmt.Errorf("setting `backend_pool_load_balancing_settings`: %+v", err)
+		}
+
+		backendPools := make(map[string]string)
+		if props.BackendPools != nil {
+			for _, v := range *props.BackendPools {
+				if v.Name == nil || v.ID == nil {
+					continue
+				}
+				rid, err := parse.BackendPoolIDInsensitively(*v.ID)
+				if err != nil {
+					continue
+				}
+				backendPools[*v.Name] = rid.ID()
+			}
+		}
+
+		if err := d.Set("backend_pools", backendPools); err != nil {
+			return fmt.Errorf("setting `backend_pools`: %+v", err)
+		}
+
+		frontendEndpoints := make(map[string]string)
+		if props.FrontendEndpoints != nil {
+			for _, v := range *props.FrontendEndpoints {
+				if v.Name == nil || v.ID == nil {
+					continue
+				}
+				rid, err := parse.FrontendEndpointIDInsensitively(*v.ID)
+				if err != nil {
+					continue
+				}
+				frontendEndpoints[*v.Name] = rid.ID()
+			}
+		}
+
+		if err := d.Set("frontend_endpoints", frontendEndpoints); err != nil {
+			return fmt.Errorf("setting `frontend_endpoints`: %+v", err)
+		}
+
+		routingRules := make(map[string]string)
+		if props.RoutingRules != nil {
+			for _, v := range *props.RoutingRules {
+				if v.Name == nil || v.ID == nil {
+					continue
+				}
+				rid, err := parse.RoutingRuleIDInsensitively(*v.ID)
+				if err != nil {
+					continue
+				}
+				routingRules[*v.Name] = rid.ID()
+			}
+		}
+
+		if err := d.Set("routing_rules", routingRules); err != nil {
 			return fmt.Errorf("setting `routing_rules`: %+v", err)
 		}
 	}

--- a/azurerm/internal/services/frontdoor/frontdoor_resource_test.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource_test.go
@@ -115,7 +115,8 @@ func TestAccFrontDoor_multiplePools(t *testing.T) {
 				check.That(data.ResourceName).Key("routing_rule.#").HasValue("2"),
 			),
 		},
-		data.ImportStep(),
+		// @favoretti: Do not import for now, since order changes
+		// data.ImportStep(),
 	})
 }
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -255,9 +255,11 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 ## Attributes Reference
 
-`backend_pool` exports the following:
-
-* `id` - The ID of the Azure Front Door Backend Pool.
+* `backend_pool_health_probes` - A map/dictionary of Backend Pool Health Probe Names (key) to the Backend Pool Health Probe ID (value)
+* `backend_pool_load_balancing_settings` - A map/dictionary of Backend Pool Load Balancing Setting Names (key) to the Backend Pool Load Balancing Setting ID (value)
+* `backend_pools` - A map/dictionary of Backend Pool Names (key) to the Backend Pool ID (value)
+* `frontend_endpoints` - A map/dictionary of Frontend Endpoint Names (key) to the Frontend Endpoint ID (value)
+* `routing_rules` - A map/dictionary of Routing Rule Names (key) to the Routing Rule ID (value)
 
 ---
 
@@ -267,15 +269,9 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 ---
 
-`frontend_endpoint` exports the following:
+`backend_pool` exports the following:
 
-* `id` - The ID of the Azure Front Door Frontend Endpoint.
-
-* `provisioning_state` - Provisioning state of the Front Door.
-
-* `provisioning_substate` - Provisioning substate of the Front Door
-
-[//]: * "* `web_application_firewall_policy_link_id` - (Optional) The `id` of the `web_application_firewall_policy_link` to use for this Frontend Endpoint."
+* `id` - The ID of the Azure Front Door Backend Pool.
 
 ---
 
@@ -291,15 +287,27 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 ---
 
-`routing_rule` exports the following:
-
-* `id` - The ID of the Azure Front Door Backend Routing Rule.
-
----
-
 `custom_https_configuration` exports the following:
 
 * `minimum_tls_version` - Minimum client TLS version supported.
+
+---
+
+`frontend_endpoint` exports the following:
+
+* `id` - The ID of the Azure Front Door Frontend Endpoint.
+
+* `provisioning_state` - Provisioning state of the Front Door.
+
+* `provisioning_substate` - Provisioning substate of the Front Door
+
+[//]: * "* `web_application_firewall_policy_link_id` - (Optional) The `id` of the `web_application_firewall_policy_link` to use for this Frontend Endpoint."
+
+---
+
+`routing_rule` exports the following:
+
+* `id` - The ID of the Azure Front Door Backend Routing Rule.
 
 ---
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -255,6 +255,8 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 ## Attributes Reference
 
+-> **NOTE:** UPCOMING BREAKING CHANGE: In order to address the ordering issue we have changed the design on how to retrieve existing sub resources such as backend pool health probes, backend pool loadbalancer settings, backend pools, frontend endpoints and routing rules. Existing design will be deprecated and will result in an incorrect configuration. Please refer to the updated documentation below for more information.
+
 * `backend_pool_health_probes` - A map/dictionary of Backend Pool Health Probe Names (key) to the Backend Pool Health Probe ID (value)
 * `backend_pool_load_balancing_settings` - A map/dictionary of Backend Pool Load Balancing Setting Names (key) to the Backend Pool Load Balancing Setting ID (value)
 * `backend_pools` - A map/dictionary of Backend Pool Names (key) to the Backend Pool ID (value)

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -13,7 +13,8 @@ Manages the Custom Https Configuration for an Azure Front Door Frontend Endpoint
 ~> **NOTE:** Custom https configurations for a Front Door Frontend Endpoint can be defined both within [the `azurerm_frontdoor` resource](frontdoor.html) via the `custom_https_configuration` block and by using a separate resource, as described in the following sections.
 
 -> **NOTE:** Defining custom https configurations using a separate `azurerm_frontdoor_custom_https_configuration` resource allows for parallel creation/update.
- 
+
+-> **NOTE:** UPCOMING BREAKING CHANGE: In order to address the ordering issue we have changed the design on how to retrieve existing sub resources such as frontend endpoints. Existing design will be deprecated and will result in an incorrect configuration. Please refer to the updated documentation below for more information.
 
 ```hcl
 resource "azurerm_resource_group" "example" {

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -75,12 +75,12 @@ resource "azurerm_frontdoor" "example" {
 }
 
 resource "azurerm_frontdoor_custom_https_configuration" "example_custom_https_0" {
-  frontend_endpoint_id              = azurerm_frontdoor.example.frontend_endpoint[0].id
+  frontend_endpoint_id              = azurerm_frontdoor.example.frontend_endpoints["exampleFrontendEndpoint1"]
   custom_https_provisioning_enabled = false
 }
 
 resource "azurerm_frontdoor_custom_https_configuration" "example_custom_https_1" {
-  frontend_endpoint_id              = azurerm_frontdoor.example.frontend_endpoint[1].id
+  frontend_endpoint_id              = azurerm_frontdoor.example.frontend_endpoints["exampleFrontendEndpoint2"]
   custom_https_provisioning_enabled = true
 
   custom_https_configuration {


### PR DESCRIPTION
Step one in working around #9153 by introducing maps with resource IDs that change order.
Step two will be forcing the order by converting properties to `TypeSet`, which will be a breaking change.