### PR TITLE
provider: removing `Supported` from the front of the TypedServiceRegistration

### DIFF
--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -44,7 +44,7 @@ func azureProvider(supportLegacyTestSuite bool) terraform.ResourceProvider {
 	// first handle the typed services
 	for _, service := range SupportedTypedServices() {
 		debugLog("[DEBUG] Registering Data Sources for %q..", service.Name())
-		for _, ds := range service.SupportedDataSources() {
+		for _, ds := range service.DataSources() {
 			key := ds.ResourceType()
 			if existing := dataSources[key]; existing != nil {
 				panic(fmt.Sprintf("An existing Data Source exists for %q", key))
@@ -60,7 +60,7 @@ func azureProvider(supportLegacyTestSuite bool) terraform.ResourceProvider {
 		}
 
 		debugLog("[DEBUG] Registering Resources for %q..", service.Name())
-		for _, r := range service.SupportedResources() {
+		for _, r := range service.Resources() {
 			key := r.ResourceType()
 			if existing := resources[key]; existing != nil {
 				panic(fmt.Sprintf("An existing Resource exists for %q", key))

--- a/azurerm/internal/provider/services_test.go
+++ b/azurerm/internal/provider/services_test.go
@@ -9,7 +9,7 @@ import (
 func TestTypedDataSourcesContainValidModelObjects(t *testing.T) {
 	for _, service := range SupportedTypedServices() {
 		t.Logf("Service %q..", service.Name())
-		for _, resource := range service.SupportedDataSources() {
+		for _, resource := range service.DataSources() {
 			t.Logf("- DataSources %q..", resource.ResourceType())
 			obj := resource.ModelObject()
 			if err := sdk.ValidateModelObject(&obj); err != nil {
@@ -22,7 +22,7 @@ func TestTypedDataSourcesContainValidModelObjects(t *testing.T) {
 func TestTypedResourcesContainValidModelObjects(t *testing.T) {
 	for _, service := range SupportedTypedServices() {
 		t.Logf("Service %q..", service.Name())
-		for _, resource := range service.SupportedResources() {
+		for _, resource := range service.Resources() {
 			t.Logf("- Resource %q..", resource.ResourceType())
 			obj := resource.ModelObject()
 			if err := sdk.ValidateModelObject(&obj); err != nil {

--- a/azurerm/internal/sdk/service_registration.go
+++ b/azurerm/internal/sdk/service_registration.go
@@ -12,11 +12,11 @@ type TypedServiceRegistration interface {
 	// PackagePath is the relative path to this package
 	PackagePath() string
 
-	// SupportedResources returns a list of Data Sources supported by this Service
-	SupportedDataSources() []DataSource
+	// DataSources returns a list of Data Sources supported by this Service
+	DataSources() []DataSource
 
-	// SupportedResources returns a list of Resources supported by this Service
-	SupportedResources() []Resource
+	// Resources returns a list of Resources supported by this Service
+	Resources() []Resource
 
 	// WebsiteCategories returns a list of categories which can be used for the sidebar
 	WebsiteCategories() []string

--- a/azurerm/internal/tools/website-scaffold/main.go
+++ b/azurerm/internal/tools/website-scaffold/main.go
@@ -90,7 +90,7 @@ func getContent(resourceName, brandName string, resourceId *string, isResource b
 
 	if !isResource {
 		for _, service := range provider.SupportedTypedServices() {
-			for _, ds := range service.SupportedDataSources() {
+			for _, ds := range service.DataSources() {
 				if ds.ResourceType() == resourceName {
 					wrapper := sdk.NewDataSourceWrapper(ds)
 					dsWrapper, err := wrapper.DataSource()
@@ -119,7 +119,7 @@ func getContent(resourceName, brandName string, resourceId *string, isResource b
 		}
 	} else {
 		for _, service := range provider.SupportedTypedServices() {
-			for _, rs := range service.SupportedResources() {
+			for _, rs := range service.Resources() {
 				if rs.ResourceType() == resourceName {
 					wrapper := sdk.NewResourceWrapper(rs)
 					rsWrapper, err := wrapper.Resource()


### PR DESCRIPTION
This allows us to support both a Typed and Untyped Service Registration implementation on the same struct to allow us to migrate across gradually rather than in a big-bang - mixing and matching.

Example:

```
package resource

import (
	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
)

type Registration struct{}

// Name is the name of this Service
func (r Registration) Name() string {
	return "Resources"
}

// WebsiteCategories returns a list of categories which can be used for the sidebar
func (r Registration) WebsiteCategories() []string {
	return []string{
		"Base",
		"Management",
		"Template",
	}
}

// SupportedDataSources returns the supported Data Sources supported by this Service
func (r Registration) SupportedDataSources() map[string]*schema.Resource {
	return map[string]*schema.Resource{
		"azurerm_resources":      dataSourceArmResources(),
		"azurerm_resource_group": dataSourceArmResourceGroup(),
	}
}

// SupportedResources returns the supported Resources supported by this Service
func (r Registration) SupportedResources() map[string]*schema.Resource {
	return map[string]*schema.Resource{
		"azurerm_management_lock":     resourceArmManagementLock(),
		"azurerm_resource_group":      resourceArmResourceGroup(),
		"azurerm_template_deployment": resourceArmTemplateDeployment(),

		"azurerm_resource_group_template_deployment": resourceGroupTemplateDeploymentResource(),
		"azurerm_subscription_template_deployment":   subscriptionTemplateDeploymentResource(),
	}
}

// PackagePath is the relative path to this package
func (r Registration) PackagePath() string {
	return ""
}

// DataSources returns a list of Data Sources supported by this Service
func (r Registration) DataSources() []sdk.DataSource {
	return []sdk.DataSource{}
}

// Resources returns a list of Resources supported by this Service
func (r Registration) Resources() []sdk.Resource {
	return []sdk.Resource{}
}
```