### PR TITLE
securitycenter: refactoring to use an ID Formatter

### DIFF
--- a/azurerm/internal/services/securitycenter/advanced_threat_protection.go
+++ b/azurerm/internal/services/securitycenter/advanced_threat_protection.go
@@ -7,13 +7,24 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type AdvancedThreatProtectionResourceID struct {
-	Base azure.ResourceID
-
+type AdvancedThreatProtectionId struct {
 	TargetResourceID string
+	SettingName      string
 }
 
-func ParseAdvancedThreatProtectionID(input string) (*AdvancedThreatProtectionResourceID, error) {
+func NewAdvancedThreatProtectionId(targetResourceId string) AdvancedThreatProtectionId {
+	return AdvancedThreatProtectionId{
+		TargetResourceID: targetResourceId,
+		SettingName:      "current",
+	}
+}
+
+func (id AdvancedThreatProtectionId) ID(_ string) string {
+	fmtString := "%s/providers/Microsoft.Security/advancedThreatProtectionSettings/%s"
+	return fmt.Sprintf(fmtString, id.TargetResourceID, id.SettingName)
+}
+
+func ParseAdvancedThreatProtectionID(input string) (*AdvancedThreatProtectionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Advanced Threat Protection Set ID %q: %+v", input, err)
@@ -24,8 +35,8 @@ func ParseAdvancedThreatProtectionID(input string) (*AdvancedThreatProtectionRes
 		return nil, fmt.Errorf("Determining target resource ID, resource ID in unexpected format: %q", id)
 	}
 
-	return &AdvancedThreatProtectionResourceID{
-		Base:             *id,
+	return &AdvancedThreatProtectionId{
 		TargetResourceID: parts[0],
+		SettingName:      parts[1],
 	}, nil
 }

--- a/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -53,7 +54,7 @@ func resourceArmAdvancedThreatProtectionCreateUpdate(d *schema.ResourceData, met
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := NewAdvancedThreatProtectionId(d.Get("target_resource_id").(string))
+	id := parse.NewAdvancedThreatProtectionId(d.Get("target_resource_id").(string))
 	if d.IsNewResource() {
 		server, err := client.Get(ctx, id.TargetResourceID)
 		if err != nil {
@@ -86,7 +87,7 @@ func resourceArmAdvancedThreatProtectionRead(d *schema.ResourceData, meta interf
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := ParseAdvancedThreatProtectionID(d.Id())
+	id, err := parse.AdvancedThreatProtectionID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -115,7 +116,7 @@ func resourceArmAdvancedThreatProtectionDelete(d *schema.ResourceData, meta inte
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := ParseAdvancedThreatProtectionID(d.Id())
+	id, err := parse.AdvancedThreatProtectionID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/internal/services/securitycenter/parse/advanced_threat_protection.go
+++ b/azurerm/internal/services/securitycenter/parse/advanced_threat_protection.go
@@ -1,4 +1,4 @@
-package securitycenter
+package parse
 
 import (
 	"fmt"
@@ -24,7 +24,7 @@ func (id AdvancedThreatProtectionId) ID(_ string) string {
 	return fmt.Sprintf(fmtString, id.TargetResourceID, id.SettingName)
 }
 
-func ParseAdvancedThreatProtectionID(input string) (*AdvancedThreatProtectionId, error) {
+func AdvancedThreatProtectionID(input string) (*AdvancedThreatProtectionId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Advanced Threat Protection Set ID %q: %+v", input, err)


### PR DESCRIPTION
This is hand-maintained due to the nature of these ID's - but this updates this service package to match the others