### PR TITLE
generator/resource-id: removing the type name from the generated name

### DIFF
--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
@@ -202,16 +202,16 @@ func resourceArmAnalysisServicesServerRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	server, err := client.GetDetails(ctx, id.ResourceGroup, id.ServerName)
+	server, err := client.GetDetails(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(server.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Analytics Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Analytics Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", id.ServerName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	if location := server.Location; location != nil {
@@ -258,25 +258,25 @@ func resourceArmAnalysisServicesServerUpdate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	serverResp, err := client.GetDetails(ctx, id.ResourceGroup, id.ServerName)
+	serverResp, err := client.GetDetails(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if serverResp.State != analysisservices.StateSucceeded && serverResp.State != analysisservices.StatePaused {
-		return fmt.Errorf("Error updating Analysis Services Server %q (Resource Group %q): State must be either Succeeded or Paused but got %q", id.ServerName, id.ResourceGroup, serverResp.State)
+		return fmt.Errorf("Error updating Analysis Services Server %q (Resource Group %q): State must be either Succeeded or Paused but got %q", id.Name, id.ResourceGroup, serverResp.State)
 	}
 
 	isPaused := serverResp.State == analysisservices.StatePaused
 
 	if isPaused {
-		resumeFuture, err := client.Resume(ctx, id.ResourceGroup, id.ServerName)
+		resumeFuture, err := client.Resume(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
-			return fmt.Errorf("Error starting Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+			return fmt.Errorf("Error starting Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 
 		if err = resumeFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error waiting for Analysis Services Server starting completion %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+			return fmt.Errorf("Error waiting for Analysis Services Server starting completion %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 
@@ -290,23 +290,23 @@ func resourceArmAnalysisServicesServerUpdate(d *schema.ResourceData, meta interf
 		ServerMutableProperties: serverProperties,
 	}
 
-	future, err := client.Update(ctx, id.ResourceGroup, id.ServerName, analysisServicesServer)
+	future, err := client.Update(ctx, id.ResourceGroup, id.Name, analysisServicesServer)
 	if err != nil {
-		return fmt.Errorf("Error creating Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Error creating Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for completion of Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for completion of Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if isPaused {
-		suspendFuture, err := client.Suspend(ctx, id.ResourceGroup, id.ServerName)
+		suspendFuture, err := client.Suspend(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
-			return fmt.Errorf("Error re-pausing Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+			return fmt.Errorf("Error re-pausing Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 
 		if err = suspendFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error waiting for Analysis Services Server pausing completion %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+			return fmt.Errorf("Error waiting for Analysis Services Server pausing completion %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 
@@ -323,13 +323,13 @@ func resourceArmAnalysisServicesServerDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.ServerName)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Error deleting Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Analysis Services Server %q (Resource Group %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of Analysis Services Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -505,9 +505,9 @@ func (t AnalysisServicesServerResource) Exists(ctx context.Context, clients *cli
 		return nil, err
 	}
 
-	resp, err := clients.AnalysisServices.ServerClient.GetDetails(ctx, id.ResourceGroup, id.ServerName)
+	resp, err := clients.AnalysisServices.ServerClient.GetDetails(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Analysis Services Server %q (resource group: %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving Analysis Services Server %q (resource group: %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(resp.ServerProperties != nil), nil
@@ -521,14 +521,14 @@ func (t AnalysisServicesServerResource) suspend(ctx context.Context, clients *cl
 		return err
 	}
 
-	suspendFuture, err := client.Suspend(ctx, id.ResourceGroup, id.ServerName)
+	suspendFuture, err := client.Suspend(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("suspending Analysis Services Server %q (resource group: %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("suspending Analysis Services Server %q (resource group: %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	err = suspendFuture.WaitForCompletionRef(ctx, client.Client)
 	if err != nil {
-		return fmt.Errorf("Wait for Suspend on Analysis Services Server %q (resource group: %q): %+v", id.ServerName, id.ResourceGroup, err)
+		return fmt.Errorf("Wait for Suspend on Analysis Services Server %q (resource group: %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil
@@ -543,7 +543,7 @@ func (t AnalysisServicesServerResource) checkState(serverState analysisservices.
 			return err
 		}
 
-		resp, err := client.GetDetails(ctx, id.ResourceGroup, id.ServerName)
+		resp, err := client.GetDetails(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on analysisServicesServerClient: %+v", err)
 		}

--- a/azurerm/internal/services/analysisservices/parse/server.go
+++ b/azurerm/internal/services/analysisservices/parse/server.go
@@ -11,20 +11,20 @@ import (
 type ServerId struct {
 	SubscriptionId string
 	ResourceGroup  string
-	ServerName     string
+	Name           string
 }
 
-func NewServerID(subscriptionId, resourceGroup, serverName string) ServerId {
+func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 	return ServerId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
-		ServerName:     serverName,
+		Name:           name,
 	}
 }
 
 func (id ServerId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AnalysisServices/servers/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ServerName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ServerID(input string) (*ServerId, error) {
@@ -38,7 +38,7 @@ func ServerID(input string) (*ServerId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.ServerName, err = id.PopSegment("servers"); err != nil {
+	if resourceId.Name, err = id.PopSegment("servers"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/analysisservices/parse/server_test.go
+++ b/azurerm/internal/services/analysisservices/parse/server_test.go
@@ -56,13 +56,13 @@ func TestServerID(t *testing.T) {
 		},
 
 		{
-			// missing ServerName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/",
 			Error: true,
 		},
 
 		{
-			// missing value for ServerName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/servers/",
 			Error: true,
 		},
@@ -73,7 +73,7 @@ func TestServerID(t *testing.T) {
 			Expected: &ServerId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
-				ServerName:     "Server1",
+				Name:           "Server1",
 			},
 		},
 
@@ -105,8 +105,8 @@ func TestServerID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.ServerName != v.Expected.ServerName {
-			t.Fatalf("Expected %q but got %q for ServerName", v.Expected.ServerName, actual.ServerName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/appconfiguration/app_configuration_resource.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_resource.go
@@ -261,21 +261,21 @@ func resourceArmAppConfigurationUpdate(d *schema.ResourceData, meta interface{})
 		parameters.Identity = expandAppConfigurationIdentity(d.Get("identity").([]interface{}))
 	}
 
-	future, err := client.Update(ctx, id.ResourceGroup, id.ConfigurationStoreName, parameters)
+	future, err := client.Update(ctx, id.ResourceGroup, id.Name, parameters)
 	if err != nil {
-		return fmt.Errorf("Error updating App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Error updating App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for update of App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for update of App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, id.ResourceGroup, id.ConfigurationStoreName)
+	read, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read App Configuration %s (resource Group %q) ID", id.ConfigurationStoreName, id.ResourceGroup)
+		return fmt.Errorf("Cannot read App Configuration %s (resource Group %q) ID", id.Name, id.ResourceGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -293,22 +293,22 @@ func resourceArmAppConfigurationRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ConfigurationStoreName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] App Configuration %q was not found in Resource Group %q - removing from state!", id.ConfigurationStoreName, id.ResourceGroup)
+			log.Printf("[DEBUG] App Configuration %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Error making Read request on App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	resultPage, err := client.ListKeys(ctx, id.ResourceGroup, id.ConfigurationStoreName, "")
+	resultPage, err := client.ListKeys(ctx, id.ResourceGroup, id.Name, "")
 	if err != nil {
-		return fmt.Errorf("Failed to receive access keys for App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Failed to receive access keys for App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", id.ConfigurationStoreName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
@@ -347,19 +347,19 @@ func resourceArmAppConfigurationDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	fut, err := client.Delete(ctx, id.ResourceGroup, id.ConfigurationStoreName)
+	fut, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if response.WasNotFound(fut.Response()) {
 			return nil
 		}
-		return fmt.Errorf("Error deleting App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Error deleting App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = fut.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if response.WasNotFound(fut.Response()) {
 			return nil
 		}
-		return fmt.Errorf("Error deleting App Configuration %q (Resource Group %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return fmt.Errorf("Error deleting App Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -151,9 +151,9 @@ func (t AppConfigurationResource) Exists(ctx context.Context, clients *clients.C
 		return nil, err
 	}
 
-	resp, err := clients.AppConfiguration.AppConfigurationsClient.Get(ctx, id.ResourceGroup, id.ConfigurationStoreName)
+	resp, err := clients.AppConfiguration.AppConfigurationsClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving App Configuration %q (resource group: %q): %+v", id.ConfigurationStoreName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving App Configuration %q (resource group: %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(resp.ConfigurationStoreProperties != nil), nil

--- a/azurerm/internal/services/appconfiguration/parse/configuration_store.go
+++ b/azurerm/internal/services/appconfiguration/parse/configuration_store.go
@@ -9,22 +9,22 @@ import (
 )
 
 type ConfigurationStoreId struct {
-	SubscriptionId         string
-	ResourceGroup          string
-	ConfigurationStoreName string
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
 }
 
-func NewConfigurationStoreID(subscriptionId, resourceGroup, configurationStoreName string) ConfigurationStoreId {
+func NewConfigurationStoreID(subscriptionId, resourceGroup, name string) ConfigurationStoreId {
 	return ConfigurationStoreId{
-		SubscriptionId:         subscriptionId,
-		ResourceGroup:          resourceGroup,
-		ConfigurationStoreName: configurationStoreName,
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
 	}
 }
 
 func (id ConfigurationStoreId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AppConfiguration/configurationStores/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ConfigurationStoreName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ConfigurationStoreID(input string) (*ConfigurationStoreId, error) {
@@ -38,7 +38,7 @@ func ConfigurationStoreID(input string) (*ConfigurationStoreId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.ConfigurationStoreName, err = id.PopSegment("configurationStores"); err != nil {
+	if resourceId.Name, err = id.PopSegment("configurationStores"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/appconfiguration/parse/configuration_store_test.go
+++ b/azurerm/internal/services/appconfiguration/parse/configuration_store_test.go
@@ -56,13 +56,13 @@ func TestConfigurationStoreID(t *testing.T) {
 		},
 
 		{
-			// missing ConfigurationStoreName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.AppConfiguration/",
 			Error: true,
 		},
 
 		{
-			// missing value for ConfigurationStoreName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.AppConfiguration/configurationStores/",
 			Error: true,
 		},
@@ -71,9 +71,9 @@ func TestConfigurationStoreID(t *testing.T) {
 			// valid
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.AppConfiguration/configurationStores/store1",
 			Expected: &ConfigurationStoreId{
-				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
-				ResourceGroup:          "group1",
-				ConfigurationStoreName: "store1",
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "store1",
 			},
 		},
 
@@ -105,8 +105,8 @@ func TestConfigurationStoreID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.ConfigurationStoreName != v.Expected.ConfigurationStoreName {
-			t.Fatalf("Expected %q but got %q for ConfigurationStoreName", v.Expected.ConfigurationStoreName, actual.ConfigurationStoreName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/applicationinsights/application_insights_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_resource.go
@@ -233,21 +233,21 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Reading AzureRM Application Insights '%s'", id)
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ComponentName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on AzureRM Application Insights '%s': %+v", id.ComponentName, err)
+		return fmt.Errorf("Error making Read request on AzureRM Application Insights '%s': %+v", id.Name, err)
 	}
 
-	billingResp, err := billingClient.Get(ctx, id.ResourceGroup, id.ComponentName)
+	billingResp, err := billingClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM Application Insights Billing Feature '%s': %+v", id.ComponentName, err)
+		return fmt.Errorf("Error making Read request on AzureRM Application Insights Billing Feature '%s': %+v", id.Name, err)
 	}
 
-	d.Set("name", id.ComponentName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
@@ -283,14 +283,14 @@ func resourceArmApplicationInsightsDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting AzureRM Application Insights %q (resource group %q)", id.ComponentName, id.ResourceGroup)
+	log.Printf("[DEBUG] Deleting AzureRM Application Insights %q (resource group %q)", id.Name, id.ResourceGroup)
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.ComponentName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			return nil
 		}
-		return fmt.Errorf("Error issuing AzureRM delete request for Application Insights %q: %+v", id.ComponentName, err)
+		return fmt.Errorf("Error issuing AzureRM delete request for Application Insights %q: %+v", id.Name, err)
 	}
 
 	return err

--- a/azurerm/internal/services/applicationinsights/application_insights_resource_test.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_resource_test.go
@@ -154,9 +154,9 @@ func (t AppInsightsResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, err
 	}
 
-	resp, err := clients.AppInsights.ComponentsClient.Get(ctx, id.ResourceGroup, id.ComponentName)
+	resp, err := clients.AppInsights.ComponentsClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Application Insights %q (resource group: %q) does not exist", id.ComponentName, id.ResourceGroup)
+		return nil, fmt.Errorf("retrieving Application Insights %q (resource group: %q) does not exist", id.Name, id.ResourceGroup)
 	}
 
 	return utils.Bool(resp.ApplicationInsightsComponentProperties != nil), nil

--- a/azurerm/internal/services/applicationinsights/application_insights_webtests_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_webtests_resource.go
@@ -218,14 +218,14 @@ func resourceArmApplicationInsightsWebTestsRead(d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Reading AzureRM Application Insights WebTests %q", id)
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.WebtestName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Application Insights WebTest %q was not found in Resource Group %q - removing from state!", id.WebtestName, id.ResourceGroup)
+			log.Printf("[DEBUG] Application Insights WebTest %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Application Insights WebTests %q (Resource Group %q): %+v", id.WebtestName, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Application Insights WebTests %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	appInsightsId := ""
@@ -235,7 +235,7 @@ func resourceArmApplicationInsightsWebTestsRead(d *schema.ResourceData, meta int
 		}
 	}
 	d.Set("application_insights_id", appInsightsId)
-	d.Set("name", id.WebtestName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("kind", resp.Kind)
 
@@ -277,14 +277,14 @@ func resourceArmApplicationInsightsWebTestsDelete(d *schema.ResourceData, meta i
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting AzureRM Application Insights WebTest '%s' (resource group '%s')", id.WebtestName, id.ResourceGroup)
+	log.Printf("[DEBUG] Deleting AzureRM Application Insights WebTest '%s' (resource group '%s')", id.Name, id.ResourceGroup)
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.WebtestName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			return nil
 		}
-		return fmt.Errorf("Error issuing AzureRM delete request for Application Insights WebTest '%s': %+v", id.WebtestName, err)
+		return fmt.Errorf("Error issuing AzureRM delete request for Application Insights WebTest '%s': %+v", id.Name, err)
 	}
 
 	return err

--- a/azurerm/internal/services/applicationinsights/application_insights_webtests_resource_test.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_webtests_resource_test.go
@@ -103,9 +103,9 @@ func (t AppInsightsWebTestsResource) Exists(ctx context.Context, clients *client
 		return nil, err
 	}
 
-	resp, err := clients.AppInsights.WebTestsClient.Get(ctx, id.ResourceGroup, id.WebtestName)
+	resp, err := clients.AppInsights.WebTestsClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Application Insights '%q' (resource group: '%q') does not exist", id.ResourceGroup, id.WebtestName)
+		return nil, fmt.Errorf("retrieving Application Insights '%q' (resource group: '%q') does not exist", id.ResourceGroup, id.Name)
 	}
 
 	return utils.Bool(resp.WebTestProperties != nil), nil

--- a/azurerm/internal/services/applicationinsights/parse/component.go
+++ b/azurerm/internal/services/applicationinsights/parse/component.go
@@ -11,20 +11,20 @@ import (
 type ComponentId struct {
 	SubscriptionId string
 	ResourceGroup  string
-	ComponentName  string
+	Name           string
 }
 
-func NewComponentID(subscriptionId, resourceGroup, componentName string) ComponentId {
+func NewComponentID(subscriptionId, resourceGroup, name string) ComponentId {
 	return ComponentId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
-		ComponentName:  componentName,
+		Name:           name,
 	}
 }
 
 func (id ComponentId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/microsoft.insights/components/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ComponentName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ComponentID(input string) (*ComponentId, error) {
@@ -38,7 +38,7 @@ func ComponentID(input string) (*ComponentId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.ComponentName, err = id.PopSegment("components"); err != nil {
+	if resourceId.Name, err = id.PopSegment("components"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/applicationinsights/parse/component_test.go
+++ b/azurerm/internal/services/applicationinsights/parse/component_test.go
@@ -56,13 +56,13 @@ func TestComponentID(t *testing.T) {
 		},
 
 		{
-			// missing ComponentName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/microsoft.insights/",
 			Error: true,
 		},
 
 		{
-			// missing value for ComponentName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/microsoft.insights/components/",
 			Error: true,
 		},
@@ -73,7 +73,7 @@ func TestComponentID(t *testing.T) {
 			Expected: &ComponentId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "group1",
-				ComponentName:  "component1",
+				Name:           "component1",
 			},
 		},
 
@@ -105,8 +105,8 @@ func TestComponentID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.ComponentName != v.Expected.ComponentName {
-			t.Fatalf("Expected %q but got %q for ComponentName", v.Expected.ComponentName, actual.ComponentName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/applicationinsights/parse/web_test_id.go
+++ b/azurerm/internal/services/applicationinsights/parse/web_test_id.go
@@ -11,20 +11,20 @@ import (
 type WebTestId struct {
 	SubscriptionId string
 	ResourceGroup  string
-	WebtestName    string
+	Name           string
 }
 
-func NewWebTestID(subscriptionId, resourceGroup, webtestName string) WebTestId {
+func NewWebTestID(subscriptionId, resourceGroup, name string) WebTestId {
 	return WebTestId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
-		WebtestName:    webtestName,
+		Name:           name,
 	}
 }
 
 func (id WebTestId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/microsoft.insights/webtests/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.WebtestName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func WebTestID(input string) (*WebTestId, error) {
@@ -38,7 +38,7 @@ func WebTestID(input string) (*WebTestId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.WebtestName, err = id.PopSegment("webtests"); err != nil {
+	if resourceId.Name, err = id.PopSegment("webtests"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/applicationinsights/parse/web_test_id_test.go
+++ b/azurerm/internal/services/applicationinsights/parse/web_test_id_test.go
@@ -56,13 +56,13 @@ func TestWebTestID(t *testing.T) {
 		},
 
 		{
-			// missing WebtestName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/microsoft.insights/",
 			Error: true,
 		},
 
 		{
-			// missing value for WebtestName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/microsoft.insights/webtests/",
 			Error: true,
 		},
@@ -73,7 +73,7 @@ func TestWebTestID(t *testing.T) {
 			Expected: &WebTestId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "group1",
-				WebtestName:    "test1",
+				Name:           "test1",
 			},
 		},
 
@@ -105,8 +105,8 @@ func TestWebTestID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.WebtestName != v.Expected.WebtestName {
-			t.Fatalf("Expected %q but got %q for WebtestName", v.Expected.WebtestName, actual.WebtestName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/automation/automation_connection_certificate_resource.go
+++ b/azurerm/internal/services/automation/automation_connection_certificate_resource.go
@@ -140,14 +140,14 @@ func resourceArmAutomationConnectionCertificateRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	d.Set("name", resp.Name)
@@ -177,13 +177,13 @@ func resourceArmAutomationConnectionCertificateDelete(d *schema.ResourceData, me
 		return err
 	}
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/automation/automation_connection_classic_certificate_resource.go
+++ b/azurerm/internal/services/automation/automation_connection_classic_certificate_resource.go
@@ -147,14 +147,14 @@ func resourceArmAutomationConnectionClassicCertificateRead(d *schema.ResourceDat
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	d.Set("name", resp.Name)
@@ -187,13 +187,13 @@ func resourceArmAutomationConnectionClassicCertificateDelete(d *schema.ResourceD
 		return err
 	}
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/automation/automation_connection_import.go
+++ b/azurerm/internal/services/automation/automation_connection_import.go
@@ -20,13 +20,13 @@ func importAutomationConnection(connectionType string) func(d *schema.ResourceDa
 		ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 		defer cancel()
 
-		resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 		if err != nil {
-			return []*schema.ResourceData{}, fmt.Errorf("retrieving automation connection %q (Account %q / Resource Group %q): %+v", id.ConnectionName, id.AutomationAccountName, id.ResourceGroup, err)
+			return []*schema.ResourceData{}, fmt.Errorf("retrieving automation connection %q (Account %q / Resource Group %q): %+v", id.Name, id.AutomationAccountName, id.ResourceGroup, err)
 		}
 
 		if resp.ConnectionProperties == nil || resp.ConnectionProperties.ConnectionType == nil || resp.ConnectionProperties.ConnectionType.Name == nil {
-			return []*schema.ResourceData{}, fmt.Errorf("retrieving automation connection %q (Account %q / Resource Group %q): `properties`, `properties.connectionType` or `properties.connectionType.name` was nil", id.ConnectionName, id.AutomationAccountName, id.ResourceGroup)
+			return []*schema.ResourceData{}, fmt.Errorf("retrieving automation connection %q (Account %q / Resource Group %q): `properties`, `properties.connectionType` or `properties.connectionType.name` was nil", id.Name, id.AutomationAccountName, id.ResourceGroup)
 		}
 
 		if *resp.ConnectionProperties.ConnectionType.Name != connectionType {

--- a/azurerm/internal/services/automation/automation_connection_resource.go
+++ b/azurerm/internal/services/automation/automation_connection_resource.go
@@ -162,14 +162,14 @@ func resourceArmAutomationConnectionRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	d.Set("name", resp.Name)
@@ -201,13 +201,13 @@ func resourceArmAutomationConnectionDelete(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/automation/automation_connection_service_principal_resource.go
+++ b/azurerm/internal/services/automation/automation_connection_service_principal_resource.go
@@ -154,14 +154,14 @@ func resourceArmAutomationConnectionServicePrincipalRead(d *schema.ResourceData,
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("Read request on AzureRM Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	d.Set("name", resp.Name)
@@ -197,13 +197,13 @@ func resourceArmAutomationConnectionServicePrincipalDelete(d *schema.ResourceDat
 		return err
 	}
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.AutomationAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.ConnectionName, err)
+		return fmt.Errorf("deleting Automation Connection '%s': %+v", id.Name, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/automation/parse/connection.go
+++ b/azurerm/internal/services/automation/parse/connection.go
@@ -12,21 +12,21 @@ type ConnectionId struct {
 	SubscriptionId        string
 	ResourceGroup         string
 	AutomationAccountName string
-	ConnectionName        string
+	Name                  string
 }
 
-func NewConnectionID(subscriptionId, resourceGroup, automationAccountName, connectionName string) ConnectionId {
+func NewConnectionID(subscriptionId, resourceGroup, automationAccountName, name string) ConnectionId {
 	return ConnectionId{
 		SubscriptionId:        subscriptionId,
 		ResourceGroup:         resourceGroup,
 		AutomationAccountName: automationAccountName,
-		ConnectionName:        connectionName,
+		Name:                  name,
 	}
 }
 
 func (id ConnectionId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Automation/automationAccounts/%s/connections/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AutomationAccountName, id.ConnectionName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AutomationAccountName, id.Name)
 }
 
 func ConnectionID(input string) (*ConnectionId, error) {
@@ -43,7 +43,7 @@ func ConnectionID(input string) (*ConnectionId, error) {
 	if resourceId.AutomationAccountName, err = id.PopSegment("automationAccounts"); err != nil {
 		return nil, err
 	}
-	if resourceId.ConnectionName, err = id.PopSegment("connections"); err != nil {
+	if resourceId.Name, err = id.PopSegment("connections"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/automation/parse/connection_test.go
+++ b/azurerm/internal/services/automation/parse/connection_test.go
@@ -68,13 +68,13 @@ func TestConnectionID(t *testing.T) {
 		},
 
 		{
-			// missing ConnectionName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/",
 			Error: true,
 		},
 
 		{
-			// missing value for ConnectionName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/connections/",
 			Error: true,
 		},
@@ -86,7 +86,7 @@ func TestConnectionID(t *testing.T) {
 				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:         "group1",
 				AutomationAccountName: "account1",
-				ConnectionName:        "connection1",
+				Name:                  "connection1",
 			},
 		},
 
@@ -121,8 +121,8 @@ func TestConnectionID(t *testing.T) {
 		if actual.AutomationAccountName != v.Expected.AutomationAccountName {
 			t.Fatalf("Expected %q but got %q for AutomationAccountName", v.Expected.AutomationAccountName, actual.AutomationAccountName)
 		}
-		if actual.ConnectionName != v.Expected.ConnectionName {
-			t.Fatalf("Expected %q but got %q for ConnectionName", v.Expected.ConnectionName, actual.ConnectionName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/batch/batch_application_resource.go
+++ b/azurerm/internal/services/batch/batch_application_resource.go
@@ -131,17 +131,17 @@ func resourceArmBatchApplicationRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.ApplicationName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			log.Printf("[INFO] Batch Application %q does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Batch Application %q (Account Name %q / Resource Group %q): %+v", id.ApplicationName, id.BatchAccountName, id.ResourceGroup, err)
+		return fmt.Errorf("Error reading Batch Application %q (Account Name %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
-	d.Set("name", id.ApplicationName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("account_name", id.BatchAccountName)
 	if applicationProperties := resp.ApplicationProperties; applicationProperties != nil {
@@ -175,8 +175,8 @@ func resourceArmBatchApplicationUpdate(d *schema.ResourceData, meta interface{})
 		},
 	}
 
-	if _, err := client.Update(ctx, id.ResourceGroup, id.BatchAccountName, id.ApplicationName, parameters); err != nil {
-		return fmt.Errorf("Error updating Batch Application %q (Account Name %q / Resource Group %q): %+v", id.ApplicationName, id.BatchAccountName, id.ResourceGroup, err)
+	if _, err := client.Update(ctx, id.ResourceGroup, id.BatchAccountName, id.Name, parameters); err != nil {
+		return fmt.Errorf("Error updating Batch Application %q (Account Name %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
 	return resourceArmBatchApplicationRead(d, meta)
@@ -192,8 +192,8 @@ func resourceArmBatchApplicationDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if _, err := client.Delete(ctx, id.ResourceGroup, id.BatchAccountName, id.ApplicationName); err != nil {
-		return fmt.Errorf("Error deleting Batch Application %q (Account Name %q / Resource Group %q): %+v", id.ApplicationName, id.BatchAccountName, id.ResourceGroup, err)
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
+		return fmt.Errorf("Error deleting Batch Application %q (Account Name %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/batch/batch_application_resource_test.go
+++ b/azurerm/internal/services/batch/batch_application_resource_test.go
@@ -72,9 +72,9 @@ func testCheckBatchApplicationExists(resourceName string) resource.TestCheckFunc
 			return err
 		}
 
-		if resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.ApplicationName); err != nil {
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Batch Application %q (Account Name %q / Resource Group %q) does not exist", id.ApplicationName, id.BatchAccountName, id.ResourceGroup)
+				return fmt.Errorf("Bad: Batch Application %q (Account Name %q / Resource Group %q) does not exist", id.Name, id.BatchAccountName, id.ResourceGroup)
 			}
 			return fmt.Errorf("Bad: Get on batchApplicationClient: %+v", err)
 		}
@@ -97,7 +97,7 @@ func testCheckBatchApplicationDestroy(s *terraform.State) error {
 			return err
 		}
 
-		if resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.ApplicationName); err != nil {
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name); err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Get on batchApplicationClient: %+v", err)
 			}

--- a/azurerm/internal/services/batch/batch_certificate_resource.go
+++ b/azurerm/internal/services/batch/batch_certificate_resource.go
@@ -173,17 +173,17 @@ func resourceArmBatchCertificateRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.CertificateName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
-			log.Printf("[DEBUG] Batch certificate %q was not found in Account %q / Resource Group %q - removing from state!", id.CertificateName, id.BatchAccountName, id.ResourceGroup)
+			log.Printf("[DEBUG] Batch certificate %q was not found in Account %q / Resource Group %q - removing from state!", id.Name, id.BatchAccountName, id.ResourceGroup)
 			return nil
 		}
-		return fmt.Errorf("Error retrieving Batch Certificate %q (Account %q / Resource Group %q): %+v", id.CertificateName, id.BatchAccountName, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Batch Certificate %q (Account %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
-	d.Set("name", id.CertificateName)
+	d.Set("name", id.Name)
 	d.Set("account_name", id.BatchAccountName)
 	d.Set("resource_group_name", id.ResourceGroup)
 
@@ -220,7 +220,7 @@ func resourceArmBatchCertificateUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	parameters := batch.CertificateCreateOrUpdateParameters{
-		Name: &id.CertificateName,
+		Name: &id.Name,
 		CertificateCreateOrUpdateProperties: &batch.CertificateCreateOrUpdateProperties{
 			Data:                &certificate,
 			Format:              batch.CertificateFormat(format),
@@ -230,17 +230,17 @@ func resourceArmBatchCertificateUpdate(d *schema.ResourceData, meta interface{})
 		},
 	}
 
-	if _, err = client.Update(ctx, id.ResourceGroup, id.BatchAccountName, id.CertificateName, parameters, ""); err != nil {
-		return fmt.Errorf("Error updating Batch certificate %q (Account %q / Resource Group %q): %+v", id.CertificateName, id.BatchAccountName, id.ResourceGroup, err)
+	if _, err = client.Update(ctx, id.ResourceGroup, id.BatchAccountName, id.Name, parameters, ""); err != nil {
+		return fmt.Errorf("Error updating Batch certificate %q (Account %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.CertificateName)
+	read, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Batch Certificate %q (Account %q / Resource Group %q): %+v", id.CertificateName, id.BatchAccountName, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Batch Certificate %q (Account %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read ID for Batch certificate %q (Account: %q, Resource Group %q) ID", id.CertificateName, id.BatchAccountName, id.ResourceGroup)
+		return fmt.Errorf("Cannot read ID for Batch certificate %q (Account: %q, Resource Group %q) ID", id.Name, id.BatchAccountName, id.ResourceGroup)
 	}
 
 	return resourceArmBatchCertificateRead(d, meta)
@@ -256,14 +256,14 @@ func resourceArmBatchCertificateDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.BatchAccountName, id.CertificateName)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Batch Certificate %q (Account %q / Resource Group %q): %+v", id.CertificateName, id.BatchAccountName, id.ResourceGroup, err)
+		return fmt.Errorf("Error deleting Batch Certificate %q (Account %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("Error waiting for deletion of Batch Certificate %q (Account %q / Resource Group %q): %+v", id.CertificateName, id.BatchAccountName, id.ResourceGroup, err)
+			return fmt.Errorf("Error waiting for deletion of Batch Certificate %q (Account %q / Resource Group %q): %+v", id.Name, id.BatchAccountName, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/batch/batch_certificate_resource_test.go
+++ b/azurerm/internal/services/batch/batch_certificate_resource_test.go
@@ -232,7 +232,7 @@ func testCheckBatchCertificateDestroy(s *terraform.State) error {
 			return err
 		}
 
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.CertificateName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return err

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -463,13 +463,13 @@ func testCheckBatchPoolExists(name string) resource.TestCheckFunc {
 			return err
 		}
 
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.PoolName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on batchPoolClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Batch pool %q (account: %q, resource group: %q) does not exist", id.PoolName, id.BatchAccountName, id.ResourceGroup)
+			return fmt.Errorf("Bad: Batch pool %q (account: %q, resource group: %q) does not exist", id.Name, id.BatchAccountName, id.ResourceGroup)
 		}
 
 		return nil
@@ -489,7 +489,7 @@ func testCheckBatchPoolDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.PoolName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return err

--- a/azurerm/internal/services/batch/parse/application.go
+++ b/azurerm/internal/services/batch/parse/application.go
@@ -12,21 +12,21 @@ type ApplicationId struct {
 	SubscriptionId   string
 	ResourceGroup    string
 	BatchAccountName string
-	ApplicationName  string
+	Name             string
 }
 
-func NewApplicationID(subscriptionId, resourceGroup, batchAccountName, applicationName string) ApplicationId {
+func NewApplicationID(subscriptionId, resourceGroup, batchAccountName, name string) ApplicationId {
 	return ApplicationId{
 		SubscriptionId:   subscriptionId,
 		ResourceGroup:    resourceGroup,
 		BatchAccountName: batchAccountName,
-		ApplicationName:  applicationName,
+		Name:             name,
 	}
 }
 
 func (id ApplicationId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s/applications/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.ApplicationName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.Name)
 }
 
 func ApplicationID(input string) (*ApplicationId, error) {
@@ -43,7 +43,7 @@ func ApplicationID(input string) (*ApplicationId, error) {
 	if resourceId.BatchAccountName, err = id.PopSegment("batchAccounts"); err != nil {
 		return nil, err
 	}
-	if resourceId.ApplicationName, err = id.PopSegment("applications"); err != nil {
+	if resourceId.Name, err = id.PopSegment("applications"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/batch/parse/application_test.go
+++ b/azurerm/internal/services/batch/parse/application_test.go
@@ -68,13 +68,13 @@ func TestApplicationID(t *testing.T) {
 		},
 
 		{
-			// missing ApplicationName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Batch/batchAccounts/account1/",
 			Error: true,
 		},
 
 		{
-			// missing value for ApplicationName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Batch/batchAccounts/account1/applications/",
 			Error: true,
 		},
@@ -86,7 +86,7 @@ func TestApplicationID(t *testing.T) {
 				SubscriptionId:   "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:    "resGroup1",
 				BatchAccountName: "account1",
-				ApplicationName:  "application1",
+				Name:             "application1",
 			},
 		},
 
@@ -121,8 +121,8 @@ func TestApplicationID(t *testing.T) {
 		if actual.BatchAccountName != v.Expected.BatchAccountName {
 			t.Fatalf("Expected %q but got %q for BatchAccountName", v.Expected.BatchAccountName, actual.BatchAccountName)
 		}
-		if actual.ApplicationName != v.Expected.ApplicationName {
-			t.Fatalf("Expected %q but got %q for ApplicationName", v.Expected.ApplicationName, actual.ApplicationName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/batch/parse/certificate.go
+++ b/azurerm/internal/services/batch/parse/certificate.go
@@ -12,21 +12,21 @@ type CertificateId struct {
 	SubscriptionId   string
 	ResourceGroup    string
 	BatchAccountName string
-	CertificateName  string
+	Name             string
 }
 
-func NewCertificateID(subscriptionId, resourceGroup, batchAccountName, certificateName string) CertificateId {
+func NewCertificateID(subscriptionId, resourceGroup, batchAccountName, name string) CertificateId {
 	return CertificateId{
 		SubscriptionId:   subscriptionId,
 		ResourceGroup:    resourceGroup,
 		BatchAccountName: batchAccountName,
-		CertificateName:  certificateName,
+		Name:             name,
 	}
 }
 
 func (id CertificateId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s/certificates/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.CertificateName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.Name)
 }
 
 func CertificateID(input string) (*CertificateId, error) {
@@ -43,7 +43,7 @@ func CertificateID(input string) (*CertificateId, error) {
 	if resourceId.BatchAccountName, err = id.PopSegment("batchAccounts"); err != nil {
 		return nil, err
 	}
-	if resourceId.CertificateName, err = id.PopSegment("certificates"); err != nil {
+	if resourceId.Name, err = id.PopSegment("certificates"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/batch/parse/certificate_test.go
+++ b/azurerm/internal/services/batch/parse/certificate_test.go
@@ -68,13 +68,13 @@ func TestCertificateID(t *testing.T) {
 		},
 
 		{
-			// missing CertificateName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Batch/batchAccounts/account1/",
 			Error: true,
 		},
 
 		{
-			// missing value for CertificateName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Batch/batchAccounts/account1/certificates/",
 			Error: true,
 		},
@@ -86,7 +86,7 @@ func TestCertificateID(t *testing.T) {
 				SubscriptionId:   "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:    "resGroup1",
 				BatchAccountName: "account1",
-				CertificateName:  "certificate1",
+				Name:             "certificate1",
 			},
 		},
 
@@ -121,8 +121,8 @@ func TestCertificateID(t *testing.T) {
 		if actual.BatchAccountName != v.Expected.BatchAccountName {
 			t.Fatalf("Expected %q but got %q for BatchAccountName", v.Expected.BatchAccountName, actual.BatchAccountName)
 		}
-		if actual.CertificateName != v.Expected.CertificateName {
-			t.Fatalf("Expected %q but got %q for CertificateName", v.Expected.CertificateName, actual.CertificateName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/batch/parse/pool.go
+++ b/azurerm/internal/services/batch/parse/pool.go
@@ -12,21 +12,21 @@ type PoolId struct {
 	SubscriptionId   string
 	ResourceGroup    string
 	BatchAccountName string
-	PoolName         string
+	Name             string
 }
 
-func NewPoolID(subscriptionId, resourceGroup, batchAccountName, poolName string) PoolId {
+func NewPoolID(subscriptionId, resourceGroup, batchAccountName, name string) PoolId {
 	return PoolId{
 		SubscriptionId:   subscriptionId,
 		ResourceGroup:    resourceGroup,
 		BatchAccountName: batchAccountName,
-		PoolName:         poolName,
+		Name:             name,
 	}
 }
 
 func (id PoolId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Batch/batchAccounts/%s/pools/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.PoolName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.Name)
 }
 
 func PoolID(input string) (*PoolId, error) {
@@ -43,7 +43,7 @@ func PoolID(input string) (*PoolId, error) {
 	if resourceId.BatchAccountName, err = id.PopSegment("batchAccounts"); err != nil {
 		return nil, err
 	}
-	if resourceId.PoolName, err = id.PopSegment("pools"); err != nil {
+	if resourceId.Name, err = id.PopSegment("pools"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/batch/parse/pool_test.go
+++ b/azurerm/internal/services/batch/parse/pool_test.go
@@ -68,13 +68,13 @@ func TestPoolID(t *testing.T) {
 		},
 
 		{
-			// missing PoolName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Batch/batchAccounts/account1/",
 			Error: true,
 		},
 
 		{
-			// missing value for PoolName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Batch/batchAccounts/account1/pools/",
 			Error: true,
 		},
@@ -86,7 +86,7 @@ func TestPoolID(t *testing.T) {
 				SubscriptionId:   "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:    "resGroup1",
 				BatchAccountName: "account1",
-				PoolName:         "pool1",
+				Name:             "pool1",
 			},
 		},
 
@@ -121,8 +121,8 @@ func TestPoolID(t *testing.T) {
 		if actual.BatchAccountName != v.Expected.BatchAccountName {
 			t.Fatalf("Expected %q but got %q for BatchAccountName", v.Expected.BatchAccountName, actual.BatchAccountName)
 		}
-		if actual.PoolName != v.Expected.PoolName {
-			t.Fatalf("Expected %q but got %q for PoolName", v.Expected.PoolName, actual.PoolName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -378,7 +378,7 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	profile, err := profilesClient.Get(profileGetCtx, id.ResourceGroup, id.ProfileName)
 	if err != nil {
-		return fmt.Errorf("Error creating CDN Endpoint %q while getting CDN Profile (Profile %q / Resource Group %q): %+v", id.EndpointName, id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error creating CDN Endpoint %q while getting CDN Profile (Profile %q / Resource Group %q): %+v", id.Name, id.ProfileName, id.ResourceGroup, err)
 	}
 
 	if profile.Sku != nil {
@@ -396,13 +396,13 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 		endpoint.EndpointPropertiesUpdateParameters.DeliveryPolicy = deliveryPolicy
 	}
 
-	future, err := endpointsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.EndpointName, endpoint)
+	future, err := endpointsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.Name, endpoint)
 	if err != nil {
-		return fmt.Errorf("Error updating CDN Endpoint %q (Profile %q / Resource Group %q): %s", id.EndpointName, id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error updating CDN Endpoint %q (Profile %q / Resource Group %q): %s", id.Name, id.ProfileName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, endpointsClient.Client); err != nil {
-		return fmt.Errorf("Error waiting for the CDN Endpoint %q (Profile %q / Resource Group %q) to finish updating: %+v", id.EndpointName, id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for the CDN Endpoint %q (Profile %q / Resource Group %q) to finish updating: %+v", id.Name, id.ProfileName, id.ResourceGroup, err)
 	}
 
 	return resourceArmCdnEndpointRead(d, meta)
@@ -418,19 +418,19 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	log.Printf("[INFO] Retrieving CDN Endpoint %q (Profile %q / Resource Group %q)", id.EndpointName, id.ProfileName, id.ResourceGroup)
+	log.Printf("[INFO] Retrieving CDN Endpoint %q (Profile %q / Resource Group %q)", id.Name, id.ProfileName, id.ResourceGroup)
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.EndpointName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error making Read request on Azure CDN Endpoint %q (Profile %q / Resource Group %q): %+v", id.EndpointName, id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error making Read request on Azure CDN Endpoint %q (Profile %q / Resource Group %q): %+v", id.Name, id.ProfileName, id.ResourceGroup, err)
 	}
 
-	d.Set("name", id.EndpointName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("profile_name", id.ProfileName)
 
@@ -494,19 +494,19 @@ func resourceArmCdnEndpointDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.ProfileName, id.EndpointName)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.ProfileName, id.Name)
 	if err != nil {
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
-		return fmt.Errorf("Error deleting CDN Endpoint %q (Profile %q / Resource Group %q): %+v", id.EndpointName, id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error deleting CDN Endpoint %q (Profile %q / Resource Group %q): %+v", id.Name, id.ProfileName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
-		return fmt.Errorf("Error waiting for CDN Endpoint %q (Profile %q / Resource Group %q) to be deleted: %+v", id.EndpointName, id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for CDN Endpoint %q (Profile %q / Resource Group %q) to be deleted: %+v", id.Name, id.ProfileName, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -165,13 +165,13 @@ func resourceArmCdnProfileUpdate(d *schema.ResourceData, meta interface{}) error
 		Tags: tags.Expand(newTags),
 	}
 
-	future, err := client.Update(ctx, id.ResourceGroup, id.ProfileName, props)
+	future, err := client.Update(ctx, id.ResourceGroup, id.Name, props)
 	if err != nil {
-		return fmt.Errorf("Error issuing update request for CDN Profile %q (Resource Group %q): %+v", id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error issuing update request for CDN Profile %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for the update of CDN Profile %q (Resource Group %q) to commplete: %+v", id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for the update of CDN Profile %q (Resource Group %q) to commplete: %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return resourceArmCdnProfileRead(d, meta)
@@ -187,16 +187,16 @@ func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure CDN Profile %q (Resource Group %q): %+v", id.ProfileName, id.ResourceGroup, err)
+		return fmt.Errorf("Error making Read request on Azure CDN Profile %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", id.ProfileName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))

--- a/azurerm/internal/services/cdn/parse/endpoint.go
+++ b/azurerm/internal/services/cdn/parse/endpoint.go
@@ -12,21 +12,21 @@ type EndpointId struct {
 	SubscriptionId string
 	ResourceGroup  string
 	ProfileName    string
-	EndpointName   string
+	Name           string
 }
 
-func NewEndpointID(subscriptionId, resourceGroup, profileName, endpointName string) EndpointId {
+func NewEndpointID(subscriptionId, resourceGroup, profileName, name string) EndpointId {
 	return EndpointId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
 		ProfileName:    profileName,
-		EndpointName:   endpointName,
+		Name:           name,
 	}
 }
 
 func (id EndpointId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/endpoints/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ProfileName, id.EndpointName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ProfileName, id.Name)
 }
 
 func EndpointID(input string) (*EndpointId, error) {
@@ -43,7 +43,7 @@ func EndpointID(input string) (*EndpointId, error) {
 	if resourceId.ProfileName, err = id.PopSegment("profiles"); err != nil {
 		return nil, err
 	}
-	if resourceId.EndpointName, err = id.PopSegment("endpoints"); err != nil {
+	if resourceId.Name, err = id.PopSegment("endpoints"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/cdn/parse/endpoint_test.go
+++ b/azurerm/internal/services/cdn/parse/endpoint_test.go
@@ -68,13 +68,13 @@ func TestEndpointID(t *testing.T) {
 		},
 
 		{
-			// missing EndpointName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/",
 			Error: true,
 		},
 
 		{
-			// missing value for EndpointName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/endpoints/",
 			Error: true,
 		},
@@ -86,7 +86,7 @@ func TestEndpointID(t *testing.T) {
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
 				ProfileName:    "profile1",
-				EndpointName:   "endpoint1",
+				Name:           "endpoint1",
 			},
 		},
 
@@ -121,8 +121,8 @@ func TestEndpointID(t *testing.T) {
 		if actual.ProfileName != v.Expected.ProfileName {
 			t.Fatalf("Expected %q but got %q for ProfileName", v.Expected.ProfileName, actual.ProfileName)
 		}
-		if actual.EndpointName != v.Expected.EndpointName {
-			t.Fatalf("Expected %q but got %q for EndpointName", v.Expected.EndpointName, actual.EndpointName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/cdn/parse/profile.go
+++ b/azurerm/internal/services/cdn/parse/profile.go
@@ -11,20 +11,20 @@ import (
 type ProfileId struct {
 	SubscriptionId string
 	ResourceGroup  string
-	ProfileName    string
+	Name           string
 }
 
-func NewProfileID(subscriptionId, resourceGroup, profileName string) ProfileId {
+func NewProfileID(subscriptionId, resourceGroup, name string) ProfileId {
 	return ProfileId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
-		ProfileName:    profileName,
+		Name:           name,
 	}
 }
 
 func (id ProfileId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ProfileName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func ProfileID(input string) (*ProfileId, error) {
@@ -38,7 +38,7 @@ func ProfileID(input string) (*ProfileId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.ProfileName, err = id.PopSegment("profiles"); err != nil {
+	if resourceId.Name, err = id.PopSegment("profiles"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/cdn/parse/profile_test.go
+++ b/azurerm/internal/services/cdn/parse/profile_test.go
@@ -56,13 +56,13 @@ func TestProfileID(t *testing.T) {
 		},
 
 		{
-			// missing ProfileName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/",
 			Error: true,
 		},
 
 		{
-			// missing value for ProfileName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/",
 			Error: true,
 		},
@@ -73,7 +73,7 @@ func TestProfileID(t *testing.T) {
 			Expected: &ProfileId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
-				ProfileName:    "profile1",
+				Name:           "profile1",
 			},
 		},
 
@@ -105,8 +105,8 @@ func TestProfileID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.ProfileName != v.Expected.ProfileName {
-			t.Fatalf("Expected %q but got %q for ProfileName", v.Expected.ProfileName, actual.ProfileName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
@@ -399,13 +399,13 @@ func testCheckAzureRMCdnEndpointExists(resourceName string) resource.TestCheckFu
 			return err
 		}
 
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.ProfileName, id.EndpointName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.ProfileName, id.Name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on cdnEndpointsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: CDN Endpoint %q (resource group: %q) does not exist", id.EndpointName, id.ResourceGroup)
+			return fmt.Errorf("Bad: CDN Endpoint %q (resource group: %q) does not exist", id.Name, id.ResourceGroup)
 		}
 
 		return nil
@@ -457,7 +457,7 @@ func testCheckAzureRMCdnEndpointDestroy(s *terraform.State) error {
 			return err
 		}
 
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.ProfileName, id.EndpointName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.ProfileName, id.Name)
 		if err != nil {
 			return nil
 		}

--- a/azurerm/internal/services/cdn/tests/cdn_profile_resource_test.go
+++ b/azurerm/internal/services/cdn/tests/cdn_profile_resource_test.go
@@ -189,13 +189,13 @@ func testCheckAzureRMCdnProfileExists(resourceName string) resource.TestCheckFun
 			return err
 		}
 
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.ProfileName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on cdnProfilesClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: CDN Profile %q (resource group: %q) does not exist", id.ProfileName, id.ResourceGroup)
+			return fmt.Errorf("Bad: CDN Profile %q (resource group: %q) does not exist", id.Name, id.ResourceGroup)
 		}
 
 		return nil
@@ -215,7 +215,7 @@ func testCheckAzureRMCdnProfileDestroy(s *terraform.State) error {
 		if err != nil {
 			return err
 		}
-		resp, err := conn.Get(ctx, id.ResourceGroup, id.ProfileName)
+		resp, err := conn.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			return nil
 		}

--- a/azurerm/internal/services/cognitive/cognitive_account_resource.go
+++ b/azurerm/internal/services/cognitive/cognitive_account_resource.go
@@ -212,7 +212,7 @@ func resourceArmCognitiveAccountUpdate(d *schema.ResourceData, meta interface{})
 
 	sku, err := expandAccountSkuName(d.Get("sku_name").(string))
 	if err != nil {
-		return fmt.Errorf("error expanding sku_name for Cognitive Account %s (Resource Group %q): %v", id.AccountName, id.ResourceGroup, err)
+		return fmt.Errorf("error expanding sku_name for Cognitive Account %s (Resource Group %q): %v", id.Name, id.ResourceGroup, err)
 	}
 
 	props := cognitiveservices.Account{
@@ -231,8 +231,8 @@ func resourceArmCognitiveAccountUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if _, err = client.Update(ctx, id.ResourceGroup, id.AccountName, props); err != nil {
-		return fmt.Errorf("Error updating Cognitive Services Account %q (Resource Group %q): %+v", id.AccountName, id.ResourceGroup, err)
+	if _, err = client.Update(ctx, id.ResourceGroup, id.Name, props); err != nil {
+		return fmt.Errorf("Error updating Cognitive Services Account %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return resourceArmCognitiveAccountRead(d, meta)
@@ -248,17 +248,17 @@ func resourceArmCognitiveAccountRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	resp, err := client.GetProperties(ctx, id.ResourceGroup, id.AccountName)
+	resp, err := client.GetProperties(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Cognitive Services Account %q was not found in Resource Group %q - removing from state!", id.AccountName, id.ResourceGroup)
+			log.Printf("[DEBUG] Cognitive Services Account %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 		return err
 	}
 
-	d.Set("name", id.AccountName)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("kind", resp.Kind)
 
@@ -277,14 +277,14 @@ func resourceArmCognitiveAccountRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("endpoint", props.Endpoint)
 	}
 
-	keys, err := client.ListKeys(ctx, id.ResourceGroup, id.AccountName)
+	keys, err := client.ListKeys(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Not able to obtain keys for Cognitive Services Account %q in Resource Group %q - removing from state!", id.AccountName, id.ResourceGroup)
+			log.Printf("[DEBUG] Not able to obtain keys for Cognitive Services Account %q in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error obtaining keys for Cognitive Services Account %q in Resource Group %q: %v", id.AccountName, id.ResourceGroup, err)
+		return fmt.Errorf("Error obtaining keys for Cognitive Services Account %q in Resource Group %q: %v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.Set("primary_access_key", keys.Key1)
@@ -303,10 +303,10 @@ func resourceArmCognitiveAccountDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.AccountName)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if !response.WasNotFound(resp.Response) {
-			return fmt.Errorf("Error deleting Cognitive Services Account %q (Resource Group %q): %+v", id.AccountName, id.ResourceGroup, err)
+			return fmt.Errorf("Error deleting Cognitive Services Account %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/cognitive/parse/account.go
+++ b/azurerm/internal/services/cognitive/parse/account.go
@@ -11,20 +11,20 @@ import (
 type AccountId struct {
 	SubscriptionId string
 	ResourceGroup  string
-	AccountName    string
+	Name           string
 }
 
-func NewAccountID(subscriptionId, resourceGroup, accountName string) AccountId {
+func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 	return AccountId{
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
-		AccountName:    accountName,
+		Name:           name,
 	}
 }
 
 func (id AccountId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.CognitiveServices/accounts/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AccountName)
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
 func AccountID(input string) (*AccountId, error) {
@@ -38,7 +38,7 @@ func AccountID(input string) (*AccountId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.AccountName, err = id.PopSegment("accounts"); err != nil {
+	if resourceId.Name, err = id.PopSegment("accounts"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/cognitive/parse/account_test.go
+++ b/azurerm/internal/services/cognitive/parse/account_test.go
@@ -56,13 +56,13 @@ func TestAccountID(t *testing.T) {
 		},
 
 		{
-			// missing AccountName
+			// missing Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.CognitiveServices/",
 			Error: true,
 		},
 
 		{
-			// missing value for AccountName
+			// missing value for Name
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.CognitiveServices/accounts/",
 			Error: true,
 		},
@@ -73,7 +73,7 @@ func TestAccountID(t *testing.T) {
 			Expected: &AccountId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
-				AccountName:    "account1",
+				Name:           "account1",
 			},
 		},
 
@@ -105,8 +105,8 @@ func TestAccountID(t *testing.T) {
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
 			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-		if actual.AccountName != v.Expected.AccountName {
-			t.Fatalf("Expected %q but got %q for AccountName", v.Expected.AccountName, actual.AccountName)
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 	}
 }

--- a/azurerm/internal/services/cognitive/tests/cognitive_account_resource_test.go
+++ b/azurerm/internal/services/cognitive/tests/cognitive_account_resource_test.go
@@ -243,7 +243,7 @@ func testCheckAzureRMAppCognitiveAccountDestroy(s *terraform.State) error {
 			return err
 		}
 
-		resp, err := client.GetProperties(ctx, id.ResourceGroup, id.AccountName)
+		resp, err := client.GetProperties(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if resp.StatusCode != http.StatusNotFound {
 				return fmt.Errorf("Cognitive Services Account still exists:\n%#v", resp)
@@ -272,10 +272,10 @@ func testCheckAzureRMCognitiveAccountExists(resourceName string) resource.TestCh
 			return err
 		}
 
-		resp, err := conn.GetProperties(ctx, id.ResourceGroup, id.AccountName)
+		resp, err := conn.GetProperties(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Cognitive Services Account %q (Resource Group: %q) does not exist", id.AccountName, id.ResourceGroup)
+				return fmt.Errorf("Bad: Cognitive Services Account %q (Resource Group: %q) does not exist", id.Name, id.ResourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on cognitiveAccountsClient: %+v", err)

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -151,10 +151,17 @@ func NewResourceID(typeName, resourceId string) (*ResourceId, error) {
 			}
 
 			if strings.HasSuffix(key, "s") {
-				// remove {Thing}s and make that {Thing}Name
-				rewritten = fmt.Sprintf("%sName", strings.TrimSuffix(key, "s"))
-				segment.FieldName = strings.Title(rewritten)
-				segment.ArgumentName = toCamelCase(rewritten)
+				key = strings.TrimSuffix(key, "s")
+
+				if strings.EqualFold(key, typeName) {
+					segment.FieldName = "Name"
+					segment.ArgumentName = "name"
+				} else {
+					// remove {Thing}s and make that {Thing}Name
+					rewritten = fmt.Sprintf("%sName", key)
+					segment.FieldName = strings.Title(rewritten)
+					segment.ArgumentName = toCamelCase(rewritten)
+				}
 			}
 
 			return segment


### PR DESCRIPTION
This PR/the first commit changes the Resource ID generator slightly so that should the singular segment key match the type name, we'll switch it out for `Name` - meaning that (for example) `CertificateName` for a Batch Certificate becomes `Name` - which better matches the existing convention

The follow up commits then fix up these changes in the existing generated resources