### PR TITLE
bot: switching the hand-written ID Parsers out for generated ones

### DIFF
--- a/azurerm/internal/services/bot/bot_channel_directline_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_directline_resource.go
@@ -12,6 +12,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -23,9 +26,10 @@ func resourceArmBotChannelDirectline() *schema.Resource {
 		Delete: resourceArmBotChannelDirectlineDelete,
 		Update: resourceArmBotChannelDirectlineUpdate,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BotChannelID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -42,6 +46,7 @@ func resourceArmBotChannelDirectline() *schema.Resource {
 			"bot_name": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -50,7 +55,6 @@ func resourceArmBotChannelDirectline() *schema.Resource {
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-
 						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
@@ -115,21 +119,20 @@ func resourceArmBotChannelDirectline() *schema.Resource {
 
 func resourceArmBotChannelDirectlineCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Bot.ChannelClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	botName := d.Get("bot_name").(string)
-
+	resourceId := parse.NewBotChannelID(subscriptionId, d.Get("resource_group_name").(string), d.Get("bot_name").(string), string(botservice.ChannelNameDirectLineChannel))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, string(botservice.ChannelNameDirectLineChannel1), botName)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, resourceId.ChannelName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of creating Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+				return fmt.Errorf("checking for presence of existing Directline Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_bot_channel_directline", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_bot_channel_directline", resourceId.ID(""))
 		}
 	}
 
@@ -144,25 +147,15 @@ func resourceArmBotChannelDirectlineCreate(d *schema.ResourceData, meta interfac
 		Kind:     botservice.KindBot,
 	}
 
-	if _, err := client.Create(ctx, resourceGroup, botName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
-		return fmt.Errorf("Error issuing create request for Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
+		return fmt.Errorf("creating Directline Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 	}
+	d.SetId(resourceId.ID(""))
 
 	// Unable to create a new site with enhanced_authentication_enabled in the same operation, so we need to make two calls
-	if _, err := client.Update(ctx, resourceGroup, botName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
-		return fmt.Errorf("Error issuing create request for Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+	if _, err := client.Update(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
+		return fmt.Errorf("updating Directline Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 	}
-
-	resp, err := client.Get(ctx, resourceGroup, botName, string(botservice.ChannelNameDirectLineChannel1))
-	if err != nil {
-		return fmt.Errorf("Error making get request for Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	d.SetId(*resp.ID)
 
 	return resourceArmBotChannelDirectlineRead(d, meta)
 }
@@ -172,28 +165,31 @@ func resourceArmBotChannelDirectlineRead(d *schema.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-	resp, err := client.Get(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameDirectLineChannel1))
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameDirectLineChannel1))
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Channel Directline for Bot %q (Resource Group %q) was not found - removing from state!", id.ResourceGroup, botName)
+			log.Printf("[INFO] Directline Channel for Bot %q (Resource Group %q) was not found - removing from state!", id.ResourceGroup, id.BotServiceName)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Channel Directline for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
+		return fmt.Errorf("retrieving Channel Directline for Bot %q (Resource Group %q): %+v", id.ResourceGroup, id.BotServiceName, err)
 	}
 
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", resp.Location)
-	d.Set("bot_name", botName)
+	channelsResp, err := client.ListWithKeys(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameDirectLineChannel)
+	if err != nil {
+		return fmt.Errorf("listing Keys for Directline Channel for Bot %q (Resource Group %q): %+v", id.ResourceGroup, id.BotServiceName, err)
+	}
 
-	channelsResp, _ := client.ListWithKeys(ctx, id.ResourceGroup, botName, botservice.ChannelNameDirectLineChannel)
+	d.Set("bot_name", id.BotServiceName)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+
 	if props := channelsResp.Properties; props != nil {
 		if channel, ok := props.AsDirectLineChannel(); ok {
 			if channelProps := channel.Properties; channelProps != nil {
@@ -210,8 +206,10 @@ func resourceArmBotChannelDirectlineUpdate(d *schema.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	botName := d.Get("bot_name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
+	id, err := parse.BotChannelID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	channel := botservice.BotChannel{
 		Properties: botservice.DirectLineChannel{
@@ -224,25 +222,9 @@ func resourceArmBotChannelDirectlineUpdate(d *schema.ResourceData, meta interfac
 		Kind:     botservice.KindBot,
 	}
 
-	if _, err := client.Update(ctx, resourceGroup, botName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
-		return fmt.Errorf("Error issuing create request for Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
+		return fmt.Errorf("updating Directline Channel for Bot %q (Resource Group %q): %+v", id.BotServiceName, id.ResourceGroup, err)
 	}
-
-	// Unable to create a new site with enhanced_authentication_enabled in the same operation, so we need to make two calls
-	if _, err := client.Update(ctx, resourceGroup, botName, botservice.ChannelNameDirectLineChannel, channel); err != nil {
-		return fmt.Errorf("Error issuing create request for Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	resp, err := client.Get(ctx, resourceGroup, botName, string(botservice.ChannelNameDirectLineChannel1))
-	if err != nil {
-		return fmt.Errorf("Error making get request for Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Channel Directline for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	d.SetId(*resp.ID)
 
 	return resourceArmBotChannelDirectlineRead(d, meta)
 }
@@ -252,17 +234,15 @@ func resourceArmBotChannelDirectlineDelete(d *schema.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-
-	resp, err := client.Delete(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameDirectLineChannel1))
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameDirectLineChannel1))
 	if err != nil {
 		if !response.WasNotFound(resp.Response) {
-			return fmt.Errorf("Error deleting Channel Directline for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
+			return fmt.Errorf("deleting Directline Channel for Bot %q (Resource Group %q): %+v", id.BotServiceName, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/bot/bot_channel_email_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_email_resource.go
@@ -12,6 +12,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -23,9 +26,10 @@ func resourceArmBotChannelEmail() *schema.Resource {
 		Delete: resourceArmBotChannelEmailDelete,
 		Update: resourceArmBotChannelEmailUpdate,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BotChannelID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -64,21 +68,20 @@ func resourceArmBotChannelEmail() *schema.Resource {
 
 func resourceArmBotChannelEmailCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Bot.ChannelClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	botName := d.Get("bot_name").(string)
-
+	resourceId := parse.NewBotChannelID(subscriptionId, d.Get("resource_group_name").(string), d.Get("bot_name").(string), string(botservice.ChannelNameEmailChannel))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, string(botservice.ChannelNameEmailChannel), botName)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, resourceId.ChannelName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of creating Channel Email for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+				return fmt.Errorf("checking for presence of existing Email Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_bot_channel_email", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_bot_channel_email", resourceId.ID(""))
 		}
 	}
 
@@ -95,21 +98,11 @@ func resourceArmBotChannelEmailCreate(d *schema.ResourceData, meta interface{}) 
 		Kind:     botservice.KindBot,
 	}
 
-	if _, err := client.Create(ctx, resourceGroup, botName, botservice.ChannelNameEmailChannel, channel); err != nil {
-		return fmt.Errorf("Error issuing create request for Channel Email for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, botservice.ChannelNameEmailChannel, channel); err != nil {
+		return fmt.Errorf("creating Email Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resourceGroup, botName, string(botservice.ChannelNameEmailChannel))
-	if err != nil {
-		return fmt.Errorf("Error making get request for Channel Email for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Channel Email for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmBotChannelEmailRead(d, meta)
 }
 
@@ -118,26 +111,25 @@ func resourceArmBotChannelEmailRead(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-	resp, err := client.Get(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameEmailChannel))
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameEmailChannel))
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Channel Email for Bot %q (Resource Group %q) was not found - removing from state!", id.ResourceGroup, botName)
+			log.Printf("[INFO] Email Channel for Bot %q (Resource Group %q) was not found - removing from state!", id.BotServiceName, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Channel Email for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
+		return fmt.Errorf("retrieving Email Channel for Bot %q (Resource Group %q): %+v", id.BotServiceName, id.ResourceGroup, err)
 	}
 
+	d.Set("bot_name", id.BotServiceName)
 	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", resp.Location)
-	d.Set("bot_name", botName)
+	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if props := resp.Properties; props != nil {
 		if channel, ok := props.AsEmailChannel(); ok {
@@ -155,12 +147,10 @@ func resourceArmBotChannelEmailUpdate(d *schema.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
-
-	botName := id.Path["botServices"]
 
 	channel := botservice.BotChannel{
 		Properties: botservice.EmailChannel{
@@ -175,20 +165,9 @@ func resourceArmBotChannelEmailUpdate(d *schema.ResourceData, meta interface{}) 
 		Kind:     botservice.KindBot,
 	}
 
-	if _, err := client.Update(ctx, id.ResourceGroup, botName, botservice.ChannelNameEmailChannel, channel); err != nil {
-		return fmt.Errorf("Error issuing create request for Channel Email for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
+	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameEmailChannel, channel); err != nil {
+		return fmt.Errorf("updating Email Channel for Bot %q (Resource Group %q): %+v", id.ResourceGroup, id.BotServiceName, err)
 	}
-
-	resp, err := client.Get(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameEmailChannel))
-	if err != nil {
-		return fmt.Errorf("Error making get request for Channel Email for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Channel Email for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
-	}
-
-	d.SetId(*resp.ID)
 
 	return resourceArmBotChannelEmailRead(d, meta)
 }
@@ -198,17 +177,15 @@ func resourceArmBotChannelEmailDelete(d *schema.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-
-	resp, err := client.Delete(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameEmailChannel))
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameEmailChannel))
 	if err != nil {
 		if !response.WasNotFound(resp.Response) {
-			return fmt.Errorf("Error deleting Channel Email for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
+			return fmt.Errorf("deleting Email Channel for Bot %q (Resource Group %q): %+v", id.ResourceGroup, id.BotServiceName, err)
 		}
 	}
 

--- a/azurerm/internal/services/bot/bot_channel_ms_teams_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_ms_teams_resource.go
@@ -13,6 +13,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -24,9 +27,10 @@ func resourceArmBotChannelMsTeams() *schema.Resource {
 		Delete: resourceArmBotChannelMsTeamsDelete,
 		Update: resourceArmBotChannelMsTeamsUpdate,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BotChannelID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -43,6 +47,7 @@ func resourceArmBotChannelMsTeams() *schema.Resource {
 			"bot_name": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
@@ -66,21 +71,20 @@ func resourceArmBotChannelMsTeams() *schema.Resource {
 
 func resourceArmBotChannelMsTeamsCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Bot.ChannelClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	botName := d.Get("bot_name").(string)
-
+	resourceId := parse.NewBotChannelID(subscriptionId, d.Get("resource_group_name").(string), d.Get("bot_name").(string), string(botservice.ChannelNameMsTeamsChannel))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, string(botservice.ChannelNameMsTeamsChannel), botName)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, resourceId.ChannelName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of creating Channel MsTeams for Bot %q (Resource Group %q): %+v", resourceGroup, botName, err)
+				return fmt.Errorf("checking for the presence of existing MS Teams Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_bot_channel_ms_teams", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_bot_channel_ms_teams", resourceId.ID(""))
 		}
 	}
 
@@ -101,21 +105,11 @@ func resourceArmBotChannelMsTeamsCreate(d *schema.ResourceData, meta interface{}
 		channel.Properties.CallingWebHook = utils.String(v.(string))
 	}
 
-	if _, err := client.Create(ctx, resourceGroup, botName, botservice.ChannelNameMsTeamsChannel, channel); err != nil {
-		return fmt.Errorf("creating Channel MsTeams for Bot %q (Resource Group %q): %+v", botName, resourceGroup, err)
+	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, botservice.ChannelNameMsTeamsChannel, channel); err != nil {
+		return fmt.Errorf("creating MS Teams Channel for Bot %q (Resource Group %q): %+v", resourceId.BotServiceName, resourceId.ResourceGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resourceGroup, botName, string(botservice.ChannelNameMsTeamsChannel))
-	if err != nil {
-		return fmt.Errorf("retrieving Channel MsTeams for Bot %q (Resource Group %q): %+v", botName, resourceGroup, err)
-	}
-
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("empty or nil ID returned for Channel MsTeams for Bot %q (Resource Group %q): %+v", botName, resourceGroup, err)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmBotChannelMsTeamsRead(d, meta)
 }
 
@@ -124,26 +118,25 @@ func resourceArmBotChannelMsTeamsRead(d *schema.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-	resp, err := client.Get(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameMsTeamsChannel))
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameMsTeamsChannel))
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Channel MsTeams for Bot %q (Resource Group %q) was not found - removing from state!", id.ResourceGroup, botName)
+			log.Printf("[INFO] MS Teams Channel for Bot %q (Resource Group %q) was not found - removing from state!", id.BotServiceName, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Channel MsTeams for Bot %q (Resource Group %q): %+v", id.ResourceGroup, botName, err)
+		return fmt.Errorf("retrieving MS Teams Channel for Bot %q (Resource Group %q): %+v", id.BotServiceName, id.ResourceGroup, err)
 	}
 
+	d.Set("bot_name", id.BotServiceName)
 	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", resp.Location)
-	d.Set("bot_name", botName)
+	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if props := resp.Properties; props != nil {
 		if channel, ok := props.AsMsTeamsChannel(); ok {
@@ -162,8 +155,10 @@ func resourceArmBotChannelMsTeamsUpdate(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	botName := d.Get("bot_name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
+	id, err := parse.BotChannelID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	channel := botservice.BotChannel{
 		Properties: botservice.MsTeamsChannel{
@@ -178,8 +173,8 @@ func resourceArmBotChannelMsTeamsUpdate(d *schema.ResourceData, meta interface{}
 		Kind:     botservice.KindBot,
 	}
 
-	if _, err := client.Update(ctx, resourceGroup, botName, botservice.ChannelNameMsTeamsChannel, channel); err != nil {
-		return fmt.Errorf("updating Channel MsTeams for Bot %q (Resource Group %q): %+v", botName, resourceGroup, err)
+	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameMsTeamsChannel, channel); err != nil {
+		return fmt.Errorf("updating MS Teams Channel for Bot %q (Resource Group %q): %+v", id.BotServiceName, id.ResourceGroup, err)
 	}
 
 	return resourceArmBotChannelMsTeamsRead(d, meta)
@@ -190,17 +185,15 @@ func resourceArmBotChannelMsTeamsDelete(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotChannelID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-
-	resp, err := client.Delete(ctx, id.ResourceGroup, botName, string(botservice.ChannelNameMsTeamsChannel))
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameMsTeamsChannel))
 	if err != nil {
 		if !response.WasNotFound(resp.Response) {
-			return fmt.Errorf("deleting Channel MsTeams for Bot %q (Resource Group %q): %+v", botName, id.ResourceGroup, err)
+			return fmt.Errorf("deleting MS Teams Channel for Bot %q (Resource Group %q): %+v", id.BotServiceName, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/bot/bot_connection_resource.go
+++ b/azurerm/internal/services/bot/bot_connection_resource.go
@@ -54,6 +54,7 @@ func resourceArmBotConnection() *schema.Resource {
 			"bot_name": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 

--- a/azurerm/internal/services/bot/bot_connection_resource.go
+++ b/azurerm/internal/services/bot/bot_connection_resource.go
@@ -13,7 +13,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -24,9 +27,10 @@ func resourceArmBotConnection() *schema.Resource {
 		Read:   resourceArmBotConnectionRead,
 		Update: resourceArmBotConnectionUpdate,
 		Delete: resourceArmBotConnectionDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BotConnectionID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -94,22 +98,20 @@ func resourceArmBotConnection() *schema.Resource {
 
 func resourceArmBotConnectionCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Bot.ConnectionClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-	botName := d.Get("bot_name").(string)
-
+	resourceId := parse.NewBotConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("bot_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, name, botName)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, resourceId.ConnectionName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of creating Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
+				return fmt.Errorf("checking for presence of existing Bot Connection %q (Bot %q / Resource Group %q): %+v", resourceId.ConnectionName, resourceId.BotServiceName, resourceId.ResourceGroup, err)
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_bot_connection", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_bot_connection", resourceId.ID(""))
 		}
 	}
 
@@ -154,21 +156,11 @@ func resourceArmBotConnectionCreate(d *schema.ResourceData, meta interface{}) er
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if _, err := client.Create(ctx, resourceGroup, botName, name, connection); err != nil {
-		return fmt.Errorf("Error issuing create request for creating Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
+	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, resourceId.ConnectionName, connection); err != nil {
+		return fmt.Errorf("creating Bot Connection %q (Bot %q / Resource Group %q): %+v", resourceId.ConnectionName, resourceId.BotServiceName, resourceId.ResourceGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resourceGroup, botName, name)
-	if err != nil {
-		return fmt.Errorf("Error making get request for Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmBotConnectionRead(d, meta)
 }
 
@@ -177,35 +169,32 @@ func resourceArmBotConnectionRead(d *schema.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	botName := id.Path["botServices"]
-	name := id.Path["connections"]
-
-	resp, err := client.Get(ctx, id.ResourceGroup, botName, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BotServiceName, id.ConnectionName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Error reading Bot Connection %q (Resource Group %q / Bot %q)", name, id.ResourceGroup, botName)
+			log.Printf("[INFO] Bot Connection %q (Bot %q / Resource Group %q) was not found - removing from state!", id.ConnectionName, id.BotServiceName, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Bot Connection %q (Resource Group %q / Bot %q): %+v", name, id.ResourceGroup, botName, err)
+		return fmt.Errorf("Error reading Bot Connection %q (Bot %q / Resource Group %q): %+v", id.ConnectionName, id.BotServiceName, id.ResourceGroup, err)
 	}
 
+	d.Set("name", id.ConnectionName)
+	d.Set("bot_name", id.BotServiceName)
 	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("name", name)
-	d.Set("bot_name", botName)
-	d.Set("location", resp.Location)
+	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if props := resp.Properties; props != nil {
 		d.Set("client_id", props.ClientID)
 		d.Set("scopes", props.Scopes)
 		if err := d.Set("parameters", flattenAzureRMBotConnectionParameters(props.Parameters)); err != nil {
-			return fmt.Errorf("Error setting `parameters`: %+v", err)
+			return fmt.Errorf("setting `parameters`: %+v", err)
 		}
 	}
 
@@ -217,9 +206,10 @@ func resourceArmBotConnectionUpdate(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-	botName := d.Get("bot_name").(string)
+	id, err := parse.BotConnectionID(d.Id())
+	if err != nil {
+		return err
+	}
 
 	connection := botservice.ConnectionSetting{
 		Properties: &botservice.ConnectionSettingProperties{
@@ -234,20 +224,9 @@ func resourceArmBotConnectionUpdate(d *schema.ResourceData, meta interface{}) er
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if _, err := client.Update(ctx, resourceGroup, botName, name, connection); err != nil {
-		return fmt.Errorf("Error issuing update request for creating Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
+	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, id.ConnectionName, connection); err != nil {
+		return fmt.Errorf("updating Bot Connection %q (Bot %q / Resource Group %q): %+v", id.ConnectionName, id.BotServiceName, id.ResourceGroup, err)
 	}
-
-	resp, err := client.Get(ctx, resourceGroup, botName, name)
-	if err != nil {
-		return fmt.Errorf("Error making get request for Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Bot Connection %q (Resource Group %q / Bot %q): %+v", name, resourceGroup, botName, err)
-	}
-
-	d.SetId(*resp.ID)
 
 	return resourceArmBotConnectionRead(d, meta)
 }
@@ -257,17 +236,15 @@ func resourceArmBotConnectionDelete(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotConnectionID(d.Id())
 	if err != nil {
 		return err
 	}
-	botName := id.Path["botServices"]
-	name := id.Path["connections"]
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, botName, name)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.BotServiceName, id.ConnectionName)
 	if err != nil {
 		if !response.WasNotFound(resp.Response) {
-			return fmt.Errorf("Error deleting Bot Connection %q (Resource Group %q / Bot %q): %+v", name, id.ResourceGroup, botName, err)
+			return fmt.Errorf("deleting Bot Connection %q (Bot %q / Resource Group %q): %+v", id.ConnectionName, id.BotServiceName, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/bot/bot_web_app_resource.go
+++ b/azurerm/internal/services/bot/bot_web_app_resource.go
@@ -194,8 +194,8 @@ func resourceArmBotWebAppRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("retrieving Web App Bot %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if sku := resp.Sku; sku != nil {
@@ -260,16 +260,15 @@ func resourceArmBotWebAppDelete(d *schema.ResourceData, meta interface{}) error 
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.BotServiceID(d.Id())
 	if err != nil {
 		return err
 	}
-	name := id.Path["botServices"]
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, name)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if !response.WasNotFound(resp.Response) {
-			return fmt.Errorf("Error deleting Web App Bot %q (Resource Group %q): %+v", name, id.ResourceGroup, err)
+			return fmt.Errorf("deleting Web App Bot %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/bot/bot_web_app_resource.go
+++ b/azurerm/internal/services/bot/bot_web_app_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -23,12 +24,12 @@ func resourceArmBotWebApp() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmBotWebAppCreate,
 		Read:   resourceArmBotWebAppRead,
-		Delete: resourceArmBotWebAppDelete,
 		Update: resourceArmBotWebAppUpdate,
-
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Delete: resourceArmBotWebAppDelete,
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BotServiceID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/bot/bot_web_app_resource.go
+++ b/azurerm/internal/services/bot/bot_web_app_resource.go
@@ -193,6 +193,8 @@ func resourceArmBotWebAppCreate(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("creating Web App Bot %q (Resource Group %q): %+v", resourceId.Name, resourceId.ResourceGroup, err)
 	}
 
+	// TODO: in 3.0 we should remove the "Default Site" on the Directline resource at this point if we can
+
 	d.SetId(resourceId.ID(""))
 	return resourceArmBotWebAppRead(d, meta)
 }

--- a/azurerm/internal/services/bot/parse/bot_channel.go
+++ b/azurerm/internal/services/bot/parse/bot_channel.go
@@ -1,0 +1,64 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type BotChannelId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	BotServiceName string
+	ChannelName    string
+}
+
+func NewBotChannelID(subscriptionId, resourceGroup, botServiceName, channelName string) BotChannelId {
+	return BotChannelId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		BotServiceName: botServiceName,
+		ChannelName:    channelName,
+	}
+}
+
+func (id BotChannelId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.BotService/botServices/%s/channels/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BotServiceName, id.ChannelName)
+}
+
+// BotChannelID parses a BotChannel ID into an BotChannelId struct
+func BotChannelID(input string) (*BotChannelId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := BotChannelId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.BotServiceName, err = id.PopSegment("botServices"); err != nil {
+		return nil, err
+	}
+	if resourceId.ChannelName, err = id.PopSegment("channels"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/bot/parse/bot_channel_test.go
+++ b/azurerm/internal/services/bot/parse/bot_channel_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = BotChannelId{}
+
+func TestBotChannelIDFormatter(t *testing.T) {
+	actual := NewBotChannelID("12345678-1234-9876-4563-123456789012", "resGroup1", "botService1", "Discovery1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/channels/Discovery1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestBotChannelID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *BotChannelId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/",
+			Error: true,
+		},
+
+		{
+			// missing value for BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/",
+			Error: true,
+		},
+
+		{
+			// missing ChannelName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/",
+			Error: true,
+		},
+
+		{
+			// missing value for ChannelName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/channels/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/channels/Discovery1",
+			Expected: &BotChannelId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				BotServiceName: "botService1",
+				ChannelName:    "Discovery1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.BOTSERVICE/BOTSERVICES/BOTSERVICE1/CHANNELS/DISCOVERY1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := BotChannelID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.BotServiceName != v.Expected.BotServiceName {
+			t.Fatalf("Expected %q but got %q for BotServiceName", v.Expected.BotServiceName, actual.BotServiceName)
+		}
+		if actual.ChannelName != v.Expected.ChannelName {
+			t.Fatalf("Expected %q but got %q for ChannelName", v.Expected.ChannelName, actual.ChannelName)
+		}
+	}
+}

--- a/azurerm/internal/services/bot/parse/bot_connection.go
+++ b/azurerm/internal/services/bot/parse/bot_connection.go
@@ -1,0 +1,64 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type BotConnectionId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	BotServiceName string
+	ConnectionName string
+}
+
+func NewBotConnectionID(subscriptionId, resourceGroup, botServiceName, connectionName string) BotConnectionId {
+	return BotConnectionId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		BotServiceName: botServiceName,
+		ConnectionName: connectionName,
+	}
+}
+
+func (id BotConnectionId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.BotService/botServices/%s/connections/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BotServiceName, id.ConnectionName)
+}
+
+// BotConnectionID parses a BotConnection ID into an BotConnectionId struct
+func BotConnectionID(input string) (*BotConnectionId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := BotConnectionId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.BotServiceName, err = id.PopSegment("botServices"); err != nil {
+		return nil, err
+	}
+	if resourceId.ConnectionName, err = id.PopSegment("connections"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/bot/parse/bot_connection_test.go
+++ b/azurerm/internal/services/bot/parse/bot_connection_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = BotConnectionId{}
+
+func TestBotConnectionIDFormatter(t *testing.T) {
+	actual := NewBotConnectionID("12345678-1234-9876-4563-123456789012", "resGroup1", "botService1", "connection1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/connection1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestBotConnectionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *BotConnectionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/",
+			Error: true,
+		},
+
+		{
+			// missing value for BotServiceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/",
+			Error: true,
+		},
+
+		{
+			// missing ConnectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/",
+			Error: true,
+		},
+
+		{
+			// missing value for ConnectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/connection1",
+			Expected: &BotConnectionId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				BotServiceName: "botService1",
+				ConnectionName: "connection1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.BOTSERVICE/BOTSERVICES/BOTSERVICE1/CONNECTIONS/CONNECTION1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := BotConnectionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.BotServiceName != v.Expected.BotServiceName {
+			t.Fatalf("Expected %q but got %q for BotServiceName", v.Expected.BotServiceName, actual.BotServiceName)
+		}
+		if actual.ConnectionName != v.Expected.ConnectionName {
+			t.Fatalf("Expected %q but got %q for ConnectionName", v.Expected.ConnectionName, actual.ConnectionName)
+		}
+	}
+}

--- a/azurerm/internal/services/bot/parse/bot_service.go
+++ b/azurerm/internal/services/bot/parse/bot_service.go
@@ -1,0 +1,59 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type BotServiceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewBotServiceID(subscriptionId, resourceGroup, name string) BotServiceId {
+	return BotServiceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id BotServiceId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.BotService/botServices/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// BotServiceID parses a BotService ID into an BotServiceId struct
+func BotServiceID(input string) (*BotServiceId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := BotServiceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("botServices"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/bot/parse/bot_service_test.go
+++ b/azurerm/internal/services/bot/parse/bot_service_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = BotServiceId{}
+
+func TestBotServiceIDFormatter(t *testing.T) {
+	actual := NewBotServiceID("12345678-1234-9876-4563-123456789012", "resGroup1", "botService1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestBotServiceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *BotServiceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1",
+			Expected: &BotServiceId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "botService1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.BOTSERVICE/BOTSERVICES/BOTSERVICE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := BotServiceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/bot/registration.go
+++ b/azurerm/internal/services/bot/registration.go
@@ -26,10 +26,10 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_bot_channel_email":         resourceArmBotChannelEmail(),
-		"azurerm_bot_channel_slack":         resourceArmBotChannelSlack(),
-		"azurerm_bot_channel_ms_teams":      resourceArmBotChannelMsTeams(),
 		"azurerm_bot_channel_directline":    resourceArmBotChannelDirectline(),
+		"azurerm_bot_channel_email":         resourceArmBotChannelEmail(),
+		"azurerm_bot_channel_ms_teams":      resourceArmBotChannelMsTeams(),
+		"azurerm_bot_channel_slack":         resourceArmBotChannelSlack(),
 		"azurerm_bot_channels_registration": resourceArmBotChannelsRegistration(),
 		"azurerm_bot_connection":            resourceArmBotConnection(),
 		"azurerm_bot_web_app":               resourceArmBotWebApp(),

--- a/azurerm/internal/services/bot/resourceids.go
+++ b/azurerm/internal/services/bot/resourceids.go
@@ -1,4 +1,5 @@
 package bot
 
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BotChannel -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/channels/Discovery1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BotConnection -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/connection1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BotService -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1

--- a/azurerm/internal/services/bot/resourceids.go
+++ b/azurerm/internal/services/bot/resourceids.go
@@ -1,0 +1,3 @@
+package bot
+
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BotService -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1

--- a/azurerm/internal/services/bot/resourceids.go
+++ b/azurerm/internal/services/bot/resourceids.go
@@ -1,3 +1,4 @@
 package bot
 
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BotConnection -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1/connections/connection1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BotService -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.BotService/botServices/botService1

--- a/azurerm/internal/services/bot/tests/bot_channel_directline_resource_test.go
+++ b/azurerm/internal/services/bot/tests/bot_channel_directline_resource_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMBotChannelDirectline_basic(t *testing.T) {
-	testAccAzureRMBotChannelDirectline_basic(t)
-}
-
 func testAccAzureRMBotChannelDirectline_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_directline", "test")
 

--- a/azurerm/internal/services/bot/tests/bot_channel_directline_resource_test.go
+++ b/azurerm/internal/services/bot/tests/bot_channel_directline_resource_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+func TestAccAzureRMBotChannelDirectline_basic(t *testing.T) {
+	testAccAzureRMBotChannelDirectline_basic(t)
+}
+
 func testAccAzureRMBotChannelDirectline_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_directline", "test")
 


### PR DESCRIPTION
This PR switches all of the Bot Resources over to using Generated Resource ID Parsers - ultimately this contains the following:

Improvements:

* `azurerm_bot_channel_directline` - support for enhanced import validation
* `azurerm_bot_channel_email` - support for enhanced import validation
* `azurerm_bot_channel_ms_teams` - support for enhanced import validation
* `azurerm_bot_channel_slack` - support for enhanced import validation
* `azurerm_bot_channels_registration` - support for enhanced import validation
* `azurerm_bot_connection` - support for enhanced import validation
* `azurerm_bot_web_app` - support for enhanced import validation

Bug Fixes:

* `azurerm_bot_channel_directline` - the field `bot_name` is now ForceNew to match the documentation/API behaviour
* `azurerm_bot_channel_ms_teams` - the field `bot_name` is now ForceNew to match the documentation/API behaviour
* `azurerm_bot_channel_slack` - the field `bot_name` is now ForceNew to match the documentation/API behaviour
* `azurerm_bot_connection` - the field `bot_name` is now ForceNew to match the documentation/API behaviour
