### PR TITLE
sdk: support for Deprecations on Typed Resources

### DIFF
--- a/azurerm/internal/sdk/resource.go
+++ b/azurerm/internal/sdk/resource.go
@@ -76,6 +76,18 @@ type ResourceWithUpdate interface {
 	Update() ResourceFunc
 }
 
+// ResourceWithDeprecation is an optional interface
+//
+// Resources implementing this interface will be marked as Deprecated
+// and output the DeprecationMessage during Terraform operations.
+type ResourceWithDeprecation interface {
+	Resource
+
+	// DeprecationMessage returns the Deprecation message for this resource
+	// NOTE: this must return a non-empty string
+	DeprecationMessage() string
+}
+
 // ResourceRunFunc is the function which can be run
 // ctx provides a Context instance with the user-provided timeout
 // metadata is a reference to an object containing the Client, ResourceData and a Logger

--- a/azurerm/internal/sdk/resource.go
+++ b/azurerm/internal/sdk/resource.go
@@ -67,6 +67,10 @@ type Resource interface {
 // TODO: a generic state migration for updating ID's
 
 // ResourceWithUpdate is an optional interface
+//
+// Notably the Arguments for Resources implementing this interface
+// cannot be entirely ForceNew - else this interface implementation
+// is superfluous.
 type ResourceWithUpdate interface {
 	Resource
 

--- a/azurerm/internal/sdk/wrapper_resource.go
+++ b/azurerm/internal/sdk/wrapper_resource.go
@@ -116,6 +116,15 @@ func (rw *ResourceWrapper) Resource() (*schema.Resource, error) {
 		resource.Timeouts.Update = d(v.Update().Timeout)
 	}
 
+	if v, ok := rw.resource.(ResourceWithDeprecation); ok {
+		message := v.DeprecationMessage()
+		if message == "" {
+			return nil, fmt.Errorf("Resource %q must return a non-empty DeprecationMessage if implementing ResourceWithDeprecation", rw.resource.ResourceType())
+		}
+
+		resource.DeprecationMessage = message
+	}
+
 	// TODO: CustomizeDiff
 	// TODO: State Migrations
 


### PR DESCRIPTION
This PR adds support for Deprecating a Typed Resource, through implementing the `ResourceWithDeprecation` interface.

There's some sanity checking in the Resource Wrapper to ensure that a Resource implementing this Interface includes a Deprecation message, else it's not really Deprecated (and this method can be removed).