### PR TITLE
Example sku fails in with terraform cli version 14

### DIFF
--- a/examples/app-service/windows-container/main.tf
+++ b/examples/app-service/windows-container/main.tf
@@ -15,8 +15,8 @@ resource "azurerm_app_service_plan" "example" {
   is_xenon            = true
 
   sku {
-    tier = "PremiumContainer"
-    size = "PC2"
+    tier = "PremiumV3"
+    size = "P1V3"
   }
 }
 


### PR DESCRIPTION
Example error output

Note: app_settings do not pass creds to azure cli call but that may be another issue that is being tracked.

{"Code":"Conflict","Message":"The pricing tier 'PremiumContainer' is not allowed in this resource group. Use this link to learn more: http://go.microsoft.com/fwlink/?LinkId=825764","Target":null,"Details":[{"Message":"The pricing tier 'PremiumContainer' is not allowed in this resource group. Use this link to learn more: http://go.microsoft.com/fwlink/?LinkId=825764"},{"Code":"Conflict"},{"ErrorEntity":{"ExtendedCode":"04114","MessageTemplate":"The pricing tier '{0}' is not allowed in this resource group. Use this link to learn more: http://go.microsoft.com/fwlink/?LinkId=825764","Parameters":["PremiumContainer"],"Code":"Conflict","Message":"The pricing tier 'PremiumContainer' is not allowed in this resource group. Use this link to learn more: http://go.microsoft.com/fwlink/?LinkId=825764"}}],"Innererror":null}