### PR TITLE
refactor: removing unnecessary arguments with subscriptionId for auto-generated Resource ID Formatters/Parsers

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -215,7 +215,6 @@ func resourceCdnEndpoint() *schema.Resource {
 }
 
 func resourceCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	endpointsClient := meta.(*clients.Client).Cdn.EndpointsClient
 	profilesClient := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
@@ -321,7 +320,7 @@ func resourceCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	return resourceCdnEndpointRead(d, meta)
 }

--- a/azurerm/internal/services/cdn/cdn_profile_data_source.go
+++ b/azurerm/internal/services/cdn/cdn_profile_data_source.go
@@ -43,7 +43,6 @@ func dataSourceCdnProfile() *schema.Resource {
 }
 
 func dataSourceCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -64,7 +63,7 @@ func dataSourceCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -81,7 +81,6 @@ func resourceCdnProfile() *schema.Resource {
 }
 
 func resourceCdnProfileCreate(d *schema.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -138,7 +137,7 @@ func resourceCdnProfileCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	return resourceCdnProfileRead(d, meta)
 }

--- a/azurerm/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
@@ -10,9 +10,9 @@ type WorkspaceApplicationGroupAssociationId struct {
 	ApplicationGroup ApplicationGroupId
 }
 
-func (id WorkspaceApplicationGroupAssociationId) ID(subscriptionId string) string {
-	workspaceId := id.Workspace.ID(subscriptionId)
-	applicationGroupId := id.ApplicationGroup.ID(subscriptionId)
+func (id WorkspaceApplicationGroupAssociationId) ID(_ string) string {
+	workspaceId := id.Workspace.ID("")
+	applicationGroupId := id.ApplicationGroup.ID("")
 	return fmt.Sprintf("%s|%s", workspaceId, applicationGroupId)
 }
 

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -156,7 +156,6 @@ func resourceVirtualDesktopApplicationGroupCreateUpdate(d *schema.ResourceData, 
 
 func resourceVirtualDesktopApplicationGroupRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DesktopVirtualization.ApplicationGroupsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -196,7 +195,7 @@ func resourceVirtualDesktopApplicationGroupRead(d *schema.ResourceData, meta int
 				return fmt.Errorf("parsing Host Pool ID %q: %+v", *props.HostPoolArmPath, err)
 			}
 
-			hostPoolIdStr = hostPoolId.ID(subscriptionId)
+			hostPoolIdStr = hostPoolId.ID("")
 		}
 		d.Set("host_pool_id", hostPoolIdStr)
 	}

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -66,7 +66,6 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociation() *schema.Resour
 
 func resourceVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DesktopVirtualization.WorkspacesClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -101,7 +100,7 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *schema.
 		applicationGroupAssociations = *props.ApplicationGroupReferences
 	}
 
-	applicationGroupIdStr := applicationGroupId.ID(subscriptionId)
+	applicationGroupIdStr := applicationGroupId.ID("")
 	if associationExists(workspace.WorkspaceProperties, applicationGroupIdStr) {
 		return tf.ImportAsExistsError("azurerm_virtual_desktop_workspace_application_group_association", associationId)
 	}
@@ -154,7 +153,6 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociationRead(d *schema.Re
 
 func resourceVirtualDesktopWorkspaceApplicationGroupAssociationDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DesktopVirtualization.WorkspacesClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -179,7 +177,7 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociationDelete(d *schema.
 	}
 
 	applicationGroupReferences := []string{}
-	applicationGroupId := id.ApplicationGroup.ID(subscriptionId)
+	applicationGroupId := id.ApplicationGroup.ID("")
 	if workspace.WorkspaceProperties != nil && workspace.WorkspaceProperties.ApplicationGroupReferences != nil {
 		for _, referenceId := range *workspace.WorkspaceProperties.ApplicationGroupReferences {
 			if strings.EqualFold(referenceId, applicationGroupId) {

--- a/azurerm/internal/services/network/firewall_policy_rule_collection_group_resource.go
+++ b/azurerm/internal/services/network/firewall_policy_rule_collection_group_resource.go
@@ -375,7 +375,6 @@ func resourceArmFirewallPolicyRuleCollectionGroup() *schema.Resource {
 }
 
 func resourceArmFirewallPolicyRuleCollectionGroupCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Network.FirewallPolicyRuleGroupClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -432,7 +431,7 @@ func resourceArmFirewallPolicyRuleCollectionGroupCreateUpdate(d *schema.Resource
 	if err != nil {
 		return err
 	}
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	return resourceArmFirewallPolicyRuleCollectionGroupRead(d, meta)
 }

--- a/azurerm/internal/services/network/lb_backend_address_pool_resource.go
+++ b/azurerm/internal/services/network/lb_backend_address_pool_resource.go
@@ -83,7 +83,6 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 
 func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -93,7 +92,7 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 		return fmt.Errorf("parsing Load Balancer Name and Group: %+v", err)
 	}
 
-	loadBalancerID := loadBalancerId.ID(subscriptionId)
+	loadBalancerID := loadBalancerId.ID("")
 	locks.ByID(loadBalancerID)
 	defer locks.UnlockByID(loadBalancerID)
 

--- a/azurerm/internal/services/network/lb_nat_pool_resource.go
+++ b/azurerm/internal/services/network/lb_nat_pool_resource.go
@@ -108,7 +108,6 @@ func resourceArmLoadBalancerNatPool() *schema.Resource {
 
 func resourceArmLoadBalancerNatPoolCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -118,7 +117,7 @@ func resourceArmLoadBalancerNatPoolCreateUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("parsing Load Balancer Name and Group: %+v", err)
 	}
 
-	loadBalancerID := loadBalancerId.ID(subscriptionId)
+	loadBalancerID := loadBalancerId.ID("")
 	locks.ByID(loadBalancerID)
 	defer locks.UnlockByID(loadBalancerID)
 

--- a/azurerm/internal/services/network/lb_nat_rule_resource.go
+++ b/azurerm/internal/services/network/lb_nat_rule_resource.go
@@ -125,7 +125,6 @@ func resourceArmLoadBalancerNatRule() *schema.Resource {
 
 func resourceArmLoadBalancerNatRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -134,7 +133,7 @@ func resourceArmLoadBalancerNatRuleCreateUpdate(d *schema.ResourceData, meta int
 	if err != nil {
 		return fmt.Errorf("retrieving Load Balancer Name and Group: %+v", err)
 	}
-	loadBalancerIdRaw := loadBalancerId.ID(subscriptionId)
+	loadBalancerIdRaw := loadBalancerId.ID("")
 	locks.ByID(loadBalancerIdRaw)
 	defer locks.UnlockByID(loadBalancerIdRaw)
 

--- a/azurerm/internal/services/network/lb_outbound_rule_resource.go
+++ b/azurerm/internal/services/network/lb_outbound_rule_resource.go
@@ -117,7 +117,6 @@ func resourceArmLoadBalancerOutboundRule() *schema.Resource {
 
 func resourceArmLoadBalancerOutboundRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -126,7 +125,7 @@ func resourceArmLoadBalancerOutboundRuleCreateUpdate(d *schema.ResourceData, met
 	if err != nil {
 		return err
 	}
-	loadBalancerIDRaw := loadBalancerId.ID(subscriptionId)
+	loadBalancerIDRaw := loadBalancerId.ID("")
 	locks.ByID(loadBalancerIDRaw)
 	defer locks.UnlockByID(loadBalancerIDRaw)
 
@@ -203,7 +202,6 @@ func resourceArmLoadBalancerOutboundRuleCreateUpdate(d *schema.ResourceData, met
 
 func resourceArmLoadBalancerOutboundRuleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -247,7 +245,7 @@ func resourceArmLoadBalancerOutboundRuleRead(d *schema.ResourceData, meta interf
 				return err
 			}
 
-			backendAddressPoolId = bapid.ID(subscriptionId)
+			backendAddressPoolId = bapid.ID("")
 		}
 		d.Set("backend_address_pool_id", backendAddressPoolId)
 		d.Set("enable_tcp_reset", props.EnableTCPReset)
@@ -263,7 +261,7 @@ func resourceArmLoadBalancerOutboundRuleRead(d *schema.ResourceData, meta interf
 			}
 
 			frontendIpConfigurations = append(frontendIpConfigurations, map[string]interface{}{
-				"id":   feid.ID(subscriptionId),
+				"id":   feid.ID(""),
 				"name": feid.FrontendIPConfigurationName,
 			})
 		}

--- a/azurerm/internal/services/network/lb_probe_resource.go
+++ b/azurerm/internal/services/network/lb_probe_resource.go
@@ -112,7 +112,6 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 
 func resourceArmLoadBalancerProbeCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -121,7 +120,7 @@ func resourceArmLoadBalancerProbeCreateUpdate(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-	loadBalancerIDRaw := loadBalancerId.ID(subscriptionId)
+	loadBalancerIDRaw := loadBalancerId.ID("")
 	locks.ByID(loadBalancerIDRaw)
 	defer locks.UnlockByID(loadBalancerIDRaw)
 

--- a/azurerm/internal/services/network/lb_rule_resource.go
+++ b/azurerm/internal/services/network/lb_rule_resource.go
@@ -143,7 +143,6 @@ func resourceArmLoadBalancerRule() *schema.Resource {
 
 func resourceArmLoadBalancerRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.LoadBalancersClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -153,7 +152,7 @@ func resourceArmLoadBalancerRuleCreateUpdate(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	loadBalancerID := loadBalancerId.ID(subscriptionId)
+	loadBalancerID := loadBalancerId.ID("")
 	locks.ByID(loadBalancerID)
 	defer locks.UnlockByID(loadBalancerID)
 

--- a/azurerm/internal/services/network/loadbalancer.go
+++ b/azurerm/internal/services/network/loadbalancer.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -126,13 +125,12 @@ func FindLoadBalancerProbeByName(lb *network.LoadBalancer, name string) (*networ
 func loadBalancerSubResourceImporter(parser func(input string) (*parse.LoadBalancerId, error)) *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-			subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 			lbId, err := parser(d.Id())
 			if err != nil {
 				return nil, err
 			}
 
-			d.Set("loadbalancer_id", lbId.ID(subscriptionId))
+			d.Set("loadbalancer_id", lbId.ID(""))
 			return []*schema.ResourceData{d}, nil
 		},
 	}

--- a/azurerm/internal/services/network/vpn_gateway_connection_resource.go
+++ b/azurerm/internal/services/network/vpn_gateway_connection_resource.go
@@ -284,7 +284,6 @@ func resourceArmVPNGatewayConnection() *schema.Resource {
 
 func resourceArmVpnGatewayConnectionResourceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VpnConnectionsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -343,7 +342,7 @@ func resourceArmVpnGatewayConnectionResourceCreateUpdate(d *schema.ResourceData,
 	if err != nil {
 		return err
 	}
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	return resourceArmVpnGatewayConnectionResourceRead(d, meta)
 }

--- a/azurerm/internal/services/network/vpn_site_resource.go
+++ b/azurerm/internal/services/network/vpn_site_resource.go
@@ -148,7 +148,6 @@ func resourceArmVpnSite() *schema.Resource {
 
 func resourceArmVpnSiteCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VpnSitesClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -202,7 +201,7 @@ func resourceArmVpnSiteCreateUpdate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	return resourceArmVpnSiteRead(d, meta)
 }

--- a/azurerm/internal/services/storage/data_source_storage_sync_group.go
+++ b/azurerm/internal/services/storage/data_source_storage_sync_group.go
@@ -38,7 +38,6 @@ func dataSourceArmStorageSyncGroup() *schema.Resource {
 
 func dataSourceArmStorageSyncGroupRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Storage.SyncGroupsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -63,6 +62,6 @@ func dataSourceArmStorageSyncGroupRead(d *schema.ResourceData, meta interface{})
 	d.SetId(*resp.ID)
 
 	d.Set("name", name)
-	d.Set("storage_sync_id", storageSyncId.ID(subscriptionId))
+	d.Set("storage_sync_id", storageSyncId.ID(""))
 	return nil
 }


### PR DESCRIPTION
This cleans up some now unnecessary code for the generated Resource ID Formatters/Parsers - there's still some manual ones which require further work - but that's one for another PR.