### PR TITLE
traffic-manager: updating to use Resource ID Formatters/Parsers

### DIFF
--- a/azurerm/internal/services/trafficmanager/parse/azure_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/azure_endpoint.go
@@ -1,0 +1,64 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type AzureEndpointId struct {
+	SubscriptionId            string
+	ResourceGroup             string
+	TrafficManagerProfileName string
+	Name                      string
+}
+
+func NewAzureEndpointID(subscriptionId, resourceGroup, trafficManagerProfileName, name string) AzureEndpointId {
+	return AzureEndpointId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroup:             resourceGroup,
+		TrafficManagerProfileName: trafficManagerProfileName,
+		Name:                      name,
+	}
+}
+
+func (id AzureEndpointId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s/azureEndpoints/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.TrafficManagerProfileName, id.Name)
+}
+
+// AzureEndpointID parses a AzureEndpoint ID into an AzureEndpointId struct
+func AzureEndpointID(input string) (*AzureEndpointId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AzureEndpointId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.TrafficManagerProfileName, err = id.PopSegment("trafficManagerProfiles"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("azureEndpoints"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/trafficmanager/parse/azure_endpoint_test.go
+++ b/azurerm/internal/services/trafficmanager/parse/azure_endpoint_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = AzureEndpointId{}
+
+func TestAzureEndpointIDFormatter(t *testing.T) {
+	actual := NewAzureEndpointID("12345678-1234-9876-4563-123456789012", "resGroup1", "trafficManagerProfile1", "azureEndpoint1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/azureEndpoints/azureEndpoint1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestAzureEndpointID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AzureEndpointId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/azureEndpoints/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/azureEndpoints/azureEndpoint1",
+			Expected: &AzureEndpointId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:             "resGroup1",
+				TrafficManagerProfileName: "trafficManagerProfile1",
+				Name:                      "azureEndpoint1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1/AZUREENDPOINTS/AZUREENDPOINT1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AzureEndpointID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.TrafficManagerProfileName != v.Expected.TrafficManagerProfileName {
+			t.Fatalf("Expected %q but got %q for TrafficManagerProfileName", v.Expected.TrafficManagerProfileName, actual.TrafficManagerProfileName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/parse/endpoint_type.go
+++ b/azurerm/internal/services/trafficmanager/parse/endpoint_type.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = EndpointId{}
+
+// TODO: remove this shim layer once the resources have been split / in 3.0
+
+type EndpointId struct {
+	SubscriptionId            string
+	ResourceGroup             string
+	TrafficManagerProfileName string
+	Name                      string
+	endpointName              string
+}
+
+func (id EndpointId) EndpointType() string {
+	return fmt.Sprintf("%sEndpoints", id.endpointName)
+}
+
+func NewEndpointId(subscriptionId, resourceGroup, trafficManagerProfile, endpoint, name string) (*EndpointId, error) {
+	if endpoint != "azure" && endpoint != "external" && endpoint != "nested" {
+		return nil, fmt.Errorf("unsupported value for Endpoint")
+	}
+
+	return &EndpointId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroup:             resourceGroup,
+		TrafficManagerProfileName: trafficManagerProfile,
+		Name:                      name,
+		endpointName:              endpoint,
+	}, nil
+}
+
+func (id EndpointId) ID(_ string) string {
+	if id.endpointName == "azure" {
+		return NewAzureEndpointID(id.SubscriptionId, id.ResourceGroup, id.TrafficManagerProfileName, id.Name).ID("")
+	}
+
+	if id.endpointName == "external" {
+		return NewExternalEndpointID(id.SubscriptionId, id.ResourceGroup, id.TrafficManagerProfileName, id.Name).ID("")
+	}
+
+	if id.endpointName == "nested" {
+		return NewNestedEndpointID(id.SubscriptionId, id.ResourceGroup, id.TrafficManagerProfileName, id.Name).ID("")
+	}
+
+	// NOTE: this looks bad but is caught above in the `New` function and below in the Parse
+	panic("not implemented")
+}
+
+func EndpointID(input string) (*EndpointId, error) {
+	azureEndpoint, err := AzureEndpointID(input)
+	if err == nil {
+		return &EndpointId{
+			SubscriptionId:            azureEndpoint.SubscriptionId,
+			ResourceGroup:             azureEndpoint.ResourceGroup,
+			TrafficManagerProfileName: azureEndpoint.TrafficManagerProfileName,
+			Name:                      azureEndpoint.Name,
+			endpointName:              "azure",
+		}, nil
+	}
+
+	externalEndpoint, err := ExternalEndpointID(input)
+	if err == nil {
+		return &EndpointId{
+			SubscriptionId:            externalEndpoint.SubscriptionId,
+			ResourceGroup:             externalEndpoint.ResourceGroup,
+			TrafficManagerProfileName: externalEndpoint.TrafficManagerProfileName,
+			Name:                      externalEndpoint.Name,
+			endpointName:              "external",
+		}, nil
+	}
+
+	nestedEndpoint, err := NestedEndpointID(input)
+	if err != nil {
+		return nil, err
+	}
+	return &EndpointId{
+		SubscriptionId:            nestedEndpoint.SubscriptionId,
+		ResourceGroup:             nestedEndpoint.ResourceGroup,
+		TrafficManagerProfileName: nestedEndpoint.TrafficManagerProfileName,
+		Name:                      nestedEndpoint.Name,
+		endpointName:              "nested",
+	}, nil
+}

--- a/azurerm/internal/services/trafficmanager/parse/endpoint_type.go
+++ b/azurerm/internal/services/trafficmanager/parse/endpoint_type.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
@@ -23,6 +24,7 @@ func (id EndpointId) EndpointType() string {
 }
 
 func NewEndpointId(subscriptionId, resourceGroup, trafficManagerProfile, endpoint, name string) (*EndpointId, error) {
+	endpoint = strings.TrimSuffix(endpoint, "Endpoints")
 	if endpoint != "azure" && endpoint != "external" && endpoint != "nested" {
 		return nil, fmt.Errorf("unsupported value for Endpoint")
 	}

--- a/azurerm/internal/services/trafficmanager/parse/external_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/external_endpoint.go
@@ -1,0 +1,64 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ExternalEndpointId struct {
+	SubscriptionId            string
+	ResourceGroup             string
+	TrafficManagerProfileName string
+	Name                      string
+}
+
+func NewExternalEndpointID(subscriptionId, resourceGroup, trafficManagerProfileName, name string) ExternalEndpointId {
+	return ExternalEndpointId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroup:             resourceGroup,
+		TrafficManagerProfileName: trafficManagerProfileName,
+		Name:                      name,
+	}
+}
+
+func (id ExternalEndpointId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s/externalEndpoints/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.TrafficManagerProfileName, id.Name)
+}
+
+// ExternalEndpointID parses a ExternalEndpoint ID into an ExternalEndpointId struct
+func ExternalEndpointID(input string) (*ExternalEndpointId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ExternalEndpointId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.TrafficManagerProfileName, err = id.PopSegment("trafficManagerProfiles"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("externalEndpoints"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/trafficmanager/parse/external_endpoint_test.go
+++ b/azurerm/internal/services/trafficmanager/parse/external_endpoint_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = ExternalEndpointId{}
+
+func TestExternalEndpointIDFormatter(t *testing.T) {
+	actual := NewExternalEndpointID("12345678-1234-9876-4563-123456789012", "resGroup1", "trafficManagerProfile1", "externalEndpoint1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/externalEndpoints/externalEndpoint1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestExternalEndpointID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ExternalEndpointId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/externalEndpoints/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/externalEndpoints/externalEndpoint1",
+			Expected: &ExternalEndpointId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:             "resGroup1",
+				TrafficManagerProfileName: "trafficManagerProfile1",
+				Name:                      "externalEndpoint1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1/EXTERNALENDPOINTS/EXTERNALENDPOINT1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ExternalEndpointID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.TrafficManagerProfileName != v.Expected.TrafficManagerProfileName {
+			t.Fatalf("Expected %q but got %q for TrafficManagerProfileName", v.Expected.TrafficManagerProfileName, actual.TrafficManagerProfileName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/parse/nested_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/nested_endpoint.go
@@ -1,0 +1,64 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type NestedEndpointId struct {
+	SubscriptionId            string
+	ResourceGroup             string
+	TrafficManagerProfileName string
+	Name                      string
+}
+
+func NewNestedEndpointID(subscriptionId, resourceGroup, trafficManagerProfileName, name string) NestedEndpointId {
+	return NestedEndpointId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroup:             resourceGroup,
+		TrafficManagerProfileName: trafficManagerProfileName,
+		Name:                      name,
+	}
+}
+
+func (id NestedEndpointId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s/nestedEndpoints/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.TrafficManagerProfileName, id.Name)
+}
+
+// NestedEndpointID parses a NestedEndpoint ID into an NestedEndpointId struct
+func NestedEndpointID(input string) (*NestedEndpointId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NestedEndpointId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.TrafficManagerProfileName, err = id.PopSegment("trafficManagerProfiles"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("nestedEndpoints"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/trafficmanager/parse/nested_endpoint_test.go
+++ b/azurerm/internal/services/trafficmanager/parse/nested_endpoint_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = NestedEndpointId{}
+
+func TestNestedEndpointIDFormatter(t *testing.T) {
+	actual := NewNestedEndpointID("12345678-1234-9876-4563-123456789012", "resGroup1", "trafficManagerProfile1", "nestedEndpoint1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/nestedEndpoints/nestedEndpoint1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNestedEndpointID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NestedEndpointId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/nestedEndpoints/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/nestedEndpoints/nestedEndpoint1",
+			Expected: &NestedEndpointId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:             "resGroup1",
+				TrafficManagerProfileName: "trafficManagerProfile1",
+				Name:                      "nestedEndpoint1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1/NESTEDENDPOINTS/NESTEDENDPOINT1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NestedEndpointID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.TrafficManagerProfileName != v.Expected.TrafficManagerProfileName {
+			t.Fatalf("Expected %q but got %q for TrafficManagerProfileName", v.Expected.TrafficManagerProfileName, actual.TrafficManagerProfileName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile.go
+++ b/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile.go
@@ -1,0 +1,59 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type TrafficManagerProfileId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewTrafficManagerProfileID(subscriptionId, resourceGroup, name string) TrafficManagerProfileId {
+	return TrafficManagerProfileId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id TrafficManagerProfileId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/trafficManagerProfiles/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// TrafficManagerProfileID parses a TrafficManagerProfile ID into an TrafficManagerProfileId struct
+func TrafficManagerProfileID(input string) (*TrafficManagerProfileId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := TrafficManagerProfileId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("trafficManagerProfiles"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile_test.go
+++ b/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = TrafficManagerProfileId{}
+
+func TestTrafficManagerProfileIDFormatter(t *testing.T) {
+	actual := NewTrafficManagerProfileID("12345678-1234-9876-4563-123456789012", "resGroup1", "trafficManagerProfile1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestTrafficManagerProfileID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *TrafficManagerProfileId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1",
+			Expected: &TrafficManagerProfileId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "trafficManagerProfile1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := TrafficManagerProfileID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/resourceids.go
+++ b/azurerm/internal/services/trafficmanager/resourceids.go
@@ -1,3 +1,6 @@
 package trafficmanager
 
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AzureEndpoint -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/azureEndpoints/azureEndpoint1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ExternalEndpoint -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/externalEndpoints/externalEndpoint1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NestedEndpoint -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/nestedEndpoints/nestedEndpoint1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=TrafficManagerProfile -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1

--- a/azurerm/internal/services/trafficmanager/resourceids.go
+++ b/azurerm/internal/services/trafficmanager/resourceids.go
@@ -1,0 +1,3 @@
+package trafficmanager
+
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=TrafficManagerProfile -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1

--- a/azurerm/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
@@ -19,6 +19,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+// TODO: split this resource
+
 func resourceArmTrafficManagerEndpoint() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmTrafficManagerEndpointCreateUpdate,

--- a/azurerm/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_endpoint_resource.go
@@ -3,7 +3,6 @@ package trafficmanager
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2018-04-01/trafficmanager"
@@ -15,11 +14,12 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/trafficmanager/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-// TODO: split this resource
+// TODO: split and deprecate this resource prior to 3.0
 
 func resourceArmTrafficManagerEndpoint() *schema.Resource {
 	return &schema.Resource{
@@ -178,6 +178,7 @@ func resourceArmTrafficManagerEndpoint() *schema.Resource {
 
 func resourceArmTrafficManagerEndpointCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).TrafficManager.EndpointsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -189,6 +190,11 @@ func resourceArmTrafficManagerEndpointCreateUpdate(d *schema.ResourceData, meta 
 	profileName := d.Get("profile_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
+	resourceId, err := parse.NewEndpointId(subscriptionId, resourceGroup, profileName, endpointType, name)
+	if err != nil {
+		return err
+	}
+
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, profileName, endpointType, name)
 		if err != nil {
@@ -198,7 +204,7 @@ func resourceArmTrafficManagerEndpointCreateUpdate(d *schema.ResourceData, meta 
 		}
 
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_traffic_manager_endpoint", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_traffic_manager_endpoint", resourceId.ID(""))
 		}
 	}
 
@@ -209,19 +215,10 @@ func resourceArmTrafficManagerEndpointCreateUpdate(d *schema.ResourceData, meta 
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, profileName, endpointType, name, params); err != nil {
-		return err
+		return fmt.Errorf("creating/updating %s Endpoint %q (Traffic Manager Profile %q / Resource Group %q): %+v", resourceId.EndpointType(), resourceId.Name, resourceId.TrafficManagerProfileName, resourceId.ResourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, resourceGroup, profileName, endpointType, name)
-	if err != nil {
-		return err
-	}
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read Traffic Manager Endpoint %q (Resource Group %q) ID", name, resourceGroup)
-	}
-
-	d.SetId(*read.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmTrafficManagerEndpointRead(d, meta)
 }
 
@@ -230,36 +227,24 @@ func resourceArmTrafficManagerEndpointRead(d *schema.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.EndpointID(d.Id())
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
 
-	// lookup endpointType in Azure ID path
-	var endpointType string
-	typeRegex := regexp.MustCompile("azureEndpoints|externalEndpoints|nestedEndpoints")
-	for k := range id.Path {
-		if typeRegex.MatchString(k) {
-			endpointType = k
-		}
-	}
-	profileName := id.Path["trafficManagerProfiles"]
-	name := id.Path[endpointType]
-
-	resp, err := client.Get(ctx, resGroup, profileName, endpointType, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.TrafficManagerProfileName, id.EndpointType(), id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on TrafficManager Endpoint %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("retrieving Endpoint %q (Traffic Manager Profile %q / Resource Group %q): %+v", id.Name, id.TrafficManagerProfileName, id.ResourceGroup, err)
 	}
 
-	d.Set("resource_group_name", resGroup)
-	d.Set("name", resp.Name)
-	d.Set("type", endpointType)
-	d.Set("profile_name", profileName)
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("type", id.EndpointType())
+	d.Set("profile_name", id.TrafficManagerProfileName)
 
 	if props := resp.EndpointProperties; props != nil {
 		d.Set("endpoint_status", string(props.EndpointStatus))
@@ -272,52 +257,13 @@ func resourceArmTrafficManagerEndpointRead(d *schema.ResourceData, meta interfac
 		d.Set("min_child_endpoints", props.MinChildEndpoints)
 		d.Set("geo_mappings", props.GeoMapping)
 		if err := d.Set("subnet", flattenAzureRMTrafficManagerEndpointSubnetConfig(props.Subnets)); err != nil {
-			return fmt.Errorf("Error setting `subnet`: %s", err)
+			return fmt.Errorf("setting `subnet`: %s", err)
 		}
 		if err := d.Set("custom_header", flattenAzureRMTrafficManagerEndpointCustomHeaderConfig(props.CustomHeaders)); err != nil {
-			return fmt.Errorf("Error setting `custom_header`: %s", err)
+			return fmt.Errorf("setting `custom_header`: %s", err)
 		}
 	}
 	return nil
-}
-
-func flattenAzureRMTrafficManagerEndpointSubnetConfig(input *[]trafficmanager.EndpointPropertiesSubnetsItem) []interface{} {
-	result := make([]interface{}, 0)
-	if input == nil {
-		return result
-	}
-	for _, subnet := range *input {
-		flatSubnet := make(map[string]interface{}, 3)
-		if subnet.First != nil {
-			flatSubnet["first"] = *subnet.First
-		}
-		if subnet.Last != nil {
-			flatSubnet["last"] = *subnet.Last
-		}
-		if subnet.Scope != nil {
-			flatSubnet["scope"] = int(*subnet.Scope)
-		}
-		result = append(result, flatSubnet)
-	}
-	return result
-}
-
-func flattenAzureRMTrafficManagerEndpointCustomHeaderConfig(input *[]trafficmanager.EndpointPropertiesCustomHeadersItem) []interface{} {
-	result := make([]interface{}, 0)
-	if input == nil {
-		return result
-	}
-	for _, header := range *input {
-		flatHeader := make(map[string]interface{}, 2)
-		if header.Name != nil {
-			flatHeader["name"] = *header.Name
-		}
-		if header.Value != nil {
-			flatHeader["value"] = *header.Value
-		}
-		result = append(result, flatHeader)
-	}
-	return result
 }
 
 func resourceArmTrafficManagerEndpointDelete(d *schema.ResourceData, meta interface{}) error {
@@ -325,23 +271,16 @@ func resourceArmTrafficManagerEndpointDelete(d *schema.ResourceData, meta interf
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.EndpointID(d.Id())
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
-	endpointType := d.Get("type").(string)
-	profileName := id.Path["trafficManagerProfiles"]
 
-	// endpoint name is keyed by endpoint type in ARM ID
-	name := id.Path[endpointType]
-	resp, err := client.Delete(ctx, resGroup, profileName, endpointType, name)
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.TrafficManagerProfileName, id.EndpointType(), id.Name)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return nil
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("deleting Endpoint %q (Traffic Manager Profile %q / Resource Group %q): %+v", id.Name, id.TrafficManagerProfileName, id.ResourceGroup, err)
 		}
-
-		return err
 	}
 
 	return nil
@@ -422,4 +361,43 @@ func getArmTrafficManagerEndpointProperties(d *schema.ResourceData) *trafficmana
 	}
 
 	return &endpointProps
+}
+
+func flattenAzureRMTrafficManagerEndpointSubnetConfig(input *[]trafficmanager.EndpointPropertiesSubnetsItem) []interface{} {
+	result := make([]interface{}, 0)
+	if input == nil {
+		return result
+	}
+	for _, subnet := range *input {
+		flatSubnet := make(map[string]interface{}, 3)
+		if subnet.First != nil {
+			flatSubnet["first"] = *subnet.First
+		}
+		if subnet.Last != nil {
+			flatSubnet["last"] = *subnet.Last
+		}
+		if subnet.Scope != nil {
+			flatSubnet["scope"] = int(*subnet.Scope)
+		}
+		result = append(result, flatSubnet)
+	}
+	return result
+}
+
+func flattenAzureRMTrafficManagerEndpointCustomHeaderConfig(input *[]trafficmanager.EndpointPropertiesCustomHeadersItem) []interface{} {
+	result := make([]interface{}, 0)
+	if input == nil {
+		return result
+	}
+	for _, header := range *input {
+		flatHeader := make(map[string]interface{}, 2)
+		if header.Name != nil {
+			flatHeader["name"] = *header.Name
+		}
+		if header.Value != nil {
+			flatHeader["value"] = *header.Value
+		}
+		result = append(result, flatHeader)
+	}
+	return result
 }

--- a/azurerm/internal/services/trafficmanager/validate/azure_endpoint_id.go
+++ b/azurerm/internal/services/trafficmanager/validate/azure_endpoint_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/trafficmanager/parse"
+)
+
+func AzureEndpointID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.AzureEndpointID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/trafficmanager/validate/azure_endpoint_id_test.go
+++ b/azurerm/internal/services/trafficmanager/validate/azure_endpoint_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestAzureEndpointID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/azureEndpoints/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/azureEndpoints/azureEndpoint1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1/AZUREENDPOINTS/AZUREENDPOINT1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := AzureEndpointID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/validate/external_endpoint_id.go
+++ b/azurerm/internal/services/trafficmanager/validate/external_endpoint_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/trafficmanager/parse"
+)
+
+func ExternalEndpointID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.ExternalEndpointID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/trafficmanager/validate/external_endpoint_id_test.go
+++ b/azurerm/internal/services/trafficmanager/validate/external_endpoint_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestExternalEndpointID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/externalEndpoints/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/externalEndpoints/externalEndpoint1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1/EXTERNALENDPOINTS/EXTERNALENDPOINT1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ExternalEndpointID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/validate/nested_endpoint_id.go
+++ b/azurerm/internal/services/trafficmanager/validate/nested_endpoint_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/trafficmanager/parse"
+)
+
+func NestedEndpointID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.NestedEndpointID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/trafficmanager/validate/nested_endpoint_id_test.go
+++ b/azurerm/internal/services/trafficmanager/validate/nested_endpoint_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestNestedEndpointID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for TrafficManagerProfileName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/nestedEndpoints/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1/nestedEndpoints/nestedEndpoint1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1/NESTEDENDPOINTS/NESTEDENDPOINT1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := NestedEndpointID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/trafficmanager/validate/traffic_manager_profile_id.go
+++ b/azurerm/internal/services/trafficmanager/validate/traffic_manager_profile_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/trafficmanager/parse"
+)
+
+func TrafficManagerProfileID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.TrafficManagerProfileID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/trafficmanager/validate/traffic_manager_profile_id_test.go
+++ b/azurerm/internal/services/trafficmanager/validate/traffic_manager_profile_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestTrafficManagerProfileID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/trafficManagerProfiles/trafficManagerProfile1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/TRAFFICMANAGERPROFILES/TRAFFICMANAGERPROFILE1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := TrafficManagerProfileID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
This PR updates the Traffic Manager Profile & Traffic Manager Endpoint Resources & Data Source to use a Resource ID Formatter/Parser

Ultimately the Traffic Manager Endpoint resource will want splitting, since this is currently provisioning 3 types of resource within one, but that's one for another day.