### PR TITLE
azurerm_traffic_manager_profile - allow upto `2147483647`for the `ttl` property

### DIFF
--- a/azurerm/internal/services/trafficmanager/resource_arm_traffic_manager_profile.go
+++ b/azurerm/internal/services/trafficmanager/resource_arm_traffic_manager_profile.go
@@ -84,7 +84,7 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 						"ttl": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 999999),
+							ValidateFunc: validation.IntBetween(0, 2147483647),
 						},
 					},
 				},

--- a/azurerm/internal/services/trafficmanager/tests/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/internal/services/trafficmanager/tests/resource_arm_traffic_manager_profile_test.go
@@ -206,14 +206,14 @@ func TestAccAzureRMTrafficManagerProfile_updateTTL(t *testing.T) {
 		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMTrafficManagerProfile_withTTLLowerLimit(data, "Geographic"),
+				Config: testAccAzureRMTrafficManagerProfile_withTTL(data, "Geographic", 0),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMTrafficManagerProfileExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMTrafficManagerProfile_withTTLUpperLimit(data, "Geographic"),
+				Config: testAccAzureRMTrafficManagerProfile_withTTL(data, "Geographic", 2147483647),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMTrafficManagerProfileExists(data.ResourceName),
 				),
@@ -553,7 +553,7 @@ resource "azurerm_traffic_manager_profile" "test" {
 `, template, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMTrafficManagerProfile_withTTLLowerLimit(data acceptance.TestData, method string) string {
+func testAccAzureRMTrafficManagerProfile_withTTL(data acceptance.TestData, method string, ttl int) string {
 	template := testAccAzureRMTrafficManagerProfile_template(data)
 	return fmt.Sprintf(`
 %s
@@ -565,7 +565,7 @@ resource "azurerm_traffic_manager_profile" "test" {
 
   dns_config {
     relative_name = "acctest-tmp-%d"
-    ttl           = 0
+    ttl           = %d
   }
 
   monitor_config {
@@ -574,29 +574,5 @@ resource "azurerm_traffic_manager_profile" "test" {
     path     = "/"
   }
 }
-`, template, data.RandomInteger, method, data.RandomInteger)
-}
-
-func testAccAzureRMTrafficManagerProfile_withTTLUpperLimit(data acceptance.TestData, method string) string {
-	template := testAccAzureRMTrafficManagerProfile_template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_traffic_manager_profile" "test" {
-  name                   = "acctest-TMP-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  traffic_routing_method = "%s"
-
-  dns_config {
-    relative_name = "acctest-tmp-%d"
-    ttl           = 2147483647
-  }
-
-  monitor_config {
-    protocol = "https"
-    port     = 443
-    path     = "/"
-  }
-}
-`, template, data.RandomInteger, method, data.RandomInteger)
+`, template, data.RandomInteger, method, data.RandomInteger, ttl)
 }


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/8891

--- PASS: TestAccAzureRMTrafficManagerProfile_fastEndpointFailoverSettingsError (79.03s)
--- PASS: TestAccAzureRMTrafficManagerProfile_basic (117.44s)
--- PASS: TestAccAzureRMTrafficManagerProfile_complete (117.96s)
--- PASS: TestAccAzureRMTrafficManagerProfile_requiresImport (129.04s)
--- PASS: TestAccAzureRMTrafficManagerProfile_updateTTL (171.77s)
--- PASS: TestAccAzureRMTrafficManagerProfile_updateEnsureDoNotEraseEndpoints (176.49s)
--- PASS: TestAccAzureRMTrafficManagerProfile_update (188.92s)
--- PASS: TestAccAzureRMTrafficManagerProfile_cycleMethod (277.05s)