### PR TITLE
generator/resource-id: outputting human-readable segments

### DIFF
--- a/azurerm/internal/services/analysisservices/parse/server.go
+++ b/azurerm/internal/services/analysisservices/parse/server.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/api_diagnostic.go
+++ b/azurerm/internal/services/apimanagement/parse/api_diagnostic.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewApiDiagnosticID(subscriptionId, resourceGroup, serviceName, apiName, dia
 		ApiName:        apiName,
 		DiagnosticName: diagnosticName,
 	}
+}
+
+func (id ApiDiagnosticId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Api Name %q", id.ApiName),
+		fmt.Sprintf("Diagnostic Name %q", id.DiagnosticName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApiDiagnosticId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/api_management.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewApiManagementID(subscriptionId, resourceGroup, serviceName string) ApiMa
 		ResourceGroup:  resourceGroup,
 		ServiceName:    serviceName,
 	}
+}
+
+func (id ApiManagementId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApiManagementId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/api_version_set.go
+++ b/azurerm/internal/services/apimanagement/parse/api_version_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewApiVersionSetID(subscriptionId, resourceGroup, serviceName, name string)
 		ServiceName:    serviceName,
 		Name:           name,
 	}
+}
+
+func (id ApiVersionSetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApiVersionSetId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/custom_domain.go
+++ b/azurerm/internal/services/apimanagement/parse/custom_domain.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewCustomDomainID(subscriptionId, resourceGroup, serviceName, name string) 
 		ServiceName:    serviceName,
 		Name:           name,
 	}
+}
+
+func (id CustomDomainId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CustomDomainId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/diagnostic.go
+++ b/azurerm/internal/services/apimanagement/parse/diagnostic.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDiagnosticID(subscriptionId, resourceGroup, serviceName, name string) Di
 		ServiceName:    serviceName,
 		Name:           name,
 	}
+}
+
+func (id DiagnosticId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DiagnosticId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/logger.go
+++ b/azurerm/internal/services/apimanagement/parse/logger.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoggerID(subscriptionId, resourceGroup, serviceName, name string) Logger
 		ServiceName:    serviceName,
 		Name:           name,
 	}
+}
+
+func (id LoggerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoggerId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/policy.go
+++ b/azurerm/internal/services/apimanagement/parse/policy.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewPolicyID(subscriptionId, resourceGroup, serviceName, name string) Policy
 		ServiceName:    serviceName,
 		Name:           name,
 	}
+}
+
+func (id PolicyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PolicyId) ID(_ string) string {

--- a/azurerm/internal/services/appconfiguration/parse/configuration_store.go
+++ b/azurerm/internal/services/appconfiguration/parse/configuration_store.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewConfigurationStoreID(subscriptionId, resourceGroup, name string) Configu
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ConfigurationStoreId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ConfigurationStoreId) ID(_ string) string {

--- a/azurerm/internal/services/applicationinsights/parse/component.go
+++ b/azurerm/internal/services/applicationinsights/parse/component.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewComponentID(subscriptionId, resourceGroup, name string) ComponentId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ComponentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ComponentId) ID(_ string) string {

--- a/azurerm/internal/services/applicationinsights/parse/web_test_id.go
+++ b/azurerm/internal/services/applicationinsights/parse/web_test_id.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewWebTestID(subscriptionId, resourceGroup, name string) WebTestId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id WebTestId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id WebTestId) ID(_ string) string {

--- a/azurerm/internal/services/appplatform/parse/spring_cloud_app.go
+++ b/azurerm/internal/services/appplatform/parse/spring_cloud_app.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSpringCloudAppID(subscriptionId, resourceGroup, springName, appName stri
 		SpringName:     springName,
 		AppName:        appName,
 	}
+}
+
+func (id SpringCloudAppId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Spring Name %q", id.SpringName),
+		fmt.Sprintf("App Name %q", id.AppName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SpringCloudAppId) ID(_ string) string {

--- a/azurerm/internal/services/appplatform/parse/spring_cloud_certificate.go
+++ b/azurerm/internal/services/appplatform/parse/spring_cloud_certificate.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSpringCloudCertificateID(subscriptionId, resourceGroup, springName, cert
 		SpringName:      springName,
 		CertificateName: certificateName,
 	}
+}
+
+func (id SpringCloudCertificateId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Spring Name %q", id.SpringName),
+		fmt.Sprintf("Certificate Name %q", id.CertificateName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SpringCloudCertificateId) ID(_ string) string {

--- a/azurerm/internal/services/appplatform/parse/spring_cloud_service.go
+++ b/azurerm/internal/services/appplatform/parse/spring_cloud_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSpringCloudServiceID(subscriptionId, resourceGroup, springName string) S
 		ResourceGroup:  resourceGroup,
 		SpringName:     springName,
 	}
+}
+
+func (id SpringCloudServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Spring Name %q", id.SpringName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SpringCloudServiceId) ID(_ string) string {

--- a/azurerm/internal/services/attestation/parse/provider.go
+++ b/azurerm/internal/services/attestation/parse/provider.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewProviderID(subscriptionId, resourceGroup, attestationProviderName string
 		ResourceGroup:           resourceGroup,
 		AttestationProviderName: attestationProviderName,
 	}
+}
+
+func (id ProviderId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Attestation Provider Name %q", id.AttestationProviderName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ProviderId) ID(_ string) string {

--- a/azurerm/internal/services/automation/parse/connection.go
+++ b/azurerm/internal/services/automation/parse/connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewConnectionID(subscriptionId, resourceGroup, automationAccountName, name 
 		AutomationAccountName: automationAccountName,
 		Name:                  name,
 	}
+}
+
+func (id ConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Automation Account Name %q", id.AutomationAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/account.go
+++ b/azurerm/internal/services/batch/parse/account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAccountID(subscriptionId, resourceGroup, batchAccountName string) Accoun
 		ResourceGroup:    resourceGroup,
 		BatchAccountName: batchAccountName,
 	}
+}
+
+func (id AccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/application.go
+++ b/azurerm/internal/services/batch/parse/application.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewApplicationID(subscriptionId, resourceGroup, batchAccountName, name stri
 		BatchAccountName: batchAccountName,
 		Name:             name,
 	}
+}
+
+func (id ApplicationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/certificate.go
+++ b/azurerm/internal/services/batch/parse/certificate.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewCertificateID(subscriptionId, resourceGroup, batchAccountName, name stri
 		BatchAccountName: batchAccountName,
 		Name:             name,
 	}
+}
+
+func (id CertificateId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CertificateId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/pool.go
+++ b/azurerm/internal/services/batch/parse/pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewPoolID(subscriptionId, resourceGroup, batchAccountName, name string) Poo
 		BatchAccountName: batchAccountName,
 		Name:             name,
 	}
+}
+
+func (id PoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PoolId) ID(_ string) string {

--- a/azurerm/internal/services/bot/parse/bot_channel.go
+++ b/azurerm/internal/services/bot/parse/bot_channel.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewBotChannelID(subscriptionId, resourceGroup, botServiceName, channelName 
 		BotServiceName: botServiceName,
 		ChannelName:    channelName,
 	}
+}
+
+func (id BotChannelId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Bot Service Name %q", id.BotServiceName),
+		fmt.Sprintf("Channel Name %q", id.ChannelName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id BotChannelId) ID(_ string) string {

--- a/azurerm/internal/services/bot/parse/bot_connection.go
+++ b/azurerm/internal/services/bot/parse/bot_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewBotConnectionID(subscriptionId, resourceGroup, botServiceName, connectio
 		BotServiceName: botServiceName,
 		ConnectionName: connectionName,
 	}
+}
+
+func (id BotConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Bot Service Name %q", id.BotServiceName),
+		fmt.Sprintf("Connection Name %q", id.ConnectionName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id BotConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/bot/parse/bot_service.go
+++ b/azurerm/internal/services/bot/parse/bot_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewBotServiceID(subscriptionId, resourceGroup, name string) BotServiceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id BotServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id BotServiceId) ID(_ string) string {

--- a/azurerm/internal/services/bot/validate/bot_channel_id.go
+++ b/azurerm/internal/services/bot/validate/bot_channel_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+)
+
+func BotChannelID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.BotChannelID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/bot/validate/bot_channel_id_test.go
+++ b/azurerm/internal/services/bot/validate/bot_channel_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestBotChannelID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/",
+			Valid: false,
+		},
+
+		{
+			// missing value for BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/",
+			Valid: false,
+		},
+
+		{
+			// missing ChannelName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ChannelName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/channels/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/channels/Discovery1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.BOTSERVICE/BOTSERVICES/BOTSERVICE1/CHANNELS/DISCOVERY1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := BotChannelID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/bot/validate/bot_connection_id.go
+++ b/azurerm/internal/services/bot/validate/bot_connection_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+)
+
+func BotConnectionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.BotConnectionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/bot/validate/bot_connection_id_test.go
+++ b/azurerm/internal/services/bot/validate/bot_connection_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestBotConnectionID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/",
+			Valid: false,
+		},
+
+		{
+			// missing value for BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/",
+			Valid: false,
+		},
+
+		{
+			// missing ConnectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ConnectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/connection1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.BOTSERVICE/BOTSERVICES/BOTSERVICE1/CONNECTIONS/CONNECTION1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := BotConnectionID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/bot/validate/bot_service_id.go
+++ b/azurerm/internal/services/bot/validate/bot_service_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+)
+
+func BotServiceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.BotServiceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/bot/validate/bot_service_id_test.go
+++ b/azurerm/internal/services/bot/validate/bot_service_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestBotServiceID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.BOTSERVICE/BOTSERVICES/BOTSERVICE1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := BotServiceID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/cdn/parse/endpoint.go
+++ b/azurerm/internal/services/cdn/parse/endpoint.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewEndpointID(subscriptionId, resourceGroup, profileName, name string) Endp
 		ProfileName:    profileName,
 		Name:           name,
 	}
+}
+
+func (id EndpointId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Profile Name %q", id.ProfileName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id EndpointId) ID(_ string) string {

--- a/azurerm/internal/services/cdn/parse/profile.go
+++ b/azurerm/internal/services/cdn/parse/profile.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewProfileID(subscriptionId, resourceGroup, name string) ProfileId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ProfileId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ProfileId) ID(_ string) string {

--- a/azurerm/internal/services/cognitive/parse/account.go
+++ b/azurerm/internal/services/cognitive/parse/account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id AccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/availability_set.go
+++ b/azurerm/internal/services/compute/parse/availability_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAvailabilitySetID(subscriptionId, resourceGroup, name string) Availabili
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id AvailabilitySetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AvailabilitySetId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/dedicated_host.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDedicatedHostID(subscriptionId, resourceGroup, hostGroupName, hostName s
 		HostGroupName:  hostGroupName,
 		HostName:       hostName,
 	}
+}
+
+func (id DedicatedHostId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Host Group Name %q", id.HostGroupName),
+		fmt.Sprintf("Host Name %q", id.HostName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DedicatedHostId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/dedicated_host_group.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDedicatedHostGroupID(subscriptionId, resourceGroup, hostGroupName string
 		ResourceGroup:  resourceGroup,
 		HostGroupName:  hostGroupName,
 	}
+}
+
+func (id DedicatedHostGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Host Group Name %q", id.HostGroupName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DedicatedHostGroupId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/disk_encryption_set.go
+++ b/azurerm/internal/services/compute/parse/disk_encryption_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDiskEncryptionSetID(subscriptionId, resourceGroup, name string) DiskEncr
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id DiskEncryptionSetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DiskEncryptionSetId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/image.go
+++ b/azurerm/internal/services/compute/parse/image.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewImageID(subscriptionId, resourceGroup, name string) ImageId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ImageId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ImageId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/managed_disk.go
+++ b/azurerm/internal/services/compute/parse/managed_disk.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewManagedDiskID(subscriptionId, resourceGroup, diskName string) ManagedDis
 		ResourceGroup:  resourceGroup,
 		DiskName:       diskName,
 	}
+}
+
+func (id ManagedDiskId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Disk Name %q", id.DiskName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ManagedDiskId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/proximity_placement_group.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewProximityPlacementGroupID(subscriptionId, resourceGroup, name string) Pr
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ProximityPlacementGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ProximityPlacementGroupId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/shared_image.go
+++ b/azurerm/internal/services/compute/parse/shared_image.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSharedImageID(subscriptionId, resourceGroup, galleryName, imageName stri
 		GalleryName:    galleryName,
 		ImageName:      imageName,
 	}
+}
+
+func (id SharedImageId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Gallery Name %q", id.GalleryName),
+		fmt.Sprintf("Image Name %q", id.ImageName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SharedImageId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/shared_image_gallery.go
+++ b/azurerm/internal/services/compute/parse/shared_image_gallery.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSharedImageGalleryID(subscriptionId, resourceGroup, galleryName string) 
 		ResourceGroup:  resourceGroup,
 		GalleryName:    galleryName,
 	}
+}
+
+func (id SharedImageGalleryId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Gallery Name %q", id.GalleryName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SharedImageGalleryId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/shared_image_version.go
+++ b/azurerm/internal/services/compute/parse/shared_image_version.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewSharedImageVersionID(subscriptionId, resourceGroup, galleryName, imageNa
 		ImageName:      imageName,
 		VersionName:    versionName,
 	}
+}
+
+func (id SharedImageVersionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Gallery Name %q", id.GalleryName),
+		fmt.Sprintf("Image Name %q", id.ImageName),
+		fmt.Sprintf("Version Name %q", id.VersionName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SharedImageVersionId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVirtualMachineID(subscriptionId, resourceGroup, name string) VirtualMach
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VirtualMachineId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualMachineId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_extension.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVirtualMachineExtensionID(subscriptionId, resourceGroup, virtualMachineN
 		VirtualMachineName: virtualMachineName,
 		ExtensionName:      extensionName,
 	}
+}
+
+func (id VirtualMachineExtensionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Machine Name %q", id.VirtualMachineName),
+		fmt.Sprintf("Extension Name %q", id.ExtensionName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualMachineExtensionId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVirtualMachineScaleSetID(subscriptionId, resourceGroup, name string) Vir
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VirtualMachineScaleSetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualMachineScaleSetId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVirtualMachineScaleSetExtensionID(subscriptionId, resourceGroup, virtual
 		VirtualMachineScaleSetName: virtualMachineScaleSetName,
 		ExtensionName:              extensionName,
 	}
+}
+
+func (id VirtualMachineScaleSetExtensionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Machine Scale Set Name %q", id.VirtualMachineScaleSetName),
+		fmt.Sprintf("Extension Name %q", id.ExtensionName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualMachineScaleSetExtensionId) ID(_ string) string {

--- a/azurerm/internal/services/containers/parse/cluster.go
+++ b/azurerm/internal/services/containers/parse/cluster.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewClusterID(subscriptionId, resourceGroup, managedClusterName string) Clus
 		ResourceGroup:      resourceGroup,
 		ManagedClusterName: managedClusterName,
 	}
+}
+
+func (id ClusterId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Managed Cluster Name %q", id.ManagedClusterName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/containers/parse/node_pool.go
+++ b/azurerm/internal/services/containers/parse/node_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewNodePoolID(subscriptionId, resourceGroup, managedClusterName, agentPoolN
 		ManagedClusterName: managedClusterName,
 		AgentPoolName:      agentPoolName,
 	}
+}
+
+func (id NodePoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Managed Cluster Name %q", id.ManagedClusterName),
+		fmt.Sprintf("Agent Pool Name %q", id.AgentPoolName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NodePoolId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/cassandra_keyspace.go
+++ b/azurerm/internal/services/cosmos/parse/cassandra_keyspace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewCassandraKeyspaceID(subscriptionId, resourceGroup, databaseAccountName, 
 		DatabaseAccountName: databaseAccountName,
 		Name:                name,
 	}
+}
+
+func (id CassandraKeyspaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CassandraKeyspaceId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/database_account.go
+++ b/azurerm/internal/services/cosmos/parse/database_account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDatabaseAccountID(subscriptionId, resourceGroup, name string) DatabaseAc
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id DatabaseAccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabaseAccountId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/gremlin_database.go
+++ b/azurerm/internal/services/cosmos/parse/gremlin_database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewGremlinDatabaseID(subscriptionId, resourceGroup, databaseAccountName, na
 		DatabaseAccountName: databaseAccountName,
 		Name:                name,
 	}
+}
+
+func (id GremlinDatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id GremlinDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/gremlin_graph.go
+++ b/azurerm/internal/services/cosmos/parse/gremlin_graph.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewGremlinGraphID(subscriptionId, resourceGroup, databaseAccountName, greml
 		GremlinDatabaseName: gremlinDatabaseName,
 		GraphName:           graphName,
 	}
+}
+
+func (id GremlinGraphId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Gremlin Database Name %q", id.GremlinDatabaseName),
+		fmt.Sprintf("Graph Name %q", id.GraphName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id GremlinGraphId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/mongodb_collection.go
+++ b/azurerm/internal/services/cosmos/parse/mongodb_collection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewMongodbCollectionID(subscriptionId, resourceGroup, databaseAccountName, 
 		MongodbDatabaseName: mongodbDatabaseName,
 		CollectionName:      collectionName,
 	}
+}
+
+func (id MongodbCollectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Mongodb Database Name %q", id.MongodbDatabaseName),
+		fmt.Sprintf("Collection Name %q", id.CollectionName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id MongodbCollectionId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/mongodb_database.go
+++ b/azurerm/internal/services/cosmos/parse/mongodb_database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewMongodbDatabaseID(subscriptionId, resourceGroup, databaseAccountName, na
 		DatabaseAccountName: databaseAccountName,
 		Name:                name,
 	}
+}
+
+func (id MongodbDatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id MongodbDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/sql_container.go
+++ b/azurerm/internal/services/cosmos/parse/sql_container.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewSqlContainerID(subscriptionId, resourceGroup, databaseAccountName, sqlDa
 		SqlDatabaseName:     sqlDatabaseName,
 		ContainerName:       containerName,
 	}
+}
+
+func (id SqlContainerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Sql Database Name %q", id.SqlDatabaseName),
+		fmt.Sprintf("Container Name %q", id.ContainerName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SqlContainerId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/sql_database.go
+++ b/azurerm/internal/services/cosmos/parse/sql_database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSqlDatabaseID(subscriptionId, resourceGroup, databaseAccountName, name s
 		DatabaseAccountName: databaseAccountName,
 		Name:                name,
 	}
+}
+
+func (id SqlDatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SqlDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/sql_stored_procedure.go
+++ b/azurerm/internal/services/cosmos/parse/sql_stored_procedure.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -26,6 +27,17 @@ func NewSqlStoredProcedureID(subscriptionId, resourceGroup, databaseAccountName,
 		ContainerName:       containerName,
 		StoredProcedureName: storedProcedureName,
 	}
+}
+
+func (id SqlStoredProcedureId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Sql Database Name %q", id.SqlDatabaseName),
+		fmt.Sprintf("Container Name %q", id.ContainerName),
+		fmt.Sprintf("Stored Procedure Name %q", id.StoredProcedureName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SqlStoredProcedureId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/table.go
+++ b/azurerm/internal/services/cosmos/parse/table.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewTableID(subscriptionId, resourceGroup, databaseAccountName, name string)
 		DatabaseAccountName: databaseAccountName,
 		Name:                name,
 	}
+}
+
+func (id TableId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id TableId) ID(_ string) string {

--- a/azurerm/internal/services/customproviders/parse/resource_provider.go
+++ b/azurerm/internal/services/customproviders/parse/resource_provider.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewResourceProviderID(subscriptionId, resourceGroup, name string) ResourceP
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ResourceProviderId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ResourceProviderId) ID(_ string) string {

--- a/azurerm/internal/services/databasemigration/parse/project.go
+++ b/azurerm/internal/services/databasemigration/parse/project.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewProjectID(subscriptionId, resourceGroup, serviceName, name string) Proje
 		ServiceName:    serviceName,
 		Name:           name,
 	}
+}
+
+func (id ProjectId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ProjectId) ID(_ string) string {

--- a/azurerm/internal/services/databasemigration/parse/service.go
+++ b/azurerm/internal/services/databasemigration/parse/service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServiceID(subscriptionId, resourceGroup, name string) ServiceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServiceId) ID(_ string) string {

--- a/azurerm/internal/services/databricks/parse/workspace.go
+++ b/azurerm/internal/services/databricks/parse/workspace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewWorkspaceID(subscriptionId, resourceGroup, name string) WorkspaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id WorkspaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id WorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/datafactory/parse/integration_runtime.go
+++ b/azurerm/internal/services/datafactory/parse/integration_runtime.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewIntegrationRuntimeID(subscriptionId, resourceGroup, factoryName, name st
 		FactoryName:    factoryName,
 		Name:           name,
 	}
+}
+
+func (id IntegrationRuntimeId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Factory Name %q", id.FactoryName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id IntegrationRuntimeId) ID(_ string) string {

--- a/azurerm/internal/services/datafactory/parse/linked_service.go
+++ b/azurerm/internal/services/datafactory/parse/linked_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLinkedServiceID(subscriptionId, resourceGroup, factoryName, name string)
 		FactoryName:    factoryName,
 		Name:           name,
 	}
+}
+
+func (id LinkedServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Factory Name %q", id.FactoryName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LinkedServiceId) ID(_ string) string {

--- a/azurerm/internal/services/datalake/parse/account.go
+++ b/azurerm/internal/services/datalake/parse/account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id AccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/datashare/parse/account.go
+++ b/azurerm/internal/services/datashare/parse/account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id AccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/datashare/parse/data_set.go
+++ b/azurerm/internal/services/datashare/parse/data_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewDataSetID(subscriptionId, resourceGroup, accountName, shareName, name st
 		ShareName:      shareName,
 		Name:           name,
 	}
+}
+
+func (id DataSetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Share Name %q", id.ShareName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DataSetId) ID(_ string) string {

--- a/azurerm/internal/services/datashare/parse/share.go
+++ b/azurerm/internal/services/datashare/parse/share.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewShareID(subscriptionId, resourceGroup, accountName, name string) ShareId
 		AccountName:    accountName,
 		Name:           name,
 	}
+}
+
+func (id ShareId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ShareId) ID(_ string) string {

--- a/azurerm/internal/services/desktopvirtualization/parse/application_group.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/application_group.go
@@ -23,6 +23,14 @@ func NewApplicationGroupID(subscriptionId, resourceGroup, name string) Applicati
 	}
 }
 
+func (id ApplicationGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
+}
+
 func (id ApplicationGroupId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/applicationGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)

--- a/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
@@ -23,6 +23,14 @@ func NewHostPoolID(subscriptionId, resourceGroup, name string) HostPoolId {
 	}
 }
 
+func (id HostPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
+}
+
 func (id HostPoolId) ID(_ string) string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DesktopVirtualization/hostPools/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)

--- a/azurerm/internal/services/desktopvirtualization/parse/workspace.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/workspace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewWorkspaceID(subscriptionId, resourceGroup, name string) WorkspaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id WorkspaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id WorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/devspace/parse/controller.go
+++ b/azurerm/internal/services/devspace/parse/controller.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewControllerID(subscriptionId, resourceGroup, name string) ControllerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ControllerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ControllerId) ID(_ string) string {

--- a/azurerm/internal/services/devtestlabs/parse/schedule.go
+++ b/azurerm/internal/services/devtestlabs/parse/schedule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewScheduleID(subscriptionId, resourceGroup, name string) ScheduleId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ScheduleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ScheduleId) ID(_ string) string {

--- a/azurerm/internal/services/digitaltwins/parse/digital_twins_endpoint.go
+++ b/azurerm/internal/services/digitaltwins/parse/digital_twins_endpoint.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDigitalTwinsEndpointID(subscriptionId, resourceGroup, digitalTwinsInstan
 		DigitalTwinsInstanceName: digitalTwinsInstanceName,
 		EndpointName:             endpointName,
 	}
+}
+
+func (id DigitalTwinsEndpointId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Digital Twins Instance Name %q", id.DigitalTwinsInstanceName),
+		fmt.Sprintf("Endpoint Name %q", id.EndpointName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DigitalTwinsEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/digitaltwins/parse/digital_twins_instance.go
+++ b/azurerm/internal/services/digitaltwins/parse/digital_twins_instance.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDigitalTwinsInstanceID(subscriptionId, resourceGroup, name string) Digit
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id DigitalTwinsInstanceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DigitalTwinsInstanceId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/a_record.go
+++ b/azurerm/internal/services/dns/parse/a_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewARecordID(subscriptionId, resourceGroup, dnszoneName, aName string) ARec
 		DnszoneName:    dnszoneName,
 		AName:          aName,
 	}
+}
+
+func (id ARecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("A Name %q", id.AName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ARecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/aaaa_record.go
+++ b/azurerm/internal/services/dns/parse/aaaa_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAaaaRecordID(subscriptionId, resourceGroup, dnszoneName, aAAAName string
 		DnszoneName:    dnszoneName,
 		AAAAName:       aAAAName,
 	}
+}
+
+func (id AaaaRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("A A A A Name %q", id.AAAAName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AaaaRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/caa_record.go
+++ b/azurerm/internal/services/dns/parse/caa_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewCaaRecordID(subscriptionId, resourceGroup, dnszoneName, cAAName string) 
 		DnszoneName:    dnszoneName,
 		CAAName:        cAAName,
 	}
+}
+
+func (id CaaRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("C A A Name %q", id.CAAName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CaaRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/cname_record.go
+++ b/azurerm/internal/services/dns/parse/cname_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewCnameRecordID(subscriptionId, resourceGroup, dnszoneName, cNAMEName stri
 		DnszoneName:    dnszoneName,
 		CNAMEName:      cNAMEName,
 	}
+}
+
+func (id CnameRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("C N A M E Name %q", id.CNAMEName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CnameRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/dns_zone.go
+++ b/azurerm/internal/services/dns/parse/dns_zone.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDnsZoneID(subscriptionId, resourceGroup, name string) DnsZoneId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id DnsZoneId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DnsZoneId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/mx_record.go
+++ b/azurerm/internal/services/dns/parse/mx_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewMxRecordID(subscriptionId, resourceGroup, dnszoneName, mXName string) Mx
 		DnszoneName:    dnszoneName,
 		MXName:         mXName,
 	}
+}
+
+func (id MxRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("M X Name %q", id.MXName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id MxRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/ns_record.go
+++ b/azurerm/internal/services/dns/parse/ns_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewNsRecordID(subscriptionId, resourceGroup, dnszoneName, nSName string) Ns
 		DnszoneName:    dnszoneName,
 		NSName:         nSName,
 	}
+}
+
+func (id NsRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("N S Name %q", id.NSName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NsRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/ptr_record.go
+++ b/azurerm/internal/services/dns/parse/ptr_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewPtrRecordID(subscriptionId, resourceGroup, dnszoneName, pTRName string) 
 		DnszoneName:    dnszoneName,
 		PTRName:        pTRName,
 	}
+}
+
+func (id PtrRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("P T R Name %q", id.PTRName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PtrRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/srv_record.go
+++ b/azurerm/internal/services/dns/parse/srv_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSrvRecordID(subscriptionId, resourceGroup, dnszoneName, sRVName string) 
 		DnszoneName:    dnszoneName,
 		SRVName:        sRVName,
 	}
+}
+
+func (id SrvRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("S R V Name %q", id.SRVName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SrvRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/txt_record.go
+++ b/azurerm/internal/services/dns/parse/txt_record.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewTxtRecordID(subscriptionId, resourceGroup, dnszoneName, tXTName string) 
 		DnszoneName:    dnszoneName,
 		TXTName:        tXTName,
 	}
+}
+
+func (id TxtRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("T X T Name %q", id.TXTName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id TxtRecordId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/domain.go
+++ b/azurerm/internal/services/eventgrid/parse/domain.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDomainID(subscriptionId, resourceGroup, name string) DomainId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id DomainId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DomainId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/domain_topic.go
+++ b/azurerm/internal/services/eventgrid/parse/domain_topic.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDomainTopicID(subscriptionId, resourceGroup, domainName, topicName strin
 		DomainName:     domainName,
 		TopicName:      topicName,
 	}
+}
+
+func (id DomainTopicId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Domain Name %q", id.DomainName),
+		fmt.Sprintf("Topic Name %q", id.TopicName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DomainTopicId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/system_topic.go
+++ b/azurerm/internal/services/eventgrid/parse/system_topic.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSystemTopicID(subscriptionId, resourceGroup, name string) SystemTopicId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SystemTopicId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SystemTopicId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/topic.go
+++ b/azurerm/internal/services/eventgrid/parse/topic.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewTopicID(subscriptionId, resourceGroup, name string) TopicId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id TopicId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id TopicId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/cluster.go
+++ b/azurerm/internal/services/eventhub/parse/cluster.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ClusterId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/event_hub_consumer_group.go
+++ b/azurerm/internal/services/eventhub/parse/event_hub_consumer_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewEventHubConsumerGroupID(subscriptionId, resourceGroup, namespaceName, ev
 		EventhubName:      eventhubName,
 		ConsumergroupName: consumergroupName,
 	}
+}
+
+func (id EventHubConsumerGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Eventhub Name %q", id.EventhubName),
+		fmt.Sprintf("Consumergroup Name %q", id.ConsumergroupName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id EventHubConsumerGroupId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/namespace.go
+++ b/azurerm/internal/services/eventhub/parse/namespace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/namespace_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/parse/namespace_authorization_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewNamespaceAuthorizationRuleID(subscriptionId, resourceGroup, namespaceNam
 		NamespaceName:         namespaceName,
 		AuthorizationRuleName: authorizationRuleName,
 	}
+}
+
+func (id NamespaceAuthorizationRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NamespaceAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/healthcare/parse/service.go
+++ b/azurerm/internal/services/healthcare/parse/service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServiceID(subscriptionId, resourceGroup, name string) ServiceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServiceId) ID(_ string) string {

--- a/azurerm/internal/services/hpccache/parse/cache.go
+++ b/azurerm/internal/services/hpccache/parse/cache.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewCacheID(subscriptionId, resourceGroup, name string) CacheId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id CacheId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CacheId) ID(_ string) string {

--- a/azurerm/internal/services/hpccache/parse/storage_target.go
+++ b/azurerm/internal/services/hpccache/parse/storage_target.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewStorageTargetID(subscriptionId, resourceGroup, cacheName, name string) S
 		CacheName:      cacheName,
 		Name:           name,
 	}
+}
+
+func (id StorageTargetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cache Name %q", id.CacheName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id StorageTargetId) ID(_ string) string {

--- a/azurerm/internal/services/hsm/parse/dedicated_hardware_security_module.go
+++ b/azurerm/internal/services/hsm/parse/dedicated_hardware_security_module.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDedicatedHardwareSecurityModuleID(subscriptionId, resourceGroup, dedicat
 		ResourceGroup:    resourceGroup,
 		DedicatedHSMName: dedicatedHSMName,
 	}
+}
+
+func (id DedicatedHardwareSecurityModuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Dedicated H S M Name %q", id.DedicatedHSMName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DedicatedHardwareSecurityModuleId) ID(_ string) string {

--- a/azurerm/internal/services/iotcentral/parse/application.go
+++ b/azurerm/internal/services/iotcentral/parse/application.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewApplicationID(subscriptionId, resourceGroup, ioTAppName string) Applicat
 		ResourceGroup:  resourceGroup,
 		IoTAppName:     ioTAppName,
 	}
+}
+
+func (id ApplicationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Io T App Name %q", id.IoTAppName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/iothub/parse/iot_hub.go
+++ b/azurerm/internal/services/iothub/parse/iot_hub.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewIotHubID(subscriptionId, resourceGroup, name string) IotHubId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id IotHubId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id IotHubId) ID(_ string) string {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/access_policy.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/access_policy.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAccessPolicyID(subscriptionId, resourceGroup, environmentName, name stri
 		EnvironmentName: environmentName,
 		Name:            name,
 	}
+}
+
+func (id AccessPolicyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Environment Name %q", id.EnvironmentName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccessPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/environment.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/environment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewEnvironmentID(subscriptionId, resourceGroup, name string) EnvironmentId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id EnvironmentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id EnvironmentId) ID(_ string) string {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/reference_data_set.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/reference_data_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewReferenceDataSetID(subscriptionId, resourceGroup, environmentName, name 
 		EnvironmentName: environmentName,
 		Name:            name,
 	}
+}
+
+func (id ReferenceDataSetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Environment Name %q", id.EnvironmentName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ReferenceDataSetId) ID(_ string) string {

--- a/azurerm/internal/services/keyvault/parse/vault.go
+++ b/azurerm/internal/services/keyvault/parse/vault.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVaultID(subscriptionId, resourceGroup, name string) VaultId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VaultId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VaultId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/attached_database_configuration.go
+++ b/azurerm/internal/services/kusto/parse/attached_database_configuration.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAttachedDatabaseConfigurationID(subscriptionId, resourceGroup, clusterNa
 		ClusterName:    clusterName,
 		Name:           name,
 	}
+}
+
+func (id AttachedDatabaseConfigurationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AttachedDatabaseConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/cluster.go
+++ b/azurerm/internal/services/kusto/parse/cluster.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ClusterId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/cluster_principal_assignment.go
+++ b/azurerm/internal/services/kusto/parse/cluster_principal_assignment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewClusterPrincipalAssignmentID(subscriptionId, resourceGroup, clusterName,
 		ClusterName:             clusterName,
 		PrincipalAssignmentName: principalAssignmentName,
 	}
+}
+
+func (id ClusterPrincipalAssignmentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Principal Assignment Name %q", id.PrincipalAssignmentName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ClusterPrincipalAssignmentId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/data_connection.go
+++ b/azurerm/internal/services/kusto/parse/data_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewDataConnectionID(subscriptionId, resourceGroup, clusterName, databaseNam
 		DatabaseName:   databaseName,
 		Name:           name,
 	}
+}
+
+func (id DataConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DataConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/database.go
+++ b/azurerm/internal/services/kusto/parse/database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDatabaseID(subscriptionId, resourceGroup, clusterName, name string) Data
 		ClusterName:    clusterName,
 		Name:           name,
 	}
+}
+
+func (id DatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/database_principal.go
+++ b/azurerm/internal/services/kusto/parse/database_principal.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -26,6 +27,17 @@ func NewDatabasePrincipalID(subscriptionId, resourceGroup, clusterName, database
 		RoleName:       roleName,
 		FQNName:        fQNName,
 	}
+}
+
+func (id DatabasePrincipalId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Role Name %q", id.RoleName),
+		fmt.Sprintf("F Q N Name %q", id.FQNName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabasePrincipalId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/database_principal_assignment.go
+++ b/azurerm/internal/services/kusto/parse/database_principal_assignment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewDatabasePrincipalAssignmentID(subscriptionId, resourceGroup, clusterName
 		DatabaseName:            databaseName,
 		PrincipalAssignmentName: principalAssignmentName,
 	}
+}
+
+func (id DatabasePrincipalAssignmentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Principal Assignment Name %q", id.PrincipalAssignmentName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabasePrincipalAssignmentId) ID(_ string) string {

--- a/azurerm/internal/services/logic/parse/integration_account.go
+++ b/azurerm/internal/services/logic/parse/integration_account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewIntegrationAccountID(subscriptionId, resourceGroup, name string) Integra
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id IntegrationAccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id IntegrationAccountId) ID(_ string) string {

--- a/azurerm/internal/services/logic/parse/integration_service_environment.go
+++ b/azurerm/internal/services/logic/parse/integration_service_environment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewIntegrationServiceEnvironmentID(subscriptionId, resourceGroup, name stri
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id IntegrationServiceEnvironmentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id IntegrationServiceEnvironmentId) ID(_ string) string {

--- a/azurerm/internal/services/managedapplications/parse/application.go
+++ b/azurerm/internal/services/managedapplications/parse/application.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewApplicationID(subscriptionId, resourceGroup, name string) ApplicationId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ApplicationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/managedapplications/parse/application_definition.go
+++ b/azurerm/internal/services/managedapplications/parse/application_definition.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewApplicationDefinitionID(subscriptionId, resourceGroup, name string) Appl
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ApplicationDefinitionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApplicationDefinitionId) ID(_ string) string {

--- a/azurerm/internal/services/maps/parse/account.go
+++ b/azurerm/internal/services/maps/parse/account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id AccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/mariadb/parse/server.go
+++ b/azurerm/internal/services/mariadb/parse/server.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/media/parse/media_service.go
+++ b/azurerm/internal/services/media/parse/media_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewMediaServiceID(subscriptionId, resourceGroup, name string) MediaServiceI
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id MediaServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id MediaServiceId) ID(_ string) string {

--- a/azurerm/internal/services/mixedreality/parse/spatial_anchors_account.go
+++ b/azurerm/internal/services/mixedreality/parse/spatial_anchors_account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSpatialAnchorsAccountID(subscriptionId, resourceGroup, name string) Spat
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SpatialAnchorsAccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SpatialAnchorsAccountId) ID(_ string) string {

--- a/azurerm/internal/services/monitor/parse/action_group.go
+++ b/azurerm/internal/services/monitor/parse/action_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewActionGroupID(subscriptionId, resourceGroup, name string) ActionGroupId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ActionGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ActionGroupId) ID(_ string) string {

--- a/azurerm/internal/services/monitor/parse/action_rule.go
+++ b/azurerm/internal/services/monitor/parse/action_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewActionRuleID(subscriptionId, resourceGroup, name string) ActionRuleId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ActionRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ActionRuleId) ID(_ string) string {

--- a/azurerm/internal/services/monitor/parse/smart_detector_alert_rule.go
+++ b/azurerm/internal/services/monitor/parse/smart_detector_alert_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSmartDetectorAlertRuleID(subscriptionId, resourceGroup, name string) Sma
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SmartDetectorAlertRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SmartDetectorAlertRuleId) ID(_ string) string {

--- a/azurerm/internal/services/msi/parse/user_assigned_identity.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewUserAssignedIdentityID(subscriptionId, resourceGroup, name string) UserA
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id UserAssignedIdentityId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id UserAssignedIdentityId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/database.go
+++ b/azurerm/internal/services/mssql/parse/database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDatabaseID(subscriptionId, resourceGroup, serverName, name string) Datab
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id DatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/database_extended_auditing_policy.go
+++ b/azurerm/internal/services/mssql/parse/database_extended_auditing_policy.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewDatabaseExtendedAuditingPolicyID(subscriptionId, resourceGroup, serverNa
 		DatabaseName:                databaseName,
 		ExtendedAuditingSettingName: extendedAuditingSettingName,
 	}
+}
+
+func (id DatabaseExtendedAuditingPolicyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Extended Auditing Setting Name %q", id.ExtendedAuditingSettingName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabaseExtendedAuditingPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/elastic_pool.go
+++ b/azurerm/internal/services/mssql/parse/elastic_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewElasticPoolID(subscriptionId, resourceGroup, serverName, name string) El
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id ElasticPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ElasticPoolId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/recoverable_database.go
+++ b/azurerm/internal/services/mssql/parse/recoverable_database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewRecoverableDatabaseID(subscriptionId, resourceGroup, serverName, name st
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id RecoverableDatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id RecoverableDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/server.go
+++ b/azurerm/internal/services/mssql/parse/server.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/server_extended_auditing_policy.go
+++ b/azurerm/internal/services/mssql/parse/server_extended_auditing_policy.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewServerExtendedAuditingPolicyID(subscriptionId, resourceGroup, serverName
 		ServerName:                  serverName,
 		ExtendedAuditingSettingName: extendedAuditingSettingName,
 	}
+}
+
+func (id ServerExtendedAuditingPolicyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Extended Auditing Setting Name %q", id.ExtendedAuditingSettingName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerExtendedAuditingPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/sql_virtual_machine.go
+++ b/azurerm/internal/services/mssql/parse/sql_virtual_machine.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSqlVirtualMachineID(subscriptionId, resourceGroup, name string) SqlVirtu
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SqlVirtualMachineId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SqlVirtualMachineId) ID(_ string) string {

--- a/azurerm/internal/services/mysql/parse/key.go
+++ b/azurerm/internal/services/mysql/parse/key.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewKeyID(subscriptionId, resourceGroup, serverName, name string) KeyId {
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id KeyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id KeyId) ID(_ string) string {

--- a/azurerm/internal/services/mysql/parse/server.go
+++ b/azurerm/internal/services/mysql/parse/server.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/account.go
+++ b/azurerm/internal/services/netapp/parse/account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAccountID(subscriptionId, resourceGroup, netAppAccountName string) Accou
 		ResourceGroup:     resourceGroup,
 		NetAppAccountName: netAppAccountName,
 	}
+}
+
+func (id AccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/capacity_pool.go
+++ b/azurerm/internal/services/netapp/parse/capacity_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewCapacityPoolID(subscriptionId, resourceGroup, netAppAccountName, name st
 		NetAppAccountName: netAppAccountName,
 		Name:              name,
 	}
+}
+
+func (id CapacityPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CapacityPoolId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/snapshot.go
+++ b/azurerm/internal/services/netapp/parse/snapshot.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -26,6 +27,17 @@ func NewSnapshotID(subscriptionId, resourceGroup, netAppAccountName, capacityPoo
 		VolumeName:        volumeName,
 		Name:              name,
 	}
+}
+
+func (id SnapshotId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Capacity Pool Name %q", id.CapacityPoolName),
+		fmt.Sprintf("Volume Name %q", id.VolumeName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SnapshotId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/volume.go
+++ b/azurerm/internal/services/netapp/parse/volume.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewVolumeID(subscriptionId, resourceGroup, netAppAccountName, capacityPoolN
 		CapacityPoolName:  capacityPoolName,
 		Name:              name,
 	}
+}
+
+func (id VolumeId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Capacity Pool Name %q", id.CapacityPoolName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VolumeId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/bgp_connection.go
+++ b/azurerm/internal/services/network/parse/bgp_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewBgpConnectionID(subscriptionId, resourceGroup, virtualHubName, name stri
 		VirtualHubName: virtualHubName,
 		Name:           name,
 	}
+}
+
+func (id BgpConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id BgpConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/connection_monitor.go
+++ b/azurerm/internal/services/network/parse/connection_monitor.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewConnectionMonitorID(subscriptionId, resourceGroup, networkWatcherName, n
 		NetworkWatcherName: networkWatcherName,
 		Name:               name,
 	}
+}
+
+func (id ConnectionMonitorId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Network Watcher Name %q", id.NetworkWatcherName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ConnectionMonitorId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/firewall_policy.go
+++ b/azurerm/internal/services/network/parse/firewall_policy.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewFirewallPolicyID(subscriptionId, resourceGroup, name string) FirewallPol
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id FirewallPolicyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FirewallPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/firewall_policy_rule_collection_group.go
+++ b/azurerm/internal/services/network/parse/firewall_policy_rule_collection_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewFirewallPolicyRuleCollectionGroupID(subscriptionId, resourceGroup, firew
 		FirewallPolicyName:      firewallPolicyName,
 		RuleCollectionGroupName: ruleCollectionGroupName,
 	}
+}
+
+func (id FirewallPolicyRuleCollectionGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Firewall Policy Name %q", id.FirewallPolicyName),
+		fmt.Sprintf("Rule Collection Group Name %q", id.RuleCollectionGroupName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FirewallPolicyRuleCollectionGroupId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/hub_route_table.go
+++ b/azurerm/internal/services/network/parse/hub_route_table.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewHubRouteTableID(subscriptionId, resourceGroup, virtualHubName, name stri
 		VirtualHubName: virtualHubName,
 		Name:           name,
 	}
+}
+
+func (id HubRouteTableId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id HubRouteTableId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/hub_virtual_network_connection.go
+++ b/azurerm/internal/services/network/parse/hub_virtual_network_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewHubVirtualNetworkConnectionID(subscriptionId, resourceGroup, virtualHubN
 		VirtualHubName: virtualHubName,
 		Name:           name,
 	}
+}
+
+func (id HubVirtualNetworkConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id HubVirtualNetworkConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/ip_group.go
+++ b/azurerm/internal/services/network/parse/ip_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewIpGroupID(subscriptionId, resourceGroup, name string) IpGroupId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id IpGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id IpGroupId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer.go
+++ b/azurerm/internal/services/network/parse/load_balancer.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewLoadBalancerID(subscriptionId, resourceGroup, name string) LoadBalancerI
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id LoadBalancerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer_backend_address_pool.go
+++ b/azurerm/internal/services/network/parse/load_balancer_backend_address_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancerBackendAddressPoolID(subscriptionId, resourceGroup, loadBala
 		LoadBalancerName:       loadBalancerName,
 		BackendAddressPoolName: backendAddressPoolName,
 	}
+}
+
+func (id LoadBalancerBackendAddressPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Backend Address Pool Name %q", id.BackendAddressPoolName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerBackendAddressPoolId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer_frontend_ip_configuration.go
+++ b/azurerm/internal/services/network/parse/load_balancer_frontend_ip_configuration.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancerFrontendIpConfigurationID(subscriptionId, resourceGroup, loa
 		LoadBalancerName:            loadBalancerName,
 		FrontendIPConfigurationName: frontendIPConfigurationName,
 	}
+}
+
+func (id LoadBalancerFrontendIpConfigurationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Frontend I P Configuration Name %q", id.FrontendIPConfigurationName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerFrontendIpConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer_inbound_nat_pool.go
+++ b/azurerm/internal/services/network/parse/load_balancer_inbound_nat_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancerInboundNatPoolID(subscriptionId, resourceGroup, loadBalancer
 		LoadBalancerName:   loadBalancerName,
 		InboundNatPoolName: inboundNatPoolName,
 	}
+}
+
+func (id LoadBalancerInboundNatPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Inbound Nat Pool Name %q", id.InboundNatPoolName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerInboundNatPoolId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer_inbound_nat_rule.go
+++ b/azurerm/internal/services/network/parse/load_balancer_inbound_nat_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancerInboundNatRuleID(subscriptionId, resourceGroup, loadBalancer
 		LoadBalancerName:   loadBalancerName,
 		InboundNatRuleName: inboundNatRuleName,
 	}
+}
+
+func (id LoadBalancerInboundNatRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Inbound Nat Rule Name %q", id.InboundNatRuleName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerInboundNatRuleId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer_outbound_rule.go
+++ b/azurerm/internal/services/network/parse/load_balancer_outbound_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancerOutboundRuleID(subscriptionId, resourceGroup, loadBalancerNa
 		LoadBalancerName: loadBalancerName,
 		OutboundRuleName: outboundRuleName,
 	}
+}
+
+func (id LoadBalancerOutboundRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Outbound Rule Name %q", id.OutboundRuleName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerOutboundRuleId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancer_probe.go
+++ b/azurerm/internal/services/network/parse/load_balancer_probe.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancerProbeID(subscriptionId, resourceGroup, loadBalancerName, pro
 		LoadBalancerName: loadBalancerName,
 		ProbeName:        probeName,
 	}
+}
+
+func (id LoadBalancerProbeId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Probe Name %q", id.ProbeName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancerProbeId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/load_balancing_rule.go
+++ b/azurerm/internal/services/network/parse/load_balancing_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewLoadBalancingRuleID(subscriptionId, resourceGroup, loadBalancerName, nam
 		LoadBalancerName: loadBalancerName,
 		Name:             name,
 	}
+}
+
+func (id LoadBalancingRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id LoadBalancingRuleId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/nat_gateway.go
+++ b/azurerm/internal/services/network/parse/nat_gateway.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNatGatewayID(subscriptionId, resourceGroup, name string) NatGatewayId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NatGatewayId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NatGatewayId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/network_interface.go
+++ b/azurerm/internal/services/network/parse/network_interface.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNetworkInterfaceID(subscriptionId, resourceGroup, name string) NetworkIn
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NetworkInterfaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NetworkInterfaceId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/network_watcher.go
+++ b/azurerm/internal/services/network/parse/network_watcher.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNetworkWatcherID(subscriptionId, resourceGroup, name string) NetworkWatc
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NetworkWatcherId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NetworkWatcherId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/packet_capture.go
+++ b/azurerm/internal/services/network/parse/packet_capture.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewPacketCaptureID(subscriptionId, resourceGroup, networkWatcherName, name 
 		NetworkWatcherName: networkWatcherName,
 		Name:               name,
 	}
+}
+
+func (id PacketCaptureId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Network Watcher Name %q", id.NetworkWatcherName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PacketCaptureId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/private_dns_zone_config.go
+++ b/azurerm/internal/services/network/parse/private_dns_zone_config.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewPrivateDnsZoneConfigID(subscriptionId, resourceGroup, privateEndpointNam
 		PrivateDnsZoneGroupName: privateDnsZoneGroupName,
 		Name:                    name,
 	}
+}
+
+func (id PrivateDnsZoneConfigId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Private Endpoint Name %q", id.PrivateEndpointName),
+		fmt.Sprintf("Private Dns Zone Group Name %q", id.PrivateDnsZoneGroupName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PrivateDnsZoneConfigId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/private_dns_zone_group.go
+++ b/azurerm/internal/services/network/parse/private_dns_zone_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewPrivateDnsZoneGroupID(subscriptionId, resourceGroup, privateEndpointName
 		PrivateEndpointName: privateEndpointName,
 		Name:                name,
 	}
+}
+
+func (id PrivateDnsZoneGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Private Endpoint Name %q", id.PrivateEndpointName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PrivateDnsZoneGroupId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/private_endpoint.go
+++ b/azurerm/internal/services/network/parse/private_endpoint.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewPrivateEndpointID(subscriptionId, resourceGroup, name string) PrivateEnd
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id PrivateEndpointId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PrivateEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/public_ip_address.go
+++ b/azurerm/internal/services/network/parse/public_ip_address.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewPublicIpAddressID(subscriptionId, resourceGroup, name string) PublicIpAd
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id PublicIpAddressId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PublicIpAddressId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/route_filter.go
+++ b/azurerm/internal/services/network/parse/route_filter.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewRouteFilterID(subscriptionId, resourceGroup, name string) RouteFilterId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id RouteFilterId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id RouteFilterId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/security_partner_provider.go
+++ b/azurerm/internal/services/network/parse/security_partner_provider.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSecurityPartnerProviderID(subscriptionId, resourceGroup, name string) Se
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SecurityPartnerProviderId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SecurityPartnerProviderId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/subnet.go
+++ b/azurerm/internal/services/network/parse/subnet.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSubnetID(subscriptionId, resourceGroup, virtualNetworkName, name string)
 		VirtualNetworkName: virtualNetworkName,
 		Name:               name,
 	}
+}
+
+func (id SubnetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Network Name %q", id.VirtualNetworkName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SubnetId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_hub.go
+++ b/azurerm/internal/services/network/parse/virtual_hub.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVirtualHubID(subscriptionId, resourceGroup, name string) VirtualHubId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VirtualHubId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualHubId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_hub_ip_configuration.go
+++ b/azurerm/internal/services/network/parse/virtual_hub_ip_configuration.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVirtualHubIpConfigurationID(subscriptionId, resourceGroup, virtualHubNam
 		VirtualHubName:      virtualHubName,
 		IpConfigurationName: ipConfigurationName,
 	}
+}
+
+func (id VirtualHubIpConfigurationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Ip Configuration Name %q", id.IpConfigurationName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualHubIpConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_network.go
+++ b/azurerm/internal/services/network/parse/virtual_network.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVirtualNetworkID(subscriptionId, resourceGroup, name string) VirtualNetw
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VirtualNetworkId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualNetworkId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_wan.go
+++ b/azurerm/internal/services/network/parse/virtual_wan.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVirtualWanID(subscriptionId, resourceGroup, name string) VirtualWanId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VirtualWanId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualWanId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_connection.go
+++ b/azurerm/internal/services/network/parse/vpn_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVpnConnectionID(subscriptionId, resourceGroup, vpnGatewayName, name stri
 		VpnGatewayName: vpnGatewayName,
 		Name:           name,
 	}
+}
+
+func (id VpnConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Vpn Gateway Name %q", id.VpnGatewayName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VpnConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_gateway.go
+++ b/azurerm/internal/services/network/parse/vpn_gateway.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVpnGatewayID(subscriptionId, resourceGroup, name string) VpnGatewayId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VpnGatewayId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VpnGatewayId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_site.go
+++ b/azurerm/internal/services/network/parse/vpn_site.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewVpnSiteID(subscriptionId, resourceGroup, name string) VpnSiteId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id VpnSiteId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VpnSiteId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_site_link.go
+++ b/azurerm/internal/services/network/parse/vpn_site_link.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVpnSiteLinkID(subscriptionId, resourceGroup, vpnSiteName, name string) V
 		VpnSiteName:    vpnSiteName,
 		Name:           name,
 	}
+}
+
+func (id VpnSiteLinkId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Vpn Site Name %q", id.VpnSiteName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VpnSiteLinkId) ID(_ string) string {

--- a/azurerm/internal/services/notificationhub/parse/namespace.go
+++ b/azurerm/internal/services/notificationhub/parse/namespace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/notificationhub/parse/notification_hub.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewNotificationHubID(subscriptionId, resourceGroup, namespaceName, name str
 		NamespaceName:  namespaceName,
 		Name:           name,
 	}
+}
+
+func (id NotificationHubId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NotificationHubId) ID(_ string) string {

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewNotificationHubAuthorizationRuleID(subscriptionId, resourceGroup, namesp
 		NotificationHubName:   notificationHubName,
 		AuthorizationRuleName: authorizationRuleName,
 	}
+}
+
+func (id NotificationHubAuthorizationRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Notification Hub Name %q", id.NotificationHubName),
+		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NotificationHubAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/portal/parse/dashboard.go
+++ b/azurerm/internal/services/portal/parse/dashboard.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewDashboardID(subscriptionId, resourceGroup, name string) DashboardId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id DashboardId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DashboardId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/azure_active_directory_administrator.go
+++ b/azurerm/internal/services/postgres/parse/azure_active_directory_administrator.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAzureActiveDirectoryAdministratorID(subscriptionId, resourceGroup, serve
 		ServerName:        serverName,
 		AdministratorName: administratorName,
 	}
+}
+
+func (id AzureActiveDirectoryAdministratorId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Administrator Name %q", id.AdministratorName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AzureActiveDirectoryAdministratorId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/configuration.go
+++ b/azurerm/internal/services/postgres/parse/configuration.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewConfigurationID(subscriptionId, resourceGroup, serverName, name string) 
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id ConfigurationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/database.go
+++ b/azurerm/internal/services/postgres/parse/database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDatabaseID(subscriptionId, resourceGroup, serverName, name string) Datab
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id DatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/firewall_rule.go
+++ b/azurerm/internal/services/postgres/parse/firewall_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, serverName, name string) F
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id FirewallRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/server.go
+++ b/azurerm/internal/services/postgres/parse/server.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/server_key.go
+++ b/azurerm/internal/services/postgres/parse/server_key.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewServerKeyID(subscriptionId, resourceGroup, serverName, keyName string) S
 		ServerName:     serverName,
 		KeyName:        keyName,
 	}
+}
+
+func (id ServerKeyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Key Name %q", id.KeyName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerKeyId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/virtual_network_rule.go
+++ b/azurerm/internal/services/postgres/parse/virtual_network_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVirtualNetworkRuleID(subscriptionId, resourceGroup, serverName, name str
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id VirtualNetworkRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualNetworkRuleId) ID(_ string) string {

--- a/azurerm/internal/services/powerbi/parse/embedded.go
+++ b/azurerm/internal/services/powerbi/parse/embedded.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewEmbeddedID(subscriptionId, resourceGroup, capacityName string) EmbeddedI
 		ResourceGroup:  resourceGroup,
 		CapacityName:   capacityName,
 	}
+}
+
+func (id EmbeddedId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Capacity Name %q", id.CapacityName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id EmbeddedId) ID(_ string) string {

--- a/azurerm/internal/services/privatedns/parse/private_dns_zone.go
+++ b/azurerm/internal/services/privatedns/parse/private_dns_zone.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewPrivateDnsZoneID(subscriptionId, resourceGroup, name string) PrivateDnsZ
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id PrivateDnsZoneId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id PrivateDnsZoneId) ID(_ string) string {

--- a/azurerm/internal/services/relay/parse/hybrid_connection.go
+++ b/azurerm/internal/services/relay/parse/hybrid_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewHybridConnectionID(subscriptionId, resourceGroup, namespaceName, name st
 		NamespaceName:  namespaceName,
 		Name:           name,
 	}
+}
+
+func (id HybridConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id HybridConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/relay/parse/namespace.go
+++ b/azurerm/internal/services/relay/parse/namespace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/resource/parse/resource_group.go
+++ b/azurerm/internal/services/resource/parse/resource_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -18,6 +19,13 @@ func NewResourceGroupID(subscriptionId, resourceGroup string) ResourceGroupId {
 		SubscriptionId: subscriptionId,
 		ResourceGroup:  resourceGroup,
 	}
+}
+
+func (id ResourceGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ResourceGroupId) ID(_ string) string {

--- a/azurerm/internal/services/resource/parse/resource_group_template_deployment.go
+++ b/azurerm/internal/services/resource/parse/resource_group_template_deployment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewResourceGroupTemplateDeploymentID(subscriptionId, resourceGroup, deploym
 		ResourceGroup:  resourceGroup,
 		DeploymentName: deploymentName,
 	}
+}
+
+func (id ResourceGroupTemplateDeploymentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Deployment Name %q", id.DeploymentName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ResourceGroupTemplateDeploymentId) ID(_ string) string {

--- a/azurerm/internal/services/resource/parse/subscription_template_deployment.go
+++ b/azurerm/internal/services/resource/parse/subscription_template_deployment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -18,6 +19,13 @@ func NewSubscriptionTemplateDeploymentID(subscriptionId, deploymentName string) 
 		SubscriptionId: subscriptionId,
 		DeploymentName: deploymentName,
 	}
+}
+
+func (id SubscriptionTemplateDeploymentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Deployment Name %q", id.DeploymentName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SubscriptionTemplateDeploymentId) ID(_ string) string {

--- a/azurerm/internal/services/search/parse/search_service.go
+++ b/azurerm/internal/services/search/parse/search_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSearchServiceID(subscriptionId, resourceGroup, name string) SearchServic
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SearchServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SearchServiceId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/namespace.go
+++ b/azurerm/internal/services/servicebus/parse/namespace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/namespace_network_rule_set.go
+++ b/azurerm/internal/services/servicebus/parse/namespace_network_rule_set.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewNamespaceNetworkRuleSetID(subscriptionId, resourceGroup, namespaceName, 
 		NamespaceName:      namespaceName,
 		NetworkrulesetName: networkrulesetName,
 	}
+}
+
+func (id NamespaceNetworkRuleSetId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Networkruleset Name %q", id.NetworkrulesetName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NamespaceNetworkRuleSetId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabric/parse/cluster.go
+++ b/azurerm/internal/services/servicefabric/parse/cluster.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ClusterId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/application.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/application.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewApplicationID(subscriptionId, resourceGroup, name string) ApplicationId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ApplicationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/network.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/network.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewNetworkID(subscriptionId, resourceGroup, name string) NetworkId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id NetworkId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NetworkId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/secret.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/secret.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewSecretID(subscriptionId, resourceGroup, name string) SecretId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id SecretId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SecretId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/secret_value.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/secret_value.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSecretValueID(subscriptionId, resourceGroup, secretName, valueName strin
 		SecretName:     secretName,
 		ValueName:      valueName,
 	}
+}
+
+func (id SecretValueId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Secret Name %q", id.SecretName),
+		fmt.Sprintf("Value Name %q", id.ValueName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SecretValueId) ID(_ string) string {

--- a/azurerm/internal/services/signalr/parse/service.go
+++ b/azurerm/internal/services/signalr/parse/service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServiceID(subscriptionId, resourceGroup, signalRName string) ServiceId {
 		ResourceGroup:  resourceGroup,
 		SignalRName:    signalRName,
 	}
+}
+
+func (id ServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Signal R Name %q", id.SignalRName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServiceId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/azure_active_directory_administrator.go
+++ b/azurerm/internal/services/sql/parse/azure_active_directory_administrator.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAzureActiveDirectoryAdministratorID(subscriptionId, resourceGroup, serve
 		ServerName:        serverName,
 		AdministratorName: administratorName,
 	}
+}
+
+func (id AzureActiveDirectoryAdministratorId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Administrator Name %q", id.AdministratorName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AzureActiveDirectoryAdministratorId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/database.go
+++ b/azurerm/internal/services/sql/parse/database.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewDatabaseID(subscriptionId, resourceGroup, serverName, name string) Datab
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id DatabaseId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/elastic_pool.go
+++ b/azurerm/internal/services/sql/parse/elastic_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewElasticPoolID(subscriptionId, resourceGroup, serverName, name string) El
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id ElasticPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ElasticPoolId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/failover_group.go
+++ b/azurerm/internal/services/sql/parse/failover_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewFailoverGroupID(subscriptionId, resourceGroup, serverName, name string) 
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id FailoverGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FailoverGroupId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/firewall_rule.go
+++ b/azurerm/internal/services/sql/parse/firewall_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, serverName, name string) F
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id FirewallRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/server.go
+++ b/azurerm/internal/services/sql/parse/server.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id ServerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/virtual_network_rule.go
+++ b/azurerm/internal/services/sql/parse/virtual_network_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVirtualNetworkRuleID(subscriptionId, resourceGroup, serverName, name str
 		ServerName:     serverName,
 		Name:           name,
 	}
+}
+
+func (id VirtualNetworkRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualNetworkRuleId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/encryption_scope.go
+++ b/azurerm/internal/services/storage/parse/encryption_scope.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewEncryptionScopeID(subscriptionId, resourceGroup, storageAccountName, nam
 		StorageAccountName: storageAccountName,
 		Name:               name,
 	}
+}
+
+func (id EncryptionScopeId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id EncryptionScopeId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_account.go
+++ b/azurerm/internal/services/storage/parse/storage_account.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewStorageAccountID(subscriptionId, resourceGroup, name string) StorageAcco
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id StorageAccountId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id StorageAccountId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_container_resource_manager.go
+++ b/azurerm/internal/services/storage/parse/storage_container_resource_manager.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewStorageContainerResourceManagerID(subscriptionId, resourceGroup, storage
 		BlobServiceName:    blobServiceName,
 		ContainerName:      containerName,
 	}
+}
+
+func (id StorageContainerResourceManagerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
+		fmt.Sprintf("Blob Service Name %q", id.BlobServiceName),
+		fmt.Sprintf("Container Name %q", id.ContainerName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id StorageContainerResourceManagerId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_share_resource_manager.go
+++ b/azurerm/internal/services/storage/parse/storage_share_resource_manager.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewStorageShareResourceManagerID(subscriptionId, resourceGroup, storageAcco
 		FileServiceName:    fileServiceName,
 		ShareName:          shareName,
 	}
+}
+
+func (id StorageShareResourceManagerId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
+		fmt.Sprintf("File Service Name %q", id.FileServiceName),
+		fmt.Sprintf("Share Name %q", id.ShareName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id StorageShareResourceManagerId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_sync_group.go
+++ b/azurerm/internal/services/storage/parse/storage_sync_group.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewStorageSyncGroupID(subscriptionId, resourceGroup, storageSyncServiceName
 		StorageSyncServiceName: storageSyncServiceName,
 		SyncGroupName:          syncGroupName,
 	}
+}
+
+func (id StorageSyncGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Storage Sync Service Name %q", id.StorageSyncServiceName),
+		fmt.Sprintf("Sync Group Name %q", id.SyncGroupName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id StorageSyncGroupId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_sync_service.go
+++ b/azurerm/internal/services/storage/parse/storage_sync_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewStorageSyncServiceID(subscriptionId, resourceGroup, name string) Storage
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id StorageSyncServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id StorageSyncServiceId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/firewall_rule.go
+++ b/azurerm/internal/services/synapse/parse/firewall_rule.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, workspaceName, name string
 		WorkspaceName:  workspaceName,
 		Name:           name,
 	}
+}
+
+func (id FirewallRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/spark_pool.go
+++ b/azurerm/internal/services/synapse/parse/spark_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSparkPoolID(subscriptionId, resourceGroup, workspaceName, bigDataPoolNam
 		WorkspaceName:   workspaceName,
 		BigDataPoolName: bigDataPoolName,
 	}
+}
+
+func (id SparkPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Big Data Pool Name %q", id.BigDataPoolName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SparkPoolId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/sql_pool.go
+++ b/azurerm/internal/services/synapse/parse/sql_pool.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewSqlPoolID(subscriptionId, resourceGroup, workspaceName, name string) Sql
 		WorkspaceName:  workspaceName,
 		Name:           name,
 	}
+}
+
+func (id SqlPoolId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SqlPoolId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/workspace.go
+++ b/azurerm/internal/services/synapse/parse/workspace.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewWorkspaceID(subscriptionId, resourceGroup, name string) WorkspaceId {
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id WorkspaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id WorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/azure_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/azure_endpoint.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAzureEndpointID(subscriptionId, resourceGroup, trafficManagerProfileName
 		TrafficManagerProfileName: trafficManagerProfileName,
 		Name:                      name,
 	}
+}
+
+func (id AzureEndpointId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AzureEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/external_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/external_endpoint.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewExternalEndpointID(subscriptionId, resourceGroup, trafficManagerProfileN
 		TrafficManagerProfileName: trafficManagerProfileName,
 		Name:                      name,
 	}
+}
+
+func (id ExternalEndpointId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ExternalEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/nested_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/nested_endpoint.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewNestedEndpointID(subscriptionId, resourceGroup, trafficManagerProfileNam
 		TrafficManagerProfileName: trafficManagerProfileName,
 		Name:                      name,
 	}
+}
+
+func (id NestedEndpointId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id NestedEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile.go
+++ b/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewTrafficManagerProfileID(subscriptionId, resourceGroup, name string) Traf
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id TrafficManagerProfileId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id TrafficManagerProfileId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service.go
+++ b/azurerm/internal/services/web/parse/app_service.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAppServiceID(subscriptionId, resourceGroup, siteName string) AppServiceI
 		ResourceGroup:  resourceGroup,
 		SiteName:       siteName,
 	}
+}
+
+func (id AppServiceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AppServiceId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service_environment.go
+++ b/azurerm/internal/services/web/parse/app_service_environment.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAppServiceEnvironmentID(subscriptionId, resourceGroup, hostingEnvironmen
 		ResourceGroup:          resourceGroup,
 		HostingEnvironmentName: hostingEnvironmentName,
 	}
+}
+
+func (id AppServiceEnvironmentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Hosting Environment Name %q", id.HostingEnvironmentName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AppServiceEnvironmentId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service_plan.go
+++ b/azurerm/internal/services/web/parse/app_service_plan.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewAppServicePlanID(subscriptionId, resourceGroup, serverfarmName string) A
 		ResourceGroup:  resourceGroup,
 		ServerfarmName: serverfarmName,
 	}
+}
+
+func (id AppServicePlanId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Serverfarm Name %q", id.ServerfarmName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AppServicePlanId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service_slot.go
+++ b/azurerm/internal/services/web/parse/app_service_slot.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewAppServiceSlotID(subscriptionId, resourceGroup, siteName, slotName strin
 		SiteName:       siteName,
 		SlotName:       slotName,
 	}
+}
+
+func (id AppServiceSlotId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Slot Name %q", id.SlotName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id AppServiceSlotId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/certificate.go
+++ b/azurerm/internal/services/web/parse/certificate.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewCertificateID(subscriptionId, resourceGroup, name string) CertificateId 
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id CertificateId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CertificateId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/certificate_order.go
+++ b/azurerm/internal/services/web/parse/certificate_order.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewCertificateOrderID(subscriptionId, resourceGroup, name string) Certifica
 		ResourceGroup:  resourceGroup,
 		Name:           name,
 	}
+}
+
+func (id CertificateOrderId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id CertificateOrderId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/function_app.go
+++ b/azurerm/internal/services/web/parse/function_app.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewFunctionAppID(subscriptionId, resourceGroup, siteName string) FunctionAp
 		ResourceGroup:  resourceGroup,
 		SiteName:       siteName,
 	}
+}
+
+func (id FunctionAppId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FunctionAppId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/function_app_slot.go
+++ b/azurerm/internal/services/web/parse/function_app_slot.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewFunctionAppSlotID(subscriptionId, resourceGroup, siteName, slotName stri
 		SiteName:       siteName,
 		SlotName:       slotName,
 	}
+}
+
+func (id FunctionAppSlotId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Slot Name %q", id.SlotName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id FunctionAppSlotId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/hybrid_connection.go
+++ b/azurerm/internal/services/web/parse/hybrid_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewHybridConnectionID(subscriptionId, resourceGroup, siteName, hybridConnec
 		HybridConnectionNamespaceName: hybridConnectionNamespaceName,
 		RelayName:                     relayName,
 	}
+}
+
+func (id HybridConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Hybrid Connection Namespace Name %q", id.HybridConnectionNamespaceName),
+		fmt.Sprintf("Relay Name %q", id.RelayName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id HybridConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/managed_certificate.go
+++ b/azurerm/internal/services/web/parse/managed_certificate.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -20,6 +21,14 @@ func NewManagedCertificateID(subscriptionId, resourceGroup, certificateName stri
 		ResourceGroup:   resourceGroup,
 		CertificateName: certificateName,
 	}
+}
+
+func (id ManagedCertificateId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Certificate Name %q", id.CertificateName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id ManagedCertificateId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/slot_virtual_network_swift_connection.go
+++ b/azurerm/internal/services/web/parse/slot_virtual_network_swift_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -24,6 +25,16 @@ func NewSlotVirtualNetworkSwiftConnectionID(subscriptionId, resourceGroup, siteN
 		SlotName:       slotName,
 		ConfigName:     configName,
 	}
+}
+
+func (id SlotVirtualNetworkSwiftConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Slot Name %q", id.SlotName),
+		fmt.Sprintf("Config Name %q", id.ConfigName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id SlotVirtualNetworkSwiftConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/virtual_network_swift_connection.go
+++ b/azurerm/internal/services/web/parse/virtual_network_swift_connection.go
@@ -4,6 +4,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -22,6 +23,15 @@ func NewVirtualNetworkSwiftConnectionID(subscriptionId, resourceGroup, siteName,
 		SiteName:       siteName,
 		ConfigName:     configName,
 	}
+}
+
+func (id VirtualNetworkSwiftConnectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Config Name %q", id.ConfigName),
+	}
+	return strings.Join(segments, " / ")
 }
 
 func (id VirtualNetworkSwiftConnectionId) ID(_ string) string {

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -288,6 +288,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
@@ -297,7 +298,8 @@ import (
 %s
 %s
 %s
-`, id.codeForType(), id.codeForConstructor(), id.codeForFormatter(), id.codeForParser(), id.codeForParserInsensitive())
+%s
+`, id.codeForType(), id.codeForConstructor(), id.codeForDescription(), id.codeForFormatter(), id.codeForParser(), id.codeForParserInsensitive())
 }
 
 func (id ResourceIdGenerator) codeForType() string {
@@ -331,6 +333,40 @@ func New%[1]sID(%[2]s string) %[1]sId {
 	}
 }
 `, id.TypeName, argumentsStr, assignmentsStr)
+}
+
+func (id ResourceIdGenerator) codeForDescription() string {
+	var makeHumanReadable = func(input string) string {
+		chars := make([]rune, 0)
+		for _, c := range input {
+			if unicode.IsUpper(c) {
+				chars = append(chars, ' ')
+			}
+
+			chars = append(chars, c)
+		}
+		out := string(chars)
+		return strings.TrimSpace(out)
+	}
+
+	formatKeys := make([]string, 0)
+	for _, segment := range id.Segments {
+		if segment.FieldName == "SubscriptionId" {
+			continue
+		}
+
+		humanReadableKey := makeHumanReadable(segment.FieldName)
+		formatKeys = append(formatKeys, fmt.Sprintf("\t\tfmt.Sprintf(\"%[1]s %%q\", id.%[2]s),", humanReadableKey, segment.FieldName))
+	}
+	formatKeysString := strings.Join(formatKeys, "\n")
+	return fmt.Sprintf(`
+func (id %[1]sId) String() string {
+	segments := []string{
+%s
+	}
+	return strings.Join(segments, " ")
+}
+`, id.TypeName, formatKeysString)
 }
 
 func (id ResourceIdGenerator) codeForFormatter() string {

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -364,7 +364,7 @@ func (id %[1]sId) String() string {
 	segments := []string{
 %s
 	}
-	return strings.Join(segments, " ")
+	return strings.Join(segments, " / ")
 }
 `, id.TypeName, formatKeysString)
 }


### PR DESCRIPTION
This allows us to keep the same quality of error messages with less code:

```
return fmt.Errorf("error retrieving %s: %+v", id, err)
```

rather than:

```
return fmt.Errorf("error retrieving %q (Thing %q / Bar %q): %+v", id.Name, id.Thing, id.Bar, err)
```

Dependent on #9654 - once that's merged we can re-generate the Resource ID Parsers from this commit