### PR TITLE
`azurerm_signalr_service` - Fix crash when expanding `cors`

### DIFF
--- a/azurerm/internal/services/signalr/resource_arm_signalr_service.go
+++ b/azurerm/internal/services/signalr/resource_arm_signalr_service.go
@@ -393,7 +393,7 @@ func flattenSignalRFeatures(features *[]signalr.Feature) []interface{} {
 func expandSignalRCors(input []interface{}) *signalr.CorsSettings {
 	corsSettings := signalr.CorsSettings{}
 
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return &corsSettings
 	}
 


### PR DESCRIPTION
Fixes #9636 