### PR TITLE
AKS: add psp back

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -729,9 +729,7 @@ func resourceArmKubernetesClusterCreate(d *schema.ResourceData, meta interface{}
 
 	nodeResourceGroup := d.Get("node_resource_group").(string)
 
-	if d.Get("enable_pod_security_policy").(bool) {
-		return fmt.Errorf("The AKS API has removed support for this field on 2020-10-15 and is no longer possible to configure this the Pod Security Policy - as such you'll need to set `enable_pod_security_policy` to `false`")
-	}
+	enablePodSecurityPolicy := d.Get("enable_pod_security_policy").(bool)
 
 	autoScalerProfileRaw := d.Get("auto_scaler_profile").([]interface{})
 	autoScalerProfile := expandKubernetesClusterAutoScalerProfile(autoScalerProfileRaw)
@@ -744,18 +742,19 @@ func resourceArmKubernetesClusterCreate(d *schema.ResourceData, meta interface{}
 			Tier: containerservice.ManagedClusterSKUTier(d.Get("sku_tier").(string)),
 		},
 		ManagedClusterProperties: &containerservice.ManagedClusterProperties{
-			APIServerAccessProfile: &apiAccessProfile,
-			AadProfile:             azureADProfile,
-			AddonProfiles:          *addonProfiles,
-			AgentPoolProfiles:      agentProfiles,
-			AutoScalerProfile:      autoScalerProfile,
-			DNSPrefix:              utils.String(dnsPrefix),
-			EnableRBAC:             utils.Bool(rbacEnabled),
-			KubernetesVersion:      utils.String(kubernetesVersion),
-			LinuxProfile:           linuxProfile,
-			WindowsProfile:         windowsProfile,
-			NetworkProfile:         networkProfile,
-			NodeResourceGroup:      utils.String(nodeResourceGroup),
+			APIServerAccessProfile:  &apiAccessProfile,
+			AadProfile:              azureADProfile,
+			AddonProfiles:           *addonProfiles,
+			AgentPoolProfiles:       agentProfiles,
+			AutoScalerProfile:       autoScalerProfile,
+			DNSPrefix:               utils.String(dnsPrefix),
+			EnableRBAC:              utils.Bool(rbacEnabled),
+			KubernetesVersion:       utils.String(kubernetesVersion),
+			LinuxProfile:            linuxProfile,
+			WindowsProfile:          windowsProfile,
+			NetworkProfile:          networkProfile,
+			NodeResourceGroup:       utils.String(nodeResourceGroup),
+			EnablePodSecurityPolicy: utils.Bool(enablePodSecurityPolicy),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -952,8 +951,10 @@ func resourceArmKubernetesClusterUpdate(d *schema.ResourceData, meta interface{}
 		existing.ManagedClusterProperties.AutoScalerProfile = autoScalerProfile
 	}
 
-	if d.HasChange("enable_pod_security_policy") && d.Get("enable_pod_security_policy").(bool) {
-		return fmt.Errorf("The AKS API has removed support for this field on 2020-10-15 and is no longer possible to configure this the Pod Security Policy - as such you'll need to set `enable_pod_security_policy` to `false`")
+	if d.HasChange("enable_pod_security_policy") {
+		updateCluster = true
+		enablePodSecurityPolicy := d.Get("enable_pod_security_policy").(bool)
+		existing.ManagedClusterProperties.EnablePodSecurityPolicy = utils.Bool(enablePodSecurityPolicy)
 	}
 
 	if d.HasChange("linux_profile") {

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_auth_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_auth_resource_test.go
@@ -10,6 +10,7 @@ import (
 
 var kubernetesAuthTests = map[string]func(t *testing.T){
 	"apiServerAuthorizedIPRanges": testAccAzureRMKubernetesCluster_apiServerAuthorizedIPRanges,
+	"enablePodSecurityPolicy":     testAccAzureRMKubernetesCluster_enablePodSecurityPolicy,
 	"managedClusterIdentity":      testAccAzureRMKubernetesCluster_managedClusterIdentity,
 	"roleBasedAccessControl":      testAccAzureRMKubernetesCluster_roleBasedAccessControl,
 	"AAD":                         testAccAzureRMKubernetesCluster_roleBasedAccessControlAAD,
@@ -49,6 +50,31 @@ func testAccAzureRMKubernetesCluster_apiServerAuthorizedIPRanges(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "kube_admin_config_raw", ""),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "default_node_pool.0.max_pods"),
 					resource.TestCheckResourceAttr(data.ResourceName, "api_server_authorized_ip_ranges.#", "3"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccAzureRMKubernetesCluster_enablePodSecurityPolicy(t)
+}
+
+func testAccAzureRMKubernetesCluster_enablePodSecurityPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKubernetesCluster_enablePodSecurityPolicyConfig(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_pod_security_policy", "true"),
 				),
 			},
 			data.ImportStep(),
@@ -447,6 +473,36 @@ resource "azurerm_kubernetes_cluster" "test" {
   ]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMKubernetesCluster_enablePodSecurityPolicyConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+resource "azurerm_kubernetes_cluster" "test" {
+  name                       = "acctestaks%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  dns_prefix                 = "acctestaks%d"
+  enable_pod_security_policy = true
+  role_based_access_control {
+    enabled = true
+  }
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func testAccAzureRMKubernetesCluster_managedClusterIdentityConfig(data acceptance.TestData) string {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -78,6 +78,10 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `auto_scaler_profile` - (Optional) A `auto_scaler_profile` block as defined below.
 
+* `enable_pod_security_policy` - (Optional) Whether Pod Security Policies are enabled. Note that this also requires role based access control to be enabled.
+
+-> **NOTE:** Support for `enable_pod_security_policy` is currently in Preview on an opt-in basis. To use it, enable feature `PodSecurityPolicyPreview` for `namespace Microsoft.ContainerService`. For an example of how to enable a Preview feature, please visit [Register scale set feature provider](https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler#register-scale-set-feature-provider).
+
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used for the Nodes and Volumes. More information [can be found in the documentation](https://docs.microsoft.com/en-us/azure/aks/azure-disk-customer-managed-keys).
 
 * `identity` - (Optional) A `identity` block as defined below. Changing this forces a new resource to be created.


### PR DESCRIPTION
Fixes [#9336](https://github.com/terraform-providers/terraform-provider-azurerm/issues/9336)

make acctests SERVICE='containers' TESTARGS='-run=TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/containers/tests/ -run=TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy
=== PAUSE TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy
=== CONT  TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy
--- PASS: TestAccAzureRMKubernetesCluster_enablePodSecurityPolicy (575.44s)