### PR TITLE
`azurerm_cosmosdb_table` doesn't call get throughput api when cosmos account is serverless

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_table_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_table_resource_test.go
@@ -98,6 +98,25 @@ func TestAccAzureRMCosmosDbTable_autoscale(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbTable_serverless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_table", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbTable_serverless(data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbTableExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbTableDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.TableClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -192,4 +211,16 @@ resource "azurerm_cosmosdb_table" "test" {
   }
 }
 `, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableTable"}), data.RandomInteger, maxThroughput)
+}
+
+func testAccAzureRMCosmosDbTable_serverless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_table" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+`, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableServerless", "EnableTable"}), data.RandomInteger)
 }


### PR DESCRIPTION
This is a fix for #9417 

This is based on #8673 #9311 #9187

```
make testacc TEST=./azurerm/internal/services/cosmos TESTARGS='-run=TestAccAzureRMCosmosDbTable' TESTTIMEOUT='60m'

=== RUN   TestAccAzureRMCosmosDbTable_basic
=== PAUSE TestAccAzureRMCosmosDbTable_basic
=== RUN   TestAccAzureRMCosmosDbTable_update
=== PAUSE TestAccAzureRMCosmosDbTable_update
=== RUN   TestAccAzureRMCosmosDbTable_autoscale
=== PAUSE TestAccAzureRMCosmosDbTable_autoscale
=== RUN   TestAccAzureRMCosmosDbTable_serverless
=== PAUSE TestAccAzureRMCosmosDbTable_serverless
=== CONT  TestAccAzureRMCosmosDbTable_basic
=== CONT  TestAccAzureRMCosmosDbTable_serverless
=== CONT  TestAccAzureRMCosmosDbTable_autoscale
=== CONT  TestAccAzureRMCosmosDbTable_update
--- PASS: TestAccAzureRMCosmosDbTable_serverless (1144.46s)
--- PASS: TestAccAzureRMCosmosDbTable_basic (1161.52s)
--- PASS: TestAccAzureRMCosmosDbTable_update (1319.06s)
--- PASS: TestAccAzureRMCosmosDbTable_autoscale (1664.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos      1664.166s
```
(fixes #9417)