### PR TITLE
remove vendor path from linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 run:
   deadline: 12m10s
   modules-download-mode: vendor
+  skip-dirs:
+    - vendor
 
 issues:
   max-per-linter: 0


### PR DESCRIPTION
Note: first run after this change will likely rebuild the GHA cache for the linter.