### PR TITLE
kubernetes_cluster: http_application_routing ForceNew removed

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -99,13 +99,11 @@ func schemaKubernetesAddOnProfiles() *schema.Schema {
 				"http_application_routing": {
 					Type:     schema.TypeList,
 					MaxItems: 1,
-					ForceNew: true,
 					Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"enabled": {
 								Type:     schema.TypeBool,
-								ForceNew: true,
 								Required: true,
 							},
 							"http_application_routing_zone_name": {

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_addons_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_addons_resource_test.go
@@ -696,6 +696,9 @@ resource "azurerm_kubernetes_cluster" "test" {
     http_application_routing {
       enabled = true
     }
+    kube_dashboard {
+      enabled = false
+    }
   }
 
   identity {
@@ -738,6 +741,9 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   addon_profile {
     http_application_routing {
+      enabled = false
+    }
+    kube_dashboard {
       enabled = false
     }
   }

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_addons_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_addons_resource_test.go
@@ -15,7 +15,7 @@ var kubernetesAddOnTests = map[string]func(t *testing.T){
 	"addonProfileKubeDashboard":             testAccAzureRMKubernetesCluster_addonProfileKubeDashboard,
 	"addonProfileOMS":                       testAccAzureRMKubernetesCluster_addonProfileOMS,
 	"addonProfileOMSToggle":                 testAccAzureRMKubernetesCluster_addonProfileOMSToggle,
-	"addonProfileRouting":                   testAccAzureRMKubernetesCluster_addonProfileRouting,
+	"addonProfileRouting":                   testAccAzureRMKubernetesCluster_addonProfileRoutingToggle,
 }
 
 func TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
@@ -244,12 +244,12 @@ func testAccAzureRMKubernetesCluster_addonProfileOMSToggle(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMKubernetesCluster_addonProfileRouting(t *testing.T) {
+func TestAccAzureRMKubernetesCluster_addonProfileRoutingToggle(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
-	testAccAzureRMKubernetesCluster_addonProfileRouting(t)
+	testAccAzureRMKubernetesCluster_addonProfileRoutingToggle(t)
 }
 
-func testAccAzureRMKubernetesCluster_addonProfileRouting(t *testing.T) {
+func testAccAzureRMKubernetesCluster_addonProfileRoutingToggle(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -262,7 +262,18 @@ func testAccAzureRMKubernetesCluster_addonProfileRouting(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.http_application_routing.#", "1"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "addon_profile.0.http_application_routing.0.enabled"),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.http_application_routing.0.enabled", "true"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "addon_profile.0.http_application_routing.0.http_application_routing_zone_name"),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.oms_agent.#", "0"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMKubernetesCluster_addonProfileRoutingConfigDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.http_application_routing.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.http_application_routing.0.enabled", "false"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "addon_profile.0.http_application_routing.0.http_application_routing_zone_name"),
 					resource.TestCheckResourceAttr(data.ResourceName, "addon_profile.0.oms_agent.#", "0"),
 				),
@@ -684,6 +695,50 @@ resource "azurerm_kubernetes_cluster" "test" {
   addon_profile {
     http_application_routing {
       enabled = true
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMKubernetesCluster_addonProfileRoutingConfigDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  addon_profile {
+    http_application_routing {
+      enabled = false
     }
   }
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -271,7 +271,7 @@ If `enable_auto_scaling` is set to `false`, then the following fields can also b
 
 A `http_application_routing` block supports the following:
 
-* `enabled` (Required) Is HTTP Application Routing Enabled? Changing this forces a new resource to be created.
+* `enabled` (Required) Is HTTP Application Routing Enabled?
 
 ---
 


### PR DESCRIPTION
### Implementation
Fixes #9367 

Changes:
- Removal of ForceNew from `http_application_routing`
- Change of `addonProfileRouting` test to `addonProfileRoutingToggle` to test both enabling and disabling `http_application_routing`
- Disabled `addon_profile.0.kube_dashboard` explicitly to let the test succeed

### Acceptance Tests
```
=== RUN   TestAccAzureRMKubernetesCluster_addonProfileRoutingToggle
=== PAUSE TestAccAzureRMKubernetesCluster_addonProfileRoutingToggle
=== CONT  TestAccAzureRMKubernetesCluster_addonProfileRoutingToggle
--- PASS: TestAccAzureRMKubernetesCluster_addonProfileRoutingToggle (767.66s)
```