### PR TITLE
kubernetes: running tests individually by default

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -189,7 +189,7 @@ func apiManagementCustomDomainRead(d *schema.ResourceData, meta interface{}) err
 		configs := flattenApiManagementHostnameConfiguration(resp.ServiceProperties.HostnameConfigurations, d)
 		for _, config := range configs {
 			for key, v := range config.(map[string]interface{}) {
-				// nolint R001: ResourceData.Set() key argument should be string literal
+				// lintignore:R001
 				if err := d.Set(key, v); err != nil {
 					return fmt.Errorf("setting `hostname_configuration` %q: %+v", key, err)
 				}

--- a/azurerm/internal/services/containers/tests/helpers_test.go
+++ b/azurerm/internal/services/containers/tests/helpers_test.go
@@ -1,18 +1,13 @@
 package tests
 
 import (
-	"os"
 	"testing"
 )
 
-func checkIfShouldRunTestsCombined(t *testing.T) {
-	if os.Getenv("TF_PROVIDER_SPLIT_COMBINED_TESTS") != "" {
-		t.Skip("Skipping since this is being run Individually")
-	}
-}
-
 func checkIfShouldRunTestsIndividually(t *testing.T) {
-	if os.Getenv("TF_PROVIDER_SPLIT_COMBINED_TESTS") == "" {
-		t.Skip("Skipping since this is being run as a Combined Test")
-	}
+	// NOTE: leaving this around so we can remove this gradually without
+	// causing merge conflicts on open PR's
+	//
+	// This is no longer necessary since we limit the concurrent tests
+	// for this package at the CI level
 }

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_resource_test.go
@@ -18,12 +18,9 @@ var (
 )
 
 func TestAccAzureRMKubernetes_all(t *testing.T) {
-	// we can conditionally run tests tests individually, or combined
-	checkIfShouldRunTestsCombined(t)
-
-	// NOTE: this is a combined test rather than separate split out tests to
-	// ease the load on the kubernetes api
-	testCases := map[string]map[string]func(t *testing.T){
+	// NOTE: this test is no longer used, but this assignment kicks around temporarily
+	// to allow us to migrate off this without causing conflicts in open PR's
+	_ = map[string]map[string]func(t *testing.T){
 		"auth":               kubernetesAuthTests,
 		"clusterAddOn":       kubernetesAddOnTests,
 		"datasource":         kubernetesDataSourceTests,
@@ -35,18 +32,7 @@ func TestAccAzureRMKubernetes_all(t *testing.T) {
 		"upgrade":            kubernetesUpgradeTests,
 	}
 
-	for group, m := range testCases {
-		m := m
-		t.Run(group, func(t *testing.T) {
-			for name, tc := range m {
-				tc := tc
-
-				t.Run(name, func(t *testing.T) {
-					tc(t)
-				})
-			}
-		})
-	}
+	t.Skip("Skipping since this is being run Individually")
 }
 
 func testCheckAzureRMKubernetesClusterExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
The "combined" test is no longer necessary, since we now limit concurrency for this service package at the CI level (and users will do the same when running this locally - so this shouldn't be an issue).

This means we no longer need to set the env var when running Kubernetes tests to get these results split.