### PR TITLE
`azurerm_iothub` - Add support for `min_tls_version`

### DIFF
--- a/azurerm/internal/services/iothub/iothub_resource.go
+++ b/azurerm/internal/services/iothub/iothub_resource.go
@@ -417,6 +417,15 @@ func resourceArmIotHub() *schema.Resource {
 				},
 			},
 
+			"min_tls_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"1.2",
+				}, false),
+			},
+
 			"public_network_access_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -552,6 +561,10 @@ func resourceArmIotHubCreateUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	if v, ok := d.GetOk("min_tls_version"); ok {
+		props.Properties.MinTLSVersion = utils.String(v.(string))
+	}
+
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, props, "")
 	if err != nil {
 		return fmt.Errorf("Error creating/updating IotHub %q (Resource Group %q): %+v", name, resourceGroup, err)
@@ -651,6 +664,8 @@ func resourceArmIotHubRead(d *schema.ResourceData, meta interface{}) error {
 		if enabled := properties.PublicNetworkAccess; enabled != "" {
 			d.Set("public_network_access_enabled", enabled == devices.Enabled)
 		}
+
+		d.Set("min_tls_version", properties.MinTLSVersion)
 	}
 
 	d.Set("name", id.Name)

--- a/azurerm/internal/services/iothub/tests/iothub_resource_test.go
+++ b/azurerm/internal/services/iothub/tests/iothub_resource_test.go
@@ -241,6 +241,25 @@ func TestAccAzureRMIotHub_publicAccess(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMIotHub_minTLSVersion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMIotHubDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMIotHub_minTLSVersion(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMIotHubExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMIotHubDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).IoTHub.ResourceClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -808,4 +827,34 @@ resource "azurerm_iothub" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMIotHub_minTLSVersion(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-iothub-%d"
+  location = "%s"
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  min_tls_version = "1.2"
+
+  sku {
+    name     = "B1"
+    capacity = "1"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -140,6 +140,8 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Is the IotHub resource accessible from a public network? 
 
+* `min_tls_version` - (Optional) Specifies the minimum TLS version to support for this hub. The only valid value is `1.2`. Changing this forces a new resource to be created.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
Fixes #9668 

```
--- PASS: TestAccAzureRMIotHub_minTLSVersion (456.71s)
```