### PR TITLE
missing changes from 9415

### DIFF
--- a/azurerm/internal/services/web/app_service_certificate_binding_resource.go
+++ b/azurerm/internal/services/web/app_service_certificate_binding_resource.go
@@ -129,7 +129,7 @@ func resourceArmAppServiceCertificateBindingCreate(d *schema.ResourceData, meta 
 	props := binding.HostNameBindingProperties
 	if props != nil {
 		if props.Thumbprint != nil && *props.Thumbprint == *thumbprint {
-			return tf.ImportAsExistsError(appServiceHostnameBindingResourceName, id.ID(""))
+			return tf.ImportAsExistsError("azurerm_app_service_certificate_binding", id.ID(""))
 		}
 	}
 

--- a/azurerm/internal/services/web/app_service_certificate_binding_resource_test.go
+++ b/azurerm/internal/services/web/app_service_certificate_binding_resource_test.go
@@ -33,6 +33,22 @@ func TestAccAzureRMAppServiceCertificateBinding_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceCertificateBinding_basicSniEnabled(t *testing.T) {
+       data := acceptance.BuildTestData(t, "azurerm_app_service_certificate_binding", "test")
+       r := AppServiceCertificateBindingResource{}
+
+	       data.ResourceTest(t, r, []resource.TestStep{
+		               {
+		                       Config: r.basicSniEnabled(data),
+		                       Check: resource.ComposeTestCheckFunc(
+		                               check.That(data.ResourceName).Key("thumbprint").Exists(),
+		                               check.That(data.ResourceName).Key("ssl_state").HasValue("SniEnabled"),
+		                       ),
+		               },
+		               data.ImportStep(),
+		       })
+}
+
 func TestAccAzureRMAppServiceCertificateBinding_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_certificate_binding", "test")
 	r := AppServiceCertificateBindingResource{}
@@ -94,6 +110,23 @@ resource "azurerm_app_service_certificate_binding" "test" {
   hostname_binding_id = azurerm_app_service_custom_hostname_binding.test.id
   certificate_id      = azurerm_app_service_managed_certificate.test.id
   ssl_state           = "IpBasedEnabled"
+}
+
+%s
+`, template)
+}
+
+func (t AppServiceCertificateBindingResource) basicSniEnabled(data acceptance.TestData) string {
+	template := t.testAccCertificateBinding_template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_app_service_certificate_binding" "test" {
+  hostname_binding_id = azurerm_app_service_custom_hostname_binding.test.id
+  certificate_id      = azurerm_app_service_managed_certificate.test.id
+  ssl_state           = "SniEnabled"
 }
 
 %s

--- a/azurerm/internal/services/web/app_service_certificate_binding_resource_test.go
+++ b/azurerm/internal/services/web/app_service_certificate_binding_resource_test.go
@@ -34,19 +34,19 @@ func TestAccAzureRMAppServiceCertificateBinding_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAppServiceCertificateBinding_basicSniEnabled(t *testing.T) {
-       data := acceptance.BuildTestData(t, "azurerm_app_service_certificate_binding", "test")
-       r := AppServiceCertificateBindingResource{}
+	data := acceptance.BuildTestData(t, "azurerm_app_service_certificate_binding", "test")
+	r := AppServiceCertificateBindingResource{}
 
-	       data.ResourceTest(t, r, []resource.TestStep{
-		               {
-		                       Config: r.basicSniEnabled(data),
-		                       Check: resource.ComposeTestCheckFunc(
-		                               check.That(data.ResourceName).Key("thumbprint").Exists(),
-		                               check.That(data.ResourceName).Key("ssl_state").HasValue("SniEnabled"),
-		                       ),
-		               },
-		               data.ImportStep(),
-		       })
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basicSniEnabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("thumbprint").Exists(),
+				check.That(data.ResourceName).Key("ssl_state").HasValue("SniEnabled"),
+			),
+		},
+		data.ImportStep(),
+	})
 }
 
 func TestAccAzureRMAppServiceCertificateBinding_requiresImport(t *testing.T) {

--- a/azurerm/internal/services/web/parse/certificate_binding.go
+++ b/azurerm/internal/services/web/parse/certificate_binding.go
@@ -25,7 +25,6 @@ func (id CertificateBindingId) ID(_ string) string {
 }
 
 func CertificateBindingID(input string) (*CertificateBindingId, error) {
-	certificateBindingId := CertificateBindingId{}
 	idParts := strings.Split(input, "|")
 	if len(idParts) != 2 {
 		return nil, fmt.Errorf("could not parse Certificate Binding ID, expected two resource IDs joined by `|`")
@@ -40,8 +39,8 @@ func CertificateBindingID(input string) (*CertificateBindingId, error) {
 		return nil, fmt.Errorf("could not parse Certificate ID portion of Certificate Binding ID: %+v", err)
 	}
 
-	certificateBindingId.HostnameBindingId = *hostnameBindingId
-	certificateBindingId.CertificateId = *certificateId
-
-	return &certificateBindingId, nil
+	return &CertificateBindingId{
+		*hostnameBindingId,
+		*certificateId,
+	}, nil
 }


### PR DESCRIPTION
tests passing:
```
=== RUN   TestAccAzureRMAppServiceCertificateBinding_basic
=== PAUSE TestAccAzureRMAppServiceCertificateBinding_basic
=== CONT  TestAccAzureRMAppServiceCertificateBinding_basic
--- PASS: TestAccAzureRMAppServiceCertificateBinding_basic (256.72s)
=== RUN   TestAccAzureRMAppServiceCertificateBinding_basicSniEnabled
=== PAUSE TestAccAzureRMAppServiceCertificateBinding_basicSniEnabled
=== CONT  TestAccAzureRMAppServiceCertificateBinding_basicSniEnabled
--- PASS: TestAccAzureRMAppServiceCertificateBinding_basicSniEnabled (251.88s)
=== RUN   TestAccAzureRMAppServiceCertificateBinding_requiresImport
=== PAUSE TestAccAzureRMAppServiceCertificateBinding_requiresImport
=== CONT  TestAccAzureRMAppServiceCertificateBinding_requiresImport
--- PASS: TestAccAzureRMAppServiceCertificateBinding_requiresImport (271.13s)
PASS
```