### PR TITLE
Add support for service tags to ip_restriction for function_app and app_service

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1745,12 +1745,14 @@ func flattenAppServiceIpRestriction(input *[]web.IPSecurityRestriction) []interf
 			if *ip == "Any" {
 				continue
 			} else {
-				if v.Tag == web.Default {
+				switch v.Tag {
+				case web.Default:
 					restriction["ip_address"] = *ip
-				} else if v.Tag == web.ServiceTag {
+				case web.ServiceTag:
 					restriction["service_tag"] = *ip
-				} else {
-					// FIXME: I want to error here if we got XffProxy. I don't remember being able to set this in the portal
+				default:
+					// FIXME: I want to error here if we got XffProxy. It doesn't seem possible to set in the portal
+					// but can theoretically come back from the API as defined
 				}
 			}
 		}

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -812,7 +812,7 @@ func schemaAppServiceIpRestriction() *schema.Schema {
 				"ip_address": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.IsCIDR,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
 				"subnet_id": {
@@ -1848,6 +1848,12 @@ func expandAppServiceIpRestriction(input interface{}) ([]web.IPSecurityRestricti
 		ipSecurityRestriction := web.IPSecurityRestriction{}
 		if ipAddress == "Any" {
 			continue
+		}
+
+		// if ipAddress doesn't look like an ipAddress, set Tag to serviceTag
+		firstChar := ipAddress[0]
+		if !('0' <= firstChar && firstChar <= '9') {
+			ipSecurityRestriction.Tag = web.ServiceTag
 		}
 
 		if ipAddress != "" {

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -812,7 +812,7 @@ func schemaAppServiceIpRestriction() *schema.Schema {
 				"ip_address": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
+					ValidateFunc: validation.IsCIDR,
 				},
 
 				"service_tag": {

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1746,13 +1746,10 @@ func flattenAppServiceIpRestriction(input *[]web.IPSecurityRestriction) []interf
 				continue
 			} else {
 				switch v.Tag {
-				case web.Default:
-					restriction["ip_address"] = *ip
 				case web.ServiceTag:
 					restriction["service_tag"] = *ip
 				default:
-					// FIXME: I want to error here if we got XffProxy. It doesn't seem possible to set in the portal
-					// but can theoretically come back from the API as defined
+					restriction["ip_address"] = *ip
 				}
 			}
 		}

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -2769,8 +2769,8 @@ resource "azurerm_app_service" "test" {
 
     ip_restriction {
       service_tag = "AzureEventGrid"
-      name       = "test-restriction-4"
-      action     = "Allow"
+      name        = "test-restriction-4"
+      action      = "Allow"
     }
   }
 }

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -493,7 +493,7 @@ func TestAccAppService_completeIpRestriction(t *testing.T) {
 			Config: r.manyCompleteIpRestrictions(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("3"),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("4"),
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.name").HasValue("test-restriction"),
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.priority").HasValue("123"),
@@ -506,6 +506,10 @@ func TestAccAppService_completeIpRestriction(t *testing.T) {
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.2.name").HasValue("test-restriction-3"),
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.2.priority").HasValue("65000"),
 				check.That(data.ResourceName).Key("site_config.0.ip_restriction.2.action").HasValue("Deny"),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.3.service_tag").HasValue("AzureEventGrid"),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.3.name").HasValue("test-restriction-4"),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.3.priority").HasValue("65000"),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.3.action").HasValue("Allow"),
 			),
 		},
 		data.ImportStep(),
@@ -2761,6 +2765,12 @@ resource "azurerm_app_service" "test" {
       ip_address = "2400:cb00::/32"
       name       = "test-restriction-3"
       action     = "Deny"
+    }
+
+    ip_restriction {
+      service_tag = "AzureEventGrid"
+      name       = "test-restriction-4"
+      action     = "Allow"
     }
   }
 }

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -683,6 +683,51 @@ func TestAccFunctionApp_oneIpRestriction(t *testing.T) {
 	})
 }
 
+func TestAccFunctionApp_oneServiceTagIpRestriction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
+	r := FunctionAppResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.oneServiceTagIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.service_tag").HasValue("AzureEventGrid"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFunctionApp_changeIpToServiceTagIpRestriction(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
+	r := FunctionAppResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.oneIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
+			),
+		},
+		{
+			Config: r.oneServiceTagIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.service_tag").HasValue("AzureEventGrid"),
+			),
+		},
+		{
+			Config: r.oneIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.0.ip_address").HasValue("10.10.10.10/32"),
+			),
+		},
+	})
+}
+
 func TestAccFunctionApp_oneVNetSubnetIpRestriction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
@@ -2401,6 +2446,53 @@ resource "azurerm_function_app" "test" {
   site_config {
     ip_restriction {
       ip_address = "10.10.10.10/32"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (r FunctionAppResource) oneServiceTagIpRestriction(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                       = "acctest-%d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    ip_restriction {
+      service_tag = "AzureEventGrid"
     }
   }
 }

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -91,6 +91,8 @@ An `ip_restriction` block exports the following:
 
 * `ip_address` - The IP Address used for this IP Restriction.
 
+* `service_tag` - The Service Tag used for this IP Restriction.
+
 * `subnet_mask` - The Subnet mask used for this IP Restriction.
 
 * `name` - The name for this IP Restriction.
@@ -103,6 +105,8 @@ An `ip_restriction` block exports the following:
 An `scm_ip_restriction` block exports the following:  
 
 * `ip_address` - The IP Address used for this IP Restriction in CIDR notation.
+
+* `service_tag` - The Service Tag used for this IP Restriction.
 
 * `virtual_network_subnet_id` - The Virtual Network Subnet ID used for this IP Restriction.
 

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -81,6 +81,8 @@ An `ip_restriction` block exports the following:
 
 * `ip_address` - The IP Address used for this IP Restriction.
 
+* `service_tag` - The Service Tag used for this IP Restriction.
+
 * `subnet_mask` - The Subnet mask used for this IP Restriction.
 
 * `name` - The name for this IP Restriction.
@@ -93,6 +95,8 @@ An `ip_restriction` block exports the following:
 An `scm_ip_restriction` block exports the following:  
 
 * `ip_address` - The IP Address used for this IP Restriction in CIDR notation.
+
+* `service_tag` - The Service Tag used for this IP Restriction.
 
 * `virtual_network_subnet_id` - The Virtual Network Subnet ID used for this IP Restriction.
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -323,9 +323,11 @@ A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
 
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 
@@ -339,9 +341,11 @@ A `scm_ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
 
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -312,9 +312,11 @@ A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
 
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -323,9 +323,11 @@ A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
 
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 
@@ -339,9 +341,11 @@ A `scm_ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
 
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -242,9 +242,11 @@ A `ip_restriction` block supports the following:
 
 * `ip_address` - (Optional) The IP Address used for this IP Restriction in CIDR notation.
 
+* `service_tag` - (Optional) The Service Tag used for this IP Restriction.
+
 * `virtual_network_subnet_id` - (Optional) The Virtual Network Subnet ID used for this IP Restriction.
 
--> **NOTE:** One of either `ip_address` or `virtual_network_subnet_id` must be specified
+-> **NOTE:** One of either `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified
 
 * `name` - (Optional) The name for this IP Restriction.
 


### PR DESCRIPTION
Service tags are now allowed in the ip restrictions. In order to support this I've weakened the field validation on ip_address field. Behaviour is that if the field does not start with a number we assume you were attempting to set a service tag, otherwise default to assuming the field contains a CIDR.

I've intentionally not updated documentation yet until I've received feedback on whether this is an acceptable solution to the issue.

I chose to reuse the ip_address field for the service tag instead of adding a new field as this is consistent with the network_security_group resource, where the user can input either an ip or a service tag for source and destination.

Unfortunately this means that I had to remove the IsCIDR validation on the field meaning that validation will not catch errors that it may have previously caught, reducing the user experience a little.

Thinking further on this, would it be possible to implement and extended service tag validation similar to the location validation (the `ServiceTagsClient` can be used to retrieve a list of all service tags)? If so that should probably be a separate PR to enable it for all places a service tag would be valid input.

Last questions, what is the best strategy for testing this change? Is it possible to unit test? How much coverage should I add in the acceptance tests (e.g. one happy day test for both function_app and app_service or do I need to duplicate the tests that remove rules like `TestAccAzureRMFunctionApp_ipRestrictionRemoved`). Is there an ELI5 guide for setting up the prerequisites for running the acceptance tests against my own subscription?

Currently I've just tested manually with the following config

```terraform
resource "azurerm_function_app" "main" {
  name                       = "${var.prefix}-function"
  resource_group_name        = azurerm_resource_group.main.name
  location                   = azurerm_resource_group.main.location
  app_service_plan_id        = azurerm_app_service_plan.main.id
  storage_account_name       = azurerm_storage_account.main.name
  storage_account_access_key = azurerm_storage_account.main.primary_access_key


  site_config {
    ip_restriction {
      ip_address = "AzureEventGrid"
      priority   = 1
      name       = "My Filter"
    }
  }
}
```

Resolves #9380