### PR TITLE
azurerm_storage_account_network_rules Fix misleading error

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account_network_rules.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_network_rules.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -121,7 +120,7 @@ func resourceArmStorageAccountNetworkRulesCreateUpdate(d *schema.ResourceData, m
 		}
 
 		if checkForNonDefaultStorageAccountNetworkRule(storageAccount.AccountProperties.NetworkRuleSet) {
-			return tf.ImportAsExistsError("azurerm_storage_account_network_rule", *storageAccount.ID)
+			return fmt.Errorf("Error the storage account already has networking rules configured. Remove these before attempting to manage rules with this resource. Storage Account %q (Resource Group %q)", storageAccountName, resourceGroup)
 		}
 	}
 


### PR DESCRIPTION
In the case that you attempt to use this resource on a storage account which already has network rules attached with either `networkAcls.ipRules` or `networkAcls.virtualNetworkRules` non-empty arrays the error returned suggests that you use `terraform import` to fix it.

That won't fix it and is misleading, I've updated the error to indicate that the user should instead remove any existing network rules on the storage account.
