### PR TITLE
notificationhub: switching to use generated Resource ID Formatters/Parsers

### DIFF
--- a/azurerm/internal/services/notificationhub/notification_hub_authorization_rule_resource.go
+++ b/azurerm/internal/services/notificationhub/notification_hub_authorization_rule_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/notificationhub/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +23,10 @@ func resourceArmNotificationHubAuthorizationRule() *schema.Resource {
 		Read:   resourceArmNotificationHubAuthorizationRuleRead,
 		Update: resourceArmNotificationHubAuthorizationRuleCreateUpdate,
 		Delete: resourceArmNotificationHubAuthorizationRuleDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.NotificationHubAuthorizationRuleID(id)
+			return err
+		}),
 		// TODO: customizeDiff for send+listen when manage selected
 
 		Timeouts: &schema.ResourceTimeout{

--- a/azurerm/internal/services/notificationhub/notification_hub_namespace_resource.go
+++ b/azurerm/internal/services/notificationhub/notification_hub_namespace_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/notificationhub/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -30,10 +31,10 @@ func resourceArmNotificationHubNamespace() *schema.Resource {
 		Read:   resourceArmNotificationHubNamespaceRead,
 		Update: resourceArmNotificationHubNamespaceCreateUpdate,
 		Delete: resourceArmNotificationHubNamespaceDelete,
-
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.NamespaceID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/notificationhub/parse/namespace.go
+++ b/azurerm/internal/services/notificationhub/parse/namespace.go
@@ -1,0 +1,51 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.NotificationHubs/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/notificationhub/parse/namespace_test.go
+++ b/azurerm/internal/services/notificationhub/parse/namespace_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("12345678-1234-9876-4563-123456789012", "resGroup1", "namespace1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1",
+			Expected: &NamespaceId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "namespace1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NOTIFICATIONHUBS/NAMESPACES/NAMESPACE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/notificationhub/parse/notification_hub.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub.go
@@ -1,5 +1,7 @@
 package parse
 
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
 import (
 	"fmt"
 
@@ -7,26 +9,42 @@ import (
 )
 
 type NotificationHubId struct {
-	ResourceGroup string
-	NamespaceName string
-	Name          string
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	Name           string
 }
 
+func NewNotificationHubID(subscriptionId, resourceGroup, namespaceName, name string) NotificationHubId {
+	return NotificationHubId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		Name:           name,
+	}
+}
+
+func (id NotificationHubId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.NotificationHubs/namespaces/%s/notificationHubs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.Name)
+}
+
+// NotificationHubID parses a NotificationHub ID into an NotificationHubId struct
 func NotificationHubID(input string) (*NotificationHubId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("parsing Notification Hub ID %q: %+v", input, err)
-	}
-
-	app := NotificationHubId{
-		ResourceGroup: id.ResourceGroup,
-	}
-
-	if app.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
 		return nil, err
 	}
 
-	if app.Name, err = id.PopSegment("notificationHubs"); err != nil {
+	resourceId := NotificationHubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("notificationHubs"); err != nil {
 		return nil, err
 	}
 
@@ -34,5 +52,5 @@ func NotificationHubID(input string) (*NotificationHubId, error) {
 		return nil, err
 	}
 
-	return &app, nil
+	return &resourceId, nil
 }

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
@@ -1,0 +1,61 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type NotificationHubAuthorizationRuleId struct {
+	SubscriptionId        string
+	ResourceGroup         string
+	NamespaceName         string
+	NotificationHubName   string
+	AuthorizationRuleName string
+}
+
+func NewNotificationHubAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, notificationHubName, authorizationRuleName string) NotificationHubAuthorizationRuleId {
+	return NotificationHubAuthorizationRuleId{
+		SubscriptionId:        subscriptionId,
+		ResourceGroup:         resourceGroup,
+		NamespaceName:         namespaceName,
+		NotificationHubName:   notificationHubName,
+		AuthorizationRuleName: authorizationRuleName,
+	}
+}
+
+func (id NotificationHubAuthorizationRuleId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.NotificationHubs/namespaces/%s/notificationHubs/%s/AuthorizationRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.NotificationHubName, id.AuthorizationRuleName)
+}
+
+// NotificationHubAuthorizationRuleID parses a NotificationHubAuthorizationRule ID into an NotificationHubAuthorizationRuleId struct
+func NotificationHubAuthorizationRuleID(input string) (*NotificationHubAuthorizationRuleId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NotificationHubAuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.NotificationHubName, err = id.PopSegment("notificationHubs"); err != nil {
+		return nil, err
+	}
+	if resourceId.AuthorizationRuleName, err = id.PopSegment("AuthorizationRules"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule_test.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = NotificationHubAuthorizationRuleId{}
+
+func TestNotificationHubAuthorizationRuleIDFormatter(t *testing.T) {
+	actual := NewNotificationHubAuthorizationRuleID("12345678-1234-9876-4563-123456789012", "resGroup1", "namespace1", "hub1", "authorizationRule1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNotificationHubAuthorizationRuleID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NotificationHubAuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing NotificationHubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/",
+			Error: true,
+		},
+
+		{
+			// missing value for NotificationHubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing AuthorizationRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/",
+			Error: true,
+		},
+
+		{
+			// missing value for AuthorizationRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1",
+			Expected: &NotificationHubAuthorizationRuleId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:         "resGroup1",
+				NamespaceName:         "namespace1",
+				NotificationHubName:   "hub1",
+				AuthorizationRuleName: "authorizationRule1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NOTIFICATIONHUBS/NAMESPACES/NAMESPACE1/NOTIFICATIONHUBS/HUB1/AUTHORIZATIONRULES/AUTHORIZATIONRULE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NotificationHubAuthorizationRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.NotificationHubName != v.Expected.NotificationHubName {
+			t.Fatalf("Expected %q but got %q for NotificationHubName", v.Expected.NotificationHubName, actual.NotificationHubName)
+		}
+		if actual.AuthorizationRuleName != v.Expected.AuthorizationRuleName {
+			t.Fatalf("Expected %q but got %q for AuthorizationRuleName", v.Expected.AuthorizationRuleName, actual.AuthorizationRuleName)
+		}
+	}
+}

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_test.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_test.go
@@ -1,86 +1,126 @@
 package parse
 
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = NotificationHubId{}
+
+func TestNotificationHubIDFormatter(t *testing.T) {
+	actual := NewNotificationHubID("12345678-1234-9876-4563-123456789012", "resGroup1", "namespace1", "hub1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestNotificationHubID(t *testing.T) {
 	testData := []struct {
-		Name     string
 		Input    string
+		Error    bool
 		Expected *NotificationHubId
 	}{
+
 		{
-			Name:     "Empty",
-			Input:    "",
-			Expected: nil,
+			// empty
+			Input: "",
+			Error: true,
 		},
+
 		{
-			Name:     "No Resource Groups Segment",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
-			Expected: nil,
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
 		},
+
 		{
-			Name:     "No Resource Groups Value",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
-			Expected: nil,
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
 		},
+
 		{
-			Name:     "Resource Group ID",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/",
-			Expected: nil,
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
 		},
+
 		{
-			Name:     "No namespace Value",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces",
-			Expected: nil,
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
 		},
+
 		{
-			Name:     "Missing notification Hub Segment",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1",
-			Expected: nil,
+			// missing NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/",
+			Error: true,
 		},
+
 		{
-			Name:     "Missing notification Hub Value",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs",
-			Expected: nil,
+			// missing value for NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/",
+			Error: true,
 		},
+
 		{
-			Name:  "notification Hub ID",
-			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1",
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1",
 			Expected: &NotificationHubId{
-				ResourceGroup: "resGroup1",
-				NamespaceName: "namespace1",
-				Name:          "hub1",
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				NamespaceName:  "namespace1",
+				Name:           "hub1",
 			},
 		},
+
 		{
-			Name:     "Wrong Casing",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/NotificationHubs/hub1",
-			Expected: nil,
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NOTIFICATIONHUBS/NAMESPACES/NAMESPACE1/NOTIFICATIONHUBS/HUB1",
+			Error: true,
 		},
 	}
 
 	for _, v := range testData {
-		t.Logf("[DEBUG] Testing %q", v.Name)
+		t.Logf("[DEBUG] Testing %q", v.Input)
 
 		actual, err := NotificationHubID(v.Input)
 		if err != nil {
-			if v.Expected == nil {
+			if v.Error {
 				continue
 			}
 
-			t.Fatalf("Expected a value but got an error: %s", err)
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
 		}
 
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
-
 		if actual.NamespaceName != v.Expected.NamespaceName {
 			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
 		}
-
 		if actual.Name != v.Expected.Name {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}

--- a/azurerm/internal/services/notificationhub/resourceids.go
+++ b/azurerm/internal/services/notificationhub/resourceids.go
@@ -1,0 +1,3 @@
+package notificationhub
+
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1

--- a/azurerm/internal/services/notificationhub/resourceids.go
+++ b/azurerm/internal/services/notificationhub/resourceids.go
@@ -2,3 +2,4 @@ package notificationhub
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Namespace -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHubAuthorizationRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1

--- a/azurerm/internal/services/notificationhub/resourceids.go
+++ b/azurerm/internal/services/notificationhub/resourceids.go
@@ -1,3 +1,4 @@
 package notificationhub
 
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Namespace -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1


### PR DESCRIPTION
This PR also adds enhanced import validation to:

* `azurerm_notification_hub_authorization_rule`
* `azurerm_notification_hub_namespace`