### PR TITLE
Function App resource doc - Document default value for `ftps_state` argument

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -191,7 +191,7 @@ The following arguments are supported:
 
 * `cors` - (Optional) A `cors` block as defined below.
 
-* `ftps_state` - (Optional) State of FTP / FTPS service for this function app. Possible values include: `AllAllowed`, `FtpsOnly` and `Disabled`.
+* `ftps_state` - (Optional) State of FTP / FTPS service for this function app. Possible values include: `AllAllowed`, `FtpsOnly` and `Disabled`. Defaults to `AllAllowed`.
 
 * `health_check_path` - (Optional) Path which will be checked for this function app health.
 


### PR DESCRIPTION
Documents the default value of `site_config.ftps_state` when it's not specified: <https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app#ftps_state>.