### PR TITLE
Docs: Change wrong resource name in import section

### DIFF
--- a/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Associations between Virtual Desktop Workspaces and Virtual Desktop Application Groups can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_network_interface_security_group_association.association1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myGroup1/providers/Microsoft.DesktopVirtualization/workspaces/myworkspace|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/myapplicationgroup"
+terraform import azurerm_virtual_desktop_workspace_application_group_association.association1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myGroup1/providers/Microsoft.DesktopVirtualization/workspaces/myworkspace|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/myapplicationgroup"
 ```
 
 -> **NOTE:** This ID is specific to Terraform - and is of the format `{virtualDesktopWorkspaceID}|{virtualDesktopApplicationGroupID}`.


### PR DESCRIPTION
Docs for `azurerm_virtual_desktop_workspace_application_group_association` uses wrong resource name in the import section of the documentation.
It was `azurerm_network_interface_security_group_association`