### PR TITLE
desktopvirtualization: adding a state migration for the new ID format

### DIFF
--- a/azurerm/internal/services/analysisservices/parse/server.go
+++ b/azurerm/internal/services/analysisservices/parse/server.go
@@ -27,6 +27,7 @@ func (id ServerId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ServerID parses a Server ID into an ServerId struct
 func ServerID(input string) (*ServerId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/appconfiguration/parse/configuration_store.go
+++ b/azurerm/internal/services/appconfiguration/parse/configuration_store.go
@@ -27,6 +27,7 @@ func (id ConfigurationStoreId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ConfigurationStoreID parses a ConfigurationStore ID into an ConfigurationStoreId struct
 func ConfigurationStoreID(input string) (*ConfigurationStoreId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/applicationinsights/parse/component.go
+++ b/azurerm/internal/services/applicationinsights/parse/component.go
@@ -27,6 +27,7 @@ func (id ComponentId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ComponentID parses a Component ID into an ComponentId struct
 func ComponentID(input string) (*ComponentId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/applicationinsights/parse/web_test_id.go
+++ b/azurerm/internal/services/applicationinsights/parse/web_test_id.go
@@ -27,6 +27,7 @@ func (id WebTestId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// WebTestID parses a WebTest ID into an WebTestId struct
 func WebTestID(input string) (*WebTestId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/appplatform/parse/spring_cloud_app.go
+++ b/azurerm/internal/services/appplatform/parse/spring_cloud_app.go
@@ -29,6 +29,7 @@ func (id SpringCloudAppId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.SpringName, id.AppName)
 }
 
+// SpringCloudAppID parses a SpringCloudApp ID into an SpringCloudAppId struct
 func SpringCloudAppID(input string) (*SpringCloudAppId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/appplatform/parse/spring_cloud_certificate.go
+++ b/azurerm/internal/services/appplatform/parse/spring_cloud_certificate.go
@@ -29,6 +29,7 @@ func (id SpringCloudCertificateId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.SpringName, id.CertificateName)
 }
 
+// SpringCloudCertificateID parses a SpringCloudCertificate ID into an SpringCloudCertificateId struct
 func SpringCloudCertificateID(input string) (*SpringCloudCertificateId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/appplatform/parse/spring_cloud_service.go
+++ b/azurerm/internal/services/appplatform/parse/spring_cloud_service.go
@@ -27,6 +27,7 @@ func (id SpringCloudServiceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.SpringName)
 }
 
+// SpringCloudServiceID parses a SpringCloudService ID into an SpringCloudServiceId struct
 func SpringCloudServiceID(input string) (*SpringCloudServiceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/attestation/parse/provider.go
+++ b/azurerm/internal/services/attestation/parse/provider.go
@@ -27,6 +27,7 @@ func (id ProviderId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AttestationProviderName)
 }
 
+// ProviderID parses a Provider ID into an ProviderId struct
 func ProviderID(input string) (*ProviderId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/automation/parse/connection.go
+++ b/azurerm/internal/services/automation/parse/connection.go
@@ -29,6 +29,7 @@ func (id ConnectionId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AutomationAccountName, id.Name)
 }
 
+// ConnectionID parses a Connection ID into an ConnectionId struct
 func ConnectionID(input string) (*ConnectionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/batch/parse/account.go
+++ b/azurerm/internal/services/batch/parse/account.go
@@ -27,6 +27,7 @@ func (id AccountId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName)
 }
 
+// AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/batch/parse/application.go
+++ b/azurerm/internal/services/batch/parse/application.go
@@ -29,6 +29,7 @@ func (id ApplicationId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.Name)
 }
 
+// ApplicationID parses a Application ID into an ApplicationId struct
 func ApplicationID(input string) (*ApplicationId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/batch/parse/certificate.go
+++ b/azurerm/internal/services/batch/parse/certificate.go
@@ -29,6 +29,7 @@ func (id CertificateId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.Name)
 }
 
+// CertificateID parses a Certificate ID into an CertificateId struct
 func CertificateID(input string) (*CertificateId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/batch/parse/pool.go
+++ b/azurerm/internal/services/batch/parse/pool.go
@@ -29,6 +29,7 @@ func (id PoolId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BatchAccountName, id.Name)
 }
 
+// PoolID parses a Pool ID into an PoolId struct
 func PoolID(input string) (*PoolId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cdn/parse/endpoint.go
+++ b/azurerm/internal/services/cdn/parse/endpoint.go
@@ -29,6 +29,7 @@ func (id EndpointId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ProfileName, id.Name)
 }
 
+// EndpointID parses a Endpoint ID into an EndpointId struct
 func EndpointID(input string) (*EndpointId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cdn/parse/profile.go
+++ b/azurerm/internal/services/cdn/parse/profile.go
@@ -27,6 +27,7 @@ func (id ProfileId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ProfileID parses a Profile ID into an ProfileId struct
 func ProfileID(input string) (*ProfileId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cognitive/parse/account.go
+++ b/azurerm/internal/services/cognitive/parse/account.go
@@ -27,6 +27,7 @@ func (id AccountId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/availability_set.go
+++ b/azurerm/internal/services/compute/parse/availability_set.go
@@ -27,6 +27,7 @@ func (id AvailabilitySetId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// AvailabilitySetID parses a AvailabilitySet ID into an AvailabilitySetId struct
 func AvailabilitySetID(input string) (*AvailabilitySetId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/dedicated_host.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host.go
@@ -29,6 +29,7 @@ func (id DedicatedHostId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.HostGroupName, id.HostName)
 }
 
+// DedicatedHostID parses a DedicatedHost ID into an DedicatedHostId struct
 func DedicatedHostID(input string) (*DedicatedHostId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/dedicated_host_group.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_group.go
@@ -27,6 +27,7 @@ func (id DedicatedHostGroupId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.HostGroupName)
 }
 
+// DedicatedHostGroupID parses a DedicatedHostGroup ID into an DedicatedHostGroupId struct
 func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/disk_encryption_set.go
+++ b/azurerm/internal/services/compute/parse/disk_encryption_set.go
@@ -27,6 +27,7 @@ func (id DiskEncryptionSetId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// DiskEncryptionSetID parses a DiskEncryptionSet ID into an DiskEncryptionSetId struct
 func DiskEncryptionSetID(input string) (*DiskEncryptionSetId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/image.go
+++ b/azurerm/internal/services/compute/parse/image.go
@@ -27,6 +27,7 @@ func (id ImageId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ImageID parses a Image ID into an ImageId struct
 func ImageID(input string) (*ImageId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/managed_disk.go
+++ b/azurerm/internal/services/compute/parse/managed_disk.go
@@ -27,6 +27,7 @@ func (id ManagedDiskId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DiskName)
 }
 
+// ManagedDiskID parses a ManagedDisk ID into an ManagedDiskId struct
 func ManagedDiskID(input string) (*ManagedDiskId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/proximity_placement_group.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group.go
@@ -27,6 +27,7 @@ func (id ProximityPlacementGroupId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ProximityPlacementGroupID parses a ProximityPlacementGroup ID into an ProximityPlacementGroupId struct
 func ProximityPlacementGroupID(input string) (*ProximityPlacementGroupId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/shared_image.go
+++ b/azurerm/internal/services/compute/parse/shared_image.go
@@ -29,6 +29,7 @@ func (id SharedImageId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.GalleryName, id.ImageName)
 }
 
+// SharedImageID parses a SharedImage ID into an SharedImageId struct
 func SharedImageID(input string) (*SharedImageId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/shared_image_gallery.go
+++ b/azurerm/internal/services/compute/parse/shared_image_gallery.go
@@ -27,6 +27,7 @@ func (id SharedImageGalleryId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.GalleryName)
 }
 
+// SharedImageGalleryID parses a SharedImageGallery ID into an SharedImageGalleryId struct
 func SharedImageGalleryID(input string) (*SharedImageGalleryId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/shared_image_version.go
+++ b/azurerm/internal/services/compute/parse/shared_image_version.go
@@ -31,6 +31,7 @@ func (id SharedImageVersionId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.GalleryName, id.ImageName, id.VersionName)
 }
 
+// SharedImageVersionID parses a SharedImageVersion ID into an SharedImageVersionId struct
 func SharedImageVersionID(input string) (*SharedImageVersionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine.go
@@ -27,6 +27,7 @@ func (id VirtualMachineId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// VirtualMachineID parses a VirtualMachine ID into an VirtualMachineId struct
 func VirtualMachineID(input string) (*VirtualMachineId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_extension.go
@@ -29,6 +29,7 @@ func (id VirtualMachineExtensionId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineName, id.ExtensionName)
 }
 
+// VirtualMachineExtensionID parses a VirtualMachineExtension ID into an VirtualMachineExtensionId struct
 func VirtualMachineExtensionID(input string) (*VirtualMachineExtensionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
@@ -27,6 +27,7 @@ func (id VirtualMachineScaleSetId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// VirtualMachineScaleSetID parses a VirtualMachineScaleSet ID into an VirtualMachineScaleSetId struct
 func VirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
@@ -29,6 +29,7 @@ func (id VirtualMachineScaleSetExtensionId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualMachineScaleSetName, id.ExtensionName)
 }
 
+// VirtualMachineScaleSetExtensionID parses a VirtualMachineScaleSetExtension ID into an VirtualMachineScaleSetExtensionId struct
 func VirtualMachineScaleSetExtensionID(input string) (*VirtualMachineScaleSetExtensionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/containers/parse/cluster.go
+++ b/azurerm/internal/services/containers/parse/cluster.go
@@ -27,6 +27,7 @@ func (id ClusterId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ManagedClusterName)
 }
 
+// ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/containers/parse/node_pool.go
+++ b/azurerm/internal/services/containers/parse/node_pool.go
@@ -29,6 +29,7 @@ func (id NodePoolId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ManagedClusterName, id.AgentPoolName)
 }
 
+// NodePoolID parses a NodePool ID into an NodePoolId struct
 func NodePoolID(input string) (*NodePoolId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/cassandra_keyspace.go
+++ b/azurerm/internal/services/cosmos/parse/cassandra_keyspace.go
@@ -29,6 +29,7 @@ func (id CassandraKeyspaceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.Name)
 }
 
+// CassandraKeyspaceID parses a CassandraKeyspace ID into an CassandraKeyspaceId struct
 func CassandraKeyspaceID(input string) (*CassandraKeyspaceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/database_account.go
+++ b/azurerm/internal/services/cosmos/parse/database_account.go
@@ -27,6 +27,7 @@ func (id DatabaseAccountId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// DatabaseAccountID parses a DatabaseAccount ID into an DatabaseAccountId struct
 func DatabaseAccountID(input string) (*DatabaseAccountId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/gremlin_database.go
+++ b/azurerm/internal/services/cosmos/parse/gremlin_database.go
@@ -29,6 +29,7 @@ func (id GremlinDatabaseId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.Name)
 }
 
+// GremlinDatabaseID parses a GremlinDatabase ID into an GremlinDatabaseId struct
 func GremlinDatabaseID(input string) (*GremlinDatabaseId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/gremlin_graph.go
+++ b/azurerm/internal/services/cosmos/parse/gremlin_graph.go
@@ -31,6 +31,7 @@ func (id GremlinGraphId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.GremlinDatabaseName, id.GraphName)
 }
 
+// GremlinGraphID parses a GremlinGraph ID into an GremlinGraphId struct
 func GremlinGraphID(input string) (*GremlinGraphId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/mongodb_collection.go
+++ b/azurerm/internal/services/cosmos/parse/mongodb_collection.go
@@ -31,6 +31,7 @@ func (id MongodbCollectionId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.MongodbDatabaseName, id.CollectionName)
 }
 
+// MongodbCollectionID parses a MongodbCollection ID into an MongodbCollectionId struct
 func MongodbCollectionID(input string) (*MongodbCollectionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/mongodb_database.go
+++ b/azurerm/internal/services/cosmos/parse/mongodb_database.go
@@ -29,6 +29,7 @@ func (id MongodbDatabaseId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.Name)
 }
 
+// MongodbDatabaseID parses a MongodbDatabase ID into an MongodbDatabaseId struct
 func MongodbDatabaseID(input string) (*MongodbDatabaseId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/sql_container.go
+++ b/azurerm/internal/services/cosmos/parse/sql_container.go
@@ -31,6 +31,7 @@ func (id SqlContainerId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.SqlDatabaseName, id.ContainerName)
 }
 
+// SqlContainerID parses a SqlContainer ID into an SqlContainerId struct
 func SqlContainerID(input string) (*SqlContainerId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/sql_database.go
+++ b/azurerm/internal/services/cosmos/parse/sql_database.go
@@ -29,6 +29,7 @@ func (id SqlDatabaseId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.Name)
 }
 
+// SqlDatabaseID parses a SqlDatabase ID into an SqlDatabaseId struct
 func SqlDatabaseID(input string) (*SqlDatabaseId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/sql_stored_procedure.go
+++ b/azurerm/internal/services/cosmos/parse/sql_stored_procedure.go
@@ -33,6 +33,7 @@ func (id SqlStoredProcedureId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.SqlDatabaseName, id.ContainerName, id.StoredProcedureName)
 }
 
+// SqlStoredProcedureID parses a SqlStoredProcedure ID into an SqlStoredProcedureId struct
 func SqlStoredProcedureID(input string) (*SqlStoredProcedureId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/cosmos/parse/table.go
+++ b/azurerm/internal/services/cosmos/parse/table.go
@@ -29,6 +29,7 @@ func (id TableId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.Name)
 }
 
+// TableID parses a Table ID into an TableId struct
 func TableID(input string) (*TableId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/customproviders/parse/resource_provider.go
+++ b/azurerm/internal/services/customproviders/parse/resource_provider.go
@@ -27,6 +27,7 @@ func (id ResourceProviderId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ResourceProviderID parses a ResourceProvider ID into an ResourceProviderId struct
 func ResourceProviderID(input string) (*ResourceProviderId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/databasemigration/parse/project.go
+++ b/azurerm/internal/services/databasemigration/parse/project.go
@@ -29,6 +29,7 @@ func (id ProjectId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ServiceName, id.Name)
 }
 
+// ProjectID parses a Project ID into an ProjectId struct
 func ProjectID(input string) (*ProjectId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/databasemigration/parse/service.go
+++ b/azurerm/internal/services/databasemigration/parse/service.go
@@ -27,6 +27,7 @@ func (id ServiceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ServiceID parses a Service ID into an ServiceId struct
 func ServiceID(input string) (*ServiceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/databricks/parse/workspace.go
+++ b/azurerm/internal/services/databricks/parse/workspace.go
@@ -27,6 +27,7 @@ func (id WorkspaceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/datafactory/parse/integration_runtime.go
+++ b/azurerm/internal/services/datafactory/parse/integration_runtime.go
@@ -29,6 +29,7 @@ func (id IntegrationRuntimeId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.FactoryName, id.Name)
 }
 
+// IntegrationRuntimeID parses a IntegrationRuntime ID into an IntegrationRuntimeId struct
 func IntegrationRuntimeID(input string) (*IntegrationRuntimeId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/datafactory/parse/linked_service.go
+++ b/azurerm/internal/services/datafactory/parse/linked_service.go
@@ -29,6 +29,7 @@ func (id LinkedServiceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.FactoryName, id.Name)
 }
 
+// LinkedServiceID parses a LinkedService ID into an LinkedServiceId struct
 func LinkedServiceID(input string) (*LinkedServiceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/datalake/parse/account.go
+++ b/azurerm/internal/services/datalake/parse/account.go
@@ -27,6 +27,7 @@ func (id AccountId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/datashare/parse/account.go
+++ b/azurerm/internal/services/datashare/parse/account.go
@@ -27,6 +27,7 @@ func (id AccountId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// AccountID parses a Account ID into an AccountId struct
 func AccountID(input string) (*AccountId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/datashare/parse/data_set.go
+++ b/azurerm/internal/services/datashare/parse/data_set.go
@@ -31,6 +31,7 @@ func (id DataSetId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AccountName, id.ShareName, id.Name)
 }
 
+// DataSetID parses a DataSet ID into an DataSetId struct
 func DataSetID(input string) (*DataSetId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/datashare/parse/share.go
+++ b/azurerm/internal/services/datashare/parse/share.go
@@ -29,6 +29,7 @@ func (id ShareId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.AccountName, id.Name)
 }
 
+// ShareID parses a Share ID into an ShareId struct
 func ShareID(input string) (*ShareId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/desktopvirtualization/migration/application_group_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/application_group_v0.go
@@ -50,7 +50,7 @@ func ApplicationGroupUpgradeV0Schema() *schema.Resource {
 
 func ApplicationGroupUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	oldId := rawState["id"].(string)
-	id, err := parse.ApplicationGroupID(oldId)
+	id, err := parse.ApplicationGroupIDInsensitively(oldId)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func ApplicationGroupUpgradeV0ToV1(rawState map[string]interface{}, _ interface{
 	rawState["id"] = newId
 
 	oldHostPoolId := rawState["host_pool_id"].(string)
-	hostPoolId, err := parse.HostPoolID(oldHostPoolId)
+	hostPoolId, err := parse.HostPoolIDInsensitively(oldHostPoolId)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/services/desktopvirtualization/migration/application_group_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/application_group_v0.go
@@ -1,0 +1,71 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+)
+
+func ApplicationGroupUpgradeV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"host_pool_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"friendly_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func ApplicationGroupUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+	id, err := parse.ApplicationGroupID(oldId)
+	if err != nil {
+		return nil, err
+	}
+	newId := id.ID("")
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+	rawState["id"] = newId
+
+	oldHostPoolId := rawState["host_pool_id"].(string)
+	hostPoolId, err := parse.HostPoolID(oldHostPoolId)
+	if err != nil {
+		return nil, err
+	}
+	newHostPoolId := hostPoolId.ID("")
+	log.Printf("[DEBUG] Updating Host Pool ID from %q to %q", oldHostPoolId, newHostPoolId)
+	rawState["host_pool_id"] = newHostPoolId
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/desktopvirtualization/migration/host_pool_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/host_pool_v0.go
@@ -102,7 +102,7 @@ func HostPoolUpgradeV0Schema() *schema.Resource {
 func HostPoolUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	oldId := rawState["id"].(string)
 
-	id, err := parse.HostPoolID(oldId)
+	id, err := parse.HostPoolIDInsensitively(oldId)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/services/desktopvirtualization/migration/host_pool_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/host_pool_v0.go
@@ -1,0 +1,115 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+)
+
+func HostPoolUpgradeV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"load_balancer_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"friendly_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"validate_environment": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"personal_desktop_assignment_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"maximum_sessions_allowed": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  999999,
+			},
+
+			"preferred_app_group_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Preferred App Group type to display",
+			},
+
+			"registration_info": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"expiration_date": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"reset_token": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+
+						"token": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Computed:  true,
+						},
+					},
+				},
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func HostPoolUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+
+	id, err := parse.HostPoolID(oldId)
+	if err != nil {
+		return nil, err
+	}
+	newId := id.ID("")
+
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+	rawState["id"] = newId
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/desktopvirtualization/migration/workspace_application_group_association_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/workspace_application_group_association_v0.go
@@ -28,7 +28,7 @@ func WorkspaceApplicationGroupAssociationUpgradeV0Schema() *schema.Resource {
 func WorkspaceApplicationGroupAssociationUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	oldId := rawState["id"].(string)
 
-	id, err := parse.WorkspaceApplicationGroupAssociationID(oldId)
+	id, err := parse.WorkspaceApplicationGroupAssociationIDInsensitively(oldId)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/services/desktopvirtualization/migration/workspace_application_group_association_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/workspace_application_group_association_v0.go
@@ -1,0 +1,51 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+)
+
+func WorkspaceApplicationGroupAssociationUpgradeV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"application_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func WorkspaceApplicationGroupAssociationUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+
+	id, err := parse.WorkspaceApplicationGroupAssociationID(oldId)
+	if err != nil {
+		return nil, err
+	}
+	newId := id.ID("")
+
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+	rawState["id"] = newId
+
+	oldApplicationGroupId := rawState["application_group_id"].(string)
+	newApplicationGroupId := id.ApplicationGroup.ID("")
+	log.Printf("[DEBUG] Updating Application Group ID from %q to %q", oldApplicationGroupId, newApplicationGroupId)
+	rawState["application_group_id"] = newApplicationGroupId
+
+	oldWorkspaceId := rawState["workspace_id"].(string)
+	newWorkspaceId := id.Workspace.ID("")
+	log.Printf("[DEBUG] Updating Workspace ID from %q to %q", oldWorkspaceId, newWorkspaceId)
+	rawState["workspace_id"] = newWorkspaceId
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/desktopvirtualization/migration/workspace_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/workspace_v0.go
@@ -1,0 +1,53 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+)
+
+func WorkspaceUpgradeV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"friendly_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func WorkspaceUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+
+	id, err := parse.WorkspaceID(oldId)
+	if err != nil {
+		return nil, err
+	}
+	newId := id.ID("")
+
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+	rawState["id"] = newId
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/desktopvirtualization/parse/application_group.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/application_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -23,7 +24,7 @@ func NewApplicationGroupID(subscriptionId, resourceGroup, name string) Applicati
 }
 
 func (id ApplicationGroupId) ID(_ string) string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/applicationgroups/%s"
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/applicationGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
@@ -38,7 +39,15 @@ func ApplicationGroupID(input string) (*ApplicationGroupId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.Name, err = id.PopSegment("applicationgroups"); err != nil {
+	applicationGroupsKey := "applicationGroups"
+	// find the correct casing for the `applicationGroups` segment
+	for key := range id.Path {
+		if strings.EqualFold(key, applicationGroupsKey) {
+			applicationGroupsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(applicationGroupsKey); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/desktopvirtualization/parse/application_group.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/application_group.go
@@ -28,6 +28,7 @@ func (id ApplicationGroupId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ApplicationGroupID parses a ApplicationGroup ID into an ApplicationGroupId struct
 func ApplicationGroupID(input string) (*ApplicationGroupId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
@@ -39,8 +40,36 @@ func ApplicationGroupID(input string) (*ApplicationGroupId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
+	if resourceId.Name, err = id.PopSegment("applicationGroups"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ApplicationGroupIDInsensitively parses an ApplicationGroup ID into an ApplicationGroupId struct, insensitively
+// This should only be used to parse an ID for rewriting, the ApplicationGroupID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func ApplicationGroupIDInsensitively(input string) (*ApplicationGroupId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ApplicationGroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	// find the correct casing for the 'applicationGroups' segment
 	applicationGroupsKey := "applicationGroups"
-	// find the correct casing for the `applicationGroups` segment
 	for key := range id.Path {
 		if strings.EqualFold(key, applicationGroupsKey) {
 			applicationGroupsKey = key

--- a/azurerm/internal/services/desktopvirtualization/parse/application_group_test.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/application_group_test.go
@@ -12,7 +12,7 @@ var _ resourceid.Formatter = ApplicationGroupId{}
 
 func TestApplicationGroupIDFormatter(t *testing.T) {
 	actual := NewApplicationGroupID("12345678-1234-9876-4563-123456789012", "resGroup1", "applicationGroup1").ID("")
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/applicationGroup1"
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/applicationGroup1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -63,13 +63,13 @@ func TestApplicationGroupID(t *testing.T) {
 
 		{
 			// missing value for Name
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/applicationGroup1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/applicationGroup1",
 			Expected: &ApplicationGroupId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
@@ -88,6 +88,123 @@ func TestApplicationGroupID(t *testing.T) {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
 		actual, err := ApplicationGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestApplicationGroupIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ApplicationGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/applicationGroup1",
+			Expected: &ApplicationGroupId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "applicationGroup1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/applicationGroup1",
+			Expected: &ApplicationGroupId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "applicationGroup1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/APPLICATIONGROUPS/applicationGroup1",
+			Expected: &ApplicationGroupId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "applicationGroup1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/ApPlIcAtIoNgRoUpS/applicationGroup1",
+			Expected: &ApplicationGroupId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "applicationGroup1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ApplicationGroupIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -23,7 +24,7 @@ func NewHostPoolID(subscriptionId, resourceGroup, name string) HostPoolId {
 }
 
 func (id HostPoolId) ID(_ string) string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/hostpools/%s"
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/hostPools/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
@@ -38,7 +39,15 @@ func HostPoolID(input string) (*HostPoolId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	if resourceId.Name, err = id.PopSegment("hostpools"); err != nil {
+	// find the correct casing for the `hostPools` segment
+	hostPoolsKey := "hostPools"
+	for key := range id.Path {
+		if strings.EqualFold(key, hostPoolsKey) {
+			hostPoolsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(hostPoolsKey); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
@@ -28,6 +28,7 @@ func (id HostPoolId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// HostPoolID parses a HostPool ID into an HostPoolId struct
 func HostPoolID(input string) (*HostPoolId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
@@ -39,7 +40,35 @@ func HostPoolID(input string) (*HostPoolId, error) {
 		ResourceGroup:  id.ResourceGroup,
 	}
 
-	// find the correct casing for the `hostPools` segment
+	if resourceId.Name, err = id.PopSegment("hostPools"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// HostPoolIDInsensitively parses an HostPool ID into an HostPoolId struct, insensitively
+// This should only be used to parse an ID for rewriting, the HostPoolID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func HostPoolIDInsensitively(input string) (*HostPoolId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := HostPoolId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	// find the correct casing for the 'hostPools' segment
 	hostPoolsKey := "hostPools"
 	for key := range id.Path {
 		if strings.EqualFold(key, hostPoolsKey) {

--- a/azurerm/internal/services/desktopvirtualization/parse/host_pool_test.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/host_pool_test.go
@@ -12,7 +12,7 @@ var _ resourceid.Formatter = HostPoolId{}
 
 func TestHostPoolIDFormatter(t *testing.T) {
 	actual := NewHostPoolID("12345678-1234-9876-4563-123456789012", "resGroup1", "pool1").ID("")
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1"
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/pool1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -63,13 +63,13 @@ func TestHostPoolID(t *testing.T) {
 
 		{
 			// missing value for Name
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/pool1",
 			Expected: &HostPoolId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
@@ -88,6 +88,123 @@ func TestHostPoolID(t *testing.T) {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
 		actual, err := HostPoolID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestHostPoolIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *HostPoolId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/pool1",
+			Expected: &HostPoolId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "pool1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1",
+			Expected: &HostPoolId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "pool1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/HOSTPOOLS/pool1",
+			Expected: &HostPoolId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "pool1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/HoStPoOlS/pool1",
+			Expected: &HostPoolId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "pool1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := HostPoolIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/desktopvirtualization/parse/workspace.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/workspace.go
@@ -27,6 +27,7 @@ func (id WorkspaceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// WorkspaceID parses a Workspace ID into an WorkspaceId struct
 func WorkspaceID(input string) (*WorkspaceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
@@ -44,3 +44,25 @@ func WorkspaceApplicationGroupAssociationID(input string) (*WorkspaceApplication
 		ApplicationGroup: *applicationGroupId,
 	}, nil
 }
+
+func WorkspaceApplicationGroupAssociationIDInsensitively(input string) (*WorkspaceApplicationGroupAssociationId, error) {
+	segments := strings.Split(input, "|")
+	if len(segments) != 2 {
+		return nil, fmt.Errorf("expected an ID in the format {workspaceID}|{applicationGroupID} but got %q", input)
+	}
+
+	workspaceId, err := WorkspaceID(segments[0])
+	if err != nil {
+		return nil, fmt.Errorf("parsing Workspace ID for Workspace/Application Group Association %q: %+v", segments[0], err)
+	}
+
+	applicationGroupId, err := ApplicationGroupIDInsensitively(segments[1])
+	if err != nil {
+		return nil, fmt.Errorf("parsing Application Group ID for Workspace/Application Group Association %q: %+v", segments[1], err)
+	}
+
+	return &WorkspaceApplicationGroupAssociationId{
+		Workspace:        *workspaceId,
+		ApplicationGroup: *applicationGroupId,
+	}, nil
+}

--- a/azurerm/internal/services/desktopvirtualization/resourceids.go
+++ b/azurerm/internal/services/desktopvirtualization/resourceids.go
@@ -1,5 +1,7 @@
 package desktopvirtualization
 
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ApplicationGroup -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/applicationGroup1
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=HostPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1
+// @tombuildsstuff: temporarily disabled until insensitive rewriting is supported
+////go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ApplicationGroup -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/applicationGroup1
+////go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=HostPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1
+
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Workspace -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1

--- a/azurerm/internal/services/desktopvirtualization/resourceids.go
+++ b/azurerm/internal/services/desktopvirtualization/resourceids.go
@@ -1,7 +1,5 @@
 package desktopvirtualization
 
-// @tombuildsstuff: temporarily disabled until insensitive rewriting is supported
-////go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ApplicationGroup -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationgroups/applicationGroup1
-////go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=HostPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostpools/pool1
-
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ApplicationGroup -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/applicationGroup1 -rewrite=true
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=HostPool -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/hostPools/pool1 -rewrite=true
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Workspace -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.DesktopVirtualization/workspaces/workspace1

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -190,7 +190,8 @@ func resourceArmVirtualDesktopApplicationGroupRead(d *schema.ResourceData, meta 
 
 		hostPoolIdStr := ""
 		if props.HostPoolArmPath != nil {
-			hostPoolId, err := parse.HostPoolID(*props.HostPoolArmPath)
+			// TODO: raise an API bug
+			hostPoolId, err := parse.HostPoolIDInsensitively(*props.HostPoolArmPath)
 			if err != nil {
 				return fmt.Errorf("parsing Host Pool ID %q: %+v", *props.HostPoolArmPath, err)
 			}

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -118,7 +118,7 @@ func resourceArmVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceDat
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewApplicationGroupID(subscriptionId, resourceGroup, name)
+	resourceId := parse.NewApplicationGroupID(subscriptionId, resourceGroup, name).ID("")
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
@@ -128,7 +128,7 @@ func resourceArmVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceDat
 		}
 
 		if existing.ApplicationGroupProperties != nil {
-			return tf.ImportAsExistsError("azurerm_virtual_desktop_application_group", id.ID(""))
+			return tf.ImportAsExistsError("azurerm_virtual_desktop_application_group", resourceId)
 		}
 	}
 
@@ -150,8 +150,7 @@ func resourceArmVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceDat
 		return fmt.Errorf("creating Virtual Desktop Application Group %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(id.ID(""))
-
+	d.SetId(resourceId)
 	return resourceArmVirtualDesktopApplicationGroupRead(d, meta)
 }
 

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -41,6 +42,15 @@ func resourceArmVirtualDesktopApplicationGroup() *schema.Resource {
 			_, err := parse.ApplicationGroupID(id)
 			return err
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    migration.ApplicationGroupUpgradeV0Schema().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.ApplicationGroupUpgradeV0ToV1,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -37,6 +38,15 @@ func resourceArmVirtualDesktopHostPool() *schema.Resource {
 			_, err := parse.HostPoolID(id)
 			return err
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    migration.HostPoolUpgradeV0Schema().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.HostPoolUpgradeV0ToV1,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -171,7 +171,7 @@ func resourceArmVirtualDesktopHostPoolCreateUpdate(d *schema.ResourceData, meta 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	id := parse.NewHostPoolID(subscriptionId, resourceGroup, name)
+	resourceId := parse.NewHostPoolID(subscriptionId, resourceGroup, name).ID("")
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
@@ -181,7 +181,7 @@ func resourceArmVirtualDesktopHostPoolCreateUpdate(d *schema.ResourceData, meta 
 		}
 
 		if existing.HostPoolProperties != nil {
-			return tf.ImportAsExistsError("azurerm_virtual_desktop_host_pool", id.ID(""))
+			return tf.ImportAsExistsError("azurerm_virtual_desktop_host_pool", resourceId)
 		}
 	}
 
@@ -208,7 +208,7 @@ func resourceArmVirtualDesktopHostPoolCreateUpdate(d *schema.ResourceData, meta 
 		return fmt.Errorf("Creating Virtual Desktop Host Pool %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(id.ID(""))
+	d.SetId(resourceId)
 
 	return resourceArmVirtualDesktopHostPoolRead(d, meta)
 }

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/validate"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -35,6 +36,15 @@ func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociation() *schema.Res
 			_, err := parse.WorkspaceApplicationGroupAssociationID(id)
 			return err
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    migration.WorkspaceApplicationGroupAssociationUpgradeV0Schema().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.WorkspaceApplicationGroupAssociationUpgradeV0ToV1,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"workspace_id": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -79,7 +79,7 @@ func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *sche
 	if err != nil {
 		return err
 	}
-	associationId := parse.NewWorkspaceApplicationGroupAssociationId(*workspaceId, *applicationGroupId)
+	associationId := parse.NewWorkspaceApplicationGroupAssociationId(*workspaceId, *applicationGroupId).ID("")
 
 	locks.ByName(workspaceId.Name, workspaceResourceType)
 	defer locks.UnlockByName(workspaceId.Name, workspaceResourceType)
@@ -103,7 +103,7 @@ func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *sche
 
 	applicationGroupIdStr := applicationGroupId.ID(subscriptionId)
 	if associationExists(workspace.WorkspaceProperties, applicationGroupIdStr) {
-		return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace_application_group_association", associationId.ID(""))
+		return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace_application_group_association", associationId)
 	}
 	applicationGroupAssociations = append(applicationGroupAssociations, applicationGroupIdStr)
 
@@ -113,13 +113,12 @@ func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *sche
 		return fmt.Errorf("creating association between Virtual Desktop Workspace %q (Resource Group %q) and Application Group %q (Resource Group %q): %+v", workspaceId.Name, workspaceId.ResourceGroup, applicationGroupId.Name, applicationGroupId.ResourceGroup, err)
 	}
 
-	d.SetId(associationId.ID(""))
+	d.SetId(associationId)
 	return resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationRead(d, meta)
 }
 
 func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DesktopVirtualization.WorkspacesClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -139,7 +138,7 @@ func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationRead(d *schema
 		return fmt.Errorf("retrieving Virtual Desktop Desktop Workspace %q (Resource Group %q): %+v", id.Workspace.Name, id.Workspace.ResourceGroup, err)
 	}
 
-	applicationGroupId := id.ApplicationGroup.ID(subscriptionId)
+	applicationGroupId := id.ApplicationGroup.ID("")
 	exists := associationExists(workspace.WorkspaceProperties, applicationGroupId)
 	if !exists {
 		log.Printf("[DEBUG] Association between Virtual Desktop Workspace %q (Resource Group %q) and Application Group %q (Resource Group %q) was not found - removing from state!", id.Workspace.Name, id.Workspace.ResourceGroup, id.ApplicationGroup.Name, id.ApplicationGroup.ResourceGroup)
@@ -147,7 +146,7 @@ func resourceArmVirtualDesktopWorkspaceApplicationGroupAssociationRead(d *schema
 		return nil
 	}
 
-	d.Set("workspace_id", id.Workspace.ID(subscriptionId))
+	d.Set("workspace_id", id.Workspace.ID(""))
 	d.Set("application_group_id", applicationGroupId)
 
 	return nil

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -39,6 +40,15 @@ func resourceArmDesktopVirtualizationWorkspace() *schema.Resource {
 			_, err := parse.WorkspaceID(id)
 			return err
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    migration.WorkspaceUpgradeV0Schema().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.WorkspaceUpgradeV0ToV1,
+				Version: 0,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
@@ -90,8 +90,7 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *schema.ResourceDat
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	id := parse.NewWorkspaceID(subscriptionId, resourceGroup, name)
-
+	resourceId := parse.NewWorkspaceID(subscriptionId, resourceGroup, name).ID("")
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
@@ -101,7 +100,7 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *schema.ResourceDat
 		}
 
 		if existing.WorkspaceProperties != nil {
-			return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace", id.ID(""))
+			return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace", resourceId)
 		}
 	}
 
@@ -121,7 +120,7 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *schema.ResourceDat
 		return fmt.Errorf("creating Virtual Desktop Workspace %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(id.ID(""))
+	d.SetId(resourceId)
 
 	return resourceArmDesktopVirtualizationWorkspaceRead(d, meta)
 }

--- a/azurerm/internal/services/devspace/parse/controller.go
+++ b/azurerm/internal/services/devspace/parse/controller.go
@@ -27,6 +27,7 @@ func (id ControllerId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ControllerID parses a Controller ID into an ControllerId struct
 func ControllerID(input string) (*ControllerId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/devtestlabs/parse/schedule.go
+++ b/azurerm/internal/services/devtestlabs/parse/schedule.go
@@ -27,6 +27,7 @@ func (id ScheduleId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ScheduleID parses a Schedule ID into an ScheduleId struct
 func ScheduleID(input string) (*ScheduleId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/digitaltwins/parse/digital_twins_instance.go
+++ b/azurerm/internal/services/digitaltwins/parse/digital_twins_instance.go
@@ -27,6 +27,7 @@ func (id DigitalTwinsInstanceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// DigitalTwinsInstanceID parses a DigitalTwinsInstance ID into an DigitalTwinsInstanceId struct
 func DigitalTwinsInstanceID(input string) (*DigitalTwinsInstanceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/a_record.go
+++ b/azurerm/internal/services/dns/parse/a_record.go
@@ -29,6 +29,7 @@ func (id ARecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.AName)
 }
 
+// ARecordID parses a ARecord ID into an ARecordId struct
 func ARecordID(input string) (*ARecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/aaaa_record.go
+++ b/azurerm/internal/services/dns/parse/aaaa_record.go
@@ -29,6 +29,7 @@ func (id AaaaRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.AAAAName)
 }
 
+// AaaaRecordID parses a AaaaRecord ID into an AaaaRecordId struct
 func AaaaRecordID(input string) (*AaaaRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/caa_record.go
+++ b/azurerm/internal/services/dns/parse/caa_record.go
@@ -29,6 +29,7 @@ func (id CaaRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.CAAName)
 }
 
+// CaaRecordID parses a CaaRecord ID into an CaaRecordId struct
 func CaaRecordID(input string) (*CaaRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/cname_record.go
+++ b/azurerm/internal/services/dns/parse/cname_record.go
@@ -29,6 +29,7 @@ func (id CnameRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.CNAMEName)
 }
 
+// CnameRecordID parses a CnameRecord ID into an CnameRecordId struct
 func CnameRecordID(input string) (*CnameRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/dns_zone.go
+++ b/azurerm/internal/services/dns/parse/dns_zone.go
@@ -27,6 +27,7 @@ func (id DnsZoneId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// DnsZoneID parses a DnsZone ID into an DnsZoneId struct
 func DnsZoneID(input string) (*DnsZoneId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/mx_record.go
+++ b/azurerm/internal/services/dns/parse/mx_record.go
@@ -29,6 +29,7 @@ func (id MxRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.MXName)
 }
 
+// MxRecordID parses a MxRecord ID into an MxRecordId struct
 func MxRecordID(input string) (*MxRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/ns_record.go
+++ b/azurerm/internal/services/dns/parse/ns_record.go
@@ -29,6 +29,7 @@ func (id NsRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.NSName)
 }
 
+// NsRecordID parses a NsRecord ID into an NsRecordId struct
 func NsRecordID(input string) (*NsRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/ptr_record.go
+++ b/azurerm/internal/services/dns/parse/ptr_record.go
@@ -29,6 +29,7 @@ func (id PtrRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.PTRName)
 }
 
+// PtrRecordID parses a PtrRecord ID into an PtrRecordId struct
 func PtrRecordID(input string) (*PtrRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/srv_record.go
+++ b/azurerm/internal/services/dns/parse/srv_record.go
@@ -29,6 +29,7 @@ func (id SrvRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.SRVName)
 }
 
+// SrvRecordID parses a SrvRecord ID into an SrvRecordId struct
 func SrvRecordID(input string) (*SrvRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/dns/parse/txt_record.go
+++ b/azurerm/internal/services/dns/parse/txt_record.go
@@ -29,6 +29,7 @@ func (id TxtRecordId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DnszoneName, id.TXTName)
 }
 
+// TxtRecordID parses a TxtRecord ID into an TxtRecordId struct
 func TxtRecordID(input string) (*TxtRecordId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventgrid/parse/domain.go
+++ b/azurerm/internal/services/eventgrid/parse/domain.go
@@ -27,6 +27,7 @@ func (id DomainId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// DomainID parses a Domain ID into an DomainId struct
 func DomainID(input string) (*DomainId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventgrid/parse/domain_topic.go
+++ b/azurerm/internal/services/eventgrid/parse/domain_topic.go
@@ -29,6 +29,7 @@ func (id DomainTopicId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DomainName, id.TopicName)
 }
 
+// DomainTopicID parses a DomainTopic ID into an DomainTopicId struct
 func DomainTopicID(input string) (*DomainTopicId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventgrid/parse/system_topic.go
+++ b/azurerm/internal/services/eventgrid/parse/system_topic.go
@@ -27,6 +27,7 @@ func (id SystemTopicId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// SystemTopicID parses a SystemTopic ID into an SystemTopicId struct
 func SystemTopicID(input string) (*SystemTopicId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventgrid/parse/topic.go
+++ b/azurerm/internal/services/eventgrid/parse/topic.go
@@ -27,6 +27,7 @@ func (id TopicId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// TopicID parses a Topic ID into an TopicId struct
 func TopicID(input string) (*TopicId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventhub/parse/cluster.go
+++ b/azurerm/internal/services/eventhub/parse/cluster.go
@@ -27,6 +27,7 @@ func (id ClusterId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ClusterID parses a Cluster ID into an ClusterId struct
 func ClusterID(input string) (*ClusterId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventhub/parse/namespace.go
+++ b/azurerm/internal/services/eventhub/parse/namespace.go
@@ -27,6 +27,7 @@ func (id NamespaceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// NamespaceID parses a Namespace ID into an NamespaceId struct
 func NamespaceID(input string) (*NamespaceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/eventhub/parse/namespace_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/parse/namespace_authorization_rule.go
@@ -29,6 +29,7 @@ func (id NamespaceAuthorizationRuleId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.AuthorizationRuleName)
 }
 
+// NamespaceAuthorizationRuleID parses a NamespaceAuthorizationRule ID into an NamespaceAuthorizationRuleId struct
 func NamespaceAuthorizationRuleID(input string) (*NamespaceAuthorizationRuleId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/healthcare/parse/service.go
+++ b/azurerm/internal/services/healthcare/parse/service.go
@@ -27,6 +27,7 @@ func (id ServiceId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// ServiceID parses a Service ID into an ServiceId struct
 func ServiceID(input string) (*ServiceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/hpccache/parse/cache.go
+++ b/azurerm/internal/services/hpccache/parse/cache.go
@@ -27,6 +27,7 @@ func (id CacheId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
+// CacheID parses a Cache ID into an CacheId struct
 func CacheID(input string) (*CacheId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/hpccache/parse/storage_target.go
+++ b/azurerm/internal/services/hpccache/parse/storage_target.go
@@ -29,6 +29,7 @@ func (id StorageTargetId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.CacheName, id.Name)
 }
 
+// StorageTargetID parses a StorageTarget ID into an StorageTargetId struct
 func StorageTargetID(input string) (*StorageTargetId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/services/hsm/parse/dedicated_hardware_security_module.go
+++ b/azurerm/internal/services/hsm/parse/dedicated_hardware_security_module.go
@@ -27,6 +27,7 @@ func (id DedicatedHardwareSecurityModuleId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.DedicatedHSMName)
 }
 
+// DedicatedHardwareSecurityModuleID parses a DedicatedHardwareSecurityModule ID into an DedicatedHardwareSecurityModuleId struct
 func DedicatedHardwareSecurityModuleID(input string) (*DedicatedHardwareSecurityModuleId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -527,7 +527,7 @@ func Test%[1]sID(t *testing.T) {
 
 func (id ResourceIdGenerator) testCodeForParserInsensitive() string {
 	if !id.ShouldRewrite {
-		// this funcitonality isn't enabled by default
+		// this functionality isn't enabled by default
 		return ""
 	}
 

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -15,6 +15,7 @@ func main() {
 	servicePackagePath := flag.String("path", "", "The relative path to the service package")
 	name := flag.String("name", "", "The name of this Resource Type")
 	id := flag.String("id", "", "An example of this Resource ID")
+	rewrite := flag.Bool("rewrite", false, "Should this Resource ID be parsed insensitively, to workaround an API bug?")
 	showHelp := flag.Bool("help", false, "Display this message")
 
 	flag.Parse()
@@ -24,12 +25,12 @@ func main() {
 		return
 	}
 
-	if err := run(*servicePackagePath, *name, *id); err != nil {
+	if err := run(*servicePackagePath, *name, *id, *rewrite); err != nil {
 		panic(err)
 	}
 }
 
-func run(servicePackagePath, name, id string) error {
+func run(servicePackagePath, name, id string, shouldRewrite bool) error {
 	parsersPath := fmt.Sprintf("%s/parse", servicePackagePath)
 	if err := os.Mkdir(parsersPath, 0644); !os.IsExist(err) {
 		return fmt.Errorf("creating parse directory at %q: %+v", parsersPath, err)
@@ -47,7 +48,8 @@ func run(servicePackagePath, name, id string) error {
 	}
 
 	generator := ResourceIdGenerator{
-		ResourceId: *resourceId,
+		ResourceId:    *resourceId,
+		ShouldRewrite: shouldRewrite,
 	}
 	if err := goFmtAndWriteToFile(parserFilePath, generator.Code()); err != nil {
 		return err
@@ -208,6 +210,8 @@ func NewResourceID(typeName, resourceId string) (*ResourceId, error) {
 
 type ResourceIdGenerator struct {
 	ResourceId
+
+	ShouldRewrite bool
 }
 
 func (id ResourceIdGenerator) Code() string {
@@ -226,7 +230,8 @@ import (
 %s
 %s
 %s
-`, id.codeForType(), id.codeForConstructor(), id.codeForFormatter(), id.codeForParser())
+%s
+`, id.codeForType(), id.codeForConstructor(), id.codeForFormatter(), id.codeForParser(), id.codeForParserInsensitive())
 }
 
 func (id ResourceIdGenerator) codeForType() string {
@@ -301,9 +306,81 @@ func (id ResourceIdGenerator) codeForParser() string {
 		parserStatements = append(parserStatements, fmt.Sprintf(fmtString, segment.FieldName, segment.SegmentKey))
 	}
 	parserStatementsStr := strings.Join(parserStatements, "\n")
-
 	return fmt.Sprintf(`
+// %[1]sID parses a %[1]s ID into an %[1]sId struct 
 func %[1]sID(input string) (*%[1]sId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := %[1]sId{
+%[2]s
+	}
+
+%[3]s
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+`, id.TypeName, directAssignmentsStr, parserStatementsStr)
+}
+
+func (id ResourceIdGenerator) codeForParserInsensitive() string {
+	if !id.ShouldRewrite {
+		// this only exists to workaround broken API's to patch those ID's, so shouldn't be used in most circumstances
+		return ""
+	}
+
+	directAssignments := make([]string, 0)
+	if id.HasSubscriptionId {
+		directAssignments = append(directAssignments, "\t\tSubscriptionId: id.SubscriptionID,")
+	}
+	if id.HasResourceGroup {
+		directAssignments = append(directAssignments, "\t\tResourceGroup: id.ResourceGroup,")
+	}
+	directAssignmentsStr := strings.Join(directAssignments, "\n")
+
+	parserStatements := make([]string, 0)
+	for _, segment := range id.Segments {
+		if strings.EqualFold(segment.SegmentKey, "subscriptions") && id.HasSubscriptionId {
+			// direct assigned above
+			continue
+		}
+		if strings.EqualFold(segment.SegmentKey, "resourceGroups") && id.HasResourceGroup {
+			// direct assigned above
+			continue
+		}
+
+		// NOTE: This becomes dramatically simpler long-term - but for now has to be long-winded
+		// to avoid subtle changes to resources until this is threaded through everywhere
+		fmtString := `
+  // find the correct casing for the '%[2]s' segment
+  %[2]sKey := "%[2]s"
+  for key := range id.Path {
+  	if strings.EqualFold(key, %[2]sKey) {
+  		%[2]sKey = key
+  		break
+  	}
+  }
+  if resourceId.%[1]s, err = id.PopSegment(%[2]sKey); err != nil {
+    return nil, err
+  }
+`
+		parserStatements = append(parserStatements, fmt.Sprintf(fmtString, segment.FieldName, segment.SegmentKey))
+	}
+	parserStatementsStr := strings.Join(parserStatements, "\n")
+	return fmt.Sprintf(`
+// %[1]sIDInsensitively parses an %[1]s ID into an %[1]sId struct, insensitively
+// This should only be used to parse an ID for rewriting, the %[1]sID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func %[1]sIDInsensitively(input string) (*%[1]sId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
@@ -338,7 +415,8 @@ import (
 
 %s
 %s
-`, id.testCodeForFormatter(), id.testCodeForParser())
+%s
+`, id.testCodeForFormatter(), id.testCodeForParser(), id.testCodeForParserInsensitive())
 }
 
 func (id ResourceIdGenerator) testCodeForFormatter() string {
@@ -430,6 +508,125 @@ func Test%[1]sID(t *testing.T) {
 		t.Logf("[DEBUG] Testing %%q", v.Input)
 
 		actual, err := %[1]sID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %%s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+%[3]s
+	}
+}
+`, id.TypeName, testCasesStr, assignmentCheckStr)
+}
+
+func (id ResourceIdGenerator) testCodeForParserInsensitive() string {
+	if !id.ShouldRewrite {
+		// this funcitonality isn't enabled by default
+		return ""
+	}
+
+	testCases := make([]string, 0)
+	testCases = append(testCases, `
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+`)
+	assignmentChecks := make([]string, 0)
+	for _, segment := range id.Segments {
+		testCaseFmt := `
+		{
+			// missing %s
+			Input: %q,
+			Error: true,
+		},`
+		// missing the key
+		resourceIdToThisPointIndex := strings.Index(id.IDRaw, segment.SegmentKey)
+		resourceIdToThisPoint := id.IDRaw[0:resourceIdToThisPointIndex]
+		testCases = append(testCases, fmt.Sprintf(testCaseFmt, segment.FieldName, resourceIdToThisPoint))
+
+		// missing the value
+		resourceIdToThisPointIndex = strings.Index(id.IDRaw, segment.SegmentValue)
+		resourceIdToThisPoint = id.IDRaw[0:resourceIdToThisPointIndex]
+		testCases = append(testCases, fmt.Sprintf(testCaseFmt, fmt.Sprintf("value for %s", segment.FieldName), resourceIdToThisPoint))
+
+		assignmentsFmt := "\t\tif actual.%[1]s != v.Expected.%[1]s {\n\t\t\tt.Fatalf(\"Expected %%q but got %%q for %[1]s\", v.Expected.%[1]s, actual.%[1]s)\n\t\t}"
+		assignmentChecks = append(assignmentChecks, fmt.Sprintf(assignmentsFmt, segment.FieldName))
+	}
+
+	// add a successful test case
+	expectAssignments := make([]string, 0)
+	for _, segment := range id.Segments {
+		expectAssignments = append(expectAssignments, fmt.Sprintf("\t\t\t\t%s:\t%q,", segment.FieldName, segment.SegmentValue))
+	}
+	testCases = append(testCases, fmt.Sprintf(`
+		{
+			// valid
+			Input: "%[1]s",
+			Expected: &%[2]sId{
+%[3]s
+			},
+		},
+`, id.IDRaw, id.TypeName, strings.Join(expectAssignments, "\n")))
+
+	var testCaseWithTransformation = func(testCaseName string, transform func(in string) string) string {
+		resourceIdWithTransform := id.IDRaw
+		for _, segment := range id.Segments {
+			// we're not as concerned with these two for now
+			if segment.FieldName == "SubscriptionId" || segment.FieldName == "ResourceGroup" {
+				continue
+			}
+
+			transformedKey := transform(segment.SegmentKey)
+			resourceIdWithTransform = strings.Replace(resourceIdWithTransform, segment.SegmentKey, transformedKey, 1)
+		}
+		return fmt.Sprintf(`
+		{
+			// %[4]s
+			Input: "%[1]s",
+			Expected: &%[2]sId{
+%[3]s
+			},
+		},`, resourceIdWithTransform, id.TypeName, strings.Join(expectAssignments, "\n"), testCaseName)
+	}
+
+	testCases = append(testCases, testCaseWithTransformation("lower-cased segment names", strings.ToLower))
+	testCases = append(testCases, testCaseWithTransformation("upper-cased segment names", strings.ToUpper))
+	testCases = append(testCases, testCaseWithTransformation("mixed-cased segment names", func(in string) string {
+		out := make([]rune, 0)
+		for i, c := range in {
+			if i%2 == 0 {
+				out = append(out, unicode.ToUpper(c))
+			} else {
+				out = append(out, unicode.ToLower(c))
+			}
+		}
+		return string(out)
+	}))
+
+	testCasesStr := strings.Join(testCases, "\n")
+	assignmentCheckStr := strings.Join(assignmentChecks, "\n")
+	return fmt.Sprintf(`
+func Test%[1]sIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input  string
+		Error  bool
+		Expected *%[1]sId
+	}{
+%[2]s
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %%q", v.Input)
+
+		actual, err := %[1]sIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue


### PR DESCRIPTION
This PR introduces a state migration for each of the Desktop Virtualization resources - allowing these to be parsed insensitively and then patched up to match the apply.

This adds support for a conditional "insensitive" option within the Resource ID generator - intentionally named `rewrite`, since that's what it's intended to do - which is intentionally disabled by default, since this should be a last-resort to work around a broken API response prior to patching it.

You'll want to review this commit by commit, since the last one is a regeneration of all the parse functions to add some documentation to account for the optional `{Insensitive}` parser

Ultimately this issue fixes #9491