### PR TITLE
Allow for evenhub dedicated clusters with bigger than 1 capacity

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -59,7 +59,7 @@ func resourceArmEventHubCluster() *schema.Resource {
 				ValidateFunc: validation.StringMatch(
 					regexp.MustCompile(`^Dedicated_[1-9][0-9]*$`),
 					"SKU name must match /^Dedicated_[1-9][0-9]*$/.",
-					),
+				),
 			},
 
 			"tags": tags.Schema(),

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -3,6 +3,7 @@ package eventhub
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -55,9 +56,10 @@ func resourceArmEventHubCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Dedicated_1",
-				}, false),
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^Dedicated_[1-9][0-9]*$`),
+					"SKU name must match /^Dedicated_[1-9][0-9]*$/.",
+					),
 			},
 
 			"tags": tags.Schema(),


### PR DESCRIPTION
This should fix the broken plans (terraform 0.14) with dedicated eventhub clusters which have capacity > 1. 

This aims to fix #9650 

