### PR TITLE
network/private-endpoint: allow alias as well

### DIFF
--- a/azurerm/internal/services/network/private_endpoint_resource.go
+++ b/azurerm/internal/services/network/private_endpoint_resource.go
@@ -106,10 +106,22 @@ func resourceArmPrivateEndpoint() *schema.Resource {
 							ForceNew: true,
 						},
 						"private_connection_resource_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: azure.ValidateResourceID,
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+								v, ok := i.(string)
+								if !ok {
+									errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+									return
+								}
+
+								if strings.HasSuffix(v, ".azure.privatelinkservice") {
+									return
+								}
+
+								return azure.ValidateResourceID(i, k)
+							},
 						},
 						"subresource_names": {
 							Type:     schema.TypeList,

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -95,6 +95,39 @@ resource "azurerm_private_endpoint" "example" {
 }
 ```
 
+Using a Private Link Service Alias with existing resources:
+
+```hcl
+data "azurerm_resource_group" "rg" {
+  name = "example-resources"
+}
+
+data "azurerm_virtual_network" "vnet" {
+  name                = "example-network"
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+data "azurerm_subnet" "subnet" {
+  name                 = "default"
+  virtual_network_name = data.azurerm_virtual_network.vnet.name
+  resource_group_name  = data.azurerm_resource_group.rg.name
+}
+
+resource "azurerm_private_endpoint" "example" {
+  name                = "example-endpoint"
+  location            = data.azurerm_resource_group.rg.location
+  resource_group_name = data.azurerm_resource_group.rg.name
+  subnet_id           = data.azurerm_subnet.subnet.id
+
+  private_service_connection {
+    name                           = "example-privateserviceconnection"
+    private_connection_resource_id = "example-privatelinkservice.d20286c8-4ea5-11eb-9584-8f53157226c6.centralus.azure.privatelinkservice"
+    is_manual_connection           = true
+    request_message                = "PL"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -131,7 +164,7 @@ A `private_service_connection` supports the following:
 
 -> **NOTE:** If you are trying to connect the Private Endpoint to a remote resource without having the correct RBAC permissions on the remote resource set this value to `true`.
 
-* `private_connection_resource_id` - (Required) The ID of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. Changing this forces a new resource to be created.
+* `private_connection_resource_id` - (Required) The ID (or Service Alias) of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. Changing this forces a new resource to be created.
 
 * `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
The input Resource ID may be a resource id or service alias.  This
validation is preventing the service alias from being accepted.  The
service alias has a standard suffix that can be used to validate the
input.

https://docs.microsoft.com/en-us/rest/api/virtualnetwork/privatelinkservices/get#privatelinkservice
https://docs.microsoft.com/en-us/rest/api/virtualnetwork/privateendpoints/createorupdate#privatelinkserviceconnection

It's not clear from the documentation, but I've verified that using the
Alias is functional this way.