### PR TITLE
Fix heading formatting in service principal with secret documentation

### DIFF
--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -25,7 +25,7 @@ A Service Principal is an application within Azure Active Directory whose authen
 
 It's possible to complete this task in either the [Azure CLI](#creating-a-service-principal-using-the-azure-cli) or in the [Azure Portal](#creating-a-service-principal-in-the-azure-portal) - in both we'll create a Service Principal which has `Contributor` rights to the subscription. [It's also possible to assign other rights](https://azure.microsoft.com/en-gb/documentation/articles/role-based-access-built-in-roles/) depending on your configuration.
 
-### Creating a Service Principal using the Azure CLI
+### Creating a Service Principal using the Azure CLI
 
 ~> **Note**: If you're using the **China**, **German** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
 


### PR DESCRIPTION
Fix the heading formatting for the section for creating the service principal via the Azure CLI.

Resolves #9383