### PR TITLE
tools: adding goimports to `make tools`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,6 +17,7 @@ tools:
 	GO111MODULE=off go get -u github.com/bflad/tfproviderlint/cmd/tfproviderlint
 	GO111MODULE=off go get -u github.com/bflad/tfproviderdocs
 	GO111MODULE=off go get -u github.com/katbyte/terrafmt
+	GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
 	GO111MODULE=off go get -u mvdan.cc/gofumpt
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v1.32.0
 


### PR DESCRIPTION
Supersedes #9546 since `goimports` is already run as a part of the generation process - but errors are intentionally ignored since the error codes for `go fmt` and `goimports` aren't particularly interesting

Fixes #9544