### PR TITLE
loganalytics: removing the superflurous `subscriptionId` argument from the ID func

### DIFF
--- a/azurerm/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
+++ b/azurerm/internal/services/desktopvirtualization/parse/workspace_application_group_association.go
@@ -3,7 +3,11 @@ package parse
 import (
 	"fmt"
 	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = WorkspaceApplicationGroupAssociationId{}
 
 type WorkspaceApplicationGroupAssociationId struct {
 	Workspace        WorkspaceId

--- a/azurerm/internal/services/loganalytics/log_analytics_cluster_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_cluster_resource.go
@@ -153,8 +153,7 @@ func resourceArmLogAnalyticsClusterCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("waiting for Log Analytics Cluster to finish updating %q (Resource Group %q): %v", id.ClusterName, id.ResourceGroup, err)
 	}
 
-	d.SetId(id.ID(subscriptionId))
-
+	d.SetId(id.ID(""))
 	return resourceArmLogAnalyticsClusterRead(d, meta)
 }
 

--- a/azurerm/internal/services/loganalytics/log_analytics_storage_insights_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_storage_insights_resource.go
@@ -119,7 +119,7 @@ func resourceArmLogAnalyticsStorageInsightsCreateUpdate(d *schema.ResourceData, 
 			}
 		}
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_log_analytics_storage_insights", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_log_analytics_storage_insights", id.ID(""))
 		}
 	}
 
@@ -142,7 +142,7 @@ func resourceArmLogAnalyticsStorageInsightsCreateUpdate(d *schema.ResourceData, 
 		return fmt.Errorf("creating/updating Log Analytics Storage Insights %q (Resource Group %q / workspaceName %q): %+v", name, resourceGroup, id.WorkspaceName, err)
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 	return resourceArmLogAnalyticsStorageInsightsRead(d, meta)
 }
 

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_migrate.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_migrate.go
@@ -30,7 +30,7 @@ func workspaceStateMigrateV0toV1(is *terraform.InstanceState, meta interface{}) 
 	resourceGroup := is.Attributes["resource_group"]
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	id := parse.NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, name)
-	is.ID = id.ID(subscriptionId)
+	is.ID = id.ID("")
 
 	return is, nil
 }

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -202,7 +202,7 @@ func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta i
 		return err
 	}
 
-	d.SetId(id.ID(subscriptionId))
+	d.SetId(id.ID(""))
 
 	return resourceArmLogAnalyticsWorkspaceRead(d, meta)
 }

--- a/azurerm/internal/services/securitycenter/parse/advanced_threat_protection.go
+++ b/azurerm/internal/services/securitycenter/parse/advanced_threat_protection.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = AdvancedThreatProtectionId{}
 
 type AdvancedThreatProtectionId struct {
 	TargetResourceID string

--- a/azurerm/internal/services/storage/parse/storage_container_data_plane.go
+++ b/azurerm/internal/services/storage/parse/storage_container_data_plane.go
@@ -5,10 +5,13 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/containers"
 )
 
 // TODO: tests for this
+
+var _ resourceid.Formatter = StorageContainerDataPlaneId{}
 
 type StorageContainerDataPlaneId struct {
 	AccountName  string

--- a/azurerm/internal/services/storage/parse/storage_queue_data_plane.go
+++ b/azurerm/internal/services/storage/parse/storage_queue_data_plane.go
@@ -5,10 +5,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/queue/queues"
 )
 
 // TODO: tests for this
+var _ resourceid.Formatter = StorageQueueDataPlaneId{}
 
 type StorageQueueDataPlaneId struct {
 	AccountName  string

--- a/azurerm/internal/services/storage/parse/storage_share_data_plane.go
+++ b/azurerm/internal/services/storage/parse/storage_share_data_plane.go
@@ -5,10 +5,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/file/shares"
 )
 
 // TODO: tests for this
+var _ resourceid.Formatter = StorageShareDataPlaneId{}
 
 type StorageShareDataPlaneId struct {
 	AccountName  string

--- a/azurerm/internal/services/storage/parse/storage_table_data_plane.go
+++ b/azurerm/internal/services/storage/parse/storage_table_data_plane.go
@@ -5,10 +5,12 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/table/tables"
 )
 
 // TODO: tests for this
+var _ resourceid.Formatter = StorageTableDataPlaneId{}
 
 type StorageTableDataPlaneId struct {
 	AccountName  string

--- a/azurerm/internal/services/synapse/parse/role_assignment.go
+++ b/azurerm/internal/services/synapse/parse/role_assignment.go
@@ -3,7 +3,11 @@ package parse
 import (
 	"fmt"
 	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = RoleAssignmentId{}
 
 type RoleAssignmentId struct {
 	Workspace             WorkspaceId


### PR DESCRIPTION
This is the last remnant, at which point we can remove this unnecessary argument from the formatter and re-generate