### PR TITLE
azurerm_storage_data_lake_gen2_path: Fix error message

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_data_lake_gen2_path.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_data_lake_gen2_path.go
@@ -287,7 +287,7 @@ func resourceArmStorageDataLakeGen2PathUpdate(d *schema.ResourceData, meta inter
 			Group: group,
 		}
 		if _, err := client.SetAccessControl(ctx, id.AccountName, id.FileSystemName, path, accessControlInput); err != nil {
-			return fmt.Errorf("Error setting access control for Path %q in File System %q in Storage Account %q: %s", id.FileSystemName, path, id.AccountName, err)
+			return fmt.Errorf("Error setting access control for Path %q in File System %q in Storage Account %q: %s", path, id.FileSystemName, id.AccountName, err)
 		}
 	}
 


### PR DESCRIPTION
This fixes the error message when ACL's cannot be applied. The Path and FileSystem name are in the incorrect position in the error message. #9557 