### PR TITLE
generator: outputting the type name and sorting the segments to match the ID

### DIFF
--- a/azurerm/internal/services/analysisservices/parse/server.go
+++ b/azurerm/internal/services/analysisservices/parse/server.go
@@ -25,10 +25,11 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 
 func (id ServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server", segmentsStr)
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/api_diagnostic.go
+++ b/azurerm/internal/services/apimanagement/parse/api_diagnostic.go
@@ -29,12 +29,13 @@ func NewApiDiagnosticID(subscriptionId, resourceGroup, serviceName, apiName, dia
 
 func (id ApiDiagnosticId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
-		fmt.Sprintf("Api Name %q", id.ApiName),
 		fmt.Sprintf("Diagnostic Name %q", id.DiagnosticName),
+		fmt.Sprintf("Api Name %q", id.ApiName),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Api Diagnostic", segmentsStr)
 }
 
 func (id ApiDiagnosticId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/api_management.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management.go
@@ -25,10 +25,11 @@ func NewApiManagementID(subscriptionId, resourceGroup, serviceName string) ApiMa
 
 func (id ApiManagementId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Api Management", segmentsStr)
 }
 
 func (id ApiManagementId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/api_version_set.go
+++ b/azurerm/internal/services/apimanagement/parse/api_version_set.go
@@ -27,11 +27,12 @@ func NewApiVersionSetID(subscriptionId, resourceGroup, serviceName, name string)
 
 func (id ApiVersionSetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Api Version Set", segmentsStr)
 }
 
 func (id ApiVersionSetId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/custom_domain.go
+++ b/azurerm/internal/services/apimanagement/parse/custom_domain.go
@@ -27,11 +27,12 @@ func NewCustomDomainID(subscriptionId, resourceGroup, serviceName, name string) 
 
 func (id CustomDomainId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Custom Domain", segmentsStr)
 }
 
 func (id CustomDomainId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/diagnostic.go
+++ b/azurerm/internal/services/apimanagement/parse/diagnostic.go
@@ -27,11 +27,12 @@ func NewDiagnosticID(subscriptionId, resourceGroup, serviceName, name string) Di
 
 func (id DiagnosticId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Diagnostic", segmentsStr)
 }
 
 func (id DiagnosticId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/logger.go
+++ b/azurerm/internal/services/apimanagement/parse/logger.go
@@ -27,11 +27,12 @@ func NewLoggerID(subscriptionId, resourceGroup, serviceName, name string) Logger
 
 func (id LoggerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Logger", segmentsStr)
 }
 
 func (id LoggerId) ID(_ string) string {

--- a/azurerm/internal/services/apimanagement/parse/policy.go
+++ b/azurerm/internal/services/apimanagement/parse/policy.go
@@ -27,11 +27,12 @@ func NewPolicyID(subscriptionId, resourceGroup, serviceName, name string) Policy
 
 func (id PolicyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Policy", segmentsStr)
 }
 
 func (id PolicyId) ID(_ string) string {

--- a/azurerm/internal/services/appconfiguration/parse/configuration_store.go
+++ b/azurerm/internal/services/appconfiguration/parse/configuration_store.go
@@ -25,10 +25,11 @@ func NewConfigurationStoreID(subscriptionId, resourceGroup, name string) Configu
 
 func (id ConfigurationStoreId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Configuration Store", segmentsStr)
 }
 
 func (id ConfigurationStoreId) ID(_ string) string {

--- a/azurerm/internal/services/applicationinsights/parse/component.go
+++ b/azurerm/internal/services/applicationinsights/parse/component.go
@@ -25,10 +25,11 @@ func NewComponentID(subscriptionId, resourceGroup, name string) ComponentId {
 
 func (id ComponentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Component", segmentsStr)
 }
 
 func (id ComponentId) ID(_ string) string {

--- a/azurerm/internal/services/applicationinsights/parse/web_test_id.go
+++ b/azurerm/internal/services/applicationinsights/parse/web_test_id.go
@@ -25,10 +25,11 @@ func NewWebTestID(subscriptionId, resourceGroup, name string) WebTestId {
 
 func (id WebTestId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Web Test", segmentsStr)
 }
 
 func (id WebTestId) ID(_ string) string {

--- a/azurerm/internal/services/attestation/parse/provider.go
+++ b/azurerm/internal/services/attestation/parse/provider.go
@@ -25,10 +25,11 @@ func NewProviderID(subscriptionId, resourceGroup, attestationProviderName string
 
 func (id ProviderId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Attestation Provider Name %q", id.AttestationProviderName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Provider", segmentsStr)
 }
 
 func (id ProviderId) ID(_ string) string {

--- a/azurerm/internal/services/automation/parse/connection.go
+++ b/azurerm/internal/services/automation/parse/connection.go
@@ -27,11 +27,12 @@ func NewConnectionID(subscriptionId, resourceGroup, automationAccountName, name 
 
 func (id ConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Automation Account Name %q", id.AutomationAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Automation Account Name %q", id.AutomationAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Connection", segmentsStr)
 }
 
 func (id ConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/azurestackhci/parse/cluster.go
+++ b/azurerm/internal/services/azurestackhci/parse/cluster.go
@@ -25,10 +25,11 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 
 func (id ClusterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster", segmentsStr)
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/account.go
+++ b/azurerm/internal/services/batch/parse/account.go
@@ -25,10 +25,11 @@ func NewAccountID(subscriptionId, resourceGroup, batchAccountName string) Accoun
 
 func (id AccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Account", segmentsStr)
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/application.go
+++ b/azurerm/internal/services/batch/parse/application.go
@@ -27,11 +27,12 @@ func NewApplicationID(subscriptionId, resourceGroup, batchAccountName, name stri
 
 func (id ApplicationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Application", segmentsStr)
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/certificate.go
+++ b/azurerm/internal/services/batch/parse/certificate.go
@@ -27,11 +27,12 @@ func NewCertificateID(subscriptionId, resourceGroup, batchAccountName, name stri
 
 func (id CertificateId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Certificate", segmentsStr)
 }
 
 func (id CertificateId) ID(_ string) string {

--- a/azurerm/internal/services/batch/parse/pool.go
+++ b/azurerm/internal/services/batch/parse/pool.go
@@ -27,11 +27,12 @@ func NewPoolID(subscriptionId, resourceGroup, batchAccountName, name string) Poo
 
 func (id PoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Batch Account Name %q", id.BatchAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Pool", segmentsStr)
 }
 
 func (id PoolId) ID(_ string) string {

--- a/azurerm/internal/services/bot/parse/bot_channel.go
+++ b/azurerm/internal/services/bot/parse/bot_channel.go
@@ -27,11 +27,12 @@ func NewBotChannelID(subscriptionId, resourceGroup, botServiceName, channelName 
 
 func (id BotChannelId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Bot Service Name %q", id.BotServiceName),
 		fmt.Sprintf("Channel Name %q", id.ChannelName),
+		fmt.Sprintf("Bot Service Name %q", id.BotServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Bot Channel", segmentsStr)
 }
 
 func (id BotChannelId) ID(_ string) string {

--- a/azurerm/internal/services/bot/parse/bot_connection.go
+++ b/azurerm/internal/services/bot/parse/bot_connection.go
@@ -27,11 +27,12 @@ func NewBotConnectionID(subscriptionId, resourceGroup, botServiceName, connectio
 
 func (id BotConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Bot Service Name %q", id.BotServiceName),
 		fmt.Sprintf("Connection Name %q", id.ConnectionName),
+		fmt.Sprintf("Bot Service Name %q", id.BotServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Bot Connection", segmentsStr)
 }
 
 func (id BotConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/bot/parse/bot_service.go
+++ b/azurerm/internal/services/bot/parse/bot_service.go
@@ -25,10 +25,11 @@ func NewBotServiceID(subscriptionId, resourceGroup, name string) BotServiceId {
 
 func (id BotServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Bot Service", segmentsStr)
 }
 
 func (id BotServiceId) ID(_ string) string {

--- a/azurerm/internal/services/cdn/parse/endpoint.go
+++ b/azurerm/internal/services/cdn/parse/endpoint.go
@@ -27,11 +27,12 @@ func NewEndpointID(subscriptionId, resourceGroup, profileName, name string) Endp
 
 func (id EndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Profile Name %q", id.ProfileName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Profile Name %q", id.ProfileName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Endpoint", segmentsStr)
 }
 
 func (id EndpointId) ID(_ string) string {

--- a/azurerm/internal/services/cdn/parse/profile.go
+++ b/azurerm/internal/services/cdn/parse/profile.go
@@ -25,10 +25,11 @@ func NewProfileID(subscriptionId, resourceGroup, name string) ProfileId {
 
 func (id ProfileId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Profile", segmentsStr)
 }
 
 func (id ProfileId) ID(_ string) string {

--- a/azurerm/internal/services/cognitive/parse/account.go
+++ b/azurerm/internal/services/cognitive/parse/account.go
@@ -25,10 +25,11 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 
 func (id AccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Account", segmentsStr)
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/availability_set.go
+++ b/azurerm/internal/services/compute/parse/availability_set.go
@@ -25,10 +25,11 @@ func NewAvailabilitySetID(subscriptionId, resourceGroup, name string) Availabili
 
 func (id AvailabilitySetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Availability Set", segmentsStr)
 }
 
 func (id AvailabilitySetId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/dedicated_host.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host.go
@@ -27,11 +27,12 @@ func NewDedicatedHostID(subscriptionId, resourceGroup, hostGroupName, hostName s
 
 func (id DedicatedHostId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Host Group Name %q", id.HostGroupName),
 		fmt.Sprintf("Host Name %q", id.HostName),
+		fmt.Sprintf("Host Group Name %q", id.HostGroupName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Dedicated Host", segmentsStr)
 }
 
 func (id DedicatedHostId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/dedicated_host_group.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_group.go
@@ -25,10 +25,11 @@ func NewDedicatedHostGroupID(subscriptionId, resourceGroup, hostGroupName string
 
 func (id DedicatedHostGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Host Group Name %q", id.HostGroupName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Dedicated Host Group", segmentsStr)
 }
 
 func (id DedicatedHostGroupId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/disk_encryption_set.go
+++ b/azurerm/internal/services/compute/parse/disk_encryption_set.go
@@ -25,10 +25,11 @@ func NewDiskEncryptionSetID(subscriptionId, resourceGroup, name string) DiskEncr
 
 func (id DiskEncryptionSetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Disk Encryption Set", segmentsStr)
 }
 
 func (id DiskEncryptionSetId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/image.go
+++ b/azurerm/internal/services/compute/parse/image.go
@@ -25,10 +25,11 @@ func NewImageID(subscriptionId, resourceGroup, name string) ImageId {
 
 func (id ImageId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Image", segmentsStr)
 }
 
 func (id ImageId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/managed_disk.go
+++ b/azurerm/internal/services/compute/parse/managed_disk.go
@@ -25,10 +25,11 @@ func NewManagedDiskID(subscriptionId, resourceGroup, diskName string) ManagedDis
 
 func (id ManagedDiskId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Disk Name %q", id.DiskName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Managed Disk", segmentsStr)
 }
 
 func (id ManagedDiskId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/proximity_placement_group.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group.go
@@ -25,10 +25,11 @@ func NewProximityPlacementGroupID(subscriptionId, resourceGroup, name string) Pr
 
 func (id ProximityPlacementGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Proximity Placement Group", segmentsStr)
 }
 
 func (id ProximityPlacementGroupId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/shared_image.go
+++ b/azurerm/internal/services/compute/parse/shared_image.go
@@ -27,11 +27,12 @@ func NewSharedImageID(subscriptionId, resourceGroup, galleryName, imageName stri
 
 func (id SharedImageId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Gallery Name %q", id.GalleryName),
 		fmt.Sprintf("Image Name %q", id.ImageName),
+		fmt.Sprintf("Gallery Name %q", id.GalleryName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Shared Image", segmentsStr)
 }
 
 func (id SharedImageId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/shared_image_gallery.go
+++ b/azurerm/internal/services/compute/parse/shared_image_gallery.go
@@ -25,10 +25,11 @@ func NewSharedImageGalleryID(subscriptionId, resourceGroup, galleryName string) 
 
 func (id SharedImageGalleryId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Gallery Name %q", id.GalleryName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Shared Image Gallery", segmentsStr)
 }
 
 func (id SharedImageGalleryId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/shared_image_version.go
+++ b/azurerm/internal/services/compute/parse/shared_image_version.go
@@ -29,12 +29,13 @@ func NewSharedImageVersionID(subscriptionId, resourceGroup, galleryName, imageNa
 
 func (id SharedImageVersionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Gallery Name %q", id.GalleryName),
-		fmt.Sprintf("Image Name %q", id.ImageName),
 		fmt.Sprintf("Version Name %q", id.VersionName),
+		fmt.Sprintf("Image Name %q", id.ImageName),
+		fmt.Sprintf("Gallery Name %q", id.GalleryName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Shared Image Version", segmentsStr)
 }
 
 func (id SharedImageVersionId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine.go
@@ -25,10 +25,11 @@ func NewVirtualMachineID(subscriptionId, resourceGroup, name string) VirtualMach
 
 func (id VirtualMachineId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Machine", segmentsStr)
 }
 
 func (id VirtualMachineId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_extension.go
@@ -27,11 +27,12 @@ func NewVirtualMachineExtensionID(subscriptionId, resourceGroup, virtualMachineN
 
 func (id VirtualMachineExtensionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Machine Name %q", id.VirtualMachineName),
 		fmt.Sprintf("Extension Name %q", id.ExtensionName),
+		fmt.Sprintf("Virtual Machine Name %q", id.VirtualMachineName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Machine Extension", segmentsStr)
 }
 
 func (id VirtualMachineExtensionId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set.go
@@ -25,10 +25,11 @@ func NewVirtualMachineScaleSetID(subscriptionId, resourceGroup, name string) Vir
 
 func (id VirtualMachineScaleSetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Machine Scale Set", segmentsStr)
 }
 
 func (id VirtualMachineScaleSetId) ID(_ string) string {

--- a/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/parse/virtual_machine_scale_set_extension.go
@@ -27,11 +27,12 @@ func NewVirtualMachineScaleSetExtensionID(subscriptionId, resourceGroup, virtual
 
 func (id VirtualMachineScaleSetExtensionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Machine Scale Set Name %q", id.VirtualMachineScaleSetName),
 		fmt.Sprintf("Extension Name %q", id.ExtensionName),
+		fmt.Sprintf("Virtual Machine Scale Set Name %q", id.VirtualMachineScaleSetName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Machine Scale Set Extension", segmentsStr)
 }
 
 func (id VirtualMachineScaleSetExtensionId) ID(_ string) string {

--- a/azurerm/internal/services/containers/parse/cluster.go
+++ b/azurerm/internal/services/containers/parse/cluster.go
@@ -25,10 +25,11 @@ func NewClusterID(subscriptionId, resourceGroup, managedClusterName string) Clus
 
 func (id ClusterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Managed Cluster Name %q", id.ManagedClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster", segmentsStr)
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/containers/parse/node_pool.go
+++ b/azurerm/internal/services/containers/parse/node_pool.go
@@ -27,11 +27,12 @@ func NewNodePoolID(subscriptionId, resourceGroup, managedClusterName, agentPoolN
 
 func (id NodePoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Managed Cluster Name %q", id.ManagedClusterName),
 		fmt.Sprintf("Agent Pool Name %q", id.AgentPoolName),
+		fmt.Sprintf("Managed Cluster Name %q", id.ManagedClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Node Pool", segmentsStr)
 }
 
 func (id NodePoolId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/cassandra_keyspace.go
+++ b/azurerm/internal/services/cosmos/parse/cassandra_keyspace.go
@@ -27,11 +27,12 @@ func NewCassandraKeyspaceID(subscriptionId, resourceGroup, databaseAccountName, 
 
 func (id CassandraKeyspaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cassandra Keyspace", segmentsStr)
 }
 
 func (id CassandraKeyspaceId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/database_account.go
+++ b/azurerm/internal/services/cosmos/parse/database_account.go
@@ -25,10 +25,11 @@ func NewDatabaseAccountID(subscriptionId, resourceGroup, name string) DatabaseAc
 
 func (id DatabaseAccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database Account", segmentsStr)
 }
 
 func (id DatabaseAccountId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/gremlin_database.go
+++ b/azurerm/internal/services/cosmos/parse/gremlin_database.go
@@ -27,11 +27,12 @@ func NewGremlinDatabaseID(subscriptionId, resourceGroup, databaseAccountName, na
 
 func (id GremlinDatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Gremlin Database", segmentsStr)
 }
 
 func (id GremlinDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/gremlin_graph.go
+++ b/azurerm/internal/services/cosmos/parse/gremlin_graph.go
@@ -29,12 +29,13 @@ func NewGremlinGraphID(subscriptionId, resourceGroup, databaseAccountName, greml
 
 func (id GremlinGraphId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
-		fmt.Sprintf("Gremlin Database Name %q", id.GremlinDatabaseName),
 		fmt.Sprintf("Graph Name %q", id.GraphName),
+		fmt.Sprintf("Gremlin Database Name %q", id.GremlinDatabaseName),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Gremlin Graph", segmentsStr)
 }
 
 func (id GremlinGraphId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/mongodb_collection.go
+++ b/azurerm/internal/services/cosmos/parse/mongodb_collection.go
@@ -29,12 +29,13 @@ func NewMongodbCollectionID(subscriptionId, resourceGroup, databaseAccountName, 
 
 func (id MongodbCollectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
-		fmt.Sprintf("Mongodb Database Name %q", id.MongodbDatabaseName),
 		fmt.Sprintf("Collection Name %q", id.CollectionName),
+		fmt.Sprintf("Mongodb Database Name %q", id.MongodbDatabaseName),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Mongodb Collection", segmentsStr)
 }
 
 func (id MongodbCollectionId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/mongodb_database.go
+++ b/azurerm/internal/services/cosmos/parse/mongodb_database.go
@@ -27,11 +27,12 @@ func NewMongodbDatabaseID(subscriptionId, resourceGroup, databaseAccountName, na
 
 func (id MongodbDatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Mongodb Database", segmentsStr)
 }
 
 func (id MongodbDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/sql_container.go
+++ b/azurerm/internal/services/cosmos/parse/sql_container.go
@@ -29,12 +29,13 @@ func NewSqlContainerID(subscriptionId, resourceGroup, databaseAccountName, sqlDa
 
 func (id SqlContainerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
-		fmt.Sprintf("Sql Database Name %q", id.SqlDatabaseName),
 		fmt.Sprintf("Container Name %q", id.ContainerName),
+		fmt.Sprintf("Sql Database Name %q", id.SqlDatabaseName),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Sql Container", segmentsStr)
 }
 
 func (id SqlContainerId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/sql_database.go
+++ b/azurerm/internal/services/cosmos/parse/sql_database.go
@@ -27,11 +27,12 @@ func NewSqlDatabaseID(subscriptionId, resourceGroup, databaseAccountName, name s
 
 func (id SqlDatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Sql Database", segmentsStr)
 }
 
 func (id SqlDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/sql_stored_procedure.go
+++ b/azurerm/internal/services/cosmos/parse/sql_stored_procedure.go
@@ -31,13 +31,14 @@ func NewSqlStoredProcedureID(subscriptionId, resourceGroup, databaseAccountName,
 
 func (id SqlStoredProcedureId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
-		fmt.Sprintf("Sql Database Name %q", id.SqlDatabaseName),
-		fmt.Sprintf("Container Name %q", id.ContainerName),
 		fmt.Sprintf("Stored Procedure Name %q", id.StoredProcedureName),
+		fmt.Sprintf("Container Name %q", id.ContainerName),
+		fmt.Sprintf("Sql Database Name %q", id.SqlDatabaseName),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Sql Stored Procedure", segmentsStr)
 }
 
 func (id SqlStoredProcedureId) ID(_ string) string {

--- a/azurerm/internal/services/cosmos/parse/table.go
+++ b/azurerm/internal/services/cosmos/parse/table.go
@@ -27,11 +27,12 @@ func NewTableID(subscriptionId, resourceGroup, databaseAccountName, name string)
 
 func (id TableId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Database Account Name %q", id.DatabaseAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Table", segmentsStr)
 }
 
 func (id TableId) ID(_ string) string {

--- a/azurerm/internal/services/customproviders/parse/resource_provider.go
+++ b/azurerm/internal/services/customproviders/parse/resource_provider.go
@@ -25,10 +25,11 @@ func NewResourceProviderID(subscriptionId, resourceGroup, name string) ResourceP
 
 func (id ResourceProviderId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Resource Provider", segmentsStr)
 }
 
 func (id ResourceProviderId) ID(_ string) string {

--- a/azurerm/internal/services/databasemigration/parse/project.go
+++ b/azurerm/internal/services/databasemigration/parse/project.go
@@ -27,11 +27,12 @@ func NewProjectID(subscriptionId, resourceGroup, serviceName, name string) Proje
 
 func (id ProjectId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Service Name %q", id.ServiceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Service Name %q", id.ServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Project", segmentsStr)
 }
 
 func (id ProjectId) ID(_ string) string {

--- a/azurerm/internal/services/databasemigration/parse/service.go
+++ b/azurerm/internal/services/databasemigration/parse/service.go
@@ -25,10 +25,11 @@ func NewServiceID(subscriptionId, resourceGroup, name string) ServiceId {
 
 func (id ServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Service", segmentsStr)
 }
 
 func (id ServiceId) ID(_ string) string {

--- a/azurerm/internal/services/databricks/parse/workspace.go
+++ b/azurerm/internal/services/databricks/parse/workspace.go
@@ -25,10 +25,11 @@ func NewWorkspaceID(subscriptionId, resourceGroup, name string) WorkspaceId {
 
 func (id WorkspaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Workspace", segmentsStr)
 }
 
 func (id WorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/datafactory/parse/integration_runtime.go
+++ b/azurerm/internal/services/datafactory/parse/integration_runtime.go
@@ -27,11 +27,12 @@ func NewIntegrationRuntimeID(subscriptionId, resourceGroup, factoryName, name st
 
 func (id IntegrationRuntimeId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Factory Name %q", id.FactoryName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Factory Name %q", id.FactoryName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Integration Runtime", segmentsStr)
 }
 
 func (id IntegrationRuntimeId) ID(_ string) string {

--- a/azurerm/internal/services/datafactory/parse/linked_service.go
+++ b/azurerm/internal/services/datafactory/parse/linked_service.go
@@ -27,11 +27,12 @@ func NewLinkedServiceID(subscriptionId, resourceGroup, factoryName, name string)
 
 func (id LinkedServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Factory Name %q", id.FactoryName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Factory Name %q", id.FactoryName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Linked Service", segmentsStr)
 }
 
 func (id LinkedServiceId) ID(_ string) string {

--- a/azurerm/internal/services/datalake/parse/account.go
+++ b/azurerm/internal/services/datalake/parse/account.go
@@ -25,10 +25,11 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 
 func (id AccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Account", segmentsStr)
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/datashare/parse/account.go
+++ b/azurerm/internal/services/datashare/parse/account.go
@@ -25,10 +25,11 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 
 func (id AccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Account", segmentsStr)
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/datashare/parse/data_set.go
+++ b/azurerm/internal/services/datashare/parse/data_set.go
@@ -29,12 +29,13 @@ func NewDataSetID(subscriptionId, resourceGroup, accountName, shareName, name st
 
 func (id DataSetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Account Name %q", id.AccountName),
-		fmt.Sprintf("Share Name %q", id.ShareName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Share Name %q", id.ShareName),
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Data Set", segmentsStr)
 }
 
 func (id DataSetId) ID(_ string) string {

--- a/azurerm/internal/services/datashare/parse/share.go
+++ b/azurerm/internal/services/datashare/parse/share.go
@@ -27,11 +27,12 @@ func NewShareID(subscriptionId, resourceGroup, accountName, name string) ShareId
 
 func (id ShareId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Account Name %q", id.AccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Account Name %q", id.AccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Share", segmentsStr)
 }
 
 func (id ShareId) ID(_ string) string {

--- a/azurerm/internal/services/desktopvirtualization/parse/application_group.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/application_group.go
@@ -25,10 +25,11 @@ func NewApplicationGroupID(subscriptionId, resourceGroup, name string) Applicati
 
 func (id ApplicationGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Application Group", segmentsStr)
 }
 
 func (id ApplicationGroupId) ID(_ string) string {

--- a/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/host_pool.go
@@ -25,10 +25,11 @@ func NewHostPoolID(subscriptionId, resourceGroup, name string) HostPoolId {
 
 func (id HostPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Host Pool", segmentsStr)
 }
 
 func (id HostPoolId) ID(_ string) string {

--- a/azurerm/internal/services/desktopvirtualization/parse/workspace.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/workspace.go
@@ -25,10 +25,11 @@ func NewWorkspaceID(subscriptionId, resourceGroup, name string) WorkspaceId {
 
 func (id WorkspaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Workspace", segmentsStr)
 }
 
 func (id WorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/devspace/parse/controller.go
+++ b/azurerm/internal/services/devspace/parse/controller.go
@@ -25,10 +25,11 @@ func NewControllerID(subscriptionId, resourceGroup, name string) ControllerId {
 
 func (id ControllerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Controller", segmentsStr)
 }
 
 func (id ControllerId) ID(_ string) string {

--- a/azurerm/internal/services/devtestlabs/parse/schedule.go
+++ b/azurerm/internal/services/devtestlabs/parse/schedule.go
@@ -25,10 +25,11 @@ func NewScheduleID(subscriptionId, resourceGroup, name string) ScheduleId {
 
 func (id ScheduleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Schedule", segmentsStr)
 }
 
 func (id ScheduleId) ID(_ string) string {

--- a/azurerm/internal/services/digitaltwins/parse/digital_twins_endpoint.go
+++ b/azurerm/internal/services/digitaltwins/parse/digital_twins_endpoint.go
@@ -27,11 +27,12 @@ func NewDigitalTwinsEndpointID(subscriptionId, resourceGroup, digitalTwinsInstan
 
 func (id DigitalTwinsEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Digital Twins Instance Name %q", id.DigitalTwinsInstanceName),
 		fmt.Sprintf("Endpoint Name %q", id.EndpointName),
+		fmt.Sprintf("Digital Twins Instance Name %q", id.DigitalTwinsInstanceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Digital Twins Endpoint", segmentsStr)
 }
 
 func (id DigitalTwinsEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/digitaltwins/parse/digital_twins_instance.go
+++ b/azurerm/internal/services/digitaltwins/parse/digital_twins_instance.go
@@ -25,10 +25,11 @@ func NewDigitalTwinsInstanceID(subscriptionId, resourceGroup, name string) Digit
 
 func (id DigitalTwinsInstanceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Digital Twins Instance", segmentsStr)
 }
 
 func (id DigitalTwinsInstanceId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/a_record.go
+++ b/azurerm/internal/services/dns/parse/a_record.go
@@ -27,11 +27,12 @@ func NewARecordID(subscriptionId, resourceGroup, dnszoneName, aName string) ARec
 
 func (id ARecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("A Name %q", id.AName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "A Record", segmentsStr)
 }
 
 func (id ARecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/aaaa_record.go
+++ b/azurerm/internal/services/dns/parse/aaaa_record.go
@@ -27,11 +27,12 @@ func NewAaaaRecordID(subscriptionId, resourceGroup, dnszoneName, aAAAName string
 
 func (id AaaaRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("A A A A Name %q", id.AAAAName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Aaaa Record", segmentsStr)
 }
 
 func (id AaaaRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/caa_record.go
+++ b/azurerm/internal/services/dns/parse/caa_record.go
@@ -27,11 +27,12 @@ func NewCaaRecordID(subscriptionId, resourceGroup, dnszoneName, cAAName string) 
 
 func (id CaaRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("C A A Name %q", id.CAAName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Caa Record", segmentsStr)
 }
 
 func (id CaaRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/cname_record.go
+++ b/azurerm/internal/services/dns/parse/cname_record.go
@@ -27,11 +27,12 @@ func NewCnameRecordID(subscriptionId, resourceGroup, dnszoneName, cNAMEName stri
 
 func (id CnameRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("C N A M E Name %q", id.CNAMEName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cname Record", segmentsStr)
 }
 
 func (id CnameRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/dns_zone.go
+++ b/azurerm/internal/services/dns/parse/dns_zone.go
@@ -25,10 +25,11 @@ func NewDnsZoneID(subscriptionId, resourceGroup, name string) DnsZoneId {
 
 func (id DnsZoneId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Dns Zone", segmentsStr)
 }
 
 func (id DnsZoneId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/mx_record.go
+++ b/azurerm/internal/services/dns/parse/mx_record.go
@@ -27,11 +27,12 @@ func NewMxRecordID(subscriptionId, resourceGroup, dnszoneName, mXName string) Mx
 
 func (id MxRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("M X Name %q", id.MXName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Mx Record", segmentsStr)
 }
 
 func (id MxRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/ns_record.go
+++ b/azurerm/internal/services/dns/parse/ns_record.go
@@ -27,11 +27,12 @@ func NewNsRecordID(subscriptionId, resourceGroup, dnszoneName, nSName string) Ns
 
 func (id NsRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("N S Name %q", id.NSName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Ns Record", segmentsStr)
 }
 
 func (id NsRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/ptr_record.go
+++ b/azurerm/internal/services/dns/parse/ptr_record.go
@@ -27,11 +27,12 @@ func NewPtrRecordID(subscriptionId, resourceGroup, dnszoneName, pTRName string) 
 
 func (id PtrRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("P T R Name %q", id.PTRName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Ptr Record", segmentsStr)
 }
 
 func (id PtrRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/srv_record.go
+++ b/azurerm/internal/services/dns/parse/srv_record.go
@@ -27,11 +27,12 @@ func NewSrvRecordID(subscriptionId, resourceGroup, dnszoneName, sRVName string) 
 
 func (id SrvRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("S R V Name %q", id.SRVName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Srv Record", segmentsStr)
 }
 
 func (id SrvRecordId) ID(_ string) string {

--- a/azurerm/internal/services/dns/parse/txt_record.go
+++ b/azurerm/internal/services/dns/parse/txt_record.go
@@ -27,11 +27,12 @@ func NewTxtRecordID(subscriptionId, resourceGroup, dnszoneName, tXTName string) 
 
 func (id TxtRecordId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
 		fmt.Sprintf("T X T Name %q", id.TXTName),
+		fmt.Sprintf("Dnszone Name %q", id.DnszoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Txt Record", segmentsStr)
 }
 
 func (id TxtRecordId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/domain.go
+++ b/azurerm/internal/services/eventgrid/parse/domain.go
@@ -25,10 +25,11 @@ func NewDomainID(subscriptionId, resourceGroup, name string) DomainId {
 
 func (id DomainId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Domain", segmentsStr)
 }
 
 func (id DomainId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/domain_topic.go
+++ b/azurerm/internal/services/eventgrid/parse/domain_topic.go
@@ -27,11 +27,12 @@ func NewDomainTopicID(subscriptionId, resourceGroup, domainName, topicName strin
 
 func (id DomainTopicId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Domain Name %q", id.DomainName),
 		fmt.Sprintf("Topic Name %q", id.TopicName),
+		fmt.Sprintf("Domain Name %q", id.DomainName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Domain Topic", segmentsStr)
 }
 
 func (id DomainTopicId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/system_topic.go
+++ b/azurerm/internal/services/eventgrid/parse/system_topic.go
@@ -25,10 +25,11 @@ func NewSystemTopicID(subscriptionId, resourceGroup, name string) SystemTopicId 
 
 func (id SystemTopicId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "System Topic", segmentsStr)
 }
 
 func (id SystemTopicId) ID(_ string) string {

--- a/azurerm/internal/services/eventgrid/parse/topic.go
+++ b/azurerm/internal/services/eventgrid/parse/topic.go
@@ -25,10 +25,11 @@ func NewTopicID(subscriptionId, resourceGroup, name string) TopicId {
 
 func (id TopicId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Topic", segmentsStr)
 }
 
 func (id TopicId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/cluster.go
+++ b/azurerm/internal/services/eventhub/parse/cluster.go
@@ -25,10 +25,11 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 
 func (id ClusterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster", segmentsStr)
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/event_hub_consumer_group.go
+++ b/azurerm/internal/services/eventhub/parse/event_hub_consumer_group.go
@@ -29,12 +29,13 @@ func NewEventHubConsumerGroupID(subscriptionId, resourceGroup, namespaceName, ev
 
 func (id EventHubConsumerGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
-		fmt.Sprintf("Eventhub Name %q", id.EventhubName),
 		fmt.Sprintf("Consumergroup Name %q", id.ConsumergroupName),
+		fmt.Sprintf("Eventhub Name %q", id.EventhubName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Event Hub Consumer Group", segmentsStr)
 }
 
 func (id EventHubConsumerGroupId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/namespace.go
+++ b/azurerm/internal/services/eventhub/parse/namespace.go
@@ -25,10 +25,11 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 
 func (id NamespaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/eventhub/parse/namespace_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/parse/namespace_authorization_rule.go
@@ -27,11 +27,12 @@ func NewNamespaceAuthorizationRuleID(subscriptionId, resourceGroup, namespaceNam
 
 func (id NamespaceAuthorizationRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace Authorization Rule", segmentsStr)
 }
 
 func (id NamespaceAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/firewall/parse/firewall_policy.go
+++ b/azurerm/internal/services/firewall/parse/firewall_policy.go
@@ -25,10 +25,11 @@ func NewFirewallPolicyID(subscriptionId, resourceGroup, name string) FirewallPol
 
 func (id FirewallPolicyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Policy", segmentsStr)
 }
 
 func (id FirewallPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/firewall/parse/firewall_policy_rule_collection_group.go
+++ b/azurerm/internal/services/firewall/parse/firewall_policy_rule_collection_group.go
@@ -27,11 +27,12 @@ func NewFirewallPolicyRuleCollectionGroupID(subscriptionId, resourceGroup, firew
 
 func (id FirewallPolicyRuleCollectionGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Firewall Policy Name %q", id.FirewallPolicyName),
 		fmt.Sprintf("Rule Collection Group Name %q", id.RuleCollectionGroupName),
+		fmt.Sprintf("Firewall Policy Name %q", id.FirewallPolicyName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Policy Rule Collection Group", segmentsStr)
 }
 
 func (id FirewallPolicyRuleCollectionGroupId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/backend_pool.go
+++ b/azurerm/internal/services/frontdoor/parse/backend_pool.go
@@ -27,11 +27,12 @@ func NewBackendPoolID(subscriptionId, resourceGroup, frontDoorName, name string)
 
 func (id BackendPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Backend Pool", segmentsStr)
 }
 
 func (id BackendPoolId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/front_door.go
+++ b/azurerm/internal/services/frontdoor/parse/front_door.go
@@ -25,10 +25,11 @@ func NewFrontDoorID(subscriptionId, resourceGroup, name string) FrontDoorId {
 
 func (id FrontDoorId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Front Door", segmentsStr)
 }
 
 func (id FrontDoorId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/frontend_endpoint.go
+++ b/azurerm/internal/services/frontdoor/parse/frontend_endpoint.go
@@ -27,11 +27,12 @@ func NewFrontendEndpointID(subscriptionId, resourceGroup, frontDoorName, name st
 
 func (id FrontendEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Frontend Endpoint", segmentsStr)
 }
 
 func (id FrontendEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/health_probe.go
+++ b/azurerm/internal/services/frontdoor/parse/health_probe.go
@@ -27,11 +27,12 @@ func NewHealthProbeID(subscriptionId, resourceGroup, frontDoorName, healthProbeS
 
 func (id HealthProbeId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
 		fmt.Sprintf("Health Probe Setting Name %q", id.HealthProbeSettingName),
+		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Health Probe", segmentsStr)
 }
 
 func (id HealthProbeId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/load_balancing.go
+++ b/azurerm/internal/services/frontdoor/parse/load_balancing.go
@@ -27,11 +27,12 @@ func NewLoadBalancingID(subscriptionId, resourceGroup, frontDoorName, loadBalanc
 
 func (id LoadBalancingId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
 		fmt.Sprintf("Load Balancing Setting Name %q", id.LoadBalancingSettingName),
+		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancing", segmentsStr)
 }
 
 func (id LoadBalancingId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/routing_rule.go
+++ b/azurerm/internal/services/frontdoor/parse/routing_rule.go
@@ -27,11 +27,12 @@ func NewRoutingRuleID(subscriptionId, resourceGroup, frontDoorName, name string)
 
 func (id RoutingRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Front Door Name %q", id.FrontDoorName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Routing Rule", segmentsStr)
 }
 
 func (id RoutingRuleId) ID(_ string) string {

--- a/azurerm/internal/services/frontdoor/parse/web_application_firewall_policy.go
+++ b/azurerm/internal/services/frontdoor/parse/web_application_firewall_policy.go
@@ -25,10 +25,11 @@ func NewWebApplicationFirewallPolicyID(subscriptionId, resourceGroup, frontDoorW
 
 func (id WebApplicationFirewallPolicyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Front Door Web Application Firewall Policy Name %q", id.FrontDoorWebApplicationFirewallPolicyName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Web Application Firewall Policy", segmentsStr)
 }
 
 func (id WebApplicationFirewallPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/healthcare/parse/service.go
+++ b/azurerm/internal/services/healthcare/parse/service.go
@@ -25,10 +25,11 @@ func NewServiceID(subscriptionId, resourceGroup, name string) ServiceId {
 
 func (id ServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Service", segmentsStr)
 }
 
 func (id ServiceId) ID(_ string) string {

--- a/azurerm/internal/services/hpccache/parse/cache.go
+++ b/azurerm/internal/services/hpccache/parse/cache.go
@@ -25,10 +25,11 @@ func NewCacheID(subscriptionId, resourceGroup, name string) CacheId {
 
 func (id CacheId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cache", segmentsStr)
 }
 
 func (id CacheId) ID(_ string) string {

--- a/azurerm/internal/services/hpccache/parse/storage_target.go
+++ b/azurerm/internal/services/hpccache/parse/storage_target.go
@@ -27,11 +27,12 @@ func NewStorageTargetID(subscriptionId, resourceGroup, cacheName, name string) S
 
 func (id StorageTargetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cache Name %q", id.CacheName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Cache Name %q", id.CacheName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Target", segmentsStr)
 }
 
 func (id StorageTargetId) ID(_ string) string {

--- a/azurerm/internal/services/hsm/parse/dedicated_hardware_security_module.go
+++ b/azurerm/internal/services/hsm/parse/dedicated_hardware_security_module.go
@@ -25,10 +25,11 @@ func NewDedicatedHardwareSecurityModuleID(subscriptionId, resourceGroup, dedicat
 
 func (id DedicatedHardwareSecurityModuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Dedicated H S M Name %q", id.DedicatedHSMName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Dedicated Hardware Security Module", segmentsStr)
 }
 
 func (id DedicatedHardwareSecurityModuleId) ID(_ string) string {

--- a/azurerm/internal/services/iotcentral/parse/application.go
+++ b/azurerm/internal/services/iotcentral/parse/application.go
@@ -25,10 +25,11 @@ func NewApplicationID(subscriptionId, resourceGroup, ioTAppName string) Applicat
 
 func (id ApplicationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Io T App Name %q", id.IoTAppName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Application", segmentsStr)
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/iothub/parse/iot_hub.go
+++ b/azurerm/internal/services/iothub/parse/iot_hub.go
@@ -25,10 +25,11 @@ func NewIotHubID(subscriptionId, resourceGroup, name string) IotHubId {
 
 func (id IotHubId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Iot Hub", segmentsStr)
 }
 
 func (id IotHubId) ID(_ string) string {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/access_policy.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/access_policy.go
@@ -27,11 +27,12 @@ func NewAccessPolicyID(subscriptionId, resourceGroup, environmentName, name stri
 
 func (id AccessPolicyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Environment Name %q", id.EnvironmentName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Environment Name %q", id.EnvironmentName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Access Policy", segmentsStr)
 }
 
 func (id AccessPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/environment.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/environment.go
@@ -25,10 +25,11 @@ func NewEnvironmentID(subscriptionId, resourceGroup, name string) EnvironmentId 
 
 func (id EnvironmentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Environment", segmentsStr)
 }
 
 func (id EnvironmentId) ID(_ string) string {

--- a/azurerm/internal/services/iottimeseriesinsights/parse/reference_data_set.go
+++ b/azurerm/internal/services/iottimeseriesinsights/parse/reference_data_set.go
@@ -27,11 +27,12 @@ func NewReferenceDataSetID(subscriptionId, resourceGroup, environmentName, name 
 
 func (id ReferenceDataSetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Environment Name %q", id.EnvironmentName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Environment Name %q", id.EnvironmentName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Reference Data Set", segmentsStr)
 }
 
 func (id ReferenceDataSetId) ID(_ string) string {

--- a/azurerm/internal/services/keyvault/parse/vault.go
+++ b/azurerm/internal/services/keyvault/parse/vault.go
@@ -25,10 +25,11 @@ func NewVaultID(subscriptionId, resourceGroup, name string) VaultId {
 
 func (id VaultId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Vault", segmentsStr)
 }
 
 func (id VaultId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/attached_database_configuration.go
+++ b/azurerm/internal/services/kusto/parse/attached_database_configuration.go
@@ -27,11 +27,12 @@ func NewAttachedDatabaseConfigurationID(subscriptionId, resourceGroup, clusterNa
 
 func (id AttachedDatabaseConfigurationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cluster Name %q", id.ClusterName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Attached Database Configuration", segmentsStr)
 }
 
 func (id AttachedDatabaseConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/cluster.go
+++ b/azurerm/internal/services/kusto/parse/cluster.go
@@ -25,10 +25,11 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 
 func (id ClusterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster", segmentsStr)
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/cluster_principal_assignment.go
+++ b/azurerm/internal/services/kusto/parse/cluster_principal_assignment.go
@@ -27,11 +27,12 @@ func NewClusterPrincipalAssignmentID(subscriptionId, resourceGroup, clusterName,
 
 func (id ClusterPrincipalAssignmentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cluster Name %q", id.ClusterName),
 		fmt.Sprintf("Principal Assignment Name %q", id.PrincipalAssignmentName),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster Principal Assignment", segmentsStr)
 }
 
 func (id ClusterPrincipalAssignmentId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/data_connection.go
+++ b/azurerm/internal/services/kusto/parse/data_connection.go
@@ -29,12 +29,13 @@ func NewDataConnectionID(subscriptionId, resourceGroup, clusterName, databaseNam
 
 func (id DataConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cluster Name %q", id.ClusterName),
-		fmt.Sprintf("Database Name %q", id.DatabaseName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Data Connection", segmentsStr)
 }
 
 func (id DataConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/database.go
+++ b/azurerm/internal/services/kusto/parse/database.go
@@ -27,11 +27,12 @@ func NewDatabaseID(subscriptionId, resourceGroup, clusterName, name string) Data
 
 func (id DatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cluster Name %q", id.ClusterName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database", segmentsStr)
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/database_principal.go
+++ b/azurerm/internal/services/kusto/parse/database_principal.go
@@ -31,13 +31,14 @@ func NewDatabasePrincipalID(subscriptionId, resourceGroup, clusterName, database
 
 func (id DatabasePrincipalId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cluster Name %q", id.ClusterName),
-		fmt.Sprintf("Database Name %q", id.DatabaseName),
-		fmt.Sprintf("Role Name %q", id.RoleName),
 		fmt.Sprintf("F Q N Name %q", id.FQNName),
+		fmt.Sprintf("Role Name %q", id.RoleName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database Principal", segmentsStr)
 }
 
 func (id DatabasePrincipalId) ID(_ string) string {

--- a/azurerm/internal/services/kusto/parse/database_principal_assignment.go
+++ b/azurerm/internal/services/kusto/parse/database_principal_assignment.go
@@ -29,12 +29,13 @@ func NewDatabasePrincipalAssignmentID(subscriptionId, resourceGroup, clusterName
 
 func (id DatabasePrincipalAssignmentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Cluster Name %q", id.ClusterName),
-		fmt.Sprintf("Database Name %q", id.DatabaseName),
 		fmt.Sprintf("Principal Assignment Name %q", id.PrincipalAssignmentName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database Principal Assignment", segmentsStr)
 }
 
 func (id DatabasePrincipalAssignmentId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer.go
@@ -25,10 +25,11 @@ func NewLoadBalancerID(subscriptionId, resourceGroup, name string) LoadBalancerI
 
 func (id LoadBalancerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer", segmentsStr)
 }
 
 func (id LoadBalancerId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer_backend_address_pool.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer_backend_address_pool.go
@@ -27,11 +27,12 @@ func NewLoadBalancerBackendAddressPoolID(subscriptionId, resourceGroup, loadBala
 
 func (id LoadBalancerBackendAddressPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Backend Address Pool Name %q", id.BackendAddressPoolName),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer Backend Address Pool", segmentsStr)
 }
 
 func (id LoadBalancerBackendAddressPoolId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer_frontend_ip_configuration.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer_frontend_ip_configuration.go
@@ -27,11 +27,12 @@ func NewLoadBalancerFrontendIpConfigurationID(subscriptionId, resourceGroup, loa
 
 func (id LoadBalancerFrontendIpConfigurationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Frontend I P Configuration Name %q", id.FrontendIPConfigurationName),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer Frontend Ip Configuration", segmentsStr)
 }
 
 func (id LoadBalancerFrontendIpConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer_inbound_nat_pool.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer_inbound_nat_pool.go
@@ -27,11 +27,12 @@ func NewLoadBalancerInboundNatPoolID(subscriptionId, resourceGroup, loadBalancer
 
 func (id LoadBalancerInboundNatPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Inbound Nat Pool Name %q", id.InboundNatPoolName),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer Inbound Nat Pool", segmentsStr)
 }
 
 func (id LoadBalancerInboundNatPoolId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer_inbound_nat_rule.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer_inbound_nat_rule.go
@@ -27,11 +27,12 @@ func NewLoadBalancerInboundNatRuleID(subscriptionId, resourceGroup, loadBalancer
 
 func (id LoadBalancerInboundNatRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Inbound Nat Rule Name %q", id.InboundNatRuleName),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer Inbound Nat Rule", segmentsStr)
 }
 
 func (id LoadBalancerInboundNatRuleId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer_outbound_rule.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer_outbound_rule.go
@@ -27,11 +27,12 @@ func NewLoadBalancerOutboundRuleID(subscriptionId, resourceGroup, loadBalancerNa
 
 func (id LoadBalancerOutboundRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Outbound Rule Name %q", id.OutboundRuleName),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer Outbound Rule", segmentsStr)
 }
 
 func (id LoadBalancerOutboundRuleId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancer_probe.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancer_probe.go
@@ -27,11 +27,12 @@ func NewLoadBalancerProbeID(subscriptionId, resourceGroup, loadBalancerName, pro
 
 func (id LoadBalancerProbeId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Probe Name %q", id.ProbeName),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancer Probe", segmentsStr)
 }
 
 func (id LoadBalancerProbeId) ID(_ string) string {

--- a/azurerm/internal/services/loadbalancer/parse/load_balancing_rule.go
+++ b/azurerm/internal/services/loadbalancer/parse/load_balancing_rule.go
@@ -27,11 +27,12 @@ func NewLoadBalancingRuleID(subscriptionId, resourceGroup, loadBalancerName, nam
 
 func (id LoadBalancingRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Load Balancer Name %q", id.LoadBalancerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Load Balancing Rule", segmentsStr)
 }
 
 func (id LoadBalancingRuleId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_cluster.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_cluster.go
@@ -25,10 +25,11 @@ func NewLogAnalyticsClusterID(subscriptionId, resourceGroup, clusterName string)
 
 func (id LogAnalyticsClusterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Cluster Name %q", id.ClusterName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Cluster", segmentsStr)
 }
 
 func (id LogAnalyticsClusterId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_data_export.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_data_export.go
@@ -27,11 +27,12 @@ func NewLogAnalyticsDataExportID(subscriptionId, resourceGroup, workspaceName, d
 
 func (id LogAnalyticsDataExportId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Dataexport Name %q", id.DataexportName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Data Export", segmentsStr)
 }
 
 func (id LogAnalyticsDataExportId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_data_source_windows_event.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_data_source_windows_event.go
@@ -27,11 +27,12 @@ func NewLogAnalyticsDataSourceWindowsEventID(subscriptionId, resourceGroup, work
 
 func (id LogAnalyticsDataSourceWindowsEventId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Data Source Name %q", id.DataSourceName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Data Source Windows Event", segmentsStr)
 }
 
 func (id LogAnalyticsDataSourceWindowsEventId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_linked_service.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_linked_service.go
@@ -27,11 +27,12 @@ func NewLogAnalyticsLinkedServiceID(subscriptionId, resourceGroup, workspaceName
 
 func (id LogAnalyticsLinkedServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Linked Service Name %q", id.LinkedServiceName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Linked Service", segmentsStr)
 }
 
 func (id LogAnalyticsLinkedServiceId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_linked_storage_account.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_linked_storage_account.go
@@ -27,11 +27,12 @@ func NewLogAnalyticsLinkedStorageAccountID(subscriptionId, resourceGroup, worksp
 
 func (id LogAnalyticsLinkedStorageAccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Linked Storage Account Name %q", id.LinkedStorageAccountName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Linked Storage Account", segmentsStr)
 }
 
 func (id LogAnalyticsLinkedStorageAccountId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_saved_search.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_saved_search.go
@@ -27,11 +27,12 @@ func NewLogAnalyticsSavedSearchID(subscriptionId, resourceGroup, workspaceName, 
 
 func (id LogAnalyticsSavedSearchId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Saved Searche Name %q", id.SavedSearcheName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Saved Search", segmentsStr)
 }
 
 func (id LogAnalyticsSavedSearchId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_solution.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_solution.go
@@ -25,10 +25,11 @@ func NewLogAnalyticsSolutionID(subscriptionId, resourceGroup, solutionName strin
 
 func (id LogAnalyticsSolutionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Solution Name %q", id.SolutionName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Solution", segmentsStr)
 }
 
 func (id LogAnalyticsSolutionId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_storage_insights.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_storage_insights.go
@@ -27,11 +27,12 @@ func NewLogAnalyticsStorageInsightsID(subscriptionId, resourceGroup, workspaceNa
 
 func (id LogAnalyticsStorageInsightsId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Storage Insight Config Name %q", id.StorageInsightConfigName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Storage Insights", segmentsStr)
 }
 
 func (id LogAnalyticsStorageInsightsId) ID(_ string) string {

--- a/azurerm/internal/services/loganalytics/parse/log_analytics_workspace.go
+++ b/azurerm/internal/services/loganalytics/parse/log_analytics_workspace.go
@@ -25,10 +25,11 @@ func NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, workspaceName str
 
 func (id LogAnalyticsWorkspaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Log Analytics Workspace", segmentsStr)
 }
 
 func (id LogAnalyticsWorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/logic/parse/integration_account.go
+++ b/azurerm/internal/services/logic/parse/integration_account.go
@@ -25,10 +25,11 @@ func NewIntegrationAccountID(subscriptionId, resourceGroup, name string) Integra
 
 func (id IntegrationAccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Integration Account", segmentsStr)
 }
 
 func (id IntegrationAccountId) ID(_ string) string {

--- a/azurerm/internal/services/logic/parse/integration_service_environment.go
+++ b/azurerm/internal/services/logic/parse/integration_service_environment.go
@@ -25,10 +25,11 @@ func NewIntegrationServiceEnvironmentID(subscriptionId, resourceGroup, name stri
 
 func (id IntegrationServiceEnvironmentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Integration Service Environment", segmentsStr)
 }
 
 func (id IntegrationServiceEnvironmentId) ID(_ string) string {

--- a/azurerm/internal/services/managedapplications/parse/application.go
+++ b/azurerm/internal/services/managedapplications/parse/application.go
@@ -25,10 +25,11 @@ func NewApplicationID(subscriptionId, resourceGroup, name string) ApplicationId 
 
 func (id ApplicationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Application", segmentsStr)
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/managedapplications/parse/application_definition.go
+++ b/azurerm/internal/services/managedapplications/parse/application_definition.go
@@ -25,10 +25,11 @@ func NewApplicationDefinitionID(subscriptionId, resourceGroup, name string) Appl
 
 func (id ApplicationDefinitionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Application Definition", segmentsStr)
 }
 
 func (id ApplicationDefinitionId) ID(_ string) string {

--- a/azurerm/internal/services/maps/parse/account.go
+++ b/azurerm/internal/services/maps/parse/account.go
@@ -25,10 +25,11 @@ func NewAccountID(subscriptionId, resourceGroup, name string) AccountId {
 
 func (id AccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Account", segmentsStr)
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/mariadb/parse/server.go
+++ b/azurerm/internal/services/mariadb/parse/server.go
@@ -25,10 +25,11 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 
 func (id ServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server", segmentsStr)
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/media/parse/asset.go
+++ b/azurerm/internal/services/media/parse/asset.go
@@ -27,11 +27,12 @@ func NewAssetID(subscriptionId, resourceGroup, mediaserviceName, name string) As
 
 func (id AssetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Mediaservice Name %q", id.MediaserviceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Mediaservice Name %q", id.MediaserviceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Asset", segmentsStr)
 }
 
 func (id AssetId) ID(_ string) string {

--- a/azurerm/internal/services/media/parse/media_service.go
+++ b/azurerm/internal/services/media/parse/media_service.go
@@ -25,10 +25,11 @@ func NewMediaServiceID(subscriptionId, resourceGroup, name string) MediaServiceI
 
 func (id MediaServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Media Service", segmentsStr)
 }
 
 func (id MediaServiceId) ID(_ string) string {

--- a/azurerm/internal/services/mixedreality/parse/spatial_anchors_account.go
+++ b/azurerm/internal/services/mixedreality/parse/spatial_anchors_account.go
@@ -25,10 +25,11 @@ func NewSpatialAnchorsAccountID(subscriptionId, resourceGroup, name string) Spat
 
 func (id SpatialAnchorsAccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Spatial Anchors Account", segmentsStr)
 }
 
 func (id SpatialAnchorsAccountId) ID(_ string) string {

--- a/azurerm/internal/services/monitor/parse/action_group.go
+++ b/azurerm/internal/services/monitor/parse/action_group.go
@@ -25,10 +25,11 @@ func NewActionGroupID(subscriptionId, resourceGroup, name string) ActionGroupId 
 
 func (id ActionGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Action Group", segmentsStr)
 }
 
 func (id ActionGroupId) ID(_ string) string {

--- a/azurerm/internal/services/monitor/parse/action_rule.go
+++ b/azurerm/internal/services/monitor/parse/action_rule.go
@@ -25,10 +25,11 @@ func NewActionRuleID(subscriptionId, resourceGroup, name string) ActionRuleId {
 
 func (id ActionRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Action Rule", segmentsStr)
 }
 
 func (id ActionRuleId) ID(_ string) string {

--- a/azurerm/internal/services/monitor/parse/smart_detector_alert_rule.go
+++ b/azurerm/internal/services/monitor/parse/smart_detector_alert_rule.go
@@ -25,10 +25,11 @@ func NewSmartDetectorAlertRuleID(subscriptionId, resourceGroup, name string) Sma
 
 func (id SmartDetectorAlertRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Smart Detector Alert Rule", segmentsStr)
 }
 
 func (id SmartDetectorAlertRuleId) ID(_ string) string {

--- a/azurerm/internal/services/msi/parse/user_assigned_identity.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity.go
@@ -25,10 +25,11 @@ func NewUserAssignedIdentityID(subscriptionId, resourceGroup, name string) UserA
 
 func (id UserAssignedIdentityId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "User Assigned Identity", segmentsStr)
 }
 
 func (id UserAssignedIdentityId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/database.go
+++ b/azurerm/internal/services/mssql/parse/database.go
@@ -27,11 +27,12 @@ func NewDatabaseID(subscriptionId, resourceGroup, serverName, name string) Datab
 
 func (id DatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database", segmentsStr)
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/database_extended_auditing_policy.go
+++ b/azurerm/internal/services/mssql/parse/database_extended_auditing_policy.go
@@ -29,12 +29,13 @@ func NewDatabaseExtendedAuditingPolicyID(subscriptionId, resourceGroup, serverNa
 
 func (id DatabaseExtendedAuditingPolicyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
-		fmt.Sprintf("Database Name %q", id.DatabaseName),
 		fmt.Sprintf("Extended Auditing Setting Name %q", id.ExtendedAuditingSettingName),
+		fmt.Sprintf("Database Name %q", id.DatabaseName),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database Extended Auditing Policy", segmentsStr)
 }
 
 func (id DatabaseExtendedAuditingPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/elastic_pool.go
+++ b/azurerm/internal/services/mssql/parse/elastic_pool.go
@@ -27,11 +27,12 @@ func NewElasticPoolID(subscriptionId, resourceGroup, serverName, name string) El
 
 func (id ElasticPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Elastic Pool", segmentsStr)
 }
 
 func (id ElasticPoolId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/recoverable_database.go
+++ b/azurerm/internal/services/mssql/parse/recoverable_database.go
@@ -27,11 +27,12 @@ func NewRecoverableDatabaseID(subscriptionId, resourceGroup, serverName, name st
 
 func (id RecoverableDatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Recoverable Database", segmentsStr)
 }
 
 func (id RecoverableDatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/server.go
+++ b/azurerm/internal/services/mssql/parse/server.go
@@ -25,10 +25,11 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 
 func (id ServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server", segmentsStr)
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/server_extended_auditing_policy.go
+++ b/azurerm/internal/services/mssql/parse/server_extended_auditing_policy.go
@@ -27,11 +27,12 @@ func NewServerExtendedAuditingPolicyID(subscriptionId, resourceGroup, serverName
 
 func (id ServerExtendedAuditingPolicyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Extended Auditing Setting Name %q", id.ExtendedAuditingSettingName),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server Extended Auditing Policy", segmentsStr)
 }
 
 func (id ServerExtendedAuditingPolicyId) ID(_ string) string {

--- a/azurerm/internal/services/mssql/parse/sql_virtual_machine.go
+++ b/azurerm/internal/services/mssql/parse/sql_virtual_machine.go
@@ -25,10 +25,11 @@ func NewSqlVirtualMachineID(subscriptionId, resourceGroup, name string) SqlVirtu
 
 func (id SqlVirtualMachineId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Sql Virtual Machine", segmentsStr)
 }
 
 func (id SqlVirtualMachineId) ID(_ string) string {

--- a/azurerm/internal/services/mysql/parse/key.go
+++ b/azurerm/internal/services/mysql/parse/key.go
@@ -27,11 +27,12 @@ func NewKeyID(subscriptionId, resourceGroup, serverName, name string) KeyId {
 
 func (id KeyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Key", segmentsStr)
 }
 
 func (id KeyId) ID(_ string) string {

--- a/azurerm/internal/services/mysql/parse/server.go
+++ b/azurerm/internal/services/mysql/parse/server.go
@@ -25,10 +25,11 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 
 func (id ServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server", segmentsStr)
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/account.go
+++ b/azurerm/internal/services/netapp/parse/account.go
@@ -25,10 +25,11 @@ func NewAccountID(subscriptionId, resourceGroup, netAppAccountName string) Accou
 
 func (id AccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Account", segmentsStr)
 }
 
 func (id AccountId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/capacity_pool.go
+++ b/azurerm/internal/services/netapp/parse/capacity_pool.go
@@ -27,11 +27,12 @@ func NewCapacityPoolID(subscriptionId, resourceGroup, netAppAccountName, name st
 
 func (id CapacityPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Capacity Pool", segmentsStr)
 }
 
 func (id CapacityPoolId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/snapshot.go
+++ b/azurerm/internal/services/netapp/parse/snapshot.go
@@ -31,13 +31,14 @@ func NewSnapshotID(subscriptionId, resourceGroup, netAppAccountName, capacityPoo
 
 func (id SnapshotId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
-		fmt.Sprintf("Capacity Pool Name %q", id.CapacityPoolName),
-		fmt.Sprintf("Volume Name %q", id.VolumeName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Volume Name %q", id.VolumeName),
+		fmt.Sprintf("Capacity Pool Name %q", id.CapacityPoolName),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Snapshot", segmentsStr)
 }
 
 func (id SnapshotId) ID(_ string) string {

--- a/azurerm/internal/services/netapp/parse/volume.go
+++ b/azurerm/internal/services/netapp/parse/volume.go
@@ -29,12 +29,13 @@ func NewVolumeID(subscriptionId, resourceGroup, netAppAccountName, capacityPoolN
 
 func (id VolumeId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
-		fmt.Sprintf("Capacity Pool Name %q", id.CapacityPoolName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Capacity Pool Name %q", id.CapacityPoolName),
+		fmt.Sprintf("Net App Account Name %q", id.NetAppAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Volume", segmentsStr)
 }
 
 func (id VolumeId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/bgp_connection.go
+++ b/azurerm/internal/services/network/parse/bgp_connection.go
@@ -27,11 +27,12 @@ func NewBgpConnectionID(subscriptionId, resourceGroup, virtualHubName, name stri
 
 func (id BgpConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Bgp Connection", segmentsStr)
 }
 
 func (id BgpConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/connection_monitor.go
+++ b/azurerm/internal/services/network/parse/connection_monitor.go
@@ -27,11 +27,12 @@ func NewConnectionMonitorID(subscriptionId, resourceGroup, networkWatcherName, n
 
 func (id ConnectionMonitorId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Network Watcher Name %q", id.NetworkWatcherName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Network Watcher Name %q", id.NetworkWatcherName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Connection Monitor", segmentsStr)
 }
 
 func (id ConnectionMonitorId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/hub_route_table.go
+++ b/azurerm/internal/services/network/parse/hub_route_table.go
@@ -27,11 +27,12 @@ func NewHubRouteTableID(subscriptionId, resourceGroup, virtualHubName, name stri
 
 func (id HubRouteTableId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Hub Route Table", segmentsStr)
 }
 
 func (id HubRouteTableId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/hub_virtual_network_connection.go
+++ b/azurerm/internal/services/network/parse/hub_virtual_network_connection.go
@@ -27,11 +27,12 @@ func NewHubVirtualNetworkConnectionID(subscriptionId, resourceGroup, virtualHubN
 
 func (id HubVirtualNetworkConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Hub Virtual Network Connection", segmentsStr)
 }
 
 func (id HubVirtualNetworkConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/ip_group.go
+++ b/azurerm/internal/services/network/parse/ip_group.go
@@ -25,10 +25,11 @@ func NewIpGroupID(subscriptionId, resourceGroup, name string) IpGroupId {
 
 func (id IpGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Ip Group", segmentsStr)
 }
 
 func (id IpGroupId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/nat_gateway.go
+++ b/azurerm/internal/services/network/parse/nat_gateway.go
@@ -25,10 +25,11 @@ func NewNatGatewayID(subscriptionId, resourceGroup, name string) NatGatewayId {
 
 func (id NatGatewayId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Nat Gateway", segmentsStr)
 }
 
 func (id NatGatewayId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/network_interface.go
+++ b/azurerm/internal/services/network/parse/network_interface.go
@@ -25,10 +25,11 @@ func NewNetworkInterfaceID(subscriptionId, resourceGroup, name string) NetworkIn
 
 func (id NetworkInterfaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Network Interface", segmentsStr)
 }
 
 func (id NetworkInterfaceId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/network_watcher.go
+++ b/azurerm/internal/services/network/parse/network_watcher.go
@@ -25,10 +25,11 @@ func NewNetworkWatcherID(subscriptionId, resourceGroup, name string) NetworkWatc
 
 func (id NetworkWatcherId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Network Watcher", segmentsStr)
 }
 
 func (id NetworkWatcherId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/packet_capture.go
+++ b/azurerm/internal/services/network/parse/packet_capture.go
@@ -27,11 +27,12 @@ func NewPacketCaptureID(subscriptionId, resourceGroup, networkWatcherName, name 
 
 func (id PacketCaptureId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Network Watcher Name %q", id.NetworkWatcherName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Network Watcher Name %q", id.NetworkWatcherName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Packet Capture", segmentsStr)
 }
 
 func (id PacketCaptureId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/private_dns_zone_config.go
+++ b/azurerm/internal/services/network/parse/private_dns_zone_config.go
@@ -29,12 +29,13 @@ func NewPrivateDnsZoneConfigID(subscriptionId, resourceGroup, privateEndpointNam
 
 func (id PrivateDnsZoneConfigId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Private Endpoint Name %q", id.PrivateEndpointName),
-		fmt.Sprintf("Private Dns Zone Group Name %q", id.PrivateDnsZoneGroupName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Private Dns Zone Group Name %q", id.PrivateDnsZoneGroupName),
+		fmt.Sprintf("Private Endpoint Name %q", id.PrivateEndpointName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Private Dns Zone Config", segmentsStr)
 }
 
 func (id PrivateDnsZoneConfigId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/private_dns_zone_group.go
+++ b/azurerm/internal/services/network/parse/private_dns_zone_group.go
@@ -27,11 +27,12 @@ func NewPrivateDnsZoneGroupID(subscriptionId, resourceGroup, privateEndpointName
 
 func (id PrivateDnsZoneGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Private Endpoint Name %q", id.PrivateEndpointName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Private Endpoint Name %q", id.PrivateEndpointName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Private Dns Zone Group", segmentsStr)
 }
 
 func (id PrivateDnsZoneGroupId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/private_endpoint.go
+++ b/azurerm/internal/services/network/parse/private_endpoint.go
@@ -25,10 +25,11 @@ func NewPrivateEndpointID(subscriptionId, resourceGroup, name string) PrivateEnd
 
 func (id PrivateEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Private Endpoint", segmentsStr)
 }
 
 func (id PrivateEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/public_ip_address.go
+++ b/azurerm/internal/services/network/parse/public_ip_address.go
@@ -25,10 +25,11 @@ func NewPublicIpAddressID(subscriptionId, resourceGroup, name string) PublicIpAd
 
 func (id PublicIpAddressId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Public Ip Address", segmentsStr)
 }
 
 func (id PublicIpAddressId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/route_filter.go
+++ b/azurerm/internal/services/network/parse/route_filter.go
@@ -25,10 +25,11 @@ func NewRouteFilterID(subscriptionId, resourceGroup, name string) RouteFilterId 
 
 func (id RouteFilterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Route Filter", segmentsStr)
 }
 
 func (id RouteFilterId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/security_partner_provider.go
+++ b/azurerm/internal/services/network/parse/security_partner_provider.go
@@ -25,10 +25,11 @@ func NewSecurityPartnerProviderID(subscriptionId, resourceGroup, name string) Se
 
 func (id SecurityPartnerProviderId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Security Partner Provider", segmentsStr)
 }
 
 func (id SecurityPartnerProviderId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/subnet.go
+++ b/azurerm/internal/services/network/parse/subnet.go
@@ -27,11 +27,12 @@ func NewSubnetID(subscriptionId, resourceGroup, virtualNetworkName, name string)
 
 func (id SubnetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Network Name %q", id.VirtualNetworkName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Virtual Network Name %q", id.VirtualNetworkName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subnet", segmentsStr)
 }
 
 func (id SubnetId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_hub.go
+++ b/azurerm/internal/services/network/parse/virtual_hub.go
@@ -25,10 +25,11 @@ func NewVirtualHubID(subscriptionId, resourceGroup, name string) VirtualHubId {
 
 func (id VirtualHubId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Hub", segmentsStr)
 }
 
 func (id VirtualHubId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_hub_ip_configuration.go
+++ b/azurerm/internal/services/network/parse/virtual_hub_ip_configuration.go
@@ -27,11 +27,12 @@ func NewVirtualHubIpConfigurationID(subscriptionId, resourceGroup, virtualHubNam
 
 func (id VirtualHubIpConfigurationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
 		fmt.Sprintf("Ip Configuration Name %q", id.IpConfigurationName),
+		fmt.Sprintf("Virtual Hub Name %q", id.VirtualHubName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Hub Ip Configuration", segmentsStr)
 }
 
 func (id VirtualHubIpConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_network.go
+++ b/azurerm/internal/services/network/parse/virtual_network.go
@@ -25,10 +25,11 @@ func NewVirtualNetworkID(subscriptionId, resourceGroup, name string) VirtualNetw
 
 func (id VirtualNetworkId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network", segmentsStr)
 }
 
 func (id VirtualNetworkId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/virtual_wan.go
+++ b/azurerm/internal/services/network/parse/virtual_wan.go
@@ -25,10 +25,11 @@ func NewVirtualWanID(subscriptionId, resourceGroup, name string) VirtualWanId {
 
 func (id VirtualWanId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Wan", segmentsStr)
 }
 
 func (id VirtualWanId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_connection.go
+++ b/azurerm/internal/services/network/parse/vpn_connection.go
@@ -27,11 +27,12 @@ func NewVpnConnectionID(subscriptionId, resourceGroup, vpnGatewayName, name stri
 
 func (id VpnConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Vpn Gateway Name %q", id.VpnGatewayName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Vpn Gateway Name %q", id.VpnGatewayName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Vpn Connection", segmentsStr)
 }
 
 func (id VpnConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_gateway.go
+++ b/azurerm/internal/services/network/parse/vpn_gateway.go
@@ -25,10 +25,11 @@ func NewVpnGatewayID(subscriptionId, resourceGroup, name string) VpnGatewayId {
 
 func (id VpnGatewayId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Vpn Gateway", segmentsStr)
 }
 
 func (id VpnGatewayId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_site.go
+++ b/azurerm/internal/services/network/parse/vpn_site.go
@@ -25,10 +25,11 @@ func NewVpnSiteID(subscriptionId, resourceGroup, name string) VpnSiteId {
 
 func (id VpnSiteId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Vpn Site", segmentsStr)
 }
 
 func (id VpnSiteId) ID(_ string) string {

--- a/azurerm/internal/services/network/parse/vpn_site_link.go
+++ b/azurerm/internal/services/network/parse/vpn_site_link.go
@@ -27,11 +27,12 @@ func NewVpnSiteLinkID(subscriptionId, resourceGroup, vpnSiteName, name string) V
 
 func (id VpnSiteLinkId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Vpn Site Name %q", id.VpnSiteName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Vpn Site Name %q", id.VpnSiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Vpn Site Link", segmentsStr)
 }
 
 func (id VpnSiteLinkId) ID(_ string) string {

--- a/azurerm/internal/services/notificationhub/parse/namespace.go
+++ b/azurerm/internal/services/notificationhub/parse/namespace.go
@@ -25,10 +25,11 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 
 func (id NamespaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/notificationhub/parse/notification_hub.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub.go
@@ -27,11 +27,12 @@ func NewNotificationHubID(subscriptionId, resourceGroup, namespaceName, name str
 
 func (id NotificationHubId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Notification Hub", segmentsStr)
 }
 
 func (id NotificationHubId) ID(_ string) string {

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
@@ -29,12 +29,13 @@ func NewNotificationHubAuthorizationRuleID(subscriptionId, resourceGroup, namesp
 
 func (id NotificationHubAuthorizationRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
-		fmt.Sprintf("Notification Hub Name %q", id.NotificationHubName),
 		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+		fmt.Sprintf("Notification Hub Name %q", id.NotificationHubName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Notification Hub Authorization Rule", segmentsStr)
 }
 
 func (id NotificationHubAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/portal/parse/dashboard.go
+++ b/azurerm/internal/services/portal/parse/dashboard.go
@@ -25,10 +25,11 @@ func NewDashboardID(subscriptionId, resourceGroup, name string) DashboardId {
 
 func (id DashboardId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Dashboard", segmentsStr)
 }
 
 func (id DashboardId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/azure_active_directory_administrator.go
+++ b/azurerm/internal/services/postgres/parse/azure_active_directory_administrator.go
@@ -27,11 +27,12 @@ func NewAzureActiveDirectoryAdministratorID(subscriptionId, resourceGroup, serve
 
 func (id AzureActiveDirectoryAdministratorId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Administrator Name %q", id.AdministratorName),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Azure Active Directory Administrator", segmentsStr)
 }
 
 func (id AzureActiveDirectoryAdministratorId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/configuration.go
+++ b/azurerm/internal/services/postgres/parse/configuration.go
@@ -27,11 +27,12 @@ func NewConfigurationID(subscriptionId, resourceGroup, serverName, name string) 
 
 func (id ConfigurationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Configuration", segmentsStr)
 }
 
 func (id ConfigurationId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/database.go
+++ b/azurerm/internal/services/postgres/parse/database.go
@@ -27,11 +27,12 @@ func NewDatabaseID(subscriptionId, resourceGroup, serverName, name string) Datab
 
 func (id DatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database", segmentsStr)
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/firewall_rule.go
+++ b/azurerm/internal/services/postgres/parse/firewall_rule.go
@@ -27,11 +27,12 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, serverName, name string) F
 
 func (id FirewallRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Rule", segmentsStr)
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/server.go
+++ b/azurerm/internal/services/postgres/parse/server.go
@@ -25,10 +25,11 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 
 func (id ServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server", segmentsStr)
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/server_key.go
+++ b/azurerm/internal/services/postgres/parse/server_key.go
@@ -27,11 +27,12 @@ func NewServerKeyID(subscriptionId, resourceGroup, serverName, keyName string) S
 
 func (id ServerKeyId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Key Name %q", id.KeyName),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server Key", segmentsStr)
 }
 
 func (id ServerKeyId) ID(_ string) string {

--- a/azurerm/internal/services/postgres/parse/virtual_network_rule.go
+++ b/azurerm/internal/services/postgres/parse/virtual_network_rule.go
@@ -27,11 +27,12 @@ func NewVirtualNetworkRuleID(subscriptionId, resourceGroup, serverName, name str
 
 func (id VirtualNetworkRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Rule", segmentsStr)
 }
 
 func (id VirtualNetworkRuleId) ID(_ string) string {

--- a/azurerm/internal/services/powerbi/parse/embedded.go
+++ b/azurerm/internal/services/powerbi/parse/embedded.go
@@ -25,10 +25,11 @@ func NewEmbeddedID(subscriptionId, resourceGroup, capacityName string) EmbeddedI
 
 func (id EmbeddedId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Capacity Name %q", id.CapacityName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Embedded", segmentsStr)
 }
 
 func (id EmbeddedId) ID(_ string) string {

--- a/azurerm/internal/services/privatedns/parse/private_dns_zone.go
+++ b/azurerm/internal/services/privatedns/parse/private_dns_zone.go
@@ -25,10 +25,11 @@ func NewPrivateDnsZoneID(subscriptionId, resourceGroup, name string) PrivateDnsZ
 
 func (id PrivateDnsZoneId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Private Dns Zone", segmentsStr)
 }
 
 func (id PrivateDnsZoneId) ID(_ string) string {

--- a/azurerm/internal/services/redis/parse/cache.go
+++ b/azurerm/internal/services/redis/parse/cache.go
@@ -25,10 +25,11 @@ func NewCacheID(subscriptionId, resourceGroup, rediName string) CacheId {
 
 func (id CacheId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Redi Name %q", id.RediName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cache", segmentsStr)
 }
 
 func (id CacheId) ID(_ string) string {

--- a/azurerm/internal/services/redis/parse/firewall_rule.go
+++ b/azurerm/internal/services/redis/parse/firewall_rule.go
@@ -27,11 +27,12 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, rediName, name string) Fir
 
 func (id FirewallRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Redi Name %q", id.RediName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Redi Name %q", id.RediName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Rule", segmentsStr)
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/redis/parse/linked_server.go
+++ b/azurerm/internal/services/redis/parse/linked_server.go
@@ -27,11 +27,12 @@ func NewLinkedServerID(subscriptionId, resourceGroup, rediName, name string) Lin
 
 func (id LinkedServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Redi Name %q", id.RediName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Redi Name %q", id.RediName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Linked Server", segmentsStr)
 }
 
 func (id LinkedServerId) ID(_ string) string {

--- a/azurerm/internal/services/relay/parse/hybrid_connection.go
+++ b/azurerm/internal/services/relay/parse/hybrid_connection.go
@@ -27,11 +27,12 @@ func NewHybridConnectionID(subscriptionId, resourceGroup, namespaceName, name st
 
 func (id HybridConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Hybrid Connection", segmentsStr)
 }
 
 func (id HybridConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/relay/parse/namespace.go
+++ b/azurerm/internal/services/relay/parse/namespace.go
@@ -25,10 +25,11 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 
 func (id NamespaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/resource/parse/resource_group.go
+++ b/azurerm/internal/services/resource/parse/resource_group.go
@@ -25,7 +25,8 @@ func (id ResourceGroupId) String() string {
 	segments := []string{
 		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Resource Group", segmentsStr)
 }
 
 func (id ResourceGroupId) ID(_ string) string {

--- a/azurerm/internal/services/resource/parse/resource_group_template_deployment.go
+++ b/azurerm/internal/services/resource/parse/resource_group_template_deployment.go
@@ -25,10 +25,11 @@ func NewResourceGroupTemplateDeploymentID(subscriptionId, resourceGroup, deploym
 
 func (id ResourceGroupTemplateDeploymentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Deployment Name %q", id.DeploymentName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Resource Group Template Deployment", segmentsStr)
 }
 
 func (id ResourceGroupTemplateDeploymentId) ID(_ string) string {

--- a/azurerm/internal/services/resource/parse/subscription_template_deployment.go
+++ b/azurerm/internal/services/resource/parse/subscription_template_deployment.go
@@ -25,7 +25,8 @@ func (id SubscriptionTemplateDeploymentId) String() string {
 	segments := []string{
 		fmt.Sprintf("Deployment Name %q", id.DeploymentName),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subscription Template Deployment", segmentsStr)
 }
 
 func (id SubscriptionTemplateDeploymentId) ID(_ string) string {

--- a/azurerm/internal/services/search/parse/search_service.go
+++ b/azurerm/internal/services/search/parse/search_service.go
@@ -25,10 +25,11 @@ func NewSearchServiceID(subscriptionId, resourceGroup, name string) SearchServic
 
 func (id SearchServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Search Service", segmentsStr)
 }
 
 func (id SearchServiceId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/namespace.go
+++ b/azurerm/internal/services/servicebus/parse/namespace.go
@@ -25,10 +25,11 @@ func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
 
 func (id NamespaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
 }
 
 func (id NamespaceId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/namespace_authorization_rule.go
+++ b/azurerm/internal/services/servicebus/parse/namespace_authorization_rule.go
@@ -27,11 +27,12 @@ func NewNamespaceAuthorizationRuleID(subscriptionId, resourceGroup, namespaceNam
 
 func (id NamespaceAuthorizationRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace Authorization Rule", segmentsStr)
 }
 
 func (id NamespaceAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/namespace_network_rule_set.go
+++ b/azurerm/internal/services/servicebus/parse/namespace_network_rule_set.go
@@ -27,11 +27,12 @@ func NewNamespaceNetworkRuleSetID(subscriptionId, resourceGroup, namespaceName, 
 
 func (id NamespaceNetworkRuleSetId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Networkruleset Name %q", id.NetworkrulesetName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace Network Rule Set", segmentsStr)
 }
 
 func (id NamespaceNetworkRuleSetId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/queue.go
+++ b/azurerm/internal/services/servicebus/parse/queue.go
@@ -27,11 +27,12 @@ func NewQueueID(subscriptionId, resourceGroup, namespaceName, name string) Queue
 
 func (id QueueId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Queue", segmentsStr)
 }
 
 func (id QueueId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/queue_authorization_rule.go
+++ b/azurerm/internal/services/servicebus/parse/queue_authorization_rule.go
@@ -29,12 +29,13 @@ func NewQueueAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, q
 
 func (id QueueAuthorizationRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
-		fmt.Sprintf("Queue Name %q", id.QueueName),
 		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+		fmt.Sprintf("Queue Name %q", id.QueueName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Queue Authorization Rule", segmentsStr)
 }
 
 func (id QueueAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/subscription.go
+++ b/azurerm/internal/services/servicebus/parse/subscription.go
@@ -29,12 +29,13 @@ func NewSubscriptionID(subscriptionId, resourceGroup, namespaceName, topicName, 
 
 func (id SubscriptionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
-		fmt.Sprintf("Topic Name %q", id.TopicName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Topic Name %q", id.TopicName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subscription", segmentsStr)
 }
 
 func (id SubscriptionId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/subscription_rule.go
+++ b/azurerm/internal/services/servicebus/parse/subscription_rule.go
@@ -31,13 +31,14 @@ func NewSubscriptionRuleID(subscriptionId, resourceGroup, namespaceName, topicNa
 
 func (id SubscriptionRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
-		fmt.Sprintf("Topic Name %q", id.TopicName),
-		fmt.Sprintf("Subscription Name %q", id.SubscriptionName),
 		fmt.Sprintf("Rule Name %q", id.RuleName),
+		fmt.Sprintf("Subscription Name %q", id.SubscriptionName),
+		fmt.Sprintf("Topic Name %q", id.TopicName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Subscription Rule", segmentsStr)
 }
 
 func (id SubscriptionRuleId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/topic.go
+++ b/azurerm/internal/services/servicebus/parse/topic.go
@@ -27,11 +27,12 @@ func NewTopicID(subscriptionId, resourceGroup, namespaceName, name string) Topic
 
 func (id TopicId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Topic", segmentsStr)
 }
 
 func (id TopicId) ID(_ string) string {

--- a/azurerm/internal/services/servicebus/parse/topic_authorization_rule.go
+++ b/azurerm/internal/services/servicebus/parse/topic_authorization_rule.go
@@ -29,12 +29,13 @@ func NewTopicAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, t
 
 func (id TopicAuthorizationRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
-		fmt.Sprintf("Topic Name %q", id.TopicName),
 		fmt.Sprintf("Authorization Rule Name %q", id.AuthorizationRuleName),
+		fmt.Sprintf("Topic Name %q", id.TopicName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Topic Authorization Rule", segmentsStr)
 }
 
 func (id TopicAuthorizationRuleId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabric/parse/cluster.go
+++ b/azurerm/internal/services/servicefabric/parse/cluster.go
@@ -25,10 +25,11 @@ func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
 
 func (id ClusterId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster", segmentsStr)
 }
 
 func (id ClusterId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/application.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/application.go
@@ -25,10 +25,11 @@ func NewApplicationID(subscriptionId, resourceGroup, name string) ApplicationId 
 
 func (id ApplicationId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Application", segmentsStr)
 }
 
 func (id ApplicationId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/network.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/network.go
@@ -25,10 +25,11 @@ func NewNetworkID(subscriptionId, resourceGroup, name string) NetworkId {
 
 func (id NetworkId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Network", segmentsStr)
 }
 
 func (id NetworkId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/secret.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/secret.go
@@ -25,10 +25,11 @@ func NewSecretID(subscriptionId, resourceGroup, name string) SecretId {
 
 func (id SecretId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Secret", segmentsStr)
 }
 
 func (id SecretId) ID(_ string) string {

--- a/azurerm/internal/services/servicefabricmesh/parse/secret_value.go
+++ b/azurerm/internal/services/servicefabricmesh/parse/secret_value.go
@@ -27,11 +27,12 @@ func NewSecretValueID(subscriptionId, resourceGroup, secretName, valueName strin
 
 func (id SecretValueId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Secret Name %q", id.SecretName),
 		fmt.Sprintf("Value Name %q", id.ValueName),
+		fmt.Sprintf("Secret Name %q", id.SecretName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Secret Value", segmentsStr)
 }
 
 func (id SecretValueId) ID(_ string) string {

--- a/azurerm/internal/services/signalr/parse/service.go
+++ b/azurerm/internal/services/signalr/parse/service.go
@@ -25,10 +25,11 @@ func NewServiceID(subscriptionId, resourceGroup, signalRName string) ServiceId {
 
 func (id ServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Signal R Name %q", id.SignalRName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Service", segmentsStr)
 }
 
 func (id ServiceId) ID(_ string) string {

--- a/azurerm/internal/services/springcloud/parse/spring_cloud_app.go
+++ b/azurerm/internal/services/springcloud/parse/spring_cloud_app.go
@@ -27,11 +27,12 @@ func NewSpringCloudAppID(subscriptionId, resourceGroup, springName, appName stri
 
 func (id SpringCloudAppId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Spring Name %q", id.SpringName),
 		fmt.Sprintf("App Name %q", id.AppName),
+		fmt.Sprintf("Spring Name %q", id.SpringName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Spring Cloud App", segmentsStr)
 }
 
 func (id SpringCloudAppId) ID(_ string) string {

--- a/azurerm/internal/services/springcloud/parse/spring_cloud_certificate.go
+++ b/azurerm/internal/services/springcloud/parse/spring_cloud_certificate.go
@@ -27,11 +27,12 @@ func NewSpringCloudCertificateID(subscriptionId, resourceGroup, springName, cert
 
 func (id SpringCloudCertificateId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Spring Name %q", id.SpringName),
 		fmt.Sprintf("Certificate Name %q", id.CertificateName),
+		fmt.Sprintf("Spring Name %q", id.SpringName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Spring Cloud Certificate", segmentsStr)
 }
 
 func (id SpringCloudCertificateId) ID(_ string) string {

--- a/azurerm/internal/services/springcloud/parse/spring_cloud_service.go
+++ b/azurerm/internal/services/springcloud/parse/spring_cloud_service.go
@@ -25,10 +25,11 @@ func NewSpringCloudServiceID(subscriptionId, resourceGroup, springName string) S
 
 func (id SpringCloudServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Spring Name %q", id.SpringName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Spring Cloud Service", segmentsStr)
 }
 
 func (id SpringCloudServiceId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/azure_active_directory_administrator.go
+++ b/azurerm/internal/services/sql/parse/azure_active_directory_administrator.go
@@ -27,11 +27,12 @@ func NewAzureActiveDirectoryAdministratorID(subscriptionId, resourceGroup, serve
 
 func (id AzureActiveDirectoryAdministratorId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Administrator Name %q", id.AdministratorName),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Azure Active Directory Administrator", segmentsStr)
 }
 
 func (id AzureActiveDirectoryAdministratorId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/database.go
+++ b/azurerm/internal/services/sql/parse/database.go
@@ -27,11 +27,12 @@ func NewDatabaseID(subscriptionId, resourceGroup, serverName, name string) Datab
 
 func (id DatabaseId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Database", segmentsStr)
 }
 
 func (id DatabaseId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/elastic_pool.go
+++ b/azurerm/internal/services/sql/parse/elastic_pool.go
@@ -27,11 +27,12 @@ func NewElasticPoolID(subscriptionId, resourceGroup, serverName, name string) El
 
 func (id ElasticPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Elastic Pool", segmentsStr)
 }
 
 func (id ElasticPoolId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/failover_group.go
+++ b/azurerm/internal/services/sql/parse/failover_group.go
@@ -27,11 +27,12 @@ func NewFailoverGroupID(subscriptionId, resourceGroup, serverName, name string) 
 
 func (id FailoverGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Failover Group", segmentsStr)
 }
 
 func (id FailoverGroupId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/firewall_rule.go
+++ b/azurerm/internal/services/sql/parse/firewall_rule.go
@@ -27,11 +27,12 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, serverName, name string) F
 
 func (id FirewallRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Rule", segmentsStr)
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/server.go
+++ b/azurerm/internal/services/sql/parse/server.go
@@ -25,10 +25,11 @@ func NewServerID(subscriptionId, resourceGroup, name string) ServerId {
 
 func (id ServerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Server", segmentsStr)
 }
 
 func (id ServerId) ID(_ string) string {

--- a/azurerm/internal/services/sql/parse/virtual_network_rule.go
+++ b/azurerm/internal/services/sql/parse/virtual_network_rule.go
@@ -27,11 +27,12 @@ func NewVirtualNetworkRuleID(subscriptionId, resourceGroup, serverName, name str
 
 func (id VirtualNetworkRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Server Name %q", id.ServerName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Server Name %q", id.ServerName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Rule", segmentsStr)
 }
 
 func (id VirtualNetworkRuleId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/encryption_scope.go
+++ b/azurerm/internal/services/storage/parse/encryption_scope.go
@@ -27,11 +27,12 @@ func NewEncryptionScopeID(subscriptionId, resourceGroup, storageAccountName, nam
 
 func (id EncryptionScopeId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Encryption Scope", segmentsStr)
 }
 
 func (id EncryptionScopeId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_account.go
+++ b/azurerm/internal/services/storage/parse/storage_account.go
@@ -25,10 +25,11 @@ func NewStorageAccountID(subscriptionId, resourceGroup, name string) StorageAcco
 
 func (id StorageAccountId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Account", segmentsStr)
 }
 
 func (id StorageAccountId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_container_resource_manager.go
+++ b/azurerm/internal/services/storage/parse/storage_container_resource_manager.go
@@ -29,12 +29,13 @@ func NewStorageContainerResourceManagerID(subscriptionId, resourceGroup, storage
 
 func (id StorageContainerResourceManagerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
-		fmt.Sprintf("Blob Service Name %q", id.BlobServiceName),
 		fmt.Sprintf("Container Name %q", id.ContainerName),
+		fmt.Sprintf("Blob Service Name %q", id.BlobServiceName),
+		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Container Resource Manager", segmentsStr)
 }
 
 func (id StorageContainerResourceManagerId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_share_resource_manager.go
+++ b/azurerm/internal/services/storage/parse/storage_share_resource_manager.go
@@ -29,12 +29,13 @@ func NewStorageShareResourceManagerID(subscriptionId, resourceGroup, storageAcco
 
 func (id StorageShareResourceManagerId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
-		fmt.Sprintf("File Service Name %q", id.FileServiceName),
 		fmt.Sprintf("Share Name %q", id.ShareName),
+		fmt.Sprintf("File Service Name %q", id.FileServiceName),
+		fmt.Sprintf("Storage Account Name %q", id.StorageAccountName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Share Resource Manager", segmentsStr)
 }
 
 func (id StorageShareResourceManagerId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_sync_cloud_endpoint.go
+++ b/azurerm/internal/services/storage/parse/storage_sync_cloud_endpoint.go
@@ -29,12 +29,13 @@ func NewStorageSyncCloudEndpointID(subscriptionId, resourceGroup, storageSyncSer
 
 func (id StorageSyncCloudEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Storage Sync Service Name %q", id.StorageSyncServiceName),
-		fmt.Sprintf("Sync Group Name %q", id.SyncGroupName),
 		fmt.Sprintf("Cloud Endpoint Name %q", id.CloudEndpointName),
+		fmt.Sprintf("Sync Group Name %q", id.SyncGroupName),
+		fmt.Sprintf("Storage Sync Service Name %q", id.StorageSyncServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Sync Cloud Endpoint", segmentsStr)
 }
 
 func (id StorageSyncCloudEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_sync_group.go
+++ b/azurerm/internal/services/storage/parse/storage_sync_group.go
@@ -27,11 +27,12 @@ func NewStorageSyncGroupID(subscriptionId, resourceGroup, storageSyncServiceName
 
 func (id StorageSyncGroupId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Storage Sync Service Name %q", id.StorageSyncServiceName),
 		fmt.Sprintf("Sync Group Name %q", id.SyncGroupName),
+		fmt.Sprintf("Storage Sync Service Name %q", id.StorageSyncServiceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Sync Group", segmentsStr)
 }
 
 func (id StorageSyncGroupId) ID(_ string) string {

--- a/azurerm/internal/services/storage/parse/storage_sync_service.go
+++ b/azurerm/internal/services/storage/parse/storage_sync_service.go
@@ -25,10 +25,11 @@ func NewStorageSyncServiceID(subscriptionId, resourceGroup, name string) Storage
 
 func (id StorageSyncServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Storage Sync Service", segmentsStr)
 }
 
 func (id StorageSyncServiceId) ID(_ string) string {

--- a/azurerm/internal/services/streamanalytics/parse/stream_input.go
+++ b/azurerm/internal/services/streamanalytics/parse/stream_input.go
@@ -27,11 +27,12 @@ func NewStreamInputID(subscriptionId, resourceGroup, streamingjobName, inputName
 
 func (id StreamInputId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Streamingjob Name %q", id.StreamingjobName),
 		fmt.Sprintf("Input Name %q", id.InputName),
+		fmt.Sprintf("Streamingjob Name %q", id.StreamingjobName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Stream Input", segmentsStr)
 }
 
 func (id StreamInputId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/firewall_rule.go
+++ b/azurerm/internal/services/synapse/parse/firewall_rule.go
@@ -27,11 +27,12 @@ func NewFirewallRuleID(subscriptionId, resourceGroup, workspaceName, name string
 
 func (id FirewallRuleId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Rule", segmentsStr)
 }
 
 func (id FirewallRuleId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/spark_pool.go
+++ b/azurerm/internal/services/synapse/parse/spark_pool.go
@@ -27,11 +27,12 @@ func NewSparkPoolID(subscriptionId, resourceGroup, workspaceName, bigDataPoolNam
 
 func (id SparkPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Big Data Pool Name %q", id.BigDataPoolName),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Spark Pool", segmentsStr)
 }
 
 func (id SparkPoolId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/sql_pool.go
+++ b/azurerm/internal/services/synapse/parse/sql_pool.go
@@ -27,11 +27,12 @@ func NewSqlPoolID(subscriptionId, resourceGroup, workspaceName, name string) Sql
 
 func (id SqlPoolId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Workspace Name %q", id.WorkspaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Sql Pool", segmentsStr)
 }
 
 func (id SqlPoolId) ID(_ string) string {

--- a/azurerm/internal/services/synapse/parse/workspace.go
+++ b/azurerm/internal/services/synapse/parse/workspace.go
@@ -25,10 +25,11 @@ func NewWorkspaceID(subscriptionId, resourceGroup, name string) WorkspaceId {
 
 func (id WorkspaceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Workspace", segmentsStr)
 }
 
 func (id WorkspaceId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/azure_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/azure_endpoint.go
@@ -27,11 +27,12 @@ func NewAzureEndpointID(subscriptionId, resourceGroup, trafficManagerProfileName
 
 func (id AzureEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Azure Endpoint", segmentsStr)
 }
 
 func (id AzureEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/external_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/external_endpoint.go
@@ -27,11 +27,12 @@ func NewExternalEndpointID(subscriptionId, resourceGroup, trafficManagerProfileN
 
 func (id ExternalEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "External Endpoint", segmentsStr)
 }
 
 func (id ExternalEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/nested_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/parse/nested_endpoint.go
@@ -27,11 +27,12 @@ func NewNestedEndpointID(subscriptionId, resourceGroup, trafficManagerProfileNam
 
 func (id NestedEndpointId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Traffic Manager Profile Name %q", id.TrafficManagerProfileName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Nested Endpoint", segmentsStr)
 }
 
 func (id NestedEndpointId) ID(_ string) string {

--- a/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile.go
+++ b/azurerm/internal/services/trafficmanager/parse/traffic_manager_profile.go
@@ -25,10 +25,11 @@ func NewTrafficManagerProfileID(subscriptionId, resourceGroup, name string) Traf
 
 func (id TrafficManagerProfileId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Traffic Manager Profile", segmentsStr)
 }
 
 func (id TrafficManagerProfileId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service.go
+++ b/azurerm/internal/services/web/parse/app_service.go
@@ -25,10 +25,11 @@ func NewAppServiceID(subscriptionId, resourceGroup, siteName string) AppServiceI
 
 func (id AppServiceId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "App Service", segmentsStr)
 }
 
 func (id AppServiceId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service_environment.go
+++ b/azurerm/internal/services/web/parse/app_service_environment.go
@@ -25,10 +25,11 @@ func NewAppServiceEnvironmentID(subscriptionId, resourceGroup, hostingEnvironmen
 
 func (id AppServiceEnvironmentId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Hosting Environment Name %q", id.HostingEnvironmentName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "App Service Environment", segmentsStr)
 }
 
 func (id AppServiceEnvironmentId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service_plan.go
+++ b/azurerm/internal/services/web/parse/app_service_plan.go
@@ -25,10 +25,11 @@ func NewAppServicePlanID(subscriptionId, resourceGroup, serverfarmName string) A
 
 func (id AppServicePlanId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Serverfarm Name %q", id.ServerfarmName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "App Service Plan", segmentsStr)
 }
 
 func (id AppServicePlanId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/app_service_slot.go
+++ b/azurerm/internal/services/web/parse/app_service_slot.go
@@ -27,11 +27,12 @@ func NewAppServiceSlotID(subscriptionId, resourceGroup, siteName, slotName strin
 
 func (id AppServiceSlotId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Site Name %q", id.SiteName),
 		fmt.Sprintf("Slot Name %q", id.SlotName),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "App Service Slot", segmentsStr)
 }
 
 func (id AppServiceSlotId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/certificate.go
+++ b/azurerm/internal/services/web/parse/certificate.go
@@ -25,10 +25,11 @@ func NewCertificateID(subscriptionId, resourceGroup, name string) CertificateId 
 
 func (id CertificateId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Certificate", segmentsStr)
 }
 
 func (id CertificateId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/certificate_order.go
+++ b/azurerm/internal/services/web/parse/certificate_order.go
@@ -25,10 +25,11 @@ func NewCertificateOrderID(subscriptionId, resourceGroup, name string) Certifica
 
 func (id CertificateOrderId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Certificate Order", segmentsStr)
 }
 
 func (id CertificateOrderId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/function_app.go
+++ b/azurerm/internal/services/web/parse/function_app.go
@@ -25,10 +25,11 @@ func NewFunctionAppID(subscriptionId, resourceGroup, siteName string) FunctionAp
 
 func (id FunctionAppId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Function App", segmentsStr)
 }
 
 func (id FunctionAppId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/function_app_slot.go
+++ b/azurerm/internal/services/web/parse/function_app_slot.go
@@ -27,11 +27,12 @@ func NewFunctionAppSlotID(subscriptionId, resourceGroup, siteName, slotName stri
 
 func (id FunctionAppSlotId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Site Name %q", id.SiteName),
 		fmt.Sprintf("Slot Name %q", id.SlotName),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Function App Slot", segmentsStr)
 }
 
 func (id FunctionAppSlotId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/hostname_binding.go
+++ b/azurerm/internal/services/web/parse/hostname_binding.go
@@ -27,11 +27,12 @@ func NewHostnameBindingID(subscriptionId, resourceGroup, siteName, name string) 
 
 func (id HostnameBindingId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Site Name %q", id.SiteName),
 		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Hostname Binding", segmentsStr)
 }
 
 func (id HostnameBindingId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/hybrid_connection.go
+++ b/azurerm/internal/services/web/parse/hybrid_connection.go
@@ -29,12 +29,13 @@ func NewHybridConnectionID(subscriptionId, resourceGroup, siteName, hybridConnec
 
 func (id HybridConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Site Name %q", id.SiteName),
-		fmt.Sprintf("Hybrid Connection Namespace Name %q", id.HybridConnectionNamespaceName),
 		fmt.Sprintf("Relay Name %q", id.RelayName),
+		fmt.Sprintf("Hybrid Connection Namespace Name %q", id.HybridConnectionNamespaceName),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Hybrid Connection", segmentsStr)
 }
 
 func (id HybridConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/managed_certificate.go
+++ b/azurerm/internal/services/web/parse/managed_certificate.go
@@ -25,10 +25,11 @@ func NewManagedCertificateID(subscriptionId, resourceGroup, certificateName stri
 
 func (id ManagedCertificateId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Certificate Name %q", id.CertificateName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Managed Certificate", segmentsStr)
 }
 
 func (id ManagedCertificateId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/slot_virtual_network_swift_connection.go
+++ b/azurerm/internal/services/web/parse/slot_virtual_network_swift_connection.go
@@ -29,12 +29,13 @@ func NewSlotVirtualNetworkSwiftConnectionID(subscriptionId, resourceGroup, siteN
 
 func (id SlotVirtualNetworkSwiftConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Site Name %q", id.SiteName),
-		fmt.Sprintf("Slot Name %q", id.SlotName),
 		fmt.Sprintf("Config Name %q", id.ConfigName),
+		fmt.Sprintf("Slot Name %q", id.SlotName),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Slot Virtual Network Swift Connection", segmentsStr)
 }
 
 func (id SlotVirtualNetworkSwiftConnectionId) ID(_ string) string {

--- a/azurerm/internal/services/web/parse/virtual_network_swift_connection.go
+++ b/azurerm/internal/services/web/parse/virtual_network_swift_connection.go
@@ -27,11 +27,12 @@ func NewVirtualNetworkSwiftConnectionID(subscriptionId, resourceGroup, siteName,
 
 func (id VirtualNetworkSwiftConnectionId) String() string {
 	segments := []string{
-		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
-		fmt.Sprintf("Site Name %q", id.SiteName),
 		fmt.Sprintf("Config Name %q", id.ConfigName),
+		fmt.Sprintf("Site Name %q", id.SiteName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Swift Connection", segmentsStr)
 }
 
 func (id VirtualNetworkSwiftConnectionId) ID(_ string) string {

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -387,15 +387,22 @@ func (id ResourceIdGenerator) codeForDescription() string {
 		humanReadableKey := makeHumanReadable(segment.FieldName)
 		formatKeys = append(formatKeys, fmt.Sprintf("\t\tfmt.Sprintf(\"%[1]s %%q\", id.%[2]s),", humanReadableKey, segment.FieldName))
 	}
-	formatKeysString := strings.Join(formatKeys, "\n")
+
+	reversedKeys := make([]string, 0)
+	for i := len(formatKeys); i != 0; i-- {
+		reversedKeys = append(reversedKeys, formatKeys[i-1])
+	}
+
+	formatKeysString := strings.Join(reversedKeys, "\n")
 	return fmt.Sprintf(`
 func (id %[1]sId) String() string {
 	segments := []string{
 %s
 	}
-	return strings.Join(segments, " / ")
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%%s: (%%s)", %[3]q, segmentsStr)
 }
-`, id.TypeName, formatKeysString)
+`, id.TypeName, formatKeysString, makeHumanReadable(id.TypeName))
 }
 
 func (id ResourceIdGenerator) codeForFormatter() string {


### PR DESCRIPTION
This better matches the existing output - example:

```go
type ApiDiagnosticId struct {
	SubscriptionId string
	ResourceGroup  string
	ServiceName    string
	ApiName        string
	DiagnosticName string
}

func (id ApiDiagnosticId) String() string {
	segments := []string{
		fmt.Sprintf("Diagnostic Name %q", id.DiagnosticName),
		fmt.Sprintf("Api Name %q", id.ApiName),
		fmt.Sprintf("Service Name %q", id.ServiceName),
		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
	}
	segmentsStr := strings.Join(segments, " / ")
	return fmt.Sprintf("%s: (%s)", "Api Diagnostic", segmentsStr)
}
```

Ultimately this makes this easier to consume in error messages directly e.g.:

``` go
return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
return fmt.Errorf("retrieving %s: %+v", id, err)
```

Prior to this being merged the generator will need re-running against everything - but I've intentionally not done that due to open PR's