### PR TITLE
Fix resource id generator on windows

### DIFF
--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -101,6 +101,8 @@ func parseServicePackageName(relativePath string) (*string, error) {
 		path = abs
 	}
 
+	// we do this replacement to avoid the case that on windows machine, the absolute path are using the path separator of \ instead of /
+	path = strings.ReplaceAll(path, "\\", "/")
 	segments := strings.Split(path, "/")
 	serviceIndex := -1
 	for i, v := range segments {


### PR DESCRIPTION
The resource id generator now raises errors on windows because the absolute path on windows will be using `\` as path separator instead of `/`. 
In this PR, I just simply replace all of the `\` before split the path into segments by `/` to avoid this panic