### PR TITLE
Update validation rule for allowed_ips of azurerm_search_service

### DIFF
--- a/azurerm/internal/services/search/resource_arm_search_service.go
+++ b/azurerm/internal/services/search/resource_arm_search_service.go
@@ -115,8 +115,11 @@ func resourceArmSearchService() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validate.IPv4Address,
+					Type: schema.TypeString,
+					ValidateFunc: validation.Any(
+						validate.IPv4Address,
+						validate.CIDR,
+					),
 				},
 			},
 

--- a/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
+++ b/azurerm/internal/services/search/tests/resource_arm_search_service_test.go
@@ -322,7 +322,7 @@ resource "azurerm_search_service" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
 
-  allowed_ips = ["168.1.5.65"]
+  allowed_ips = ["168.1.5.65", "1.2.3.0/24"]
 
   tags = {
     environment = "staging"

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 -> **Note:** `partition_count` and `replica_count` can only be configured when using a `standard` sku.
 
-* `allowed_ips` - (Optional) A list of IPv4 addresses that are allowed access to the search service endpoint. 
+* `allowed_ips` - (Optional) A list of IPv4 addresses or CIDRs that are allowed access to the search service endpoint. 
 
 * `identity` - (Optional) A `identity` block as defined below.
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/9488

--- PASS: TestAccAzureRMSearchService_identity (291.05s)
--- PASS: TestAccAzureRMSearchService_ipRules (552.63s)
--- PASS: TestAccAzureRMSearchService_basic (1222.93s)
--- PASS: TestAccAzureRMSearchService_requiresImport (1500.49s)
--- PASS: TestAccAzureRMSearchService_complete (1505.90s)
--- PASS: TestAccAzureRMSearchService_update (3032.71s)