### PR TITLE
dependencies: upgrading github.com/Azure/go-autorest/validation to v0.3.1

### DIFF
--- a/azurerm/internal/clients/client.go
+++ b/azurerm/internal/clients/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	advisor "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/advisor/client"
@@ -189,6 +190,8 @@ type Client struct {
 
 func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error {
 	autorest.Count429AsRetry = false
+	// Disable the Azure SDK for Go's validation since it's unhelpful for our use-case
+	validation.Disabled = true
 
 	client.Features = o.Features
 	client.StopContext = ctx

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v48.1.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.10
 	github.com/Azure/go-autorest/autorest/date v0.3.0
-	github.com/Azure/go-autorest/autorest/validation v0.3.0
+	github.com/Azure/go-autorest/autorest/validation v0.3.1
 	github.com/btubbs/datetime v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/Azure/go-autorest/autorest/validation v0.2.0 h1:15vMO4y76dehZSq7pAaOL
 github.com/Azure/go-autorest/autorest/validation v0.2.0/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=
 github.com/Azure/go-autorest/autorest/validation v0.3.0 h1:3I9AAI63HfcLtphd9g39ruUwRI+Ca+z/f36KHPFRUss=
 github.com/Azure/go-autorest/autorest/validation v0.3.0/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
+github.com/Azure/go-autorest/autorest/validation v0.3.1 h1:AgyqjAd94fwNAoTjl/WQXg4VvFeRFpO+UhNyRXqF1ac=
+github.com/Azure/go-autorest/autorest/validation v0.3.1/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
 github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=

--- a/vendor/github.com/Azure/go-autorest/autorest/validation/validation.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/validation/validation.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 )
 
+// Disabled controls if parameter validation should be globally disabled.  The default is false.
+var Disabled bool
+
 // Constraint stores constraint name, target field name
 // Rule and chain validations.
 type Constraint struct {
@@ -68,6 +71,9 @@ const (
 // Validate method validates constraints on parameter
 // passed in validation array.
 func Validate(m []Validation) error {
+	if Disabled {
+		return nil
+	}
 	for _, item := range m {
 		v := reflect.ValueOf(item.TargetValue)
 		for _, constraint := range item.Constraints {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,7 +125,7 @@ github.com/Azure/go-autorest/autorest/azure/cli
 github.com/Azure/go-autorest/autorest/date
 # github.com/Azure/go-autorest/autorest/to v0.4.0
 github.com/Azure/go-autorest/autorest/to
-# github.com/Azure/go-autorest/autorest/validation v0.3.0
+# github.com/Azure/go-autorest/autorest/validation v0.3.1
 github.com/Azure/go-autorest/autorest/validation
 # github.com/Azure/go-autorest/logger v0.2.0
 github.com/Azure/go-autorest/logger


### PR DESCRIPTION
This allows us to opt out of the Azure SDK's validation - since this isn't particularly helpful for Terraform's problem space since this only takes affect half way through an apply (when the API call is made), when this'll already be caught by Terraform's validation.