### PR TITLE
refactor: Resource Formatters now use a local Subscription ID

### DIFF
--- a/azurerm/internal/services/cdn/migration/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint.go
@@ -1007,8 +1007,8 @@ func CdnEndpointV0ToV1(rawState map[string]interface{}, _ interface{}) (map[stri
 		return rawState, err
 	}
 
-	newId := parse.NewCdnEndpointID(parse.NewCdnProfileID(resourceGroup, profileName), name)
-	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+	newId := parse.NewCdnEndpointID(parse.NewCdnProfileID(oldParsedId.SubscriptionID, resourceGroup, profileName), name)
+	newIdStr := newId.ID("")
 
 	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
 

--- a/azurerm/internal/services/cdn/migration/cdn_profile.go
+++ b/azurerm/internal/services/cdn/migration/cdn_profile.go
@@ -71,8 +71,8 @@ func CdnProfileV0ToV1(rawState map[string]interface{}, _ interface{}) (map[strin
 		return rawState, err
 	}
 
-	newId := parse.NewCdnProfileID(resourceGroup, name)
-	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+	newId := parse.NewCdnProfileID(oldParsedId.SubscriptionID, resourceGroup, name)
+	newIdStr := newId.ID("")
 
 	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
 

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint.go
@@ -7,17 +7,24 @@ import (
 )
 
 type CdnEndpointId struct {
-	ResourceGroup string
-	ProfileName   string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	ProfileName    string
+	Name           string
 }
 
 func NewCdnEndpointID(id CdnProfileId, name string) CdnEndpointId {
 	return CdnEndpointId{
-		ResourceGroup: id.ResourceGroup,
-		ProfileName:   id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		ProfileName:    id.Name,
+		Name:           name,
 	}
+}
+
+func (id CdnEndpointId) ID(_ string) string {
+	base := NewCdnProfileID(id.SubscriptionId, id.ResourceGroup, id.ProfileName)
+	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
 }
 
 func CdnEndpointID(input string) (*CdnEndpointId, error) {
@@ -27,7 +34,8 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	}
 
 	endpoint := CdnEndpointId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if endpoint.ProfileName, err = id.PopSegment("profiles"); err != nil {
@@ -43,9 +51,4 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	}
 
 	return &endpoint, nil
-}
-
-func (id CdnEndpointId) ID(subscriptionId string) string {
-	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscriptionId)
-	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint_test.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = CdnEndpointId{}
 
 func TestCdnEndpointIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewCdnEndpointID(NewCdnProfileID("group1", "profile1"), "endpoint1").ID(subscriptionId)
+	actual := NewCdnEndpointID(NewCdnProfileID(subscriptionId, "group1", "profile1"), "endpoint1").ID("")
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -62,9 +62,10 @@ func TestCdnEndpointId(t *testing.T) {
 			Name:  "CDN Endpoint ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profName1/endpoints/Endpoint1",
 			Expected: &CdnEndpointId{
-				ResourceGroup: "resGroup1",
-				ProfileName:   "profName1",
-				Name:          "Endpoint1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				ProfileName:    "profName1",
+				Name:           "Endpoint1",
 			},
 		},
 		{
@@ -94,6 +95,9 @@ func TestCdnEndpointId(t *testing.T) {
 		}
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/cdn/parse/cdn_profile.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile.go
@@ -7,15 +7,22 @@ import (
 )
 
 type CdnProfileId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewCdnProfileID(resourceGroup, name string) CdnProfileId {
+func NewCdnProfileID(subscriptionId, resourceGroup, name string) CdnProfileId {
 	return CdnProfileId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
+}
+
+func (id CdnProfileId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func CdnProfileID(input string) (*CdnProfileId, error) {
@@ -25,7 +32,8 @@ func CdnProfileID(input string) (*CdnProfileId, error) {
 	}
 
 	profile := CdnProfileId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if profile.Name, err = id.PopSegment("profiles"); err != nil {
@@ -37,9 +45,4 @@ func CdnProfileID(input string) (*CdnProfileId, error) {
 	}
 
 	return &profile, nil
-}
-
-func (id CdnProfileId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s",
-		subscriptionId, id.ResourceGroup, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_profile_test.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = CdnProfileId{}
 
 func TestCdnProfileIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewCdnProfileID("group1", "profile1").ID(subscriptionId)
+	actual := NewCdnProfileID(subscriptionId, "group1", "profile1").ID("")
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -52,8 +52,9 @@ func TestCdnProfileId(t *testing.T) {
 			Name:  "CDN Profile ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/Profile1",
 			Expected: &CdnProfileId{
-				Name:          "Profile1",
-				ResourceGroup: "resGroup1",
+				Name:           "Profile1",
+				ResourceGroup:  "resGroup1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
 			},
 		},
 		{
@@ -81,6 +82,10 @@ func TestCdnProfileId(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/availability_set.go
+++ b/azurerm/internal/services/compute/parse/availability_set.go
@@ -7,19 +7,22 @@ import (
 )
 
 type AvailabilitySetId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewAvailabilitySetId(resourceGroup, name string) AvailabilitySetId {
+func NewAvailabilitySetId(subscriptionId, resourceGroup, name string) AvailabilitySetId {
 	return AvailabilitySetId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id AvailabilitySetId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id AvailabilitySetId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/availabilitySets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func AvailabilitySetID(input string) (*AvailabilitySetId, error) {
@@ -29,7 +32,8 @@ func AvailabilitySetID(input string) (*AvailabilitySetId, error) {
 	}
 
 	set := AvailabilitySetId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if set.Name, err = id.PopSegment("availabilitySets"); err != nil {

--- a/azurerm/internal/services/compute/parse/availability_set_test.go
+++ b/azurerm/internal/services/compute/parse/availability_set_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = AvailabilitySetId{}
 
 func TestAvailabilitySetIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewAvailabilitySetId("group1", "set1").ID(subscriptionId)
+	actual := NewAvailabilitySetId(subscriptionId, "group1", "set1").ID("")
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/availabilitySets/set1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -54,8 +54,9 @@ func TestAvailabilitySetID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/availabilitySets/set1",
 			Error: false,
 			Expect: &AvailabilitySetId{
-				ResourceGroup: "resGroup1",
-				Name:          "set1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "set1",
 			},
 		},
 		{

--- a/azurerm/internal/services/compute/parse/dedicated_host.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host.go
@@ -7,21 +7,23 @@ import (
 )
 
 type DedicatedHostId struct {
-	ResourceGroup string
-	HostGroup     string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	HostGroup      string
+	Name           string
 }
 
 func NewDedicatedHostId(id DedicatedHostGroupId, name string) DedicatedHostId {
 	return DedicatedHostId{
-		ResourceGroup: id.ResourceGroup,
-		HostGroup:     id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		HostGroup:      id.Name,
+		Name:           name,
 	}
 }
 
-func (id DedicatedHostId) ID(subscriptionId string) string {
-	base := NewDedicatedHostGroupId(id.ResourceGroup, id.HostGroup).ID(subscriptionId)
+func (id DedicatedHostId) ID(_ string) string {
+	base := NewDedicatedHostGroupId(id.SubscriptionId, id.ResourceGroup, id.HostGroup).ID("")
 	return fmt.Sprintf("%s/hosts/%s", base, id.Name)
 }
 
@@ -32,7 +34,8 @@ func DedicatedHostID(input string) (*DedicatedHostId, error) {
 	}
 
 	host := DedicatedHostId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if host.HostGroup, err = id.PopSegment("hostGroups"); err != nil {

--- a/azurerm/internal/services/compute/parse/dedicated_host_group.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_group.go
@@ -7,19 +7,22 @@ import (
 )
 
 type DedicatedHostGroupId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewDedicatedHostGroupId(resourceGroup, name string) DedicatedHostGroupId {
+func NewDedicatedHostGroupId(subscriptionId, resourceGroup, name string) DedicatedHostGroupId {
 	return DedicatedHostGroupId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id DedicatedHostGroupId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/hostGroups/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id DedicatedHostGroupId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/hostGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
@@ -29,7 +32,8 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 	}
 
 	group := DedicatedHostGroupId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if group.Name, err = id.PopSegment("hostGroups"); err != nil {

--- a/azurerm/internal/services/compute/parse/dedicated_host_group_test.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_group_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = DedicatedHostGroupId{}
 
 func TestDedicatedHostGroupIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewDedicatedHostGroupId("group1", "hostGroup1").ID(subscriptionId)
+	actual := NewDedicatedHostGroupId(subscriptionId, "group1", "hostGroup1").ID("")
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/hostGroups/hostGroup1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -54,8 +54,9 @@ func TestDedicatedHostGroupID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1",
 			Error: false,
 			Expect: &DedicatedHostGroupId{
-				ResourceGroup: "resGroup1",
-				Name:          "group1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "group1",
 			},
 		},
 		{
@@ -83,6 +84,10 @@ func TestDedicatedHostGroupID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/dedicated_host_test.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = DedicatedHostId{}
 
 func TestDedicatedHostIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	hostGroupId := NewDedicatedHostGroupId("group1", "hostGroup1")
+	hostGroupId := NewDedicatedHostGroupId(subscriptionId, "group1", "hostGroup1")
 	actual := NewDedicatedHostId(hostGroupId, "host1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/hostGroups/hostGroup1/hosts/host1"
 	if actual != expected {
@@ -65,9 +65,10 @@ func TestDedicatedHostID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/host1",
 			Error: false,
 			Expect: &DedicatedHostId{
-				ResourceGroup: "resGroup1",
-				HostGroup:     "group1",
-				Name:          "host1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				HostGroup:      "group1",
+				Name:           "host1",
 			},
 		},
 		{
@@ -99,6 +100,10 @@ func TestDedicatedHostID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/disk_encryption_set.go
+++ b/azurerm/internal/services/compute/parse/disk_encryption_set.go
@@ -7,19 +7,22 @@ import (
 )
 
 type DiskEncryptionSetId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewDiskEncryptionSetId(resourceGroup, name string) DiskEncryptionSetId {
+func NewDiskEncryptionSetId(subscriptionId, resourceGroup, name string) DiskEncryptionSetId {
 	return DiskEncryptionSetId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id DiskEncryptionSetId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id DiskEncryptionSetId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func DiskEncryptionSetID(input string) (*DiskEncryptionSetId, error) {
@@ -29,7 +32,8 @@ func DiskEncryptionSetID(input string) (*DiskEncryptionSetId, error) {
 	}
 
 	encryptionSetId := DiskEncryptionSetId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if encryptionSetId.Name, err = id.PopSegment("diskEncryptionSets"); err != nil {

--- a/azurerm/internal/services/compute/parse/disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/parse/disk_encryption_set_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = DiskEncryptionSetId{}
 
 func TestDiskEncryptionSetIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewDiskEncryptionSetId("group1", "set1").ID(subscriptionId)
+	actual := NewDiskEncryptionSetId(subscriptionId, "group1", "set1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/diskEncryptionSets/set1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -54,8 +54,9 @@ func TestDiskEncryptionSetID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/diskEncryptionSets/encryptionSet1",
 			Error: false,
 			Expect: &DiskEncryptionSetId{
-				ResourceGroup: "resGroup1",
-				Name:          "encryptionSet1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "encryptionSet1",
 			},
 		},
 		{
@@ -83,6 +84,10 @@ func TestDiskEncryptionSetID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/image.go
+++ b/azurerm/internal/services/compute/parse/image.go
@@ -7,19 +7,22 @@ import (
 )
 
 type ImageId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewImageId(resourceGroup, name string) ImageId {
+func NewImageId(subscriptionId, resourceGroup, name string) ImageId {
 	return ImageId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id ImageId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id ImageId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/images/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ImageID(input string) (*ImageId, error) {
@@ -29,7 +32,8 @@ func ImageID(input string) (*ImageId, error) {
 	}
 
 	set := ImageId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if set.Name, err = id.PopSegment("images"); err != nil {

--- a/azurerm/internal/services/compute/parse/image_test.go
+++ b/azurerm/internal/services/compute/parse/image_test.go
@@ -85,5 +85,9 @@ func TestImageID(t *testing.T) {
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
 		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
+		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/image_test.go
+++ b/azurerm/internal/services/compute/parse/image_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = ImageId{}
 
 func TestImageIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewImageId("group1", "image1").ID(subscriptionId)
+	actual := NewImageId(subscriptionId, "group1", "image1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/images/image1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -54,8 +54,9 @@ func TestImageID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/images/image1",
 			Error: false,
 			Expect: &ImageId{
-				ResourceGroup: "resGroup1",
-				Name:          "image1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "image1",
 			},
 		},
 		{

--- a/azurerm/internal/services/compute/parse/managed_disk.go
+++ b/azurerm/internal/services/compute/parse/managed_disk.go
@@ -7,19 +7,22 @@ import (
 )
 
 type ManagedDiskId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewManagedDiskId(resourceGroup, name string) ManagedDiskId {
+func NewManagedDiskId(subscriptionId, resourceGroup, name string) ManagedDiskId {
 	return ManagedDiskId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id ManagedDiskId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id ManagedDiskId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ManagedDiskID(input string) (*ManagedDiskId, error) {
@@ -29,7 +32,8 @@ func ManagedDiskID(input string) (*ManagedDiskId, error) {
 	}
 
 	disk := ManagedDiskId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if disk.Name, err = id.PopSegment("disks"); err != nil {

--- a/azurerm/internal/services/compute/parse/managed_disk_test.go
+++ b/azurerm/internal/services/compute/parse/managed_disk_test.go
@@ -85,5 +85,9 @@ func TestManagedDiskID(t *testing.T) {
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
 		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
+		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/managed_disk_test.go
+++ b/azurerm/internal/services/compute/parse/managed_disk_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = ManagedDiskId{}
 
 func TestManagedDiskIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewManagedDiskId("group1", "disk1").ID(subscriptionId)
+	actual := NewManagedDiskId(subscriptionId, "group1", "disk1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/disks/disk1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -54,8 +54,9 @@ func TestManagedDiskID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/disks/disk1",
 			Error: false,
 			Expect: &ManagedDiskId{
-				ResourceGroup: "resGroup1",
-				Name:          "disk1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "disk1",
 			},
 		},
 		{

--- a/azurerm/internal/services/compute/parse/proximity_placement_group.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group.go
@@ -7,19 +7,22 @@ import (
 )
 
 type ProximityPlacementGroupId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewProximityPlacementGroupId(resourceGroup, name string) ProximityPlacementGroupId {
+func NewProximityPlacementGroupId(subscriptionId, resourceGroup, name string) ProximityPlacementGroupId {
 	return ProximityPlacementGroupId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id ProximityPlacementGroupId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/proximityPlacementGroups/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id ProximityPlacementGroupId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/proximityPlacementGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ProximityPlacementGroupID(input string) (*ProximityPlacementGroupId, error) {
@@ -29,7 +32,8 @@ func ProximityPlacementGroupID(input string) (*ProximityPlacementGroupId, error)
 	}
 
 	server := ProximityPlacementGroupId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if server.Name, err = id.PopSegment("proximityPlacementGroups"); err != nil {

--- a/azurerm/internal/services/compute/parse/proximity_placement_group_test.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = ProximityPlacementGroupId{}
 
 func TestProximityPlacementGroupIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewProximityPlacementGroupId("group1", "ppg1").ID(subscriptionId)
+	actual := NewProximityPlacementGroupId(subscriptionId, "group1", "ppg1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/proximityPlacementGroups/ppg1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -54,8 +54,9 @@ func TestProximityPlacementGroupID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/proximityPlacementGroups/group1",
 			Error: false,
 			Expect: &ProximityPlacementGroupId{
-				ResourceGroup: "resGroup1",
-				Name:          "group1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "group1",
 			},
 		},
 		{
@@ -83,6 +84,10 @@ func TestProximityPlacementGroupID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/shared_image.go
+++ b/azurerm/internal/services/compute/parse/shared_image.go
@@ -22,8 +22,8 @@ func NewSharedImageId(id SharedImageGalleryId, name string) SharedImageId {
 	}
 }
 
-func (id SharedImageId) ID(subscriptionId string) string {
-	base := NewSharedImageGalleryId(id.SubscriptionId, id.ResourceGroup, id.Gallery).ID(subscriptionId)
+func (id SharedImageId) ID(_ string) string {
+	base := NewSharedImageGalleryId(id.SubscriptionId, id.ResourceGroup, id.Gallery).ID("")
 	return fmt.Sprintf("%s/images/%s", base, id.Name)
 }
 

--- a/azurerm/internal/services/compute/parse/shared_image.go
+++ b/azurerm/internal/services/compute/parse/shared_image.go
@@ -7,21 +7,23 @@ import (
 )
 
 type SharedImageId struct {
-	ResourceGroup string
-	Gallery       string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Gallery        string
+	Name           string
 }
 
 func NewSharedImageId(id SharedImageGalleryId, name string) SharedImageId {
 	return SharedImageId{
-		ResourceGroup: id.ResourceGroup,
-		Gallery:       id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		Gallery:        id.Name,
+		Name:           name,
 	}
 }
 
 func (id SharedImageId) ID(subscriptionId string) string {
-	base := NewSharedImageGalleryId(id.ResourceGroup, id.Gallery).ID(subscriptionId)
+	base := NewSharedImageGalleryId(id.SubscriptionId, id.ResourceGroup, id.Gallery).ID(subscriptionId)
 	return fmt.Sprintf("%s/images/%s", base, id.Name)
 }
 
@@ -32,7 +34,8 @@ func SharedImageID(input string) (*SharedImageId, error) {
 	}
 
 	image := SharedImageId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if image.Gallery, err = id.PopSegment("galleries"); err != nil {

--- a/azurerm/internal/services/compute/parse/shared_image_gallery.go
+++ b/azurerm/internal/services/compute/parse/shared_image_gallery.go
@@ -7,19 +7,22 @@ import (
 )
 
 type SharedImageGalleryId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewSharedImageGalleryId(resourceGroup, name string) SharedImageGalleryId {
+func NewSharedImageGalleryId(subscriptionId, resourceGroup, name string) SharedImageGalleryId {
 	return SharedImageGalleryId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id SharedImageGalleryId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id SharedImageGalleryId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func SharedImageGalleryID(input string) (*SharedImageGalleryId, error) {
@@ -29,7 +32,8 @@ func SharedImageGalleryID(input string) (*SharedImageGalleryId, error) {
 	}
 
 	gallery := SharedImageGalleryId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if gallery.Name, err = id.PopSegment("galleries"); err != nil {

--- a/azurerm/internal/services/compute/parse/shared_image_gallery_test.go
+++ b/azurerm/internal/services/compute/parse/shared_image_gallery_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = SharedImageGalleryId{}
 
 func TestSharedImageGalleryIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewSharedImageGalleryId("group1", "gallery1").ID(subscriptionId)
+	actual := NewSharedImageGalleryId(subscriptionId, "group1", "gallery1").ID("")
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/galleries/gallery1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -59,8 +59,9 @@ func TestSharedImageGalleryID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1",
 			Error: false,
 			Expect: &SharedImageGalleryId{
-				ResourceGroup: "mygroup1",
-				Name:          "gallery1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "mygroup1",
+				Name:           "gallery1",
 			},
 		},
 		{
@@ -88,6 +89,10 @@ func TestSharedImageGalleryID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/shared_image_test.go
+++ b/azurerm/internal/services/compute/parse/shared_image_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = SharedImageId{}
 
 func TestSharedImageIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	galleryId := NewSharedImageGalleryId("group1", "gallery1")
+	galleryId := NewSharedImageGalleryId(subscriptionId, "group1", "gallery1")
 	actual := NewSharedImageId(galleryId, "image1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/galleries/gallery1/images/image1"
 	if actual != expected {
@@ -60,9 +60,10 @@ func TestSharedImageID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1/images/image1",
 			Error: false,
 			Expect: &SharedImageId{
-				ResourceGroup: "mygroup1",
-				Gallery:       "gallery1",
-				Name:          "image1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "mygroup1",
+				Gallery:        "gallery1",
+				Name:           "image1",
 			},
 		},
 		{
@@ -94,6 +95,10 @@ func TestSharedImageID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/shared_image_version.go
+++ b/azurerm/internal/services/compute/parse/shared_image_version.go
@@ -7,24 +7,26 @@ import (
 )
 
 type SharedImageVersionId struct {
-	ResourceGroup string
-	Gallery       string
-	ImageName     string
-	Version       string
+	SubscriptionId string
+	ResourceGroup  string
+	Gallery        string
+	ImageName      string
+	Version        string
 }
 
 func NewSharedImageVersionId(id SharedImageId, name string) SharedImageVersionId {
 	return SharedImageVersionId{
-		ResourceGroup: id.ResourceGroup,
-		Gallery:       id.Gallery,
-		ImageName:     id.Name,
-		Version:       name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		Gallery:        id.Gallery,
+		ImageName:      id.Name,
+		Version:        name,
 	}
 }
 
-func (id SharedImageVersionId) ID(subscriptionId string) string {
-	galleryId := NewSharedImageGalleryId(id.ResourceGroup, id.Gallery)
-	base := NewSharedImageId(galleryId, id.ImageName).ID(subscriptionId)
+func (id SharedImageVersionId) ID(_ string) string {
+	galleryId := NewSharedImageGalleryId(id.SubscriptionId, id.ResourceGroup, id.Gallery)
+	base := NewSharedImageId(galleryId, id.ImageName).ID("")
 	return fmt.Sprintf("%s/versions/%s", base, id.Version)
 }
 
@@ -35,7 +37,8 @@ func SharedImageVersionID(input string) (*SharedImageVersionId, error) {
 	}
 
 	set := SharedImageVersionId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if set.Gallery, err = id.PopSegment("galleries"); err != nil {

--- a/azurerm/internal/services/compute/parse/shared_image_version_test.go
+++ b/azurerm/internal/services/compute/parse/shared_image_version_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = SharedImageVersionId{}
 
 func TestSharedImageVersionIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	galleryId := NewSharedImageGalleryId("group1", "gallery1")
+	galleryId := NewSharedImageGalleryId(subscriptionId, "group1", "gallery1")
 	imageId := NewSharedImageId(galleryId, "image1")
 	actual := NewSharedImageVersionId(imageId, "version1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/galleries/gallery1/images/image1/versions/version1"
@@ -61,10 +61,11 @@ func TestSharedImageVersionID(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1/images/image1/versions/1.0.0",
 			Error: false,
 			Expect: &SharedImageVersionId{
-				ResourceGroup: "mygroup1",
-				Gallery:       "gallery1",
-				ImageName:     "image1",
-				Version:       "1.0.0",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "mygroup1",
+				Gallery:        "gallery1",
+				ImageName:      "image1",
+				Version:        "1.0.0",
 			},
 		},
 		{
@@ -92,6 +93,10 @@ func TestSharedImageVersionID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expect.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expect.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expect.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/virtual_machine.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine.go
@@ -7,19 +7,22 @@ import (
 )
 
 type VirtualMachineId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewVirtualMachineId(resourceGroup, name string) VirtualMachineId {
+func NewVirtualMachineId(subscriptionId, resourceGroup, name string) VirtualMachineId {
 	return VirtualMachineId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id VirtualMachineId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id VirtualMachineId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func VirtualMachineID(input string) (*VirtualMachineId, error) {
@@ -29,7 +32,8 @@ func VirtualMachineID(input string) (*VirtualMachineId, error) {
 	}
 
 	vm := VirtualMachineId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if vm.Name, err = id.PopSegment("virtualMachines"); err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_extension.go
@@ -7,21 +7,23 @@ import (
 )
 
 type VirtualMachineExtensionId struct {
+	SubscriptionId string
 	ResourceGroup  string
-	Name           string
 	VirtualMachine string
+	Name           string
 }
 
 func NewVirtualMachineExtensionId(id VirtualMachineId, name string) VirtualMachineExtensionId {
 	return VirtualMachineExtensionId{
+		SubscriptionId: id.SubscriptionId,
 		ResourceGroup:  id.ResourceGroup,
 		VirtualMachine: id.Name,
 		Name:           name,
 	}
 }
 
-func (id VirtualMachineExtensionId) ID(subscriptionId string) string {
-	base := NewVirtualMachineId(id.ResourceGroup, id.VirtualMachine).ID(subscriptionId)
+func (id VirtualMachineExtensionId) ID(_ string) string {
+	base := NewVirtualMachineId(id.SubscriptionId, id.ResourceGroup, id.VirtualMachine).ID("")
 	return fmt.Sprintf("%s/extensions/%s", base, id.Name)
 }
 
@@ -32,7 +34,8 @@ func VirtualMachineExtensionID(input string) (*VirtualMachineExtensionId, error)
 	}
 
 	virtualMachineExtension := VirtualMachineExtensionId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if virtualMachineExtension.VirtualMachine, err = id.PopSegment("virtualMachines"); err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_extension_test.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_extension_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = VirtualMachineExtensionId{}
 
 func TestVirtualMachineExtensionIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	vmId := NewVirtualMachineId("group1", "vm1")
+	vmId := NewVirtualMachineId(subscriptionId, "group1", "vm1")
 	actual := NewVirtualMachineExtensionId(vmId, "extension1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/virtualMachines/vm1/extensions/extension1"
 	if actual != expected {
@@ -48,6 +48,7 @@ func TestParseVirtualMachineExtensionID(t *testing.T) {
 			Name:  "Valid",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.Compute/virtualMachines/machine1/extensions/extName",
 			Expected: &VirtualMachineExtensionId{
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
 				ResourceGroup:  "myGroup1",
 				Name:           "extName",
 				VirtualMachine: "machine1",
@@ -72,6 +73,10 @@ func TestParseVirtualMachineExtensionID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
@@ -7,19 +7,22 @@ import (
 )
 
 type VirtualMachineScaleSetId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewVirtualMachineScaleSetId(resourceGroup, name string) VirtualMachineScaleSetId {
+func NewVirtualMachineScaleSetId(subscriptionId, resourceGroup, name string) VirtualMachineScaleSetId {
 	return VirtualMachineScaleSetId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id VirtualMachineScaleSetId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id VirtualMachineScaleSetId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func VirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
@@ -29,7 +32,8 @@ func VirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
 	}
 
 	vmScaleSet := VirtualMachineScaleSetId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if vmScaleSet.Name, err = id.PopSegment("virtualMachineScaleSets"); err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
@@ -7,6 +7,7 @@ import (
 )
 
 type VirtualMachineScaleSetExtensionId struct {
+	SubscriptionId             string
 	ResourceGroup              string
 	VirtualMachineScaleSetName string
 	Name                       string
@@ -14,14 +15,15 @@ type VirtualMachineScaleSetExtensionId struct {
 
 func NewVirtualMachineScaleSetExtensionId(id VirtualMachineScaleSetId, name string) VirtualMachineScaleSetExtensionId {
 	return VirtualMachineScaleSetExtensionId{
+		SubscriptionId:             id.SubscriptionId,
 		ResourceGroup:              id.ResourceGroup,
 		VirtualMachineScaleSetName: id.Name,
 		Name:                       name,
 	}
 }
 
-func (id VirtualMachineScaleSetExtensionId) ID(subscriptionId string) string {
-	base := NewVirtualMachineScaleSetId(id.ResourceGroup, id.VirtualMachineScaleSetName).ID(subscriptionId)
+func (id VirtualMachineScaleSetExtensionId) ID(_ string) string {
+	base := NewVirtualMachineScaleSetId(id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName).ID("")
 	return fmt.Sprintf("%s/extensions/%s", base, id.Name)
 }
 
@@ -32,7 +34,8 @@ func VirtualMachineScaleSetExtensionID(input string) (*VirtualMachineScaleSetExt
 	}
 
 	extension := VirtualMachineScaleSetExtensionId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if extension.VirtualMachineScaleSetName, err = id.PopSegment("virtualMachineScaleSets"); err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension_test.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = VirtualMachineScaleSetExtensionId{}
 
 func TestVirtualMachineScaleSetExtensionIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	vmssId := NewVirtualMachineScaleSetId("group1", "vmss1")
+	vmssId := NewVirtualMachineScaleSetId(subscriptionId, "group1", "vmss1")
 	actual := NewVirtualMachineScaleSetExtensionId(vmssId, "extension1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/extensions/extension1"
 	if actual != expected {
@@ -53,9 +53,10 @@ func TestParseVirtualMachineScaleSetExtensionID(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/machine1/extensions/extension1",
 			Expected: &VirtualMachineScaleSetExtensionId{
-				Name:                       "extension1",
-				VirtualMachineScaleSetName: "machine1",
+				SubscriptionId:             "00000000-0000-0000-0000-000000000000",
 				ResourceGroup:              "foo",
+				VirtualMachineScaleSetName: "machine1",
+				Name:                       "extension1",
 			},
 		},
 	}

--- a/azurerm/internal/services/compute/parse/virtual_machine_test.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = VirtualMachineId{}
 
 func TestVirtualMachineIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewVirtualMachineId("group1", "vm1").ID(subscriptionId)
+	actual := NewVirtualMachineId(subscriptionId, "group1", "vm1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/virtualMachines/vm1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -49,11 +49,12 @@ func TestVirtualMachineID(t *testing.T) {
 			Expected: nil,
 		},
 		{
-			Name:  "App Configuration ID",
+			Name:  "Virtual Machine ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/virtualMachines/vm1",
 			Expected: &VirtualMachineId{
-				Name:          "vm1",
-				ResourceGroup: "resGroup1",
+				Name:           "vm1",
+				ResourceGroup:  "resGroup1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
 			},
 		},
 		{
@@ -80,6 +81,10 @@ func TestVirtualMachineID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/vritual_machine_scale_set_test.go
+++ b/azurerm/internal/services/compute/parse/vritual_machine_scale_set_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = VirtualMachineScaleSetId{}
 
 func TestVirtualMachineScaleSetIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewVirtualMachineScaleSetId("group1", "vmss1").ID(subscriptionId)
+	actual := NewVirtualMachineScaleSetId(subscriptionId, "group1", "vmss1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -42,8 +42,9 @@ func TestVirtualMachineScaleSetID(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/example",
 			Expected: &VirtualMachineScaleSetId{
-				Name:          "example",
-				ResourceGroup: "foo",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				Name:           "example",
+				ResourceGroup:  "foo",
 			},
 		},
 	}
@@ -66,6 +67,10 @@ func TestVirtualMachineScaleSetID(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/datashare/data_source_data_share.go
+++ b/azurerm/internal/services/datashare/data_source_data_share.go
@@ -77,7 +77,6 @@ func dataSourceDataShare() *schema.Resource {
 
 func dataSourceArmDataShareRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DataShare.SharesClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	syncClient := meta.(*clients.Client).DataShare.SynchronizationClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -96,11 +95,11 @@ func dataSourceArmDataShareRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("retrieving DataShare %q (Account %q / Resource Group %q): %+v", name, accountId.Name, accountId.ResourceGroup, err)
 	}
 
-	dataShareId := parse.NewDataShareId(accountId.ResourceGroup, accountId.Name, name).ID(subscriptionId)
+	dataShareId := parse.NewDataShareId(accountId.SubscriptionId, accountId.ResourceGroup, accountId.Name, name).ID("")
 	d.SetId(dataShareId)
 
 	d.Set("name", name)
-	d.Set("account_id", accountId.ID(subscriptionId))
+	d.Set("account_id", accountId.ID(""))
 
 	if props := resp.ShareProperties; props != nil {
 		d.Set("description", props.Description)

--- a/azurerm/internal/services/datashare/parse/account.go
+++ b/azurerm/internal/services/datashare/parse/account.go
@@ -7,20 +7,22 @@ import (
 )
 
 type DataShareAccountId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func (id DataShareAccountId) ID(subscriptionId string) string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DataShare/accounts/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.Name)
-}
-
-func NewDataShareAccountId(resourceGroup, name string) DataShareAccountId {
+func NewDataShareAccountId(subscriptionId, resourceGroup, name string) DataShareAccountId {
 	return DataShareAccountId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
+}
+
+func (id DataShareAccountId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DataShare/accounts/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func DataShareAccountID(input string) (*DataShareAccountId, error) {
@@ -30,7 +32,8 @@ func DataShareAccountID(input string) (*DataShareAccountId, error) {
 	}
 
 	dataShareAccount := DataShareAccountId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 	if dataShareAccount.Name, err = id.PopSegment("accounts"); err != nil {
 		return nil, err

--- a/azurerm/internal/services/datashare/parse/account_test.go
+++ b/azurerm/internal/services/datashare/parse/account_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = DataShareAccountId{}
+
+func TestDataShareAccountIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewDataShareAccountId(subscriptionId, "group1", "account1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DataShare/accounts/account1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestDataShareAccountID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *DataShareAccountId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Account Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/",
+			Expected: nil,
+		},
+		{
+			Name:  "Datashare account ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1",
+			Expected: &DataShareAccountId{
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				Name:           "account1",
+				ResourceGroup:  "resGroup1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/Accounts/account1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.Name)
+
+		actual, err := DataShareAccountID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/datashare/parse/data_set.go
+++ b/azurerm/internal/services/datashare/parse/data_set.go
@@ -7,10 +7,26 @@ import (
 )
 
 type DataShareDataSetId struct {
-	ResourceGroup string
-	AccountName   string
-	ShareName     string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	AccountName    string
+	ShareName      string
+	Name           string
+}
+
+func NewDataShareDataSetId(subscriptionId, resourceGroup, accountName, shareName, name string) DataShareDataSetId {
+	return DataShareDataSetId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		AccountName:    accountName,
+		ShareName:      shareName,
+		Name:           name,
+	}
+}
+
+func (id DataShareDataSetId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DataShare/accounts/%s/shares/%s/dataSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AccountName, id.ShareName, id.Name)
 }
 
 func DataShareDataSetID(input string) (*DataShareDataSetId, error) {
@@ -20,7 +36,8 @@ func DataShareDataSetID(input string) (*DataShareDataSetId, error) {
 	}
 
 	dataShareDataSet := DataShareDataSetId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 	if dataShareDataSet.AccountName, err = id.PopSegment("accounts"); err != nil {
 		return nil, err

--- a/azurerm/internal/services/datashare/parse/data_set_test.go
+++ b/azurerm/internal/services/datashare/parse/data_set_test.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
 
-var _ resourceid.Formatter = DataShareId{}
+var _ resourceid.Formatter = DataShareDataSetId{}
 
-func TestDataShareIDFormatter(t *testing.T) {
+func TestDataShareDataSetIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewDataShareId(subscriptionId, "group1", "account1", "share1").ID("")
-	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DataShare/accounts/account1/shares/share1"
+	actual := NewDataShareDataSetId(subscriptionId, "group1", "account1", "share1", "set1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DataShare/accounts/account1/shares/share1/dataSets/set1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
 }
 
-func TestDataShareID(t *testing.T) {
+func TestDataShareDataSetID(t *testing.T) {
 	testData := []struct {
 		Name     string
 		Input    string
-		Expected *DataShareId
+		Expected *DataShareDataSetId
 	}{
 		{
 			Name:     "Empty",
@@ -59,18 +59,29 @@ func TestDataShareID(t *testing.T) {
 			Expected: nil,
 		},
 		{
-			Name:  "Data Share ID",
-			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1/shares/share1",
-			Expected: &DataShareId{
-				Name:           "share1",
+			Name:     "Missing DataSet",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1/shares/share1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing DataSet Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1/shares/share1/dataSets",
+			Expected: nil,
+		},
+		{
+			Name:  "DataSet ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1/shares/share1/dataSets/dataSet1",
+			Expected: &DataShareDataSetId{
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				Name:           "dataSet1",
 				AccountName:    "account1",
 				ResourceGroup:  "resGroup1",
-				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ShareName:      "share1",
 			},
 		},
 		{
 			Name:     "Wrong Casing",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1/Shares/share1",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DataShare/accounts/account1/shares/share1/DataSets/dataSet1",
 			Expected: nil,
 		},
 	}
@@ -78,7 +89,7 @@ func TestDataShareID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q..", v.Name)
 
-		actual, err := DataShareID(v.Input)
+		actual, err := DataShareDataSetID(v.Input)
 		if err != nil {
 			if v.Expected == nil {
 				continue
@@ -90,12 +101,16 @@ func TestDataShareID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
-		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		if actual.ShareName != v.Expected.ShareName {
+			t.Fatalf("Expected %q but got %q for Share Name", v.Expected.ShareName, actual.ShareName)
 		}
 
 		if actual.AccountName != v.Expected.AccountName {
 			t.Fatalf("Expected %q but got %q for Account Name", v.Expected.AccountName, actual.AccountName)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 
 		if actual.Name != v.Expected.Name {

--- a/azurerm/internal/services/datashare/parse/data_share.go
+++ b/azurerm/internal/services/datashare/parse/data_share.go
@@ -7,21 +7,23 @@ import (
 )
 
 type DataShareId struct {
-	ResourceGroup string
-	AccountName   string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	AccountName    string
+	Name           string
 }
 
-func (id DataShareId) ID(subscriptionId string) string {
+func (id DataShareId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DataShare/accounts/%s/shares/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.AccountName, id.Name)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AccountName, id.Name)
 }
 
-func NewDataShareId(resourceGroup, accountName, name string) DataShareId {
+func NewDataShareId(subscriptionId, resourceGroup, accountName, name string) DataShareId {
 	return DataShareId{
-		ResourceGroup: resourceGroup,
-		AccountName:   accountName,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		AccountName:    accountName,
+		Name:           name,
 	}
 }
 
@@ -32,7 +34,8 @@ func DataShareID(input string) (*DataShareId, error) {
 	}
 
 	DataShare := DataShareId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 	if DataShare.AccountName, err = id.PopSegment("accounts"); err != nil {
 		return nil, err

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_application_group.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_application_group.go
@@ -7,20 +7,22 @@ import (
 )
 
 type VirtualDesktopApplicationGroupId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewVirtualDesktopApplicationGroupId(resourceGroup, name string) VirtualDesktopApplicationGroupId {
+func NewVirtualDesktopApplicationGroupId(subscriptionId, resourceGroup, name string) VirtualDesktopApplicationGroupId {
 	return VirtualDesktopApplicationGroupId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id VirtualDesktopApplicationGroupId) ID(subscriptionId string) string {
+func (id VirtualDesktopApplicationGroupId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/applicationgroups/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.Name)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func VirtualDesktopApplicationGroupID(input string) (*VirtualDesktopApplicationGroupId, error) {
@@ -30,7 +32,8 @@ func VirtualDesktopApplicationGroupID(input string) (*VirtualDesktopApplicationG
 	}
 
 	applicationGroup := VirtualDesktopApplicationGroupId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if applicationGroup.Name, err = id.PopSegment("applicationgroups"); err != nil {

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_application_group_test.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_application_group_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualDesktopApplicationGroupId{}
+
+func TestVirtualDesktopApplicationGroupIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewVirtualDesktopApplicationGroupId(subscriptionId, "group1", "appGroup1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DesktopVirtualization/applicationgroups/appGroup1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualDesktopApplicationGroupID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *VirtualDesktopApplicationGroupId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Application Group Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/Microsoft.DesktopVirtualization/applicationgroups/",
+			Expected: nil,
+		},
+		{
+			Name:  "Virtual Desktop Application Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/appGroup1",
+			Expected: &VirtualDesktopApplicationGroupId{
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "appGroup1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/Applicationgroups/appGroup1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.Name)
+
+		actual, err := VirtualDesktopApplicationGroupID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_host_pool.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_host_pool.go
@@ -7,19 +7,21 @@ import (
 )
 
 type VirtualDesktopHostPoolId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func (id VirtualDesktopHostPoolId) ID(subscriptionId string) string {
+func (id VirtualDesktopHostPoolId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/hostpools/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.Name)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
-func NewVirtualDesktopHostPoolId(resourceGroup, name string) VirtualDesktopHostPoolId {
+func NewVirtualDesktopHostPoolId(subscriptionId, resourceGroup, name string) VirtualDesktopHostPoolId {
 	return VirtualDesktopHostPoolId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
@@ -31,7 +33,8 @@ func VirtualDesktopHostPoolID(input string) (*VirtualDesktopHostPoolId, error) {
 	}
 
 	hostPool := VirtualDesktopHostPoolId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if hostPool.Name, err = id.PopSegment("hostpools"); err != nil {

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_host_pool_test.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_host_pool_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualDesktopHostPoolId{}
+
+func TestVirtualDesktopHostPoolIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewVirtualDesktopHostPoolId(subscriptionId, "group1", "pool1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DesktopVirtualization/hostpools/pool1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualDesktopHostPoolID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *VirtualDesktopHostPoolId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Host Pools Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/Microsoft.DesktopVirtualization/hostpools/",
+			Expected: nil,
+		},
+		{
+			Name:  "Virtual Desktop Host Pool ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1",
+			Expected: &VirtualDesktopHostPoolId{
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "pool1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/Hostpools/pool1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.Name)
+
+		actual, err := VirtualDesktopHostPoolID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_workspace.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_workspace.go
@@ -7,19 +7,21 @@ import (
 )
 
 type VirtualDesktopWorkspaceId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func (id VirtualDesktopWorkspaceId) ID(subscriptionId string) string {
+func (id VirtualDesktopWorkspaceId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/workspaces/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.Name)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
-func NewVirtualDesktopWorkspaceId(resourceGroup, name string) VirtualDesktopWorkspaceId {
+func NewVirtualDesktopWorkspaceId(subscriptionId, resourceGroup, name string) VirtualDesktopWorkspaceId {
 	return VirtualDesktopWorkspaceId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
@@ -30,7 +32,8 @@ func VirtualDesktopWorkspaceID(input string) (*VirtualDesktopWorkspaceId, error)
 	}
 
 	workspace := VirtualDesktopWorkspaceId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if workspace.Name, err = id.PopSegment("workspaces"); err != nil {

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_workspace_application_group_association_test.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_workspace_application_group_association_test.go
@@ -1,0 +1,127 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualDesktopWorkspaceApplicationGroupAssociationId{}
+
+func TestVirtualDesktopWorkspaceApplicationGroupAssociationIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	workspaceId := NewVirtualDesktopWorkspaceId(subscriptionId, "group1", "workspace1")
+	applicationGroupId := NewVirtualDesktopApplicationGroupId(subscriptionId, "group1", "appGroup1")
+
+	actual := NewVirtualDesktopWorkspaceApplicationGroupAssociationId(workspaceId, applicationGroupId).ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1|/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DesktopVirtualization/applicationgroups/appGroup1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualDesktopWorkspaceApplicationGroupAssociationID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *VirtualDesktopWorkspaceApplicationGroupAssociationId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Workspace Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/Microsoft.DesktopVirtualization/workspaces/",
+			Expected: nil,
+		},
+		{
+			Name:     "Virtual Desktop Workspace ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Application Group Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/Microsoft.DesktopVirtualization/applicationgroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Virtual Desktop Application Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/appGroup1",
+			Expected: nil,
+		},
+		{
+			Name:  "Virtual Desktop Workspace ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/appGroup1",
+			Expected: &VirtualDesktopWorkspaceApplicationGroupAssociationId{
+				Workspace: VirtualDesktopWorkspaceId{
+					SubscriptionId: "00000000-0000-0000-0000-000000000000",
+					ResourceGroup:  "resGroup1",
+					Name:           "workspace1",
+				},
+				ApplicationGroup: VirtualDesktopApplicationGroupId{
+					SubscriptionId: "00000000-0000-0000-0000-000000000000",
+					ResourceGroup:  "resGroup1",
+					Name:           "appGroup1",
+				},
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/Workspaces/workspace1|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/Applicationgroups/appGroup1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.Name)
+
+		actual, err := VirtualDesktopWorkspaceApplicationGroupAssociationID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.ApplicationGroup.SubscriptionId != v.Expected.ApplicationGroup.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for ApplicationGroup.SubscriptionId", v.Expected.ApplicationGroup.SubscriptionId, actual.ApplicationGroup.SubscriptionId)
+		}
+
+		if actual.ApplicationGroup.ResourceGroup != v.Expected.ApplicationGroup.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ApplicationGroup.ResourceGroup", v.Expected.ApplicationGroup.ResourceGroup, actual.ApplicationGroup.ResourceGroup)
+		}
+
+		if actual.ApplicationGroup.Name != v.Expected.ApplicationGroup.Name {
+			t.Fatalf("Expected %q but got %q for ApplicationGroup.Name", v.Expected.ApplicationGroup.Name, actual.ApplicationGroup.Name)
+		}
+
+		if actual.Workspace.SubscriptionId != v.Expected.Workspace.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Workspace.SubscriptionId", v.Expected.Workspace.SubscriptionId, actual.Workspace.SubscriptionId)
+		}
+
+		if actual.Workspace.ResourceGroup != v.Expected.Workspace.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Workspace.ResourceGroup", v.Expected.Workspace.ResourceGroup, actual.Workspace.ResourceGroup)
+		}
+
+		if actual.Workspace.Name != v.Expected.Workspace.Name {
+			t.Fatalf("Expected %q but got %q for Workspace.Name", v.Expected.Workspace.Name, actual.Workspace.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_workspace_test.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/virtual_desktop_workspace_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualDesktopWorkspaceId{}
+
+func TestVirtualDesktopWorkspaceIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewVirtualDesktopWorkspaceId(subscriptionId, "group1", "workspace1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualDesktopWorkspaceID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *VirtualDesktopWorkspaceId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Workspace Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/Microsoft.DesktopVirtualization/workspaces/",
+			Expected: nil,
+		},
+		{
+			Name:  "Virtual Desktop Workspace ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1",
+			Expected: &VirtualDesktopWorkspaceId{
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resGroup1",
+				Name:           "workspace1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/Workspaces/workspace1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.Name)
+
+		actual, err := VirtualDesktopWorkspaceID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -108,7 +108,7 @@ func resourceArmVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceDat
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewVirtualDesktopApplicationGroupId(resourceGroup, name)
+	id := parse.NewVirtualDesktopApplicationGroupId(subscriptionId, resourceGroup, name)
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
@@ -118,7 +118,7 @@ func resourceArmVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceDat
 		}
 
 		if existing.ApplicationGroupProperties != nil {
-			return tf.ImportAsExistsError("azurerm_virtual_desktop_application_group", id.ID(subscriptionId))
+			return tf.ImportAsExistsError("azurerm_virtual_desktop_application_group", id.ID(""))
 		}
 	}
 
@@ -140,14 +140,15 @@ func resourceArmVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceDat
 		return fmt.Errorf("creating Virtual Desktop Application Group %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	if d.IsNewResource() {
+		d.SetId(id.ID(""))
+	}
 
 	return resourceArmVirtualDesktopApplicationGroupRead(d, meta)
 }
 
 func resourceArmVirtualDesktopApplicationGroupRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DesktopVirtualization.ApplicationGroupsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -186,7 +187,7 @@ func resourceArmVirtualDesktopApplicationGroupRead(d *schema.ResourceData, meta 
 				return fmt.Errorf("parsing Host Pool ID %q: %+v", *props.HostPoolArmPath, err)
 			}
 
-			hostPoolIdStr = hostPoolId.ID(subscriptionId)
+			hostPoolIdStr = hostPoolId.ID("")
 		}
 		d.Set("host_pool_id", hostPoolIdStr)
 	}

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -161,7 +161,7 @@ func resourceArmVirtualDesktopHostPoolCreateUpdate(d *schema.ResourceData, meta 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	id := parse.NewVirtualDesktopHostPoolId(resourceGroup, name)
+	id := parse.NewVirtualDesktopHostPoolId(subscriptionId, resourceGroup, name)
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
@@ -171,7 +171,7 @@ func resourceArmVirtualDesktopHostPoolCreateUpdate(d *schema.ResourceData, meta 
 		}
 
 		if existing.HostPoolProperties != nil {
-			return tf.ImportAsExistsError("azurerm_virtual_desktop_host_pool", id.ID(subscriptionId))
+			return tf.ImportAsExistsError("azurerm_virtual_desktop_host_pool", id.ID(""))
 		}
 	}
 
@@ -198,7 +198,9 @@ func resourceArmVirtualDesktopHostPoolCreateUpdate(d *schema.ResourceData, meta 
 		return fmt.Errorf("Creating Virtual Desktop Host Pool %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	if d.IsNewResource() {
+		d.SetId(id.ID(""))
+	}
 
 	return resourceArmVirtualDesktopHostPoolRead(d, meta)
 }

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
@@ -80,7 +80,7 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *schema.ResourceDat
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	id := parse.NewVirtualDesktopWorkspaceId(resourceGroup, name)
+	id := parse.NewVirtualDesktopWorkspaceId(subscriptionId, resourceGroup, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
@@ -91,7 +91,7 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *schema.ResourceDat
 		}
 
 		if existing.WorkspaceProperties != nil {
-			return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace", id.ID(subscriptionId))
+			return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace", id.ID(""))
 		}
 	}
 
@@ -111,7 +111,9 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *schema.ResourceDat
 		return fmt.Errorf("creating Virtual Desktop Workspace %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	if d.IsNewResource() {
+		d.SetId(id.ID(""))
+	}
 
 	return resourceArmDesktopVirtualizationWorkspaceRead(d, meta)
 }

--- a/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
@@ -443,7 +443,7 @@ func resourceArmFrontDoorFirewallPolicyCreateUpdate(d *schema.ResourceData, meta
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
-	id := parse.NewWebApplicationFirewallPolicyID(resourceGroup, name).ID(subscriptionId)
+	id := parse.NewWebApplicationFirewallPolicyID(subscriptionId, resourceGroup, name).ID("")
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)

--- a/azurerm/internal/services/frontdoor/migration/custom_https_configuration.go
+++ b/azurerm/internal/services/frontdoor/migration/custom_https_configuration.go
@@ -101,8 +101,8 @@ func CustomHttpsConfigurationV0ToV1(rawState map[string]interface{}, _ interface
 		return rawState, fmt.Errorf("couldn't find the `frontendEndpoints` segment in the old resource id %q", oldId)
 	}
 
-	newId := parse.NewFrontendEndpointID(parse.NewFrontDoorID(resourceGroup, frontdoorName), frontendEndpointName)
-	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+	newId := parse.NewFrontendEndpointID(parse.NewFrontDoorID(oldParsedId.SubscriptionID, resourceGroup, frontdoorName), frontendEndpointName)
+	newIdStr := newId.ID("")
 
 	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
 

--- a/azurerm/internal/services/frontdoor/migration/frontdoor.go
+++ b/azurerm/internal/services/frontdoor/migration/frontdoor.go
@@ -411,8 +411,8 @@ func FrontDoorV1ToV2(rawState map[string]interface{}, _ interface{}) (map[string
 		return rawState, fmt.Errorf("couldn't find the `frontDoors` segment in the old resource id %q", oldId)
 	}
 
-	newId := parse.NewFrontDoorID(resourceGroup, frontDoorName)
-	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+	newId := parse.NewFrontDoorID(oldParsedId.SubscriptionID, resourceGroup, frontDoorName)
+	newIdStr := newId.ID("")
 
 	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
 

--- a/azurerm/internal/services/frontdoor/migration/web_application_firewall_policy.go
+++ b/azurerm/internal/services/frontdoor/migration/web_application_firewall_policy.go
@@ -308,8 +308,8 @@ func WebApplicationFirewallPolicyV0ToV1(rawState map[string]interface{}, _ inter
 		return rawState, fmt.Errorf("couldn't find the `frontDoorWebApplicationFirewallPolicies` segment in the old resource id %q", oldId)
 	}
 
-	newId := parse.NewWebApplicationFirewallPolicyID(resourceGroup, policyName)
-	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+	newId := parse.NewWebApplicationFirewallPolicyID(oldParsedId.SubscriptionID, resourceGroup, policyName)
+	newIdStr := newId.ID("")
 
 	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
 

--- a/azurerm/internal/services/frontdoor/parse/backend_pool.go
+++ b/azurerm/internal/services/frontdoor/parse/backend_pool.go
@@ -3,21 +3,23 @@ package parse
 import "fmt"
 
 type BackendPoolId struct {
-	ResourceGroup string
-	FrontDoorName string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	FrontDoorName  string
+	Name           string
 }
 
 func NewBackendPoolID(id FrontDoorId, name string) BackendPoolId {
 	return BackendPoolId{
-		ResourceGroup: id.ResourceGroup,
-		FrontDoorName: id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		FrontDoorName:  id.Name,
+		Name:           name,
 	}
 }
 
-func (id BackendPoolId) ID(subscriptionId string) string {
-	base := NewFrontDoorID(id.ResourceGroup, id.FrontDoorName).ID(subscriptionId)
+func (id BackendPoolId) ID(_ string) string {
+	base := NewFrontDoorID(id.SubscriptionId, id.ResourceGroup, id.FrontDoorName).ID("")
 	return fmt.Sprintf("%s/backendPools/%s", base, id.Name)
 }
 
@@ -28,8 +30,9 @@ func BackendPoolID(input string) (*BackendPoolId, error) {
 	}
 
 	poolId := BackendPoolId{
-		ResourceGroup: frontDoorId.ResourceGroup,
-		FrontDoorName: frontDoorId.Name,
+		SubscriptionId: frontDoorId.SubscriptionId,
+		ResourceGroup:  frontDoorId.ResourceGroup,
+		FrontDoorName:  frontDoorId.Name,
 	}
 
 	// API is broken - https://github.com/Azure/azure-sdk-for-go/issues/6762

--- a/azurerm/internal/services/frontdoor/parse/backend_pool_test.go
+++ b/azurerm/internal/services/frontdoor/parse/backend_pool_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = BackendPoolId{}
 
 func TestBackendPoolIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	frontDoorId := NewFrontDoorID("group1", "frontdoor1")
+	frontDoorId := NewFrontDoorID(subscriptionId, "group1", "frontdoor1")
 	actual := NewBackendPoolID(frontDoorId, "pool1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1/backendPools/pool1"
 	if actual != expected {
@@ -27,27 +27,30 @@ func TestBackendPoolIDParser(t *testing.T) {
 			// lower case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontdoors/frontDoor1/backendpools/pool1",
 			expected: &BackendPoolId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "pool1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "pool1",
 			},
 		},
 		{
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1/backendPools/pool1",
 			expected: &BackendPoolId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "pool1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "pool1",
 			},
 		},
 		{
 			// title case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/Frontdoors/frontDoor1/BackendPools/pool1",
 			expected: &BackendPoolId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "pool1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "pool1",
 			},
 		},
 		{
@@ -67,6 +70,10 @@ func TestBackendPoolIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/frontdoor/parse/frontdoor.go
+++ b/azurerm/internal/services/frontdoor/parse/frontdoor.go
@@ -8,14 +8,16 @@ import (
 )
 
 type FrontDoorId struct {
-	Name          string
-	ResourceGroup string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewFrontDoorID(resourceGroup, name string) FrontDoorId {
+func NewFrontDoorID(subscriptionId, resourceGroup, name string) FrontDoorId {
 	return FrontDoorId{
-		Name:          name,
-		ResourceGroup: resourceGroup,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
@@ -39,7 +41,8 @@ func FrontDoorIDForImport(input string) (*FrontDoorId, error) {
 	}
 
 	frontDoorId := FrontDoorId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if frontDoorId.Name, err = id.PopSegment("frontDoors"); err != nil {
@@ -53,8 +56,9 @@ func FrontDoorIDForImport(input string) (*FrontDoorId, error) {
 	return &frontDoorId, nil
 }
 
-func (id FrontDoorId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/frontDoors/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id FrontDoorId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/frontDoors/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func parseFrontDoorChildResourceId(input string) (*FrontDoorId, *azure.ResourceID, error) {
@@ -64,7 +68,8 @@ func parseFrontDoorChildResourceId(input string) (*FrontDoorId, *azure.ResourceI
 	}
 
 	frontdoor := FrontDoorId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	for key, value := range id.Path {

--- a/azurerm/internal/services/frontdoor/parse/frontdoor_test.go
+++ b/azurerm/internal/services/frontdoor/parse/frontdoor_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = FrontDoorId{}
 
 func TestFrontDoorIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewFrontDoorID("group1", "frontDoor1").ID(subscriptionId)
+	actual := NewFrontDoorID(subscriptionId, "group1", "frontDoor1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -26,32 +26,36 @@ func TestFrontDoorIDParser(t *testing.T) {
 			// lower case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontdoors/frontDoor1",
 			expected: &FrontDoorId{
-				ResourceGroup: "group1",
-				Name:          "frontDoor1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "frontDoor1",
 			},
 		},
 		{
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1",
 			expected: &FrontDoorId{
-				ResourceGroup: "group1",
-				Name:          "frontDoor1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "frontDoor1",
 			},
 		},
 		{
 			// title case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/Frontdoors/frontDoor1",
 			expected: &FrontDoorId{
-				ResourceGroup: "group1",
-				Name:          "frontDoor1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "frontDoor1",
 			},
 		},
 		{
 			// pascal case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/FrontDoors/frontDoor1",
 			expected: &FrontDoorId{
-				ResourceGroup: "group1",
-				Name:          "frontDoor1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "frontDoor1",
 			},
 		},
 	}
@@ -66,6 +70,10 @@ func TestFrontDoorIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {
@@ -92,8 +100,9 @@ func TestFrontDoorIDForImportParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1",
 			expected: &FrontDoorId{
-				ResourceGroup: "group1",
-				Name:          "frontDoor1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "frontDoor1",
 			},
 		},
 		{
@@ -118,6 +127,10 @@ func TestFrontDoorIDForImportParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/frontdoor/parse/frontend_endpoint.go
+++ b/azurerm/internal/services/frontdoor/parse/frontend_endpoint.go
@@ -3,21 +3,23 @@ package parse
 import "fmt"
 
 type FrontendEndpointId struct {
-	ResourceGroup string
-	FrontDoorName string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	FrontDoorName  string
+	Name           string
 }
 
 func NewFrontendEndpointID(id FrontDoorId, name string) FrontendEndpointId {
 	return FrontendEndpointId{
-		ResourceGroup: id.ResourceGroup,
-		FrontDoorName: id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		FrontDoorName:  id.Name,
+		Name:           name,
 	}
 }
 
-func (id FrontendEndpointId) ID(subscriptionId string) string {
-	base := NewFrontDoorID(id.ResourceGroup, id.FrontDoorName).ID(subscriptionId)
+func (id FrontendEndpointId) ID(_ string) string {
+	base := NewFrontDoorID(id.SubscriptionId, id.ResourceGroup, id.FrontDoorName).ID("")
 	return fmt.Sprintf("%s/frontendEndpoints/%s", base, id.Name)
 }
 
@@ -36,8 +38,9 @@ func parseFrontendEndpointID(input string, caseSensitive bool) (*FrontendEndpoin
 	}
 
 	endpointId := FrontendEndpointId{
-		ResourceGroup: frontDoorId.ResourceGroup,
-		FrontDoorName: frontDoorId.Name,
+		SubscriptionId: frontDoorId.SubscriptionId,
+		ResourceGroup:  frontDoorId.ResourceGroup,
+		FrontDoorName:  frontDoorId.Name,
 	}
 
 	// The Azure API (per the ARM Spec/chatting with the ARM Team) should be following Postel's Law;

--- a/azurerm/internal/services/frontdoor/parse/frontend_endpoint_test.go
+++ b/azurerm/internal/services/frontdoor/parse/frontend_endpoint_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = FrontendEndpointId{}
 
 func TestFrontendEndpointIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	frontDoorId := NewFrontDoorID("group1", "frontdoor1")
+	frontDoorId := NewFrontDoorID(subscriptionId, "group1", "frontdoor1")
 	actual := NewFrontendEndpointID(frontDoorId, "endpoint1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1/frontendEndpoints/endpoint1"
 	if actual != expected {
@@ -32,18 +32,20 @@ func TestFrontendEndpointIDParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1/frontendEndpoints/endpoint1",
 			expected: &FrontendEndpointId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "endpoint1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "endpoint1",
 			},
 		},
 		{
 			// title case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/Frontdoors/frontDoor1/FrontendEndpoints/endpoint1",
 			expected: &FrontendEndpointId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "endpoint1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "endpoint1",
 			},
 		},
 		{
@@ -63,6 +65,10 @@ func TestFrontendEndpointIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {
@@ -93,9 +99,10 @@ func TestFrontendEndpointIDForImportParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1/frontendEndpoints/endpoint1",
 			expected: &FrontendEndpointId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "endpoint1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "endpoint1",
 			},
 		},
 		{
@@ -120,6 +127,10 @@ func TestFrontendEndpointIDForImportParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/frontdoor/parse/health_probe.go
+++ b/azurerm/internal/services/frontdoor/parse/health_probe.go
@@ -3,21 +3,23 @@ package parse
 import "fmt"
 
 type HealthProbeId struct {
-	ResourceGroup string
-	FrontDoorName string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	FrontDoorName  string
+	Name           string
 }
 
 func NewHealthProbeID(id FrontDoorId, name string) HealthProbeId {
 	return HealthProbeId{
-		ResourceGroup: id.ResourceGroup,
-		FrontDoorName: id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		FrontDoorName:  id.Name,
+		Name:           name,
 	}
 }
 
-func (id HealthProbeId) ID(subscriptionId string) string {
-	base := NewFrontDoorID(id.ResourceGroup, id.FrontDoorName).ID(subscriptionId)
+func (id HealthProbeId) ID(_ string) string {
+	base := NewFrontDoorID(id.SubscriptionId, id.ResourceGroup, id.FrontDoorName).ID("")
 	return fmt.Sprintf("%s/healthProbeSettings/%s", base, id.Name)
 }
 
@@ -28,8 +30,9 @@ func HealthProbeID(input string) (*HealthProbeId, error) {
 	}
 
 	probeId := HealthProbeId{
-		ResourceGroup: frontDoorId.ResourceGroup,
-		FrontDoorName: frontDoorId.Name,
+		SubscriptionId: frontDoorId.SubscriptionId,
+		ResourceGroup:  frontDoorId.ResourceGroup,
+		FrontDoorName:  frontDoorId.Name,
 	}
 
 	// https://github.com/Azure/azure-sdk-for-go/issues/6762

--- a/azurerm/internal/services/frontdoor/parse/health_probe_test.go
+++ b/azurerm/internal/services/frontdoor/parse/health_probe_test.go
@@ -10,8 +10,8 @@ var _ resourceid.Formatter = HealthProbeId{}
 
 func TestHealthProbeIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	frontDoorId := NewFrontDoorID("group1", "frontdoor1")
-	actual := NewHealthProbeID(frontDoorId, "probe1").ID(subscriptionId)
+	frontDoorId := NewFrontDoorID(subscriptionId, "group1", "frontdoor1")
+	actual := NewHealthProbeID(frontDoorId, "probe1").ID("")
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1/healthProbeSettings/probe1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -32,18 +32,20 @@ func TestHealthProbeIDParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1/healthProbeSettings/probe1",
 			expected: &HealthProbeId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "probe1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "probe1",
 			},
 		},
 		{
 			// title case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/Frontdoors/frontDoor1/HealthProbeSettings/probe1",
 			expected: &HealthProbeId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "probe1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "probe1",
 			},
 		},
 		{
@@ -63,6 +65,10 @@ func TestHealthProbeIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/frontdoor/parse/load_balancing.go
+++ b/azurerm/internal/services/frontdoor/parse/load_balancing.go
@@ -3,21 +3,23 @@ package parse
 import "fmt"
 
 type LoadBalancingId struct {
-	ResourceGroup string
-	FrontDoorName string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	FrontDoorName  string
+	Name           string
 }
 
 func NewLoadBalancingID(id FrontDoorId, name string) LoadBalancingId {
 	return LoadBalancingId{
-		ResourceGroup: id.ResourceGroup,
-		FrontDoorName: id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		FrontDoorName:  id.Name,
+		Name:           name,
 	}
 }
 
-func (id LoadBalancingId) ID(subscriptionId string) string {
-	base := NewFrontDoorID(id.ResourceGroup, id.FrontDoorName).ID(subscriptionId)
+func (id LoadBalancingId) ID(_ string) string {
+	base := NewFrontDoorID(id.SubscriptionId, id.ResourceGroup, id.FrontDoorName).ID("")
 	return fmt.Sprintf("%s/loadBalancingSettings/%s", base, id.Name)
 }
 
@@ -28,8 +30,9 @@ func LoadBalancingID(input string) (*LoadBalancingId, error) {
 	}
 
 	loadBalancingId := LoadBalancingId{
-		ResourceGroup: frontDoorId.ResourceGroup,
-		FrontDoorName: frontDoorId.Name,
+		SubscriptionId: frontDoorId.SubscriptionId,
+		ResourceGroup:  frontDoorId.ResourceGroup,
+		FrontDoorName:  frontDoorId.Name,
 	}
 
 	// https://github.com/Azure/azure-sdk-for-go/issues/6762

--- a/azurerm/internal/services/frontdoor/parse/load_balancing_test.go
+++ b/azurerm/internal/services/frontdoor/parse/load_balancing_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = LoadBalancingId{}
 
 func TestLoadBalancingIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	frontDoorId := NewFrontDoorID("group1", "frontdoor1")
+	frontDoorId := NewFrontDoorID(subscriptionId, "group1", "frontdoor1")
 	actual := NewLoadBalancingID(frontDoorId, "setting1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1/loadBalancingSettings/setting1"
 	if actual != expected {
@@ -32,18 +32,20 @@ func TestLoadBalancingIDParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1/loadBalancingSettings/setting1",
 			expected: &LoadBalancingId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "setting1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "setting1",
 			},
 		},
 		{
 			// title case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/Frontdoors/frontDoor1/LoadBalancingSettings/setting1",
 			expected: &LoadBalancingId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "setting1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "setting1",
 			},
 		},
 		{
@@ -63,6 +65,10 @@ func TestLoadBalancingIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/frontdoor/parse/routing_rule.go
+++ b/azurerm/internal/services/frontdoor/parse/routing_rule.go
@@ -3,21 +3,23 @@ package parse
 import "fmt"
 
 type RoutingRuleId struct {
-	ResourceGroup string
-	FrontDoorName string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	FrontDoorName  string
+	Name           string
 }
 
 func NewRoutingRuleID(id FrontDoorId, name string) RoutingRuleId {
 	return RoutingRuleId{
-		ResourceGroup: id.ResourceGroup,
-		FrontDoorName: id.Name,
-		Name:          name,
+		SubscriptionId: id.SubscriptionId,
+		ResourceGroup:  id.ResourceGroup,
+		FrontDoorName:  id.Name,
+		Name:           name,
 	}
 }
 
-func (id RoutingRuleId) ID(subscriptionId string) string {
-	base := NewFrontDoorID(id.ResourceGroup, id.FrontDoorName).ID(subscriptionId)
+func (id RoutingRuleId) ID(_ string) string {
+	base := NewFrontDoorID(id.SubscriptionId, id.ResourceGroup, id.FrontDoorName).ID("")
 	return fmt.Sprintf("%s/routingRules/%s", base, id.Name)
 }
 
@@ -28,8 +30,9 @@ func RoutingRuleID(input string) (*RoutingRuleId, error) {
 	}
 
 	poolId := RoutingRuleId{
-		ResourceGroup: frontDoorId.ResourceGroup,
-		FrontDoorName: frontDoorId.Name,
+		SubscriptionId: frontDoorId.SubscriptionId,
+		ResourceGroup:  frontDoorId.ResourceGroup,
+		FrontDoorName:  frontDoorId.Name,
 	}
 
 	// API is broken - https://github.com/Azure/azure-sdk-for-go/issues/6762

--- a/azurerm/internal/services/frontdoor/parse/routing_rule_test.go
+++ b/azurerm/internal/services/frontdoor/parse/routing_rule_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = RoutingRuleId{}
 
 func TestRoutingRuleIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	frontDoorId := NewFrontDoorID("group1", "frontdoor1")
+	frontDoorId := NewFrontDoorID(subscriptionId, "group1", "frontdoor1")
 	actual := NewRoutingRuleID(frontDoorId, "rule1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1/routingRules/rule1"
 	if actual != expected {
@@ -32,18 +32,20 @@ func TestRoutingRuleIDParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontDoor1/routingRules/rule1",
 			expected: &RoutingRuleId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "rule1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "rule1",
 			},
 		},
 		{
 			// title case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/Frontdoors/frontDoor1/RoutingRules/rule1",
 			expected: &RoutingRuleId{
-				ResourceGroup: "group1",
-				FrontDoorName: "frontDoor1",
-				Name:          "rule1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				FrontDoorName:  "frontDoor1",
+				Name:           "rule1",
 			},
 		},
 		{
@@ -63,6 +65,10 @@ func TestRoutingRuleIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/frontdoor/parse/web_application_firewall_policy.go
+++ b/azurerm/internal/services/frontdoor/parse/web_application_firewall_policy.go
@@ -7,19 +7,22 @@ import (
 )
 
 type WebApplicationFirewallPolicyId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewWebApplicationFirewallPolicyID(resourceGroup, name string) WebApplicationFirewallPolicyId {
+func NewWebApplicationFirewallPolicyID(subscriptionId, resourceGroup, name string) WebApplicationFirewallPolicyId {
 	return WebApplicationFirewallPolicyId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id WebApplicationFirewallPolicyId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id WebApplicationFirewallPolicyId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func WebApplicationFirewallPolicyID(input string) (*WebApplicationFirewallPolicyId, error) {
@@ -29,7 +32,8 @@ func WebApplicationFirewallPolicyID(input string) (*WebApplicationFirewallPolicy
 	}
 
 	policy := WebApplicationFirewallPolicyId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if policy.Name, err = id.PopSegment("frontDoorWebApplicationFirewallPolicies"); err != nil {

--- a/azurerm/internal/services/frontdoor/parse/web_application_firewall_policy_test.go
+++ b/azurerm/internal/services/frontdoor/parse/web_application_firewall_policy_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = WebApplicationFirewallPolicyId{}
 
 func TestWebApplicationFirewallPolicyIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	actual := NewWebApplicationFirewallPolicyID("group1", "policy1").ID(subscriptionId)
+	actual := NewWebApplicationFirewallPolicyID(subscriptionId, "group1", "policy1").ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -31,8 +31,9 @@ func TestWebApplicationFirewallPolicyIDParser(t *testing.T) {
 			// camel case
 			input: "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1",
 			expected: &WebApplicationFirewallPolicyId{
-				ResourceGroup: "group1",
-				Name:          "policy1",
+				SubscriptionId: "12345678-1234-5678-1234-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "policy1",
 			},
 		},
 		{
@@ -57,6 +58,10 @@ func TestWebApplicationFirewallPolicyIDParser(t *testing.T) {
 			} else if err != nil && test.expected != nil {
 				t.Fatalf("Expected no error but got: %+v", err)
 			}
+		}
+
+		if actual.SubscriptionId != test.expected.SubscriptionId {
+			t.Fatalf("Expected SubscriptionId to be %q but was %q", test.expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != test.expected.ResourceGroup {

--- a/azurerm/internal/services/iothub/parse/digital_twins.go
+++ b/azurerm/internal/services/iothub/parse/digital_twins.go
@@ -7,19 +7,22 @@ import (
 )
 
 type DigitalTwinsId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewDigitalTwinsID(resourcegroup string, name string) DigitalTwinsId {
+func NewDigitalTwinsID(subscriptionId, resourceGroup string, name string) DigitalTwinsId {
 	return DigitalTwinsId{
-		ResourceGroup: resourcegroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id DigitalTwinsId) ID(subscriptionId string) string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DigitalTwins/digitalTwinsInstances/%s", subscriptionId, id.ResourceGroup, id.Name)
+func (id DigitalTwinsId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DigitalTwins/digitalTwinsInstances/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func DigitalTwinsID(input string) (*DigitalTwinsId, error) {
@@ -29,7 +32,8 @@ func DigitalTwinsID(input string) (*DigitalTwinsId, error) {
 	}
 
 	digitalTwins := DigitalTwinsId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 	if digitalTwins.Name, err = id.PopSegment("digitalTwinsInstances"); err != nil {
 		return nil, err

--- a/azurerm/internal/services/iothub/parse/digital_twins_test.go
+++ b/azurerm/internal/services/iothub/parse/digital_twins_test.go
@@ -10,7 +10,7 @@ var _ resourceid.Formatter = DigitalTwinsId{}
 
 func TestDigitalTwinsIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
-	id := NewDigitalTwinsID("resourceGroup1", "resource1")
+	id := NewDigitalTwinsID(subscriptionId, "resourceGroup1", "resource1")
 	actual := id.ID(subscriptionId)
 	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DigitalTwins/digitalTwinsInstances/resource1"
 	if actual != expected {
@@ -50,11 +50,12 @@ func TestDigitalTwinsID(t *testing.T) {
 			Expected: nil,
 		},
 		{
-			Name:  "digitaltwins DigitalTwins ID",
+			Name:  "Digital Twins ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.DigitalTwins/digitalTwinsInstances/resource1",
 			Expected: &DigitalTwinsId{
-				ResourceGroup: "resourceGroup1",
-				Name:          "resource1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				ResourceGroup:  "resourceGroup1",
+				Name:           "resource1",
 			},
 		},
 		{
@@ -73,6 +74,10 @@ func TestDigitalTwinsID(t *testing.T) {
 				continue
 			}
 			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {

--- a/azurerm/internal/services/iothub/parse/iothub.go
+++ b/azurerm/internal/services/iothub/parse/iothub.go
@@ -1,12 +1,28 @@
 package parse
 
 import (
+	"fmt"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 type IotHubId struct {
-	Name          string
-	ResourceGroup string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewIoTHubId(subscriptionId, resourceGroup, name string) IotHubId {
+	return IotHubId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id IotHubId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Devices/IotHubs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func IotHubID(input string) (*IotHubId, error) {
@@ -16,7 +32,8 @@ func IotHubID(input string) (*IotHubId, error) {
 	}
 
 	iothub := IotHubId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if iothub.Name, err = id.PopSegment("IotHubs"); err != nil {

--- a/azurerm/internal/services/iothub/parse/iothub_test.go
+++ b/azurerm/internal/services/iothub/parse/iothub_test.go
@@ -2,7 +2,20 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = IotHubId{}
+
+func TestIotHubIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewIoTHubId(subscriptionId, "resourceGroup1", "iothub1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.Devices/IotHubs/iothub1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestIotHubID(t *testing.T) {
 	testData := []struct {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_access_policy.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_access_policy.go
@@ -7,22 +7,24 @@ import (
 )
 
 type TimeSeriesInsightsAccessPolicyId struct {
+	SubscriptionId  string
 	ResourceGroup   string
 	EnvironmentName string
 	Name            string
 }
 
-func NewTimeSeriesInsightsAccessPolicyID(resourceGroup, environmentName, name string) TimeSeriesInsightsAccessPolicyId {
+func NewTimeSeriesInsightsAccessPolicyID(subscriptionId, resourceGroup, environmentName, name string) TimeSeriesInsightsAccessPolicyId {
 	return TimeSeriesInsightsAccessPolicyId{
+		SubscriptionId:  subscriptionId,
 		ResourceGroup:   resourceGroup,
 		EnvironmentName: environmentName,
 		Name:            name,
 	}
 }
 
-func (id TimeSeriesInsightsAccessPolicyId) ID(subscriptionId string) string {
+func (id TimeSeriesInsightsAccessPolicyId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.TimeSeriesInsights/environments/%s/accessPolicies/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.EnvironmentName, id.Name)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.EnvironmentName, id.Name)
 }
 
 func TimeSeriesInsightsAccessPolicyID(input string) (*TimeSeriesInsightsAccessPolicyId, error) {
@@ -32,7 +34,8 @@ func TimeSeriesInsightsAccessPolicyID(input string) (*TimeSeriesInsightsAccessPo
 	}
 
 	service := TimeSeriesInsightsAccessPolicyId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if service.EnvironmentName, err = id.PopSegment("environments"); err != nil {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_access_policy_test.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_access_policy_test.go
@@ -11,7 +11,7 @@ var _ resourceid.Formatter = TimeSeriesInsightsAccessPolicyId{}
 func TestTimeSeriesInsightsAccessPolicyIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
 	actual := NewTimeSeriesInsightsAccessPolicyID(subscriptionId, "resourceGroup1", "env1", "policy1").ID("")
-	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/Microsoft.TimeSeriesInsights/environments/env1/accessPolicies/policy1"
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.TimeSeriesInsights/environments/env1/accessPolicies/policy1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_access_policy_test.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_access_policy_test.go
@@ -2,7 +2,20 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = TimeSeriesInsightsAccessPolicyId{}
+
+func TestTimeSeriesInsightsAccessPolicyIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewTimeSeriesInsightsAccessPolicyID(subscriptionId, "resourceGroup1", "env1", "policy1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/Microsoft.TimeSeriesInsights/environments/env1/accessPolicies/policy1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestTimeSeriesInsightsAccessPolicyId(t *testing.T) {
 	testData := []struct {
@@ -44,6 +57,7 @@ func TestTimeSeriesInsightsAccessPolicyId(t *testing.T) {
 			Name:  "Time Series Insight Access Policy ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.TimeSeriesInsights/environments/Environment1/accessPolicies/Policy1",
 			Expected: &TimeSeriesInsightsAccessPolicyId{
+				SubscriptionId:  "00000000-0000-0000-0000-000000000000",
 				EnvironmentName: "Environment1",
 				ResourceGroup:   "resGroup1",
 				Name:            "Policy1",
@@ -74,6 +88,10 @@ func TestTimeSeriesInsightsAccessPolicyId(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_environment.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_environment.go
@@ -7,20 +7,22 @@ import (
 )
 
 type TimeSeriesInsightsEnvironmentId struct {
-	ResourceGroup string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewTimeSeriesInsightsEnvironmentID(resourceGroup, name string) TimeSeriesInsightsEnvironmentId {
+func NewTimeSeriesInsightsEnvironmentID(subscriptionId, resourceGroup, name string) TimeSeriesInsightsEnvironmentId {
 	return TimeSeriesInsightsEnvironmentId{
-		ResourceGroup: resourceGroup,
-		Name:          name,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
-func (id TimeSeriesInsightsEnvironmentId) ID(subscriptionId string) string {
+func (id TimeSeriesInsightsEnvironmentId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.TimeSeriesInsights/environments/%s"
-	return fmt.Sprintf(fmtString, subscriptionId, id.ResourceGroup, id.Name)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func TimeSeriesInsightsEnvironmentID(input string) (*TimeSeriesInsightsEnvironmentId, error) {
@@ -30,7 +32,8 @@ func TimeSeriesInsightsEnvironmentID(input string) (*TimeSeriesInsightsEnvironme
 	}
 
 	service := TimeSeriesInsightsEnvironmentId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if service.Name, err = id.PopSegment("environments"); err != nil {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_environment_test.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_environment_test.go
@@ -11,7 +11,7 @@ var _ resourceid.Formatter = TimeSeriesInsightsEnvironmentId{}
 func TestTimeSeriesInsightsEnvironmentIDFormatter(t *testing.T) {
 	subscriptionId := "12345678-1234-5678-1234-123456789012"
 	actual := NewTimeSeriesInsightsEnvironmentID(subscriptionId, "resourceGroup1", "env1").ID("")
-	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/Microsoft.TimeSeriesInsights/environments/env1"
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.TimeSeriesInsights/environments/env1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_environment_test.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_environment_test.go
@@ -2,7 +2,20 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = TimeSeriesInsightsEnvironmentId{}
+
+func TestTimeSeriesInsightsEnvironmentIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewTimeSeriesInsightsEnvironmentID(subscriptionId, "resourceGroup1", "env1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/Microsoft.TimeSeriesInsights/environments/env1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestTimeSeriesInsightsEnvironmentId(t *testing.T) {
 	testData := []struct {
@@ -39,8 +52,9 @@ func TestTimeSeriesInsightsEnvironmentId(t *testing.T) {
 			Name:  "Time Series Insight Environment ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.TimeSeriesInsights/environments/Environment1",
 			Expected: &TimeSeriesInsightsEnvironmentId{
-				Name:          "Environment1",
-				ResourceGroup: "resGroup1",
+				SubscriptionId: "00000000-0000-0000-0000-000000000000",
+				Name:           "Environment1",
+				ResourceGroup:  "resGroup1",
 			},
 		},
 		{
@@ -68,6 +82,10 @@ func TestTimeSeriesInsightsEnvironmentId(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_reference_data_set.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_reference_data_set.go
@@ -7,9 +7,24 @@ import (
 )
 
 type TimeSeriesInsightsReferenceDataSetId struct {
+	SubscriptionId  string
 	ResourceGroup   string
 	EnvironmentName string
 	Name            string
+}
+
+func NewTimeSeriesInsightsReferenceDataSetID(subscriptionId, resourceGroup, environmentName, name string) TimeSeriesInsightsReferenceDataSetId {
+	return TimeSeriesInsightsReferenceDataSetId{
+		SubscriptionId:  subscriptionId,
+		ResourceGroup:   resourceGroup,
+		EnvironmentName: environmentName,
+		Name:            name,
+	}
+}
+
+func (id TimeSeriesInsightsReferenceDataSetId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.TimeSeriesInsights/environments/%s/referenceDataSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.EnvironmentName, id.Name)
 }
 
 func TimeSeriesInsightsReferenceDataSetID(input string) (*TimeSeriesInsightsReferenceDataSetId, error) {
@@ -19,7 +34,8 @@ func TimeSeriesInsightsReferenceDataSetID(input string) (*TimeSeriesInsightsRefe
 	}
 
 	service := TimeSeriesInsightsReferenceDataSetId{
-		ResourceGroup: id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
 	}
 
 	if service.EnvironmentName, err = id.PopSegment("environments"); err != nil {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_reference_data_set_test.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/iot_time_series_insights_reference_data_set_test.go
@@ -2,7 +2,20 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = TimeSeriesInsightsEnvironmentId{}
+
+func TestTimeSeriesInsightsReferenceDataSetIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewTimeSeriesInsightsReferenceDataSetID(subscriptionId, "resourceGroup1", "env1", "dataset1").ID("")
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.TimeSeriesInsights/environments/env1/referenceDataSets/dataset1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestTimeSeriesInsightsReferenceDataSetId(t *testing.T) {
 	testData := []struct {
@@ -39,6 +52,7 @@ func TestTimeSeriesInsightsReferenceDataSetId(t *testing.T) {
 			Name:  "Time Series Insight Environment ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.TimeSeriesInsights/environments/Environment1/referenceDataSets/DataSet1",
 			Expected: &TimeSeriesInsightsReferenceDataSetId{
+				SubscriptionId:  "00000000-0000-0000-0000-000000000000",
 				Name:            "DataSet1",
 				EnvironmentName: "Environment1",
 				ResourceGroup:   "resGroup1",
@@ -69,6 +83,10 @@ func TestTimeSeriesInsightsReferenceDataSetId(t *testing.T) {
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Subscription Id", v.Expected.SubscriptionId, actual.SubscriptionId)
 		}
 	}
 }


### PR DESCRIPTION
This PR moves away from using the global "subscriptionId" on the `IDFormatter` interface in favour of a local SubscriptionID parsed out on a per-ID basis. This is required for #9421 (and some other future work) - whilst this is incomplete I'll send a follow up in the morning