### PR TITLE
New resource `azurerm_digital_twins_endpoint_servicebus` 

### DIFF
--- a/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource.go
+++ b/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource.go
@@ -1,0 +1,179 @@
+package digitaltwins
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/digitaltwins/mgmt/2020-10-31/digitaltwins"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/digitaltwins/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/digitaltwins/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDigitalTwinsEndpointServiceBus() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDigitalTwinsEndpointServiceBusCreateUpdate,
+		Read:   resourceDigitalTwinsEndpointServiceBusRead,
+		Update: resourceDigitalTwinsEndpointServiceBusCreateUpdate,
+		Delete: resourceDigitalTwinsEndpointServiceBusDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.DigitalTwinsEndpointID(id)
+			return err
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DigitalTwinsInstanceName,
+			},
+
+			"digital_twins_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DigitalTwinsInstanceID,
+			},
+
+			"servicebus_primary_connection_string": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"servicebus_secondary_connection_string": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"dead_letter_storage_secret": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}
+func resourceDigitalTwinsEndpointServiceBusCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).DigitalTwins.EndpointClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	digitalTwinsId, err := parse.DigitalTwinsInstanceID(d.Get("digital_twins_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := parse.NewDigitalTwinsEndpointID(subscriptionId, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, name).ID("")
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for present of existing Digital Twins Endpoint %q (Resource Group %q / Instance %q): %+v", name, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_digital_twins_endpoint_servicebus", id)
+		}
+	}
+
+	properties := digitaltwins.EndpointResource{
+		Properties: &digitaltwins.ServiceBus{
+			EndpointType:              digitaltwins.EndpointTypeServiceBus,
+			PrimaryConnectionString:   utils.String(d.Get("servicebus_primary_connection_string").(string)),
+			SecondaryConnectionString: utils.String(d.Get("servicebus_secondary_connection_string").(string)),
+			DeadLetterSecret:          utils.String(d.Get("dead_letter_storage_secret").(string)),
+		},
+	}
+
+	future, err := client.CreateOrUpdate(ctx, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, name, properties)
+	if err != nil {
+		return fmt.Errorf("creating/updating Digital Twins Endpoint ServiceBus %q (Resource Group %q / Instance %q): %+v", name, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of the Digital Twins Endpoint ServiceBus %q (Resource Group %q / Instance %q): %+v", name, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, err)
+	}
+
+	if _, err := client.Get(ctx, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, name); err != nil {
+		return fmt.Errorf("retrieving Digital Twins Endpoint ServiceBus %q (Resource Group %q / Instance %q): %+v", name, digitalTwinsId.ResourceGroup, digitalTwinsId.Name, err)
+	}
+
+	d.SetId(id)
+
+	return resourceDigitalTwinsEndpointServiceBusRead(d, meta)
+}
+
+func resourceDigitalTwinsEndpointServiceBusRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).DigitalTwins.EndpointClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DigitalTwinsEndpointID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.DigitalTwinsInstanceName, id.EndpointName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Digital Twins ServiceBus Endpoint %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving Digital Twins Endpoint ServiceBus %q (Resource Group %q / Instance %q): %+v", id.EndpointName, id.ResourceGroup, id.DigitalTwinsInstanceName, err)
+	}
+	d.Set("name", id.EndpointName)
+	d.Set("digital_twins_id", parse.NewDigitalTwinsInstanceID(subscriptionId, id.ResourceGroup, id.DigitalTwinsInstanceName).ID(""))
+	if resp.Properties != nil {
+		if _, ok := resp.Properties.AsServiceBus(); !ok {
+			return fmt.Errorf("retrieving Digital Twins Endpoint %q (Resource Group %q / Instance %q) is not type ServiceBus", id.EndpointName, id.ResourceGroup, id.DigitalTwinsInstanceName)
+		}
+	}
+	return nil
+}
+
+func resourceDigitalTwinsEndpointServiceBusDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DigitalTwins.EndpointClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DigitalTwinsEndpointID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.ResourceGroup, id.DigitalTwinsInstanceName, id.EndpointName)
+	if err != nil {
+		return fmt.Errorf("deleting Digital Twins Endpoint ServiceBus %q (Resource Group %q / Instance %q): %+v", id.EndpointName, id.ResourceGroup, id.DigitalTwinsInstanceName, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of the Digital Twins Endpoint ServiceBus %q (Resource Group %q / Instance %q): %+v", id.EndpointName, id.ResourceGroup, id.DigitalTwinsInstanceName, err)
+	}
+	return nil
+}

--- a/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
+++ b/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
@@ -172,8 +172,8 @@ func (r DigitalTwinsEndpointServiceBusResource) requiresImport(data acceptance.T
 resource "azurerm_digital_twins_endpoint_servicebus" "import" {
   name                                   = azurerm_digital_twins_endpoint_servicebus.test.name
   digital_twins_id                       = azurerm_digital_twins_endpoint_servicebus.test.digital_twins_id
-  servicebus_primary_connection_string   = azurerm_digital_twins_endpoint_servicebus.test.primary_connection_string
-  servicebus_secondary_connection_string = azurerm_digital_twins_endpoint_servicebus.test.secondary_connection_string
+  servicebus_primary_connection_string   = azurerm_digital_twins_endpoint_servicebus.test.servicebus_primary_connection_string
+  servicebus_secondary_connection_string = azurerm_digital_twins_endpoint_servicebus.test.servicebus_secondary_connection_string
 }
 `, r.basic(data))
 }
@@ -273,8 +273,8 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_digital_twins_endpoint_servicebus" "test" {
   name                                   = "acctest-EndpointSB-%[3]d"
   digital_twins_id                       = azurerm_digital_twins_instance.test.id
-  servicebus_primary_connection_string   = azurerm_servicebus_namespace.test.primary_connection_string
-  servicebus_secondary_connection_string = azurerm_servicebus_namespace.test.secondary_connection_string
+  servicebus_primary_connection_string   = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_topic_authorization_rule.test.secondary_connection_string
   dead_letter_storage_secret             = "${azurerm_storage_container.test.id}?${azurerm_storage_account.test.primary_access_key}"
 }
 `, r.template(data), data.RandomString, data.RandomInteger)
@@ -301,8 +301,8 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_digital_twins_endpoint_servicebus" "test" {
   name                                   = "acctest-EndpointSB-%[3]d"
   digital_twins_id                       = azurerm_digital_twins_instance.test.id
-  servicebus_primary_connection_string   = azurerm_servicebus_namespace.test.primary_connection_string
-  servicebus_secondary_connection_string = azurerm_servicebus_namespace.test.secondary_connection_string
+  servicebus_primary_connection_string   = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_topic_authorization_rule.test.secondary_connection_string
 }
 `, r.template(data), data.RandomString, data.RandomInteger)
 }

--- a/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
+++ b/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
@@ -165,7 +165,7 @@ resource "azurerm_digital_twins_endpoint_servicebus" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r DigitalTwinsEndpointServiceBusResource) requiresImport(data acceptance.TestData) string {
+func (r DigitalTwinsEndpointSeerviceBusResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
+++ b/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
@@ -1,0 +1,308 @@
+package digitaltwins_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/digitaltwins/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type DigitalTwinsEndpointServiceBusResource struct{}
+
+func TestAccDigitalTwinsEndpointServicebus_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_digital_twins_endpoint_servicebus", "test")
+	r := DigitalTwinsEndpointServiceBusResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string"),
+	})
+}
+
+func TestAccDigitalTwinsEndpointServicebus_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_digital_twins_endpoint_servicebus", "test")
+	r := DigitalTwinsEndpointServiceBusResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccDigitalTwinsEndpointServicebus_updateServiceBus(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_digital_twins_endpoint_servicebus", "test")
+	r := DigitalTwinsEndpointServiceBusResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string"),
+		{
+			Config: r.updateServiceBus(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string"),
+		{
+			Config: r.updateServiceBusRestore(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string"),
+	})
+}
+
+func TestAccDigitalTwinsEndpointServicebus_updateDeadLetter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_digital_twins_endpoint_servicebus", "test")
+	r := DigitalTwinsEndpointServiceBusResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string"),
+		{
+			Config: r.updateDeadLetter(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string", "dead_letter_storage_secret"),
+		{
+			Config: r.updateDeadLetterRestore(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("servicebus_primary_connection_string", "servicebus_secondary_connection_string", "dead_letter_storage_secret"),
+	})
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.DigitalTwinsEndpointID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.DigitalTwins.EndpointClient.Get(ctx, id.ResourceGroup, id.DigitalTwinsInstanceName, id.EndpointName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving Digital Twins Service Bus Endpoint %q (Resource Group %q / Digital Twins Instance Name %q): %+v", id.EndpointName, id.ResourceGroup, id.DigitalTwinsInstanceName, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) template(data acceptance.TestData) string {
+	iR := DigitalTwinsInstanceResource{}
+	digitalTwinsInstance := iR.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctestservicebusnamespace-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+  name                = "acctestservicebustopic-%[2]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test" {
+  name                = "acctest-rule-%[2]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+`, digitalTwinsInstance, data.RandomInteger)
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_digital_twins_endpoint_servicebus" "test" {
+  name                                   = "acctest-EndpointSB-%d"
+  digital_twins_id                       = azurerm_digital_twins_instance.test.id
+  servicebus_primary_connection_string   = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_topic_authorization_rule.test.secondary_connection_string
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_digital_twins_endpoint_servicebus" "import" {
+  name                                   = azurerm_digital_twins_endpoint_servicebus.test.name
+  digital_twins_id                       = azurerm_digital_twins_endpoint_servicebus.test.digital_twins_id
+  servicebus_primary_connection_string   = azurerm_digital_twins_endpoint_servicebus.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_digital_twins_endpoint_servicebus.test.secondary_connection_string
+}
+`, r.basic(data))
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) updateServiceBus(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_servicebus_namespace" "test_alt" {
+  name                = "acctestservicebusnamespace-alt-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "basic"
+}
+
+resource "azurerm_servicebus_topic" "test_alt" {
+  name                = "acctestservicebustopic-alt-%[2]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test_alt" {
+  name                = "acctest-rule-alt-%[2]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_digital_twins_endpoint_servicebus" "test" {
+  name                                   = "acctest-EndpointSB-%[2]d"
+  digital_twins_id                       = azurerm_digital_twins_instance.test.id
+  servicebus_primary_connection_string   = azurerm_servicebus_topic_authorization_rule.test_alt.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_topic_authorization_rule.test_alt.secondary_connection_string
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) updateServiceBusRestore(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_servicebus_namespace" "test_alt" {
+  name                = "acctestservicebusnamespace-alt-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "basic"
+}
+
+resource "azurerm_servicebus_topic" "test_alt" {
+  name                = "acctestservicebustopic-alt-%[2]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "test_alt" {
+  name                = "acctest-rule-alt-%[2]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  topic_name          = azurerm_servicebus_topic.test.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_digital_twins_endpoint_servicebus" "test" {
+  name                                   = "acctest-EndpointSB-%[2]d"
+  digital_twins_id                       = azurerm_digital_twins_instance.test.id
+  servicebus_primary_connection_string   = azurerm_servicebus_topic_authorization_rule.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_topic_authorization_rule.test.secondary_connection_string
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) updateDeadLetter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_digital_twins_endpoint_servicebus" "test" {
+  name                                   = "acctest-EndpointSB-%[3]d"
+  digital_twins_id                       = azurerm_digital_twins_instance.test.id
+  servicebus_primary_connection_string   = azurerm_servicebus_namespace.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_namespace.test.secondary_connection_string
+  dead_letter_storage_secret             = "${azurerm_storage_container.test.id}?${azurerm_storage_account.test.primary_access_key}"
+}
+`, r.template(data), data.RandomString, data.RandomInteger)
+}
+
+func (r DigitalTwinsEndpointServiceBusResource) updateDeadLetterRestore(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_digital_twins_endpoint_servicebus" "test" {
+  name                                   = "acctest-EndpointSB-%[3]d"
+  digital_twins_id                       = azurerm_digital_twins_instance.test.id
+  servicebus_primary_connection_string   = azurerm_servicebus_namespace.test.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_namespace.test.secondary_connection_string
+}
+`, r.template(data), data.RandomString, data.RandomInteger)
+}

--- a/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
+++ b/azurerm/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
@@ -165,7 +165,7 @@ resource "azurerm_digital_twins_endpoint_servicebus" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r DigitalTwinsEndpointSeerviceBusResource) requiresImport(data acceptance.TestData) string {
+func (r DigitalTwinsEndpointServiceBusResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/digitaltwins/registration.go
+++ b/azurerm/internal/services/digitaltwins/registration.go
@@ -28,8 +28,9 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_digital_twins_instance":           resourceDigitalTwinsInstance(),
-		"azurerm_digital_twins_endpoint_eventgrid": resourceDigitalTwinsEndpointEventGrid(),
-		"azurerm_digital_twins_endpoint_eventhub":  resourceDigitalTwinsEndpointEventHub(),
+		"azurerm_digital_twins_instance":            resourceDigitalTwinsInstance(),
+		"azurerm_digital_twins_endpoint_eventgrid":  resourceDigitalTwinsEndpointEventGrid(),
+		"azurerm_digital_twins_endpoint_eventhub":   resourceDigitalTwinsEndpointEventHub(),
+		"azurerm_digital_twins_endpoint_servicebus": resourceDigitalTwinsEndpointServiceBus(),
 	}
 }

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1836,6 +1836,9 @@
                 <li>
                   <a href="/docs/providers/azurerm/r/digital_twins_endpoint_eventhub.html">azurerm_digital_twins_endpoint_eventhub</a>
                 </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/digital_twins_endpoint_servicebus.html">azurerm_digital_twins_endpoint_servicebus</a>
+                </li>
               </ul>
             </li>
 

--- a/website/docs/r/digital_twins_endpoint_servicebus.html.markdown
+++ b/website/docs/r/digital_twins_endpoint_servicebus.html.markdown
@@ -1,0 +1,98 @@
+---
+subcategory: "Digital Twins"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_digital_twins_endpoint_servicebus"
+description: |-
+  Manages a Digital Twins Service Bus Endpoint.
+---
+
+# azurerm_digital_twins_endpoint_servicebus
+
+Manages a Digital Twins Service Bus Endpoint.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example_resources"
+  location = "West Europe"
+}
+
+resource "azurerm_digital_twins_instance" "example" {
+  name                = "example-DT"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_servicebus_namespace" "example" {
+  name                = "exampleservicebusnamespace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "example" {
+  name                = "exampleservicebustopic"
+  namespace_name      = azurerm_servicebus_namespace.example.name
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_servicebus_topic_authorization_rule" "example" {
+  name                = "example-rule"
+  namespace_name      = azurerm_servicebus_namespace.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  topic_name          = azurerm_servicebus_topic.example.name
+
+  listen = false
+  send   = true
+  manage = false
+}
+
+resource "azurerm_digital_twins_endpoint_servicebus" "example" {
+  name                                   = "example-EndpointSB"
+  digital_twins_id                       = azurerm_digital_twins_instance.example.id
+  servicebus_primary_connection_string   = azurerm_servicebus_topic_authorization_rule.example.primary_connection_string
+  servicebus_secondary_connection_string = azurerm_servicebus_topic_authorization_rule.example.secondary_connection_string
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Digital Twins Service Bus Endpoint. Changing this forces a new Digital Twins Service Bus Endpoint to be created.
+
+* `digital_twins_id` - (Required) The ID of the Digital Twins Instance. Changing this forces a new Digital Twins Service Bus Endpoint to be created.
+
+* `servicebus_primary_connection_string` - (Required) The primary connection string of the Service Bus Topic Authorization Rule with a minimum of `send` permission. .
+
+* `servicebus_secondary_connection_string` - (Required) The secondary connection string of the Service Bus Topic Authorization Rule with a minimum of `send` permission.
+
+* `dead_letter_storage_secret` - (Optional) The storage secret of the dead-lettering, whose format is `https://<storageAccountname>.blob.core.windows.net/<containerName>?<SASToken>`. When an endpoint can't deliver an event within a certain time period or after trying to deliver the event a certain number of times, it can send the undelivered event to a storage account.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Digital Twins Service Bus Endpoint.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Digital Twins Servicebus Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Digital Twins Servicebus Endpoint.
+* `update` - (Defaults to 30 minutes) Used when updating the Digital Twins Servicebus Endpoint.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Digital Twins Servicebus Endpoint.
+
+## Import
+
+Digital Twins Service Bus Endpoints can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_digital_twins_endpoint_servicebus.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DigitalTwins/digitalTwinsInstances/dt1/endpoints/ep1
+```


### PR DESCRIPTION
Fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/9211

=== RUN   TestAccDigitalTwinsEndpointServicebus_basic
=== PAUSE TestAccDigitalTwinsEndpointServicebus_basic
=== CONT  TestAccDigitalTwinsEndpointServicebus_basic
--- PASS: TestAccDigitalTwinsEndpointServicebus_basic (330.97s)
=== RUN   TestAccDigitalTwinsEndpointServicebus_requiresImport
=== PAUSE TestAccDigitalTwinsEndpointServicebus_requiresImport
=== CONT  TestAccDigitalTwinsEndpointServicebus_requiresImport
--- PASS: TestAccDigitalTwinsEndpointServicebus_requiresImport (295.56s)
=== RUN   TestAccDigitalTwinsEndpointServicebus_updateServiceBus
=== PAUSE TestAccDigitalTwinsEndpointServicebus_updateServiceBus
=== CONT  TestAccDigitalTwinsEndpointServicebus_updateServiceBus
--- PASS: TestAccDigitalTwinsEndpointServicebus_updateServiceBus (489.21s)
=== RUN   TestAccDigitalTwinsEndpointServicebus_updateDeadLetter
=== PAUSE TestAccDigitalTwinsEndpointServicebus_updateDeadLetter
=== CONT  TestAccDigitalTwinsEndpointServicebus_updateDeadLetter
--- PASS: TestAccDigitalTwinsEndpointServicebus_updateDeadLetter (415.59s)