### PR TITLE
`azurerm_postgresql_server` - Fix issue when specifying empty threat detection list attributes

### DIFF
--- a/azurerm/internal/services/postgres/postgresql_server_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource.go
@@ -900,8 +900,8 @@ func flattenSecurityAlertPolicy(props *postgresql.SecurityAlertPolicyProperties,
 
 	block["enabled"] = props.State == postgresql.ServerSecurityAlertPolicyStateEnabled
 
-	block["disabled_alerts"] = flattenSecurityAlertPolicyArray(props.DisabledAlerts)
-	block["email_addresses"] = flattenSecurityAlertPolicyArray(props.EmailAddresses)
+	block["disabled_alerts"] = flattenSecurityAlertPolicySet(props.DisabledAlerts)
+	block["email_addresses"] = flattenSecurityAlertPolicySet(props.EmailAddresses)
 
 	if v := props.EmailAccountAdmins; v != nil {
 		block["email_account_admins"] = *v
@@ -953,7 +953,7 @@ func flattenServerIdentity(input *postgresql.ResourceIdentity) []interface{} {
 	}
 }
 
-func flattenSecurityAlertPolicyArray(input *[]string) []interface{} {
+func flattenSecurityAlertPolicySet(input *[]string) []interface{} {
 	if input == nil {
 		return make([]interface{}, 0)
 	}
@@ -961,7 +961,7 @@ func flattenSecurityAlertPolicyArray(input *[]string) []interface{} {
 	// When empty, `disabledAlerts` and `emailAddresses` are returned as `[""]` by the api. We'll catch that here and return
 	// an empty interface to set.
 	attr := *input
-	if len(attr) == 0 || attr[0] == "" {
+	if len(attr) == 1 && attr[0] == "" {
 		return make([]interface{}, 0)
 	}
 

--- a/azurerm/internal/services/postgres/postgresql_server_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource.go
@@ -900,8 +900,8 @@ func flattenSecurityAlertPolicy(props *postgresql.SecurityAlertPolicyProperties,
 
 	block["enabled"] = props.State == postgresql.ServerSecurityAlertPolicyStateEnabled
 
-	block["disabled_alerts"] = utils.FlattenStringSlice(props.DisabledAlerts)
-	block["email_addresses"] = utils.FlattenStringSlice(props.EmailAddresses)
+	block["disabled_alerts"] = flattenSecurityAlertPolicyArray(props.DisabledAlerts)
+	block["email_addresses"] = flattenSecurityAlertPolicyArray(props.EmailAddresses)
 
 	if v := props.EmailAccountAdmins; v != nil {
 		block["email_account_admins"] = *v
@@ -951,4 +951,19 @@ func flattenServerIdentity(input *postgresql.ResourceIdentity) []interface{} {
 			"tenant_id":    tenantID,
 		},
 	}
+}
+
+func flattenSecurityAlertPolicyArray(input *[]string) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	// When empty, `disabledAlerts` and `emailAddresses` are returned as `[""]` by the api. We'll catch that here and return
+	// an empty interface to set.
+	attr := *input
+	if len(attr) == 0 || attr[0] == "" {
+		return make([]interface{}, 0)
+	}
+
+	return utils.FlattenStringSlice(input)
 }

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -867,8 +867,8 @@ resource "azurerm_postgresql_server" "test" {
   version    = "%[3]s"
   storage_mb = 640000
 
-  ssl_enforcement_enabled           = false
-  ssl_minimal_tls_version_enforced  = "TLSEnforcementDisabled"
+  ssl_enforcement_enabled          = false
+  ssl_minimal_tls_version_enforced = "TLSEnforcementDisabled"
 
   threat_detection_policy {
     enabled              = true


### PR DESCRIPTION
Fixes #9710, #8738, #7992

```
--- PASS: TestAccAzureRMPostgreSQLServer_threatDetectionEmptyAttrs (168.71s)
```