### PR TITLE
generator/resource-id: support for generating Resource ID Validator functions

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -21,3 +21,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: 'v1.32'
+          args: --timeout=30m0s

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"unicode"
 )
@@ -17,6 +18,7 @@ func main() {
 	id := flag.String("id", "", "An example of this Resource ID")
 	rewrite := flag.Bool("rewrite", false, "Should this Resource ID be parsed insensitively, to workaround an API bug?")
 	showHelp := flag.Bool("help", false, "Display this message")
+	shouldValidate := false // TODO: enable once the existing files are renamed
 
 	flag.Parse()
 
@@ -25,15 +27,27 @@ func main() {
 		return
 	}
 
-	if err := run(*servicePackagePath, *name, *id, *rewrite); err != nil {
+	if err := run(*servicePackagePath, *name, *id, *rewrite, shouldValidate); err != nil {
 		panic(err)
 	}
 }
 
-func run(servicePackagePath, name, id string, shouldRewrite bool) error {
+func run(servicePackagePath, name, id string, shouldRewrite, shouldValidate bool) error {
+	servicePackage, err := parseServicePackageName(servicePackagePath)
+	if err != nil {
+		return fmt.Errorf("determing Service Package Name for %q: %+v", servicePackagePath, err)
+	}
+
 	parsersPath := path.Join(servicePackagePath, "/parse")
 	if err := os.Mkdir(parsersPath, 0755); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("creating parse directory at %q: %+v", parsersPath, err)
+	}
+
+	validatorPath := path.Join(servicePackagePath, "/validate")
+	if shouldValidate {
+		if err := os.Mkdir(validatorPath, 0755); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("creating validate directory at %q: %+v", validatorPath, err)
+		}
 	}
 
 	fileName := convertToSnakeCase(name)
@@ -41,7 +55,7 @@ func run(servicePackagePath, name, id string, shouldRewrite bool) error {
 		// e.g. "webtest" in applicationInsights
 		fileName += "_id"
 	}
-	resourceId, err := NewResourceID(name, id)
+	resourceId, err := NewResourceID(name, *servicePackage, id)
 	if err != nil {
 		return err
 	}
@@ -61,7 +75,51 @@ func run(servicePackagePath, name, id string, shouldRewrite bool) error {
 		return fmt.Errorf("generating Parser Tests at %q: %+v", parserTestsFilePath, err)
 	}
 
+	if shouldValidate {
+		validatorFilePath := fmt.Sprintf("%s/%s_id.go", validatorPath, fileName)
+		if err := goFmtAndWriteToFile(validatorFilePath, generator.ValidatorCode()); err != nil {
+			return fmt.Errorf("generating Validator at %q: %+v", validatorFilePath, err)
+		}
+
+		validatorTestsFilePath := fmt.Sprintf("%s/%s_id_test.go", validatorPath, fileName)
+		if err := goFmtAndWriteToFile(validatorTestsFilePath, generator.ValidatorTestCode()); err != nil {
+			return fmt.Errorf("generating Validator Tests at %q: %+v", validatorTestsFilePath, err)
+		}
+	}
+
 	return nil
+}
+
+func parseServicePackageName(relativePath string) (*string, error) {
+	path := relativePath
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+
+		path = abs
+	}
+
+	segments := strings.Split(path, "/")
+	serviceIndex := -1
+	for i, v := range segments {
+		if strings.EqualFold(v, "services") {
+			serviceIndex = i
+			break
+		}
+	}
+
+	if serviceIndex == -1 {
+		return nil, fmt.Errorf("`services` segment was not found")
+	}
+
+	if len(segments) <= serviceIndex {
+		return nil, fmt.Errorf("not enough segments")
+	}
+
+	servicePackageName := segments[serviceIndex+1]
+	return &servicePackageName, nil
 }
 
 func convertToSnakeCase(input string) string {
@@ -98,12 +156,14 @@ type ResourceId struct {
 	IDFmt    string
 	IDRaw    string
 
+	ServicePackageName string
+
 	HasResourceGroup  bool
 	HasSubscriptionId bool
 	Segments          []ResourceIdSegment // this has to be a slice not a map since we care about the order
 }
 
-func NewResourceID(typeName, resourceId string) (*ResourceId, error) {
+func NewResourceID(typeName, servicePackageName, resourceId string) (*ResourceId, error) {
 	// split the string, but remove the prefix of `/` since it's an empty segment
 	split := strings.Split(strings.TrimPrefix(resourceId, "/"), "/")
 	if len(split)%2 != 0 {
@@ -206,12 +266,13 @@ func NewResourceID(typeName, resourceId string) (*ResourceId, error) {
 	}
 
 	return &ResourceId{
-		IDFmt:             fmtString,
-		IDRaw:             resourceId,
-		HasResourceGroup:  hasResourceGroup,
-		HasSubscriptionId: hasSubscriptionId,
-		Segments:          segments,
-		TypeName:          typeName,
+		IDFmt:              fmtString,
+		IDRaw:              resourceId,
+		HasResourceGroup:   hasResourceGroup,
+		HasSubscriptionId:  hasSubscriptionId,
+		Segments:           segments,
+		ServicePackageName: servicePackageName,
+		TypeName:           typeName,
 	}, nil
 }
 
@@ -495,7 +556,7 @@ func (id ResourceIdGenerator) testCodeForParser() string {
 		},
 `, id.IDRaw, id.TypeName, strings.Join(expectAssignments, "\n")))
 
-	// add an intentionally failing lower-cased test case
+	// add an intentionally failing upper-cased test case
 	testCases = append(testCases, fmt.Sprintf(`
 		{
 			// upper-cased
@@ -653,6 +714,104 @@ func Test%[1]sIDInsensitively(t *testing.T) {
 	}
 }
 `, id.TypeName, testCasesStr, assignmentCheckStr)
+}
+
+func (id ResourceIdGenerator) ValidatorCode() string {
+	return fmt.Sprintf(`package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/%[2]s/parse"
+)
+
+func %[1]sID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %%q to be a string", key))
+		return
+	}
+
+	if _, err := parse.%[1]sID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+`, id.TypeName, id.ServicePackageName)
+}
+
+func (id ResourceIdGenerator) ValidatorTestCode() string {
+	testCases := make([]string, 0)
+	testCases = append(testCases, `
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+`)
+	for _, segment := range id.Segments {
+		testCaseFmt := `
+		{
+			// missing %s
+			Input: %q,
+			Valid: false,
+		},`
+		// missing the key
+		resourceIdToThisPointIndex := strings.Index(id.IDRaw, segment.SegmentKey)
+		resourceIdToThisPoint := id.IDRaw[0:resourceIdToThisPointIndex]
+		testCases = append(testCases, fmt.Sprintf(testCaseFmt, segment.FieldName, resourceIdToThisPoint))
+
+		// missing the value
+		resourceIdToThisPointIndex = strings.Index(id.IDRaw, segment.SegmentValue)
+		resourceIdToThisPoint = id.IDRaw[0:resourceIdToThisPointIndex]
+		testCases = append(testCases, fmt.Sprintf(testCaseFmt, fmt.Sprintf("value for %s", segment.FieldName), resourceIdToThisPoint))
+	}
+
+	// add a successful test case
+	testCases = append(testCases, fmt.Sprintf(`
+		{
+			// valid
+			Input: %q,
+			Valid: true,
+		},
+`, id.IDRaw))
+
+	// add an intentionally failing upper-cased test case
+	testCases = append(testCases, fmt.Sprintf(`
+		{
+			// upper-cased
+			Input: %q,
+			Valid: false,
+		},`, strings.ToUpper(id.IDRaw)))
+
+	testCasesStr := strings.Join(testCases, "\n")
+
+	return fmt.Sprintf(`package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func Test%[1]sID(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Valid bool
+	}{
+%[2]s
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %%s", tc.Input)
+		_, errors := %[1]sID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %%t but got %%t", tc.Valid, valid)
+		}
+	}
+}
+`, id.TypeName, testCasesStr)
 }
 
 func goFmtAndWriteToFile(filePath, fileContents string) error {

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -35,7 +35,7 @@ func main() {
 func run(servicePackagePath, name, id string, shouldRewrite, shouldValidate bool) error {
 	servicePackage, err := parseServicePackageName(servicePackagePath)
 	if err != nil {
-		return fmt.Errorf("determing Service Package Name for %q: %+v", servicePackagePath, err)
+		return fmt.Errorf("determining Service Package Name for %q: %+v", servicePackagePath, err)
 	}
 
 	parsersPath := path.Join(servicePackagePath, "/parse")


### PR DESCRIPTION
This PR introduces support for generating Validate functions for Resource ID's - when the other Resource ID's are generated.

**At this time this functionality is disabled**, but ultimately generates a Validate Func:

```go
package validate

// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten

import (
	"fmt"

	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/analysisservices/parse"
)

func ServerID(input interface{}, key string) (warnings []string, errors []error) {
	v, ok := input.(string)
	if !ok {
		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
		return
	}

	if _, err := parse.ServerID(v); err != nil {
		errors = append(errors, err)
	}

	return
}
```

and associated Unit Test:

```go
package validate

// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten

import "testing"

func TestServerID(t *testing.T) {
	cases := []struct {
		Input string
		Valid bool
	}{

		{
			// empty
			Input: "",
			Valid: false,
		},

		{
			// missing SubscriptionId
			Input: "/",
			Valid: false,
		},

		{
			// missing value for SubscriptionId
			Input: "/subscriptions/",
			Valid: false,
		},

		{
			// missing ResourceGroup
			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
			Valid: false,
		},

		{
			// missing value for ResourceGroup
			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
			Valid: false,
		},

		{
			// missing Name
			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/",
			Valid: false,
		},

		{
			// missing value for Name
			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/servers/",
			Valid: false,
		},

		{
			// valid
			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/servers/Server1",
			Valid: true,
		},

		{
			// upper-cased
			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.ANALYSISSERVICES/SERVERS/SERVER1",
			Valid: false,
		},
	}
	for _, tc := range cases {
		t.Logf("[DEBUG] Testing Value %s", tc.Input)
		_, errors := ServerID(tc.Input, "test")
		valid := len(errors) == 0

		if tc.Valid != valid {
			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
		}
	}
}
```

for each Resource ID that gets generated.

This ends up in `./validate/{resource}_id.go` - once the existing ID Validators are renamed and split out, it should be possible to generate these - but at this time there's a combination of Name and ID Parsers sharing the same files, so these need to be split prior to generation, presumably it'd be worth adding `./validate/{resource}_name.go` for the `name` validators.