### PR TITLE
validators: re-generating based on the latest generator

### DIFF
--- a/azurerm/internal/services/relay/validate/hybrid_connection_id.go
+++ b/azurerm/internal/services/relay/validate/hybrid_connection_id.go
@@ -1,21 +1,23 @@
 package validate
 
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
 import (
 	"fmt"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/relay/parse"
 )
 
-// HybridConnectionID validates that the specified ID is a valid Relay Hybrid Connection ID
-func HybridConnectionID(i interface{}, k string) (warnings []string, errors []error) {
-	v, ok := i.(string)
+func HybridConnectionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
 	if !ok {
-		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
 	}
 
 	if _, err := parse.HybridConnectionID(v); err != nil {
-		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", v, err))
+		errors = append(errors, err)
 	}
 
-	return warnings, errors
+	return
 }

--- a/azurerm/internal/services/relay/validate/hybrid_connection_id_test.go
+++ b/azurerm/internal/services/relay/validate/hybrid_connection_id_test.go
@@ -1,41 +1,84 @@
 package validate
 
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
 import "testing"
 
-func TestValidateHybridConnectionID(t *testing.T) {
+func TestHybridConnectionID(t *testing.T) {
 	cases := []struct {
-		ID    string
+		Input string
 		Valid bool
 	}{
+
 		{
-			ID:    "",
+			// empty
+			Input: "",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			// missing SubscriptionId
+			Input: "/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/providers/Microsoft.Relay/namespaces/",
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Relay/namespaces/relay1/hybridConnections/hconn1",
+			// missing NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/",
+			Valid: false,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/namespaces/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/namespaces/namespace1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/namespaces/namespace1/hybridConnections/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/namespaces/namespace1/hybridConnections/hybridConnection1",
 			Valid: true,
 		},
-	}
 
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.RELAY/NAMESPACES/NAMESPACE1/HYBRIDCONNECTIONS/HYBRIDCONNECTION1",
+			Valid: false,
+		},
+	}
 	for _, tc := range cases {
-		t.Logf("[DEBUG] Testing Value %q", tc.ID)
-		_, errors := HybridConnectionID(tc.ID, "test")
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := HybridConnectionID(tc.Input, "test")
 		valid := len(errors) == 0
 
 		if tc.Valid != valid {

--- a/azurerm/internal/services/relay/validate/namespace_id.go
+++ b/azurerm/internal/services/relay/validate/namespace_id.go
@@ -1,22 +1,23 @@
 package validate
 
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
 import (
 	"fmt"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/relay/parse"
 )
 
-// ValidateNamespaceID validates that the specified ID is a valid Relay Namespace ID
-func ValidateNamespaceID(i interface{}, k string) (warnings []string, errors []error) {
-	v, ok := i.(string)
+func NamespaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
 	if !ok {
-		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
-	}
-
-	if _, err := parse.NamespaceID(v); err != nil {
-		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
 		return
 	}
 
-	return warnings, errors
+	if _, err := parse.NamespaceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
 }

--- a/azurerm/internal/services/relay/validate/namespace_id_test.go
+++ b/azurerm/internal/services/relay/validate/namespace_id_test.go
@@ -1,49 +1,72 @@
 package validate
 
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
 import "testing"
 
-func TestValidateNamespaceID(t *testing.T) {
+func TestNamespaceID(t *testing.T) {
 	cases := []struct {
-		ID    string
+		Input string
 		Valid bool
 	}{
+
 		{
-			ID:    "",
+			// empty
+			Input: "",
 			Valid: false,
 		},
+
 		{
-			ID:    "nonsense",
+			// missing SubscriptionId
+			Input: "/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups",
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo",
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/providers/Microsoft.Relay/namespaces",
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/providers/Microsoft.Relay/Namespaces/relay1",
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/namespaces/",
 			Valid: false,
 		},
+
 		{
-			ID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/providers/Microsoft.Relay/namespaces/relay1",
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Relay/namespaces/namespace1",
 			Valid: true,
 		},
-	}
 
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.RELAY/NAMESPACES/NAMESPACE1",
+			Valid: false,
+		},
+	}
 	for _, tc := range cases {
-		t.Logf("[DEBUG] Testing value %s", tc.ID)
-		_, errors := ValidateNamespaceID(tc.ID, "test")
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := NamespaceID(tc.Input, "test")
 		valid := len(errors) == 0
 
 		if tc.Valid != valid {

--- a/azurerm/internal/services/web/validate/slot_virtual_network_swift_connection_id_test.go
+++ b/azurerm/internal/services/web/validate/slot_virtual_network_swift_connection_id_test.go
@@ -65,26 +65,26 @@ func TestSlotVirtualNetworkSwiftConnectionID(t *testing.T) {
 		},
 
 		{
-			// missing NetworkConfigName
+			// missing ConfigName
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1/",
 			Valid: false,
 		},
 
 		{
-			// missing value for NetworkConfigName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1/networkConfig/",
+			// missing value for ConfigName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1/config/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1/networkConfig/virtualNetwork",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1/config/virtualNetwork",
 			Valid: true,
 		},
 
 		{
 			// upper-cased
-			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.WEB/SITES/SITE1/SLOTS/SLOT1/NETWORKCONFIG/VIRTUALNETWORK",
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.WEB/SITES/SITE1/SLOTS/SLOT1/CONFIG/VIRTUALNETWORK",
 			Valid: false,
 		},
 	}

--- a/azurerm/internal/services/web/validate/virtual_network_swift_connection_id_test.go
+++ b/azurerm/internal/services/web/validate/virtual_network_swift_connection_id_test.go
@@ -53,26 +53,26 @@ func TestVirtualNetworkSwiftConnectionID(t *testing.T) {
 		},
 
 		{
-			// missing NetworkConfigName
+			// missing ConfigName
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/",
 			Valid: false,
 		},
 
 		{
-			// missing value for NetworkConfigName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/networkConfig/",
+			// missing value for ConfigName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/config/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/networkConfig/virtualNetwork",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/config/virtualNetwork",
 			Valid: true,
 		},
 
 		{
 			// upper-cased
-			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.WEB/SITES/SITE1/NETWORKCONFIG/VIRTUALNETWORK",
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.WEB/SITES/SITE1/CONFIG/VIRTUALNETWORK",
 			Valid: false,
 		},
 	}


### PR DESCRIPTION
This'll fix master, which is out of sync

Once the generator is used across all resources we can configure a Github Action to ensure the Generated content matches what's checked in - for now this fixes the test failures based on the generation of ID Validation functions