### PR TITLE
feature: add subscription override for storage account ds

### DIFF
--- a/azurerm/internal/services/storage/client/client.go
+++ b/azurerm/internal/services/storage/client/client.go
@@ -36,6 +36,7 @@ type Client struct {
 
 	resourceManagerAuthorizer autorest.Authorizer
 	storageAdAuth             *autorest.Authorizer
+	options *common.ClientOptions
 }
 
 func NewClient(options *common.ClientOptions) *Client {
@@ -78,6 +79,7 @@ func NewClient(options *common.ClientOptions) *Client {
 		SyncGroupsClient:         &syncGroupsClient,
 
 		resourceManagerAuthorizer: options.ResourceManagerAuthorizer,
+		options: options,
 	}
 
 	if options.StorageUseAzureAD {
@@ -250,4 +252,10 @@ func (client Client) TablesClient(ctx context.Context, account accountDetails) (
 	tablesClient.Client.Authorizer = storageAuth
 	shim := shim.NewDataPlaneStorageTableWrapper(&tablesClient)
 	return shim, nil
+}
+
+func (client Client) AccountsClientOverrideSubscription(subscriptionID string) *storage.AccountsClient {
+	accountsClient := storage.NewAccountsClientWithBaseURI(client.options.ResourceManagerEndpoint, subscriptionID)
+	client.options.ConfigureClient(&accountsClient.Client, client.options.ResourceManagerAuthorizer)
+	return &accountsClient
 }

--- a/azurerm/internal/services/storage/client/client.go
+++ b/azurerm/internal/services/storage/client/client.go
@@ -36,7 +36,7 @@ type Client struct {
 
 	resourceManagerAuthorizer autorest.Authorizer
 	storageAdAuth             *autorest.Authorizer
-	options *common.ClientOptions
+	options                   *common.ClientOptions
 }
 
 func NewClient(options *common.ClientOptions) *Client {
@@ -79,7 +79,7 @@ func NewClient(options *common.ClientOptions) *Client {
 		SyncGroupsClient:         &syncGroupsClient,
 
 		resourceManagerAuthorizer: options.ResourceManagerAuthorizer,
-		options: options,
+		options:                   options,
 	}
 
 	if options.StorageUseAzureAD {

--- a/azurerm/internal/services/storage/data_source_storage_account.go
+++ b/azurerm/internal/services/storage/data_source_storage_account.go
@@ -254,7 +254,7 @@ func dataSourceArmStorageAccount() *schema.Resource {
 			},
 
 			"subscription_id": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 
@@ -271,7 +271,7 @@ func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) e
 	} else {
 		client = meta.(*clients.Client).Storage.AccountsClient
 	}
-	
+
 	endpointSuffix := meta.(*clients.Client).Account.Environment.StorageEndpointSuffix
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/azurerm/internal/services/storage/data_source_storage_account.go
+++ b/azurerm/internal/services/storage/data_source_storage_account.go
@@ -264,7 +264,7 @@ func dataSourceArmStorageAccount() *schema.Resource {
 }
 
 func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := &storage.AccountsClient{}
+	var client *storage.AccountsClient
 
 	if subscriptionID := d.Get("subscription_id").(string); subscriptionID != "" {
 		client = meta.(*clients.Client).Storage.AccountsClientOverrideSubscription(subscriptionID)

--- a/azurerm/internal/services/storage/data_source_storage_account.go
+++ b/azurerm/internal/services/storage/data_source_storage_account.go
@@ -253,13 +253,25 @@ func dataSourceArmStorageAccount() *schema.Resource {
 				Sensitive: true,
 			},
 
+			"subscription_id": {
+				Type: schema.TypeString,
+				Optional: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
 }
 
 func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Storage.AccountsClient
+	client := &storage.AccountsClient{}
+
+	if subscriptionID := d.Get("subscription_id").(string); subscriptionID != "" {
+		client = meta.(*clients.Client).Storage.AccountsClientOverrideSubscription(subscriptionID)
+	} else {
+		client = meta.(*clients.Client).Storage.AccountsClient
+	}
+	
 	endpointSuffix := meta.(*clients.Client).Account.Environment.StorageEndpointSuffix
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()


### PR DESCRIPTION
This is the implementation to support #9428 in the hopes of adding the ability to override the `subscription_id` for individual resources and data sources.