### PR TITLE
`azurerm_kusto_cluster` - Add support for `engine`

### DIFF
--- a/azurerm/internal/services/kusto/client/client.go
+++ b/azurerm/internal/services/kusto/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 )
 

--- a/azurerm/internal/services/kusto/identity.go
+++ b/azurerm/internal/services/kusto/identity.go
@@ -1,7 +1,7 @@
 package kusto
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"

--- a/azurerm/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/azurerm/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_principal_assignment_resource.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/kusto_cluster_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_resource.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/kusto_cluster_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_resource.go
@@ -241,9 +241,12 @@ func resourceArmKustoClusterCreateUpdate(d *schema.ResourceData, meta interface{
 	optimizedAutoScale := expandOptimizedAutoScale(d.Get("optimized_auto_scale").([]interface{}))
 
 	if optimizedAutoScale != nil && *optimizedAutoScale.IsEnabled {
-		// if Capacity has not been set use min instances
-		if *sku.Capacity == 0 {
+		// Ensure that requested Capcity is always between min and max to support updating to not overlapping autoscale ranges
+		if *sku.Capacity < *optimizedAutoScale.Minimum {
 			sku.Capacity = utils.Int32(*optimizedAutoScale.Minimum)
+		}
+		if *sku.Capacity > *optimizedAutoScale.Maximum {
+			sku.Capacity = utils.Int32(*optimizedAutoScale.Maximum)
 		}
 
 		// Capacity must be set for the initial creation when using OptimizedAutoScaling but cannot be updated

--- a/azurerm/internal/services/kusto/kusto_database_principal_assignment_resource.go
+++ b/azurerm/internal/services/kusto/kusto_database_principal_assignment_resource.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/kusto_database_principal_resource.go
+++ b/azurerm/internal/services/kusto/kusto_database_principal_resource.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/kusto_database_resource.go
+++ b/azurerm/internal/services/kusto/kusto_database_resource.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"

--- a/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+	"github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
+++ b/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
@@ -328,7 +328,7 @@ resource "azurerm_kusto_cluster" "test" {
     name     = "Dev(No SLA)_Standard_D11_v2"
     capacity = 1
   }
-  engine			  = "V3"
+  engine = "V3"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
+++ b/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
@@ -31,6 +31,25 @@ func TestAccAzureRMKustoCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKustoCluster_basic_V3(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKustoClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKustoCluster_basic_V3(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKustoClusterExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMKustoCluster_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
 
@@ -285,6 +304,31 @@ resource "azurerm_kusto_cluster" "test" {
     name     = "Dev(No SLA)_Standard_D11_v2"
     capacity = 1
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMKustoCluster_basic_V3(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+  engine			  = "V3"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
+++ b/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
@@ -31,25 +31,6 @@ func TestAccAzureRMKustoCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMKustoCluster_basic_V3(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMKustoClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMKustoCluster_basic_V3(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMKustoClusterExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-		},
-	})
-}
-
 func TestAccAzureRMKustoCluster_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
 
@@ -284,6 +265,25 @@ func TestAccAzureRMKustoCluster_optimizedAutoScale(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKustoCluster_engineV3(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKustoClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKustoCluster_engineV3(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKustoClusterExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testAccAzureRMKustoCluster_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -304,31 +304,6 @@ resource "azurerm_kusto_cluster" "test" {
     name     = "Dev(No SLA)_Standard_D11_v2"
     capacity = 1
   }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
-}
-
-func testAccAzureRMKustoCluster_basic_V3(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_kusto_cluster" "test" {
-  name                = "acctestkc%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-  engine = "V3"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -686,6 +661,31 @@ resource "azurerm_kusto_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMKustoCluster_engineV3(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+  engine = "V3"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func testCheckAzureRMKustoClusterDestroy(s *terraform.State) error {

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/attacheddatabaseconfigurations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/attacheddatabaseconfigurations.go
@@ -95,7 +95,7 @@ func (client AttachedDatabaseConfigurationsClient) CreateOrUpdatePreparer(ctx co
 		"subscriptionId":                    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -174,7 +174,7 @@ func (client AttachedDatabaseConfigurationsClient) DeletePreparer(ctx context.Co
 		"subscriptionId":                    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -256,7 +256,7 @@ func (client AttachedDatabaseConfigurationsClient) GetPreparer(ctx context.Conte
 		"subscriptionId":                    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -331,7 +331,7 @@ func (client AttachedDatabaseConfigurationsClient) ListByClusterPreparer(ctx con
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/client.go
@@ -1,4 +1,4 @@
-// Package kusto implements the Azure ARM Kusto service API version 2020-02-15.
+// Package kusto implements the Azure ARM Kusto service API version 2020-09-18.
 //
 // The Azure Kusto management API provides a RESTful set of web services that interact with Azure Kusto services to
 // manage your clusters and databases. The API enables you to create, update, and delete clusters and databases.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/clusterprincipalassignments.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/clusterprincipalassignments.go
@@ -97,7 +97,7 @@ func (client ClusterPrincipalAssignmentsClient) CheckNameAvailabilityPreparer(ct
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -178,7 +178,7 @@ func (client ClusterPrincipalAssignmentsClient) CreateOrUpdatePreparer(ctx conte
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -257,7 +257,7 @@ func (client ClusterPrincipalAssignmentsClient) DeletePreparer(ctx context.Conte
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -339,7 +339,7 @@ func (client ClusterPrincipalAssignmentsClient) GetPreparer(ctx context.Context,
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -414,7 +414,7 @@ func (client ClusterPrincipalAssignmentsClient) ListPreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/clusters.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/clusters.go
@@ -83,7 +83,7 @@ func (client ClustersClient) AddLanguageExtensionsPreparer(ctx context.Context, 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -171,7 +171,7 @@ func (client ClustersClient) CheckNameAvailabilityPreparer(ctx context.Context, 
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -237,7 +237,6 @@ func (client ClustersClient) CreateOrUpdate(ctx context.Context, resourceGroupNa
 							}},
 						{Target: "parameters.ClusterProperties.KeyVaultProperties", Name: validation.Null, Rule: false,
 							Chain: []validation.Constraint{{Target: "parameters.ClusterProperties.KeyVaultProperties.KeyName", Name: validation.Null, Rule: true, Chain: nil},
-								{Target: "parameters.ClusterProperties.KeyVaultProperties.KeyVersion", Name: validation.Null, Rule: true, Chain: nil},
 								{Target: "parameters.ClusterProperties.KeyVaultProperties.KeyVaultURI", Name: validation.Null, Rule: true, Chain: nil},
 							}},
 					}}}}}); err != nil {
@@ -267,7 +266,7 @@ func (client ClustersClient) CreateOrUpdatePreparer(ctx context.Context, resourc
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -344,7 +343,7 @@ func (client ClustersClient) DeletePreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -426,7 +425,7 @@ func (client ClustersClient) DetachFollowerDatabasesPreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -504,7 +503,7 @@ func (client ClustersClient) DiagnoseVirtualNetworkPreparer(ctx context.Context,
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -585,7 +584,7 @@ func (client ClustersClient) GetPreparer(ctx context.Context, resourceGroupName 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -655,7 +654,7 @@ func (client ClustersClient) ListPreparer(ctx context.Context) (*http.Request, e
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -728,7 +727,7 @@ func (client ClustersClient) ListByResourceGroupPreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -804,7 +803,7 @@ func (client ClustersClient) ListFollowerDatabasesPreparer(ctx context.Context, 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -879,7 +878,7 @@ func (client ClustersClient) ListLanguageExtensionsPreparer(ctx context.Context,
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -949,7 +948,7 @@ func (client ClustersClient) ListSkusPreparer(ctx context.Context) (*http.Reques
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1024,7 +1023,7 @@ func (client ClustersClient) ListSkusByResourcePreparer(ctx context.Context, res
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1094,7 +1093,7 @@ func (client ClustersClient) RemoveLanguageExtensionsPreparer(ctx context.Contex
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1170,7 +1169,7 @@ func (client ClustersClient) StartPreparer(ctx context.Context, resourceGroupNam
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1244,7 +1243,7 @@ func (client ClustersClient) StopPreparer(ctx context.Context, resourceGroupName
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1319,7 +1318,7 @@ func (client ClustersClient) UpdatePreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/databaseprincipalassignments.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/databaseprincipalassignments.go
@@ -99,7 +99,7 @@ func (client DatabasePrincipalAssignmentsClient) CheckNameAvailabilityPreparer(c
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -182,7 +182,7 @@ func (client DatabasePrincipalAssignmentsClient) CreateOrUpdatePreparer(ctx cont
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -263,7 +263,7 @@ func (client DatabasePrincipalAssignmentsClient) DeletePreparer(ctx context.Cont
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -347,7 +347,7 @@ func (client DatabasePrincipalAssignmentsClient) GetPreparer(ctx context.Context
 		"subscriptionId":          autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -424,7 +424,7 @@ func (client DatabasePrincipalAssignmentsClient) ListPreparer(ctx context.Contex
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/databases.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/databases.go
@@ -91,7 +91,7 @@ func (client DatabasesClient) AddPrincipalsPreparer(ctx context.Context, resourc
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -175,7 +175,7 @@ func (client DatabasesClient) CheckNameAvailabilityPreparer(ctx context.Context,
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -249,7 +249,7 @@ func (client DatabasesClient) CreateOrUpdatePreparer(ctx context.Context, resour
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -328,7 +328,7 @@ func (client DatabasesClient) DeletePreparer(ctx context.Context, resourceGroupN
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -410,7 +410,7 @@ func (client DatabasesClient) GetPreparer(ctx context.Context, resourceGroupName
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -485,7 +485,7 @@ func (client DatabasesClient) ListByClusterPreparer(ctx context.Context, resourc
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -562,7 +562,7 @@ func (client DatabasesClient) ListPrincipalsPreparer(ctx context.Context, resour
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -640,7 +640,7 @@ func (client DatabasesClient) RemovePrincipalsPreparer(ctx context.Context, reso
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -714,7 +714,7 @@ func (client DatabasesClient) UpdatePreparer(ctx context.Context, resourceGroupN
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/dataconnections.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/dataconnections.go
@@ -98,7 +98,7 @@ func (client DataConnectionsClient) CheckNameAvailabilityPreparer(ctx context.Co
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -174,7 +174,7 @@ func (client DataConnectionsClient) CreateOrUpdatePreparer(ctx context.Context, 
 		"subscriptionId":     autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -219,13 +219,13 @@ func (client DataConnectionsClient) CreateOrUpdateResponder(resp *http.Response)
 // clusterName - the name of the Kusto cluster.
 // databaseName - the name of the database in the Kusto cluster.
 // parameters - the data connection parameters supplied to the CreateOrUpdate operation.
-func (client DataConnectionsClient) DataConnectionValidationMethod(ctx context.Context, resourceGroupName string, clusterName string, databaseName string, parameters DataConnectionValidation) (result DataConnectionValidationListResult, err error) {
+func (client DataConnectionsClient) DataConnectionValidationMethod(ctx context.Context, resourceGroupName string, clusterName string, databaseName string, parameters DataConnectionValidation) (result DataConnectionsDataConnectionValidationMethodFuture, err error) {
 	if tracing.IsEnabled() {
 		ctx = tracing.StartSpan(ctx, fqdn+"/DataConnectionsClient.DataConnectionValidationMethod")
 		defer func() {
 			sc := -1
-			if result.Response.Response != nil {
-				sc = result.Response.Response.StatusCode
+			if result.Response() != nil {
+				sc = result.Response().StatusCode
 			}
 			tracing.EndSpan(ctx, sc, err)
 		}()
@@ -236,16 +236,10 @@ func (client DataConnectionsClient) DataConnectionValidationMethod(ctx context.C
 		return
 	}
 
-	resp, err := client.DataConnectionValidationMethodSender(req)
+	result, err = client.DataConnectionValidationMethodSender(req)
 	if err != nil {
-		result.Response = autorest.Response{Response: resp}
-		err = autorest.NewErrorWithError(err, "kusto.DataConnectionsClient", "DataConnectionValidationMethod", resp, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "kusto.DataConnectionsClient", "DataConnectionValidationMethod", result.Response(), "Failure sending request")
 		return
-	}
-
-	result, err = client.DataConnectionValidationMethodResponder(resp)
-	if err != nil {
-		err = autorest.NewErrorWithError(err, "kusto.DataConnectionsClient", "DataConnectionValidationMethod", resp, "Failure responding to request")
 	}
 
 	return
@@ -260,7 +254,7 @@ func (client DataConnectionsClient) DataConnectionValidationMethodPreparer(ctx c
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -277,8 +271,14 @@ func (client DataConnectionsClient) DataConnectionValidationMethodPreparer(ctx c
 
 // DataConnectionValidationMethodSender sends the DataConnectionValidationMethod request. The method will close the
 // http.Response Body if it receives an error.
-func (client DataConnectionsClient) DataConnectionValidationMethodSender(req *http.Request) (*http.Response, error) {
-	return client.Send(req, azure.DoRetryWithRegistration(client.Client))
+func (client DataConnectionsClient) DataConnectionValidationMethodSender(req *http.Request) (future DataConnectionsDataConnectionValidationMethodFuture, err error) {
+	var resp *http.Response
+	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
 }
 
 // DataConnectionValidationMethodResponder handles the response to the DataConnectionValidationMethod request. The method always
@@ -286,7 +286,7 @@ func (client DataConnectionsClient) DataConnectionValidationMethodSender(req *ht
 func (client DataConnectionsClient) DataConnectionValidationMethodResponder(resp *http.Response) (result DataConnectionValidationListResult, err error) {
 	err = autorest.Respond(
 		resp,
-		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}
@@ -335,7 +335,7 @@ func (client DataConnectionsClient) DeletePreparer(ctx context.Context, resource
 		"subscriptionId":     autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -419,7 +419,7 @@ func (client DataConnectionsClient) GetPreparer(ctx context.Context, resourceGro
 		"subscriptionId":     autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -496,7 +496,7 @@ func (client DataConnectionsClient) ListByDatabasePreparer(ctx context.Context, 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -570,7 +570,7 @@ func (client DataConnectionsClient) UpdatePreparer(ctx context.Context, resource
 		"subscriptionId":     autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/enums.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/enums.go
@@ -68,6 +68,8 @@ const (
 	StandardE2aV4 AzureSkuName = "Standard_E2a_v4"
 	// StandardE4aV4 ...
 	StandardE4aV4 AzureSkuName = "Standard_E4a_v4"
+	// StandardE64iV3 ...
+	StandardE64iV3 AzureSkuName = "Standard_E64i_v3"
 	// StandardE8asV41TBPS ...
 	StandardE8asV41TBPS AzureSkuName = "Standard_E8as_v4+1TB_PS"
 	// StandardE8asV42TBPS ...
@@ -84,7 +86,7 @@ const (
 
 // PossibleAzureSkuNameValues returns an array of possible values for the AzureSkuName const type.
 func PossibleAzureSkuNameValues() []AzureSkuName {
-	return []AzureSkuName{DevNoSLAStandardD11V2, DevNoSLAStandardE2aV4, StandardD11V2, StandardD12V2, StandardD13V2, StandardD14V2, StandardDS13V21TBPS, StandardDS13V22TBPS, StandardDS14V23TBPS, StandardDS14V24TBPS, StandardE16asV43TBPS, StandardE16asV44TBPS, StandardE16aV4, StandardE2aV4, StandardE4aV4, StandardE8asV41TBPS, StandardE8asV42TBPS, StandardE8aV4, StandardL16s, StandardL4s, StandardL8s}
+	return []AzureSkuName{DevNoSLAStandardD11V2, DevNoSLAStandardE2aV4, StandardD11V2, StandardD12V2, StandardD13V2, StandardD14V2, StandardDS13V21TBPS, StandardDS13V22TBPS, StandardDS14V23TBPS, StandardDS14V24TBPS, StandardE16asV43TBPS, StandardE16asV44TBPS, StandardE16aV4, StandardE2aV4, StandardE4aV4, StandardE64iV3, StandardE8asV41TBPS, StandardE8asV42TBPS, StandardE8aV4, StandardL16s, StandardL4s, StandardL8s}
 }
 
 // AzureSkuTier enumerates the values for azure sku tier.
@@ -100,6 +102,21 @@ const (
 // PossibleAzureSkuTierValues returns an array of possible values for the AzureSkuTier const type.
 func PossibleAzureSkuTierValues() []AzureSkuTier {
 	return []AzureSkuTier{Basic, Standard}
+}
+
+// BlobStorageEventType enumerates the values for blob storage event type.
+type BlobStorageEventType string
+
+const (
+	// MicrosoftStorageBlobCreated ...
+	MicrosoftStorageBlobCreated BlobStorageEventType = "Microsoft.Storage.BlobCreated"
+	// MicrosoftStorageBlobRenamed ...
+	MicrosoftStorageBlobRenamed BlobStorageEventType = "Microsoft.Storage.BlobRenamed"
+)
+
+// PossibleBlobStorageEventTypeValues returns an array of possible values for the BlobStorageEventType const type.
+func PossibleBlobStorageEventTypeValues() []BlobStorageEventType {
+	return []BlobStorageEventType{MicrosoftStorageBlobCreated, MicrosoftStorageBlobRenamed}
 }
 
 // ClusterPrincipalRole enumerates the values for cluster principal role.
@@ -189,10 +206,27 @@ func PossibleDefaultPrincipalsModificationKindValues() []DefaultPrincipalsModifi
 	return []DefaultPrincipalsModificationKind{DefaultPrincipalsModificationKindNone, DefaultPrincipalsModificationKindReplace, DefaultPrincipalsModificationKindUnion}
 }
 
+// EngineType enumerates the values for engine type.
+type EngineType string
+
+const (
+	// V2 ...
+	V2 EngineType = "V2"
+	// V3 ...
+	V3 EngineType = "V3"
+)
+
+// PossibleEngineTypeValues returns an array of possible values for the EngineType const type.
+func PossibleEngineTypeValues() []EngineType {
+	return []EngineType{V2, V3}
+}
+
 // EventGridDataFormat enumerates the values for event grid data format.
 type EventGridDataFormat string
 
 const (
+	// APACHEAVRO ...
+	APACHEAVRO EventGridDataFormat = "APACHEAVRO"
 	// AVRO ...
 	AVRO EventGridDataFormat = "AVRO"
 	// CSV ...
@@ -221,17 +255,21 @@ const (
 	TSVE EventGridDataFormat = "TSVE"
 	// TXT ...
 	TXT EventGridDataFormat = "TXT"
+	// W3CLOGFILE ...
+	W3CLOGFILE EventGridDataFormat = "W3CLOGFILE"
 )
 
 // PossibleEventGridDataFormatValues returns an array of possible values for the EventGridDataFormat const type.
 func PossibleEventGridDataFormatValues() []EventGridDataFormat {
-	return []EventGridDataFormat{AVRO, CSV, JSON, MULTIJSON, ORC, PARQUET, PSV, RAW, SCSV, SINGLEJSON, SOHSV, TSV, TSVE, TXT}
+	return []EventGridDataFormat{APACHEAVRO, AVRO, CSV, JSON, MULTIJSON, ORC, PARQUET, PSV, RAW, SCSV, SINGLEJSON, SOHSV, TSV, TSVE, TXT, W3CLOGFILE}
 }
 
 // EventHubDataFormat enumerates the values for event hub data format.
 type EventHubDataFormat string
 
 const (
+	// EventHubDataFormatAPACHEAVRO ...
+	EventHubDataFormatAPACHEAVRO EventHubDataFormat = "APACHEAVRO"
 	// EventHubDataFormatAVRO ...
 	EventHubDataFormatAVRO EventHubDataFormat = "AVRO"
 	// EventHubDataFormatCSV ...
@@ -260,11 +298,13 @@ const (
 	EventHubDataFormatTSVE EventHubDataFormat = "TSVE"
 	// EventHubDataFormatTXT ...
 	EventHubDataFormatTXT EventHubDataFormat = "TXT"
+	// EventHubDataFormatW3CLOGFILE ...
+	EventHubDataFormatW3CLOGFILE EventHubDataFormat = "W3CLOGFILE"
 )
 
 // PossibleEventHubDataFormatValues returns an array of possible values for the EventHubDataFormat const type.
 func PossibleEventHubDataFormatValues() []EventHubDataFormat {
-	return []EventHubDataFormat{EventHubDataFormatAVRO, EventHubDataFormatCSV, EventHubDataFormatJSON, EventHubDataFormatMULTIJSON, EventHubDataFormatORC, EventHubDataFormatPARQUET, EventHubDataFormatPSV, EventHubDataFormatRAW, EventHubDataFormatSCSV, EventHubDataFormatSINGLEJSON, EventHubDataFormatSOHSV, EventHubDataFormatTSV, EventHubDataFormatTSVE, EventHubDataFormatTXT}
+	return []EventHubDataFormat{EventHubDataFormatAPACHEAVRO, EventHubDataFormatAVRO, EventHubDataFormatCSV, EventHubDataFormatJSON, EventHubDataFormatMULTIJSON, EventHubDataFormatORC, EventHubDataFormatPARQUET, EventHubDataFormatPSV, EventHubDataFormatRAW, EventHubDataFormatSCSV, EventHubDataFormatSINGLEJSON, EventHubDataFormatSOHSV, EventHubDataFormatTSV, EventHubDataFormatTSVE, EventHubDataFormatTXT, EventHubDataFormatW3CLOGFILE}
 }
 
 // IdentityType enumerates the values for identity type.
@@ -275,17 +315,23 @@ const (
 	IdentityTypeNone IdentityType = "None"
 	// IdentityTypeSystemAssigned ...
 	IdentityTypeSystemAssigned IdentityType = "SystemAssigned"
+	// IdentityTypeSystemAssignedUserAssigned ...
+	IdentityTypeSystemAssignedUserAssigned IdentityType = "SystemAssigned, UserAssigned"
+	// IdentityTypeUserAssigned ...
+	IdentityTypeUserAssigned IdentityType = "UserAssigned"
 )
 
 // PossibleIdentityTypeValues returns an array of possible values for the IdentityType const type.
 func PossibleIdentityTypeValues() []IdentityType {
-	return []IdentityType{IdentityTypeNone, IdentityTypeSystemAssigned}
+	return []IdentityType{IdentityTypeNone, IdentityTypeSystemAssigned, IdentityTypeSystemAssignedUserAssigned, IdentityTypeUserAssigned}
 }
 
 // IotHubDataFormat enumerates the values for iot hub data format.
 type IotHubDataFormat string
 
 const (
+	// IotHubDataFormatAPACHEAVRO ...
+	IotHubDataFormatAPACHEAVRO IotHubDataFormat = "APACHEAVRO"
 	// IotHubDataFormatAVRO ...
 	IotHubDataFormatAVRO IotHubDataFormat = "AVRO"
 	// IotHubDataFormatCSV ...
@@ -314,11 +360,13 @@ const (
 	IotHubDataFormatTSVE IotHubDataFormat = "TSVE"
 	// IotHubDataFormatTXT ...
 	IotHubDataFormatTXT IotHubDataFormat = "TXT"
+	// IotHubDataFormatW3CLOGFILE ...
+	IotHubDataFormatW3CLOGFILE IotHubDataFormat = "W3CLOGFILE"
 )
 
 // PossibleIotHubDataFormatValues returns an array of possible values for the IotHubDataFormat const type.
 func PossibleIotHubDataFormatValues() []IotHubDataFormat {
-	return []IotHubDataFormat{IotHubDataFormatAVRO, IotHubDataFormatCSV, IotHubDataFormatJSON, IotHubDataFormatMULTIJSON, IotHubDataFormatORC, IotHubDataFormatPARQUET, IotHubDataFormatPSV, IotHubDataFormatRAW, IotHubDataFormatSCSV, IotHubDataFormatSINGLEJSON, IotHubDataFormatSOHSV, IotHubDataFormatTSV, IotHubDataFormatTSVE, IotHubDataFormatTXT}
+	return []IotHubDataFormat{IotHubDataFormatAPACHEAVRO, IotHubDataFormatAVRO, IotHubDataFormatCSV, IotHubDataFormatJSON, IotHubDataFormatMULTIJSON, IotHubDataFormatORC, IotHubDataFormatPARQUET, IotHubDataFormatPSV, IotHubDataFormatRAW, IotHubDataFormatSCSV, IotHubDataFormatSINGLEJSON, IotHubDataFormatSOHSV, IotHubDataFormatTSV, IotHubDataFormatTSVE, IotHubDataFormatTXT, IotHubDataFormatW3CLOGFILE}
 }
 
 // Kind enumerates the values for kind.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/models.go
@@ -28,7 +28,7 @@ import (
 )
 
 // The package's fully qualified name.
-const fqdn = "github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto"
+const fqdn = "github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto"
 
 // AttachedDatabaseConfiguration class representing an attached database configuration.
 type AttachedDatabaseConfiguration struct {
@@ -242,7 +242,7 @@ type AzureResourceSku struct {
 
 // AzureSku azure SKU definition.
 type AzureSku struct {
-	// Name - SKU name. Possible values include: 'StandardDS13V21TBPS', 'StandardDS13V22TBPS', 'StandardDS14V23TBPS', 'StandardDS14V24TBPS', 'StandardD13V2', 'StandardD14V2', 'StandardL8s', 'StandardL16s', 'StandardD11V2', 'StandardD12V2', 'StandardL4s', 'DevNoSLAStandardD11V2', 'StandardE2aV4', 'StandardE4aV4', 'StandardE8aV4', 'StandardE16aV4', 'StandardE8asV41TBPS', 'StandardE8asV42TBPS', 'StandardE16asV43TBPS', 'StandardE16asV44TBPS', 'DevNoSLAStandardE2aV4'
+	// Name - SKU name. Possible values include: 'StandardDS13V21TBPS', 'StandardDS13V22TBPS', 'StandardDS14V23TBPS', 'StandardDS14V24TBPS', 'StandardD13V2', 'StandardD14V2', 'StandardL8s', 'StandardL16s', 'StandardD11V2', 'StandardD12V2', 'StandardL4s', 'DevNoSLAStandardD11V2', 'StandardE64iV3', 'StandardE2aV4', 'StandardE4aV4', 'StandardE8aV4', 'StandardE16aV4', 'StandardE8asV41TBPS', 'StandardE8asV42TBPS', 'StandardE16asV43TBPS', 'StandardE16asV44TBPS', 'DevNoSLAStandardE2aV4'
 	Name AzureSkuName `json:"name,omitempty"`
 	// Capacity - The number of instances of the cluster.
 	Capacity *int32 `json:"capacity,omitempty"`
@@ -649,8 +649,12 @@ type ClusterProperties struct {
 	KeyVaultProperties *KeyVaultProperties `json:"keyVaultProperties,omitempty"`
 	// EnablePurge - A boolean value that indicates if the purge operations are enabled.
 	EnablePurge *bool `json:"enablePurge,omitempty"`
-	// LanguageExtensions - List of the cluster's language extensions.
+	// LanguageExtensions - READ-ONLY; List of the cluster's language extensions.
 	LanguageExtensions *LanguageExtensionsList `json:"languageExtensions,omitempty"`
+	// EnableDoubleEncryption - A boolean value that indicates if double encryption is enabled.
+	EnableDoubleEncryption *bool `json:"enableDoubleEncryption,omitempty"`
+	// EngineType - The engine type. Possible values include: 'V2', 'V3'
+	EngineType EngineType `json:"engineType,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for ClusterProperties.
@@ -677,8 +681,11 @@ func (cp ClusterProperties) MarshalJSON() ([]byte, error) {
 	if cp.EnablePurge != nil {
 		objectMap["enablePurge"] = cp.EnablePurge
 	}
-	if cp.LanguageExtensions != nil {
-		objectMap["languageExtensions"] = cp.LanguageExtensions
+	if cp.EnableDoubleEncryption != nil {
+		objectMap["enableDoubleEncryption"] = cp.EnableDoubleEncryption
+	}
+	if cp.EngineType != "" {
+		objectMap["engineType"] = cp.EngineType
 	}
 	return json.Marshal(objectMap)
 }
@@ -1681,6 +1688,35 @@ func (future *DataConnectionsCreateOrUpdateFuture) Result(client DataConnections
 	return
 }
 
+// DataConnectionsDataConnectionValidationMethodFuture an abstraction for monitoring and retrieving the results
+// of a long-running operation.
+type DataConnectionsDataConnectionValidationMethodFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *DataConnectionsDataConnectionValidationMethodFuture) Result(client DataConnectionsClient) (dcvlr DataConnectionValidationListResult, err error) {
+	var done bool
+	done, err = future.DoneWithContext(context.Background(), client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "kusto.DataConnectionsDataConnectionValidationMethodFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("kusto.DataConnectionsDataConnectionValidationMethodFuture")
+		return
+	}
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	if dcvlr.Response.Response, err = future.GetResult(sender); err == nil && dcvlr.Response.Response.StatusCode != http.StatusNoContent {
+		dcvlr, err = client.DataConnectionValidationMethodResponder(dcvlr.Response.Response)
+		if err != nil {
+			err = autorest.NewErrorWithError(err, "kusto.DataConnectionsDataConnectionValidationMethodFuture", "Result", dcvlr.Response.Response, "Failure responding to request")
+		}
+	}
+	return
+}
+
 // DataConnectionsDeleteFuture an abstraction for monitoring and retrieving the results of a long-running
 // operation.
 type DataConnectionsDeleteFuture struct {
@@ -1805,8 +1841,44 @@ type EventGridConnectionProperties struct {
 	TableName *string `json:"tableName,omitempty"`
 	// MappingRuleName - The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each message.
 	MappingRuleName *string `json:"mappingRuleName,omitempty"`
-	// DataFormat - The data format of the message. Optionally the data format can be added to each message. Possible values include: 'MULTIJSON', 'JSON', 'CSV', 'TSV', 'SCSV', 'SOHSV', 'PSV', 'TXT', 'RAW', 'SINGLEJSON', 'AVRO', 'TSVE', 'PARQUET', 'ORC'
+	// DataFormat - The data format of the message. Optionally the data format can be added to each message. Possible values include: 'MULTIJSON', 'JSON', 'CSV', 'TSV', 'SCSV', 'SOHSV', 'PSV', 'TXT', 'RAW', 'SINGLEJSON', 'AVRO', 'TSVE', 'PARQUET', 'ORC', 'APACHEAVRO', 'W3CLOGFILE'
 	DataFormat EventGridDataFormat `json:"dataFormat,omitempty"`
+	// IgnoreFirstRecord - A Boolean value that, if set to true, indicates that ingestion should ignore the first record of every file
+	IgnoreFirstRecord *bool `json:"ignoreFirstRecord,omitempty"`
+	// BlobStorageEventType - The name of blob storage event type to process. Possible values include: 'MicrosoftStorageBlobCreated', 'MicrosoftStorageBlobRenamed'
+	BlobStorageEventType BlobStorageEventType `json:"blobStorageEventType,omitempty"`
+	// ProvisioningState - READ-ONLY; The provisioned state of the resource. Possible values include: 'Running', 'Creating', 'Deleting', 'Succeeded', 'Failed', 'Moving'
+	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for EventGridConnectionProperties.
+func (egcp EventGridConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if egcp.StorageAccountResourceID != nil {
+		objectMap["storageAccountResourceId"] = egcp.StorageAccountResourceID
+	}
+	if egcp.EventHubResourceID != nil {
+		objectMap["eventHubResourceId"] = egcp.EventHubResourceID
+	}
+	if egcp.ConsumerGroup != nil {
+		objectMap["consumerGroup"] = egcp.ConsumerGroup
+	}
+	if egcp.TableName != nil {
+		objectMap["tableName"] = egcp.TableName
+	}
+	if egcp.MappingRuleName != nil {
+		objectMap["mappingRuleName"] = egcp.MappingRuleName
+	}
+	if egcp.DataFormat != "" {
+		objectMap["dataFormat"] = egcp.DataFormat
+	}
+	if egcp.IgnoreFirstRecord != nil {
+		objectMap["ignoreFirstRecord"] = egcp.IgnoreFirstRecord
+	}
+	if egcp.BlobStorageEventType != "" {
+		objectMap["blobStorageEventType"] = egcp.BlobStorageEventType
+	}
+	return json.Marshal(objectMap)
 }
 
 // EventGridDataConnection class representing an Event Grid data connection.
@@ -1945,12 +2017,41 @@ type EventHubConnectionProperties struct {
 	TableName *string `json:"tableName,omitempty"`
 	// MappingRuleName - The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each message.
 	MappingRuleName *string `json:"mappingRuleName,omitempty"`
-	// DataFormat - The data format of the message. Optionally the data format can be added to each message. Possible values include: 'EventHubDataFormatMULTIJSON', 'EventHubDataFormatJSON', 'EventHubDataFormatCSV', 'EventHubDataFormatTSV', 'EventHubDataFormatSCSV', 'EventHubDataFormatSOHSV', 'EventHubDataFormatPSV', 'EventHubDataFormatTXT', 'EventHubDataFormatRAW', 'EventHubDataFormatSINGLEJSON', 'EventHubDataFormatAVRO', 'EventHubDataFormatTSVE', 'EventHubDataFormatPARQUET', 'EventHubDataFormatORC'
+	// DataFormat - The data format of the message. Optionally the data format can be added to each message. Possible values include: 'EventHubDataFormatMULTIJSON', 'EventHubDataFormatJSON', 'EventHubDataFormatCSV', 'EventHubDataFormatTSV', 'EventHubDataFormatSCSV', 'EventHubDataFormatSOHSV', 'EventHubDataFormatPSV', 'EventHubDataFormatTXT', 'EventHubDataFormatRAW', 'EventHubDataFormatSINGLEJSON', 'EventHubDataFormatAVRO', 'EventHubDataFormatTSVE', 'EventHubDataFormatPARQUET', 'EventHubDataFormatORC', 'EventHubDataFormatAPACHEAVRO', 'EventHubDataFormatW3CLOGFILE'
 	DataFormat EventHubDataFormat `json:"dataFormat,omitempty"`
 	// EventSystemProperties - System properties of the event hub
 	EventSystemProperties *[]string `json:"eventSystemProperties,omitempty"`
 	// Compression - The event hub messages compression type. Possible values include: 'CompressionNone', 'CompressionGZip'
 	Compression Compression `json:"compression,omitempty"`
+	// ProvisioningState - READ-ONLY; The provisioned state of the resource. Possible values include: 'Running', 'Creating', 'Deleting', 'Succeeded', 'Failed', 'Moving'
+	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for EventHubConnectionProperties.
+func (ehcp EventHubConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ehcp.EventHubResourceID != nil {
+		objectMap["eventHubResourceId"] = ehcp.EventHubResourceID
+	}
+	if ehcp.ConsumerGroup != nil {
+		objectMap["consumerGroup"] = ehcp.ConsumerGroup
+	}
+	if ehcp.TableName != nil {
+		objectMap["tableName"] = ehcp.TableName
+	}
+	if ehcp.MappingRuleName != nil {
+		objectMap["mappingRuleName"] = ehcp.MappingRuleName
+	}
+	if ehcp.DataFormat != "" {
+		objectMap["dataFormat"] = ehcp.DataFormat
+	}
+	if ehcp.EventSystemProperties != nil {
+		objectMap["eventSystemProperties"] = ehcp.EventSystemProperties
+	}
+	if ehcp.Compression != "" {
+		objectMap["compression"] = ehcp.Compression
+	}
+	return json.Marshal(objectMap)
 }
 
 // EventHubDataConnection class representing an event hub data connection.
@@ -2114,7 +2215,7 @@ type Identity struct {
 	PrincipalID *string `json:"principalId,omitempty"`
 	// TenantID - READ-ONLY; The tenant ID of resource.
 	TenantID *string `json:"tenantId,omitempty"`
-	// Type - The identity type. Possible values include: 'IdentityTypeNone', 'IdentityTypeSystemAssigned'
+	// Type - The type of managed identity used. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user-assigned identities. The type 'None' will remove all identities. Possible values include: 'IdentityTypeNone', 'IdentityTypeSystemAssigned', 'IdentityTypeUserAssigned', 'IdentityTypeSystemAssignedUserAssigned'
 	Type IdentityType `json:"type,omitempty"`
 	// UserAssignedIdentities - The list of user identities associated with the Kusto cluster. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
 	UserAssignedIdentities map[string]*IdentityUserAssignedIdentitiesValue `json:"userAssignedIdentities"`
@@ -2150,12 +2251,41 @@ type IotHubConnectionProperties struct {
 	TableName *string `json:"tableName,omitempty"`
 	// MappingRuleName - The mapping rule to be used to ingest the data. Optionally the mapping information can be added to each message.
 	MappingRuleName *string `json:"mappingRuleName,omitempty"`
-	// DataFormat - The data format of the message. Optionally the data format can be added to each message. Possible values include: 'IotHubDataFormatMULTIJSON', 'IotHubDataFormatJSON', 'IotHubDataFormatCSV', 'IotHubDataFormatTSV', 'IotHubDataFormatSCSV', 'IotHubDataFormatSOHSV', 'IotHubDataFormatPSV', 'IotHubDataFormatTXT', 'IotHubDataFormatRAW', 'IotHubDataFormatSINGLEJSON', 'IotHubDataFormatAVRO', 'IotHubDataFormatTSVE', 'IotHubDataFormatPARQUET', 'IotHubDataFormatORC'
+	// DataFormat - The data format of the message. Optionally the data format can be added to each message. Possible values include: 'IotHubDataFormatMULTIJSON', 'IotHubDataFormatJSON', 'IotHubDataFormatCSV', 'IotHubDataFormatTSV', 'IotHubDataFormatSCSV', 'IotHubDataFormatSOHSV', 'IotHubDataFormatPSV', 'IotHubDataFormatTXT', 'IotHubDataFormatRAW', 'IotHubDataFormatSINGLEJSON', 'IotHubDataFormatAVRO', 'IotHubDataFormatTSVE', 'IotHubDataFormatPARQUET', 'IotHubDataFormatORC', 'IotHubDataFormatAPACHEAVRO', 'IotHubDataFormatW3CLOGFILE'
 	DataFormat IotHubDataFormat `json:"dataFormat,omitempty"`
 	// EventSystemProperties - System properties of the iot hub
 	EventSystemProperties *[]string `json:"eventSystemProperties,omitempty"`
 	// SharedAccessPolicyName - The name of the share access policy
 	SharedAccessPolicyName *string `json:"sharedAccessPolicyName,omitempty"`
+	// ProvisioningState - READ-ONLY; The provisioned state of the resource. Possible values include: 'Running', 'Creating', 'Deleting', 'Succeeded', 'Failed', 'Moving'
+	ProvisioningState ProvisioningState `json:"provisioningState,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for IotHubConnectionProperties.
+func (ihcp IotHubConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ihcp.IotHubResourceID != nil {
+		objectMap["iotHubResourceId"] = ihcp.IotHubResourceID
+	}
+	if ihcp.ConsumerGroup != nil {
+		objectMap["consumerGroup"] = ihcp.ConsumerGroup
+	}
+	if ihcp.TableName != nil {
+		objectMap["tableName"] = ihcp.TableName
+	}
+	if ihcp.MappingRuleName != nil {
+		objectMap["mappingRuleName"] = ihcp.MappingRuleName
+	}
+	if ihcp.DataFormat != "" {
+		objectMap["dataFormat"] = ihcp.DataFormat
+	}
+	if ihcp.EventSystemProperties != nil {
+		objectMap["eventSystemProperties"] = ihcp.EventSystemProperties
+	}
+	if ihcp.SharedAccessPolicyName != nil {
+		objectMap["sharedAccessPolicyName"] = ihcp.SharedAccessPolicyName
+	}
+	return json.Marshal(objectMap)
 }
 
 // IotHubDataConnection class representing an iot hub data connection.
@@ -2292,6 +2422,8 @@ type KeyVaultProperties struct {
 	KeyVersion *string `json:"keyVersion,omitempty"`
 	// KeyVaultURI - The Uri of the key vault.
 	KeyVaultURI *string `json:"keyVaultUri,omitempty"`
+	// UserIdentity - The user assigned identity (ARM resource id) that has access to the key.
+	UserIdentity *string `json:"userIdentity,omitempty"`
 }
 
 // LanguageExtension the language extension object.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/operations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/operations.go
@@ -82,7 +82,7 @@ func (client OperationsClient) List(ctx context.Context) (result OperationListRe
 
 // ListPreparer prepares the List request.
 func (client OperationsClient) ListPreparer(ctx context.Context) (*http.Request, error) {
-	const APIVersion = "2020-02-15"
+	const APIVersion = "2020-09-18"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + Version() + " kusto/2020-02-15"
+	return "Azure-SDK-For-Go/" + Version() + " kusto/2020-09-18"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral
 github.com/Azure/azure-sdk-for-go/services/iothub/mgmt/2020-03-01/devices
 github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault
 github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault
-github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto
+github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-09-18/kusto
 github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2019-05-01/logic
 github.com/Azure/azure-sdk-for-go/services/machinelearningservices/mgmt/2020-04-01/machinelearningservices
 github.com/Azure/azure-sdk-for-go/services/managedservices/mgmt/2019-06-01/managedservices

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `zones` - (Optional) A list of Availability Zones in which the cluster instances should be created in. Changing this forces a new resource to be created.
 
+* `engine` - (Optional). The engine type that should be used. Possible values are `V2` and `V3`. Defaults to `V2`.
+
 ---
 
 A `sku` block supports the following:
@@ -75,7 +77,7 @@ A `sku` block supports the following:
 * `capacity` - (Optional) Specifies the node count for the cluster. Boundaries depend on the sku name.
 
 ~> **NOTE:** If no `optimized_auto_scale` block is defined, then the capacity is required.
-~> **NOTE:** If an `optimized_auto_scale` block is defined and no capacity is set, then the capacatiy is initially set to the value of `minimum_instances`.
+~> **NOTE:** If an `optimized_auto_scale` block is defined and no capacity is set, then the capacity is initially set to the value of `minimum_instances`.
 
 ---
 


### PR DESCRIPTION
Kusto aka ADX added support for EngineV3 which promises better performance. Adding `engine` argument to the `kusto_cluster` resources.


Updating kusto API to `2020-09-18` to use new `EngineType` field in `ClusterProperties` type

Implements #9695 

Test run:
```
make testacc TEST='./azurerm/internal/services/kusto/tests/' TESTARGS='-run=TestAccAzureRMKustoCluster_ -parallel=3' TESTTIMEOUT='300m' 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/kusto/tests/ -v -run=TestAccAzureRMKustoCluster_ -parallel=3 -timeout 300m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMKustoCluster_basic
=== PAUSE TestAccAzureRMKustoCluster_basic
=== RUN   TestAccAzureRMKustoCluster_update
=== PAUSE TestAccAzureRMKustoCluster_update
=== RUN   TestAccAzureRMKustoCluster_withTags
=== PAUSE TestAccAzureRMKustoCluster_withTags
=== RUN   TestAccAzureRMKustoCluster_sku
=== PAUSE TestAccAzureRMKustoCluster_sku
=== RUN   TestAccAzureRMKustoCluster_zones
=== PAUSE TestAccAzureRMKustoCluster_zones
=== RUN   TestAccAzureRMKustoCluster_identitySystemAssigned
=== PAUSE TestAccAzureRMKustoCluster_identitySystemAssigned
=== RUN   TestAccAzureRMKustoCluster_vnet
=== PAUSE TestAccAzureRMKustoCluster_vnet
=== RUN   TestAccAzureRMKustoCluster_languageExtensions
=== PAUSE TestAccAzureRMKustoCluster_languageExtensions
=== RUN   TestAccAzureRMKustoCluster_optimizedAutoScale
=== PAUSE TestAccAzureRMKustoCluster_optimizedAutoScale
=== RUN   TestAccAzureRMKustoCluster_engineV3
=== PAUSE TestAccAzureRMKustoCluster_engineV3
=== CONT  TestAccAzureRMKustoCluster_basic
=== CONT  TestAccAzureRMKustoCluster_vnet
=== CONT  TestAccAzureRMKustoCluster_sku
--- PASS: TestAccAzureRMKustoCluster_vnet (1381.34s)
=== CONT  TestAccAzureRMKustoCluster_engineV3
--- PASS: TestAccAzureRMKustoCluster_basic (1409.33s)
=== CONT  TestAccAzureRMKustoCluster_withTags
--- PASS: TestAccAzureRMKustoCluster_sku (1914.09s)
=== CONT  TestAccAzureRMKustoCluster_identitySystemAssigned
--- PASS: TestAccAzureRMKustoCluster_withTags (1365.42s)
=== CONT  TestAccAzureRMKustoCluster_zones
--- PASS: TestAccAzureRMKustoCluster_engineV3 (1682.15s)
=== CONT  TestAccAzureRMKustoCluster_optimizedAutoScale
--- PASS: TestAccAzureRMKustoCluster_identitySystemAssigned (1470.83s)
=== CONT  TestAccAzureRMKustoCluster_languageExtensions
    TestAccAzureRMKustoCluster_zones: testing.go:684: Step 0 error: Check failed: Check 3/3 error: azurerm_kusto_cluster.test: Attribute 'zones.0' expected "1", got "2"
--- FAIL: TestAccAzureRMKustoCluster_zones (1582.72s)
=== CONT  TestAccAzureRMKustoCluster_update
--- PASS: TestAccAzureRMKustoCluster_optimizedAutoScale (2296.77s)
--- PASS: TestAccAzureRMKustoCluster_languageExtensions (2731.64s)
--- PASS: TestAccAzureRMKustoCluster_update (2664.86s)
```
TestAccAzureRMKustoCluster_zones fails in master too
Also, I fixed TestAccAzureRMKustoCluster_optimizedAutoScale, let me know if I need to do that fix in separate PR