### PR TITLE
try to retrieve apiVersion for all sub-resources

### DIFF
--- a/azurerm/internal/services/resource/template_deployment_common.go
+++ b/azurerm/internal/services/resource/template_deployment_common.go
@@ -239,7 +239,7 @@ func findApiVersionForResourceType(resourceType string, availableResourceTypes [
 			continue
 		}
 
-		if *item.ResourceType == resourceType {
+		if strings.HasPrefix(resourceType, *item.ResourceType) {
 			apiVersions := *item.APIVersions
 			apiVersion := apiVersions[0]
 			return &apiVersion

--- a/azurerm/internal/services/resource/tests/template_deployment_resource_group_resource_test.go
+++ b/azurerm/internal/services/resource/tests/template_deployment_resource_group_resource_test.go
@@ -198,14 +198,14 @@ func TestAccResourceGroupTemplateDeployment_childItems(t *testing.T) {
 		CheckDestroy: testCheckResourceGroupTemplateDeploymentDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: resourceGroupTemplateDeployment_childItemsConfig(data, "first"),
+				Config: resourceGroupTemplateDeployment_childItemsConfig(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckResourceGroupTemplateDeploymentExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: resourceGroupTemplateDeployment_childItemsConfig(data, "second"),
+				Config: resourceGroupTemplateDeployment_childItemsConfig(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckResourceGroupTemplateDeploymentExists(data.ResourceName),
 				),
@@ -577,7 +577,7 @@ TEMPLATE
 `, data.RandomInteger, data.Locations.Primary, value)
 }
 
-func resourceGroupTemplateDeployment_childItemsConfig(data acceptance.TestData, value string) string {
+func resourceGroupTemplateDeployment_childItemsConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
Fixes #9003 by retrieving API Versions for ResourceProviders of sub-resources even if the `resourceTypeName` don't exactly match the template's resourceType by matching the prefix