### PR TITLE
privatedns: refactoring to use a Resource ID Formatter/Parser

### DIFF
--- a/azurerm/internal/services/privatedns/parse/a_record.go
+++ b/azurerm/internal/services/privatedns/parse/a_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ARecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	AName              string
+}
+
+func NewARecordID(subscriptionId, resourceGroup, privateDnsZoneName, aName string) ARecordId {
+	return ARecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		AName:              aName,
+	}
+}
+
+func (id ARecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("A Name %q", id.AName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "A Record", segmentsStr)
+}
+
+func (id ARecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/A/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.AName)
+}
+
+// ARecordID parses a ARecord ID into an ARecordId struct
+func ARecordID(input string) (*ARecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ARecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.AName, err = id.PopSegment("A"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/a_record.go
+++ b/azurerm/internal/services/privatedns/parse/a_record.go
@@ -35,7 +35,7 @@ func (id ARecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "A Record", segmentsStr)
 }
 
-func (id ARecordId) ID(_ string) string {
+func (id ARecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/A/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.AName)
 }

--- a/azurerm/internal/services/privatedns/parse/a_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/a_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = ARecordId{}
+
+func TestARecordIDFormatter(t *testing.T) {
+	actual := NewARecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "eh1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/eh1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestARecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ARecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing AName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for AName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/eh1",
+			Expected: &ARecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				AName:              "eh1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/A/EH1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ARecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.AName != v.Expected.AName {
+			t.Fatalf("Expected %q but got %q for AName", v.Expected.AName, actual.AName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/a_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/a_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = ARecordId{}
 
 func TestARecordIDFormatter(t *testing.T) {
-	actual := NewARecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "eh1").ID("")
+	actual := NewARecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "eh1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/eh1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/aaaa_record.go
+++ b/azurerm/internal/services/privatedns/parse/aaaa_record.go
@@ -35,7 +35,7 @@ func (id AaaaRecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Aaaa Record", segmentsStr)
 }
 
-func (id AaaaRecordId) ID(_ string) string {
+func (id AaaaRecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/AAAA/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.AAAAName)
 }

--- a/azurerm/internal/services/privatedns/parse/aaaa_record.go
+++ b/azurerm/internal/services/privatedns/parse/aaaa_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type AaaaRecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	AAAAName           string
+}
+
+func NewAaaaRecordID(subscriptionId, resourceGroup, privateDnsZoneName, aAAAName string) AaaaRecordId {
+	return AaaaRecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		AAAAName:           aAAAName,
+	}
+}
+
+func (id AaaaRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("A A A A Name %q", id.AAAAName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Aaaa Record", segmentsStr)
+}
+
+func (id AaaaRecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/AAAA/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.AAAAName)
+}
+
+// AaaaRecordID parses a AaaaRecord ID into an AaaaRecordId struct
+func AaaaRecordID(input string) (*AaaaRecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AaaaRecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.AAAAName, err = id.PopSegment("AAAA"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/aaaa_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/aaaa_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = AaaaRecordId{}
+
+func TestAaaaRecordIDFormatter(t *testing.T) {
+	actual := NewAaaaRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "eheh1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/eheh1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestAaaaRecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AaaaRecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing AAAAName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for AAAAName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/eheh1",
+			Expected: &AaaaRecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				AAAAName:           "eheh1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/AAAA/EHEH1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AaaaRecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.AAAAName != v.Expected.AAAAName {
+			t.Fatalf("Expected %q but got %q for AAAAName", v.Expected.AAAAName, actual.AAAAName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/aaaa_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/aaaa_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = AaaaRecordId{}
 
 func TestAaaaRecordIDFormatter(t *testing.T) {
-	actual := NewAaaaRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "eheh1").ID("")
+	actual := NewAaaaRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "eheh1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/eheh1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/cname_record.go
+++ b/azurerm/internal/services/privatedns/parse/cname_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type CnameRecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	CNAMEName          string
+}
+
+func NewCnameRecordID(subscriptionId, resourceGroup, privateDnsZoneName, cNAMEName string) CnameRecordId {
+	return CnameRecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		CNAMEName:          cNAMEName,
+	}
+}
+
+func (id CnameRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("C N A M E Name %q", id.CNAMEName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cname Record", segmentsStr)
+}
+
+func (id CnameRecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/CNAME/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.CNAMEName)
+}
+
+// CnameRecordID parses a CnameRecord ID into an CnameRecordId struct
+func CnameRecordID(input string) (*CnameRecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := CnameRecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.CNAMEName, err = id.PopSegment("CNAME"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/cname_record.go
+++ b/azurerm/internal/services/privatedns/parse/cname_record.go
@@ -35,7 +35,7 @@ func (id CnameRecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Cname Record", segmentsStr)
 }
 
-func (id CnameRecordId) ID(_ string) string {
+func (id CnameRecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/CNAME/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.CNAMEName)
 }

--- a/azurerm/internal/services/privatedns/parse/cname_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/cname_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = CnameRecordId{}
+
+func TestCnameRecordIDFormatter(t *testing.T) {
+	actual := NewCnameRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "name1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/name1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestCnameRecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CnameRecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing CNAMEName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for CNAMEName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/name1",
+			Expected: &CnameRecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				CNAMEName:          "name1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/CNAME/NAME1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := CnameRecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.CNAMEName != v.Expected.CNAMEName {
+			t.Fatalf("Expected %q but got %q for CNAMEName", v.Expected.CNAMEName, actual.CNAMEName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/cname_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/cname_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = CnameRecordId{}
 
 func TestCnameRecordIDFormatter(t *testing.T) {
-	actual := NewCnameRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "name1").ID("")
+	actual := NewCnameRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "name1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/name1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/mx_record.go
+++ b/azurerm/internal/services/privatedns/parse/mx_record.go
@@ -35,7 +35,7 @@ func (id MxRecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Mx Record", segmentsStr)
 }
 
-func (id MxRecordId) ID(_ string) string {
+func (id MxRecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/MX/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.MXName)
 }

--- a/azurerm/internal/services/privatedns/parse/mx_record.go
+++ b/azurerm/internal/services/privatedns/parse/mx_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type MxRecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	MXName             string
+}
+
+func NewMxRecordID(subscriptionId, resourceGroup, privateDnsZoneName, mXName string) MxRecordId {
+	return MxRecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		MXName:             mXName,
+	}
+}
+
+func (id MxRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("M X Name %q", id.MXName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Mx Record", segmentsStr)
+}
+
+func (id MxRecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/MX/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.MXName)
+}
+
+// MxRecordID parses a MxRecord ID into an MxRecordId struct
+func MxRecordID(input string) (*MxRecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := MxRecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.MXName, err = id.PopSegment("MX"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/mx_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/mx_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = MxRecordId{}
 
 func TestMxRecordIDFormatter(t *testing.T) {
-	actual := NewMxRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "mx1").ID("")
+	actual := NewMxRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "mx1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/mx1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/mx_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/mx_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = MxRecordId{}
+
+func TestMxRecordIDFormatter(t *testing.T) {
+	actual := NewMxRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "mx1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/mx1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestMxRecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *MxRecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing MXName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for MXName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/mx1",
+			Expected: &MxRecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				MXName:             "mx1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/MX/MX1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := MxRecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.MXName != v.Expected.MXName {
+			t.Fatalf("Expected %q but got %q for MXName", v.Expected.MXName, actual.MXName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/ptr_record.go
+++ b/azurerm/internal/services/privatedns/parse/ptr_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type PtrRecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	PTRName            string
+}
+
+func NewPtrRecordID(subscriptionId, resourceGroup, privateDnsZoneName, pTRName string) PtrRecordId {
+	return PtrRecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		PTRName:            pTRName,
+	}
+}
+
+func (id PtrRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("P T R Name %q", id.PTRName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Ptr Record", segmentsStr)
+}
+
+func (id PtrRecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/PTR/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.PTRName)
+}
+
+// PtrRecordID parses a PtrRecord ID into an PtrRecordId struct
+func PtrRecordID(input string) (*PtrRecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := PtrRecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.PTRName, err = id.PopSegment("PTR"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/ptr_record.go
+++ b/azurerm/internal/services/privatedns/parse/ptr_record.go
@@ -35,7 +35,7 @@ func (id PtrRecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Ptr Record", segmentsStr)
 }
 
-func (id PtrRecordId) ID(_ string) string {
+func (id PtrRecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/PTR/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.PTRName)
 }

--- a/azurerm/internal/services/privatedns/parse/ptr_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/ptr_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = PtrRecordId{}
+
+func TestPtrRecordIDFormatter(t *testing.T) {
+	actual := NewPtrRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "ptr1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/ptr1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestPtrRecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *PtrRecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing PTRName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for PTRName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/ptr1",
+			Expected: &PtrRecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				PTRName:            "ptr1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/PTR/PTR1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := PtrRecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.PTRName != v.Expected.PTRName {
+			t.Fatalf("Expected %q but got %q for PTRName", v.Expected.PTRName, actual.PTRName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/ptr_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/ptr_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = PtrRecordId{}
 
 func TestPtrRecordIDFormatter(t *testing.T) {
-	actual := NewPtrRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "ptr1").ID("")
+	actual := NewPtrRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "ptr1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/ptr1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/srv_record.go
+++ b/azurerm/internal/services/privatedns/parse/srv_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type SrvRecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	SRVName            string
+}
+
+func NewSrvRecordID(subscriptionId, resourceGroup, privateDnsZoneName, sRVName string) SrvRecordId {
+	return SrvRecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		SRVName:            sRVName,
+	}
+}
+
+func (id SrvRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("S R V Name %q", id.SRVName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Srv Record", segmentsStr)
+}
+
+func (id SrvRecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/SRV/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.SRVName)
+}
+
+// SrvRecordID parses a SrvRecord ID into an SrvRecordId struct
+func SrvRecordID(input string) (*SrvRecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SrvRecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.SRVName, err = id.PopSegment("SRV"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/srv_record.go
+++ b/azurerm/internal/services/privatedns/parse/srv_record.go
@@ -35,7 +35,7 @@ func (id SrvRecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Srv Record", segmentsStr)
 }
 
-func (id SrvRecordId) ID(_ string) string {
+func (id SrvRecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/SRV/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.SRVName)
 }

--- a/azurerm/internal/services/privatedns/parse/srv_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/srv_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = SrvRecordId{}
 
 func TestSrvRecordIDFormatter(t *testing.T) {
-	actual := NewSrvRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "srv1").ID("")
+	actual := NewSrvRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "srv1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/srv1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/srv_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/srv_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = SrvRecordId{}
+
+func TestSrvRecordIDFormatter(t *testing.T) {
+	actual := NewSrvRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "srv1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/srv1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestSrvRecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SrvRecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing SRVName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for SRVName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/srv1",
+			Expected: &SrvRecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				SRVName:            "srv1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/SRV/SRV1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := SrvRecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.SRVName != v.Expected.SRVName {
+			t.Fatalf("Expected %q but got %q for SRVName", v.Expected.SRVName, actual.SRVName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/txt_record.go
+++ b/azurerm/internal/services/privatedns/parse/txt_record.go
@@ -35,7 +35,7 @@ func (id TxtRecordId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Txt Record", segmentsStr)
 }
 
-func (id TxtRecordId) ID(_ string) string {
+func (id TxtRecordId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/TXT/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.TXTName)
 }

--- a/azurerm/internal/services/privatedns/parse/txt_record.go
+++ b/azurerm/internal/services/privatedns/parse/txt_record.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type TxtRecordId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	TXTName            string
+}
+
+func NewTxtRecordID(subscriptionId, resourceGroup, privateDnsZoneName, tXTName string) TxtRecordId {
+	return TxtRecordId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		TXTName:            tXTName,
+	}
+}
+
+func (id TxtRecordId) String() string {
+	segments := []string{
+		fmt.Sprintf("T X T Name %q", id.TXTName),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Txt Record", segmentsStr)
+}
+
+func (id TxtRecordId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/TXT/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.TXTName)
+}
+
+// TxtRecordID parses a TxtRecord ID into an TxtRecordId struct
+func TxtRecordID(input string) (*TxtRecordId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := TxtRecordId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.TXTName, err = id.PopSegment("TXT"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/txt_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/txt_record_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = TxtRecordId{}
+
+func TestTxtRecordIDFormatter(t *testing.T) {
+	actual := NewTxtRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "txt1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/txt1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestTxtRecordID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *TxtRecordId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing TXTName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for TXTName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/txt1",
+			Expected: &TxtRecordId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				TXTName:            "txt1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/TXT/TXT1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := TxtRecordID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.TXTName != v.Expected.TXTName {
+			t.Fatalf("Expected %q but got %q for TXTName", v.Expected.TXTName, actual.TXTName)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/txt_record_test.go
+++ b/azurerm/internal/services/privatedns/parse/txt_record_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = TxtRecordId{}
 
 func TestTxtRecordIDFormatter(t *testing.T) {
-	actual := NewTxtRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "txt1").ID("")
+	actual := NewTxtRecordID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "txt1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/txt1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/parse/virtual_network_link.go
+++ b/azurerm/internal/services/privatedns/parse/virtual_network_link.go
@@ -35,7 +35,7 @@ func (id VirtualNetworkLinkId) String() string {
 	return fmt.Sprintf("%s: (%s)", "Virtual Network Link", segmentsStr)
 }
 
-func (id VirtualNetworkLinkId) ID(_ string) string {
+func (id VirtualNetworkLinkId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/virtualNetworkLinks/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.Name)
 }

--- a/azurerm/internal/services/privatedns/parse/virtual_network_link.go
+++ b/azurerm/internal/services/privatedns/parse/virtual_network_link.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type VirtualNetworkLinkId struct {
+	SubscriptionId     string
+	ResourceGroup      string
+	PrivateDnsZoneName string
+	Name               string
+}
+
+func NewVirtualNetworkLinkID(subscriptionId, resourceGroup, privateDnsZoneName, name string) VirtualNetworkLinkId {
+	return VirtualNetworkLinkId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroup:      resourceGroup,
+		PrivateDnsZoneName: privateDnsZoneName,
+		Name:               name,
+	}
+}
+
+func (id VirtualNetworkLinkId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Private Dns Zone Name %q", id.PrivateDnsZoneName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Link", segmentsStr)
+}
+
+func (id VirtualNetworkLinkId) ID(_ string) string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateDnsZones/%s/virtualNetworkLinks/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.PrivateDnsZoneName, id.Name)
+}
+
+// VirtualNetworkLinkID parses a VirtualNetworkLink ID into an VirtualNetworkLinkId struct
+func VirtualNetworkLinkID(input string) (*VirtualNetworkLinkId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := VirtualNetworkLinkId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.PrivateDnsZoneName, err = id.PopSegment("privateDnsZones"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("virtualNetworkLinks"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/privatedns/parse/virtual_network_link_test.go
+++ b/azurerm/internal/services/privatedns/parse/virtual_network_link_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualNetworkLinkId{}
+
+func TestVirtualNetworkLinkIDFormatter(t *testing.T) {
+	actual := NewVirtualNetworkLinkID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "virtualNetworkLink1").ID("")
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/virtualNetworkLink1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualNetworkLinkID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *VirtualNetworkLinkId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/virtualNetworkLink1",
+			Expected: &VirtualNetworkLinkId{
+				SubscriptionId:     "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:      "resGroup1",
+				PrivateDnsZoneName: "privateDnsZone1",
+				Name:               "virtualNetworkLink1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/VIRTUALNETWORKLINKS/VIRTUALNETWORKLINK1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := VirtualNetworkLinkID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.PrivateDnsZoneName != v.Expected.PrivateDnsZoneName {
+			t.Fatalf("Expected %q but got %q for PrivateDnsZoneName", v.Expected.PrivateDnsZoneName, actual.PrivateDnsZoneName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/parse/virtual_network_link_test.go
+++ b/azurerm/internal/services/privatedns/parse/virtual_network_link_test.go
@@ -11,7 +11,7 @@ import (
 var _ resourceid.Formatter = VirtualNetworkLinkId{}
 
 func TestVirtualNetworkLinkIDFormatter(t *testing.T) {
-	actual := NewVirtualNetworkLinkID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "virtualNetworkLink1").ID("")
+	actual := NewVirtualNetworkLinkID("12345678-1234-9876-4563-123456789012", "resGroup1", "privateDnsZone1", "virtualNetworkLink1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/virtualNetworkLink1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)

--- a/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +24,10 @@ func resourceArmPrivateDnsARecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsARecordRead,
 		Update: resourceArmPrivateDnsARecordCreateUpdate,
 		Delete: resourceArmPrivateDnsARecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.ARecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -172,8 +175,8 @@ func resourceArmPrivateDnsARecordDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	resGroup := id.ResourceGroup
-	name := id.Path["A"]
 	zoneName := id.Path["privateDnsZones"]
+	name := id.Path["A"]
 
 	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, privatedns.A, name, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
@@ -109,11 +109,10 @@ func resourceArmPrivateDnsARecordCreateUpdate(d *schema.ResourceData, meta inter
 	eTag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
 	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.A, resourceId.AName, parameters, eTag, ifNoneMatch); err != nil {
-		return fmt.Errorf("Error creating/updating Private DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsARecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
@@ -2,7 +2,6 @@ package privatedns
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
@@ -77,22 +76,20 @@ func resourceArmPrivateDnsARecord() *schema.Resource {
 
 func resourceArmPrivateDnsARecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	zoneName := d.Get("zone_name").(string)
-
+	resourceId := parse.NewARecordID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, zoneName, privatedns.A, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.A, resourceId.AName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Private DNS A Record %q (Private Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_private_dns_a_record", *existing.ID)
 		}
 	}
@@ -101,7 +98,7 @@ func resourceArmPrivateDnsARecordCreateUpdate(d *schema.ResourceData, meta inter
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := privatedns.RecordSet{
-		Name: &name,
+		Name: utils.String(resourceId.AName),
 		RecordSetProperties: &privatedns.RecordSetProperties{
 			Metadata: tags.Expand(t),
 			TTL:      &ttl,
@@ -111,17 +108,8 @@ func resourceArmPrivateDnsARecordCreateUpdate(d *schema.ResourceData, meta inter
 
 	eTag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
-	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.A, name, parameters, eTag, ifNoneMatch); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.A, resourceId.AName, parameters, eTag, ifNoneMatch); err != nil {
 		return fmt.Errorf("Error creating/updating Private DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.A, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Private DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Private DNS A Record %s (resource group %s) ID", name, resGroup)
 	}
 
 	d.SetId(*resp.ID)
@@ -134,33 +122,31 @@ func resourceArmPrivateDnsARecordRead(d *schema.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ARecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["A"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.A, name)
+	resp, err := dnsClient.Get(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.A, id.AName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Private DNS A record %s: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("zone_name", zoneName)
+	d.Set("name", id.AName)
+	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
 	d.Set("ttl", resp.TTL)
 	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("records", flattenAzureRmPrivateDnsARecords(resp.ARecords)); err != nil {
 		return err
 	}
+
 	return tags.FlattenAndSet(d, resp.Metadata)
 }
 
@@ -169,18 +155,13 @@ func resourceArmPrivateDnsARecordDelete(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ARecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	zoneName := id.Path["privateDnsZones"]
-	name := id.Path["A"]
-
-	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, privatedns.A, name, "")
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error deleting Private DNS A Record %s: %+v", name, err)
+	if _, err := dnsClient.Delete(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.A, id.AName, ""); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_a_record_resource.go
@@ -112,7 +112,7 @@ func resourceArmPrivateDnsARecordCreateUpdate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsARecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -109,7 +109,7 @@ func resourceArmPrivateDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta in
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsAaaaRecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -10,7 +10,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -21,9 +23,10 @@ func resourceArmPrivateDnsAaaaRecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsAaaaRecordRead,
 		Update: resourceArmPrivateDnsAaaaRecordCreateUpdate,
 		Delete: resourceArmPrivateDnsAaaaRecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.AaaaRecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -132,7 +132,7 @@ func resourceArmPrivateDnsAaaaRecordRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.PrivateDnsZoneName)
+	d.Set("name", id.AAAAName)
 	d.Set("zone_name", id.PrivateDnsZoneName)
 	d.Set("resource_group_name", id.ResourceGroup)
 

--- a/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -2,7 +2,6 @@ package privatedns
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
@@ -74,22 +73,20 @@ func resourceArmPrivateDnsAaaaRecord() *schema.Resource {
 
 func resourceArmPrivateDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	zoneName := d.Get("zone_name").(string)
-
+	resourceId := parse.NewAaaaRecordID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, zoneName, privatedns.AAAA, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.AAAA, resourceId.AAAAName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Private DNS AAAA Record %q (Private Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_private_dns_aaaa_record", *existing.ID)
 		}
 	}
@@ -98,7 +95,7 @@ func resourceArmPrivateDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta in
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := privatedns.RecordSet{
-		Name: &name,
+		Name: utils.String(resourceId.AAAAName),
 		RecordSetProperties: &privatedns.RecordSetProperties{
 			Metadata:    tags.Expand(t),
 			TTL:         &ttl,
@@ -108,21 +105,11 @@ func resourceArmPrivateDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta in
 
 	eTag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
-	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.AAAA, name, parameters, eTag, ifNoneMatch); err != nil {
-		return fmt.Errorf("Error creating/updating Private DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.AAAA, resourceId.AAAAName, parameters, eTag, ifNoneMatch); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.AAAA, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Private DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Private DNS AAAA Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsAaaaRecordRead(d, meta)
 }
 
@@ -131,27 +118,24 @@ func resourceArmPrivateDnsAaaaRecordRead(d *schema.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.AaaaRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["AAAA"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.AAAA, name)
+	resp, err := dnsClient.Get(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.AAAA, id.AAAAName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Private DNS AAAA record %s: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("zone_name", zoneName)
+	d.Set("name", id.PrivateDnsZoneName)
+	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
 	d.Set("ttl", resp.TTL)
 	d.Set("fqdn", resp.Fqdn)
 
@@ -166,18 +150,13 @@ func resourceArmPrivateDnsAaaaRecordDelete(d *schema.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.AaaaRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["AAAA"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, privatedns.AAAA, name, "")
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error deleting Private DNS AAAA Record %s: %+v", name, err)
+	if _, err := dnsClient.Delete(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.AAAA, id.AAAAName, ""); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -118,7 +118,7 @@ func resourceArmPrivateDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta i
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsCNameRecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -79,22 +79,20 @@ func resourceArmPrivateDnsCNameRecord() *schema.Resource {
 
 func resourceArmPrivateDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	zoneName := d.Get("zone_name").(string)
-
+	resourceId := parse.NewCnameRecordID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, zoneName, privatedns.CNAME, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.CNAME, resourceId.CNAMEName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Private DNS CNAME Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_private_dns_cname_record", *existing.ID)
 		}
 	}
@@ -104,7 +102,7 @@ func resourceArmPrivateDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta i
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := privatedns.RecordSet{
-		Name: &name,
+		Name: utils.String(resourceId.CNAMEName),
 		RecordSetProperties: &privatedns.RecordSetProperties{
 			Metadata: tags.Expand(t),
 			TTL:      &ttl,
@@ -116,21 +114,11 @@ func resourceArmPrivateDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta i
 
 	eTag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
-	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.CNAME, name, parameters, eTag, ifNoneMatch); err != nil {
-		return fmt.Errorf("Error creating/updating Private DNS CNAME Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.CNAME, resourceId.CNAMEName, parameters, eTag, ifNoneMatch); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.CNAME, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Private DNS CNAME Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Private DNS CNAME Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsCNameRecordRead(d, meta)
 }
 
@@ -139,27 +127,25 @@ func resourceArmPrivateDnsCNameRecordRead(d *schema.ResourceData, meta interface
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.CnameRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["CNAME"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.CNAME, name)
+	resp, err := dnsClient.Get(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.CNAME, id.CNAMEName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Private DNS CNAME record %s: %+v", name, err)
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("zone_name", zoneName)
+	d.Set("name", id.CNAMEName)
+	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
 	d.Set("ttl", resp.TTL)
 	d.Set("fqdn", resp.Fqdn)
 
@@ -177,18 +163,13 @@ func resourceArmPrivateDnsCNameRecordDelete(d *schema.ResourceData, meta interfa
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.CnameRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["CNAME"]
-	zoneName := id.Path["privateDnsZones"]
-
-	_, err = dnsClient.Delete(ctx, resGroup, zoneName, privatedns.CNAME, name, "")
-	if err != nil {
-		return fmt.Errorf("Error deleting Private DNS CNAME Record %s: %+v", name, err)
+	if _, err = dnsClient.Delete(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.CNAME, id.CNAMEName, ""); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +24,10 @@ func resourceArmPrivateDnsCNameRecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsCNameRecordRead,
 		Update: resourceArmPrivateDnsCNameRecordCreateUpdate,
 		Delete: resourceArmPrivateDnsCNameRecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.CnameRecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -95,22 +95,20 @@ func resourceArmPrivateDnsMxRecord() *schema.Resource {
 
 func resourceArmPrivateDnsMxRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	zoneName := d.Get("zone_name").(string)
-
+	resourceId := parse.NewMxRecordID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, zoneName, privatedns.MX, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.MX, resourceId.MXName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Private DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_private_dns_mx_record", *existing.ID)
 		}
 	}
@@ -119,7 +117,7 @@ func resourceArmPrivateDnsMxRecordCreateUpdate(d *schema.ResourceData, meta inte
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := privatedns.RecordSet{
-		Name: &name,
+		Name: utils.String(resourceId.MXName),
 		RecordSetProperties: &privatedns.RecordSetProperties{
 			Metadata:  tags.Expand(t),
 			TTL:       &ttl,
@@ -127,21 +125,11 @@ func resourceArmPrivateDnsMxRecordCreateUpdate(d *schema.ResourceData, meta inte
 		},
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.MX, name, parameters, "", ""); err != nil {
-		return fmt.Errorf("Error creating/updating Private DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.MX, resourceId.MXName, parameters, "", ""); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.MX, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Private DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Private DNS MX Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsMxRecordRead(d, meta)
 }
 
@@ -150,27 +138,25 @@ func resourceArmPrivateDnsMxRecordRead(d *schema.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.MxRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["MX"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.MX, name)
+	resp, err := dnsClient.Get(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.MX, id.MXName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Private DNS MX record %s: %+v", name, err)
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("zone_name", zoneName)
+	d.Set("name", id.MXName)
+	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
 	d.Set("ttl", resp.TTL)
 	d.Set("fqdn", resp.Fqdn)
 
@@ -186,17 +172,13 @@ func resourceArmPrivateDnsMxRecordDelete(d *schema.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.MxRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["MX"]
-	zoneName := id.Path["privateDnsZones"]
-
-	if _, err = dnsClient.Delete(ctx, resGroup, zoneName, privatedns.MX, name, ""); err != nil {
-		return fmt.Errorf("Error deleting Private DNS MX Record %s: %+v", name, err)
+	if _, err = dnsClient.Delete(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.MX, id.MXName, ""); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +24,10 @@ func resourceArmPrivateDnsMxRecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsMxRecordRead,
 		Update: resourceArmPrivateDnsMxRecordCreateUpdate,
 		Delete: resourceArmPrivateDnsMxRecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.MxRecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -129,7 +129,7 @@ func resourceArmPrivateDnsMxRecordCreateUpdate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsMxRecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_ptr_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_ptr_record_resource.go
@@ -116,7 +116,7 @@ func resourceArmPrivateDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsPtrRecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_ptr_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_ptr_record_resource.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +24,10 @@ func resourceArmPrivateDnsPtrRecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsPtrRecordRead,
 		Update: resourceArmPrivateDnsPtrRecordCreateUpdate,
 		Delete: resourceArmPrivateDnsPtrRecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.PtrRecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_ptr_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_ptr_record_resource.go
@@ -80,22 +80,20 @@ func resourceArmPrivateDnsPtrRecord() *schema.Resource {
 
 func resourceArmPrivateDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	zoneName := d.Get("zone_name").(string)
-
+	resourceId := parse.NewPtrRecordID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, zoneName, privatedns.PTR, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.PTR, resourceId.PTRName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Private DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
+		if !utils.ResponseWasNotFound(existing.Response) {
 			return tf.ImportAsExistsError("azurerm_private_dns_ptr_record", *existing.ID)
 		}
 	}
@@ -104,7 +102,7 @@ func resourceArmPrivateDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta int
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := privatedns.RecordSet{
-		Name: &name,
+		Name: utils.String(resourceId.PTRName),
 		RecordSetProperties: &privatedns.RecordSetProperties{
 			Metadata:   tags.Expand(t),
 			TTL:        &ttl,
@@ -114,21 +112,11 @@ func resourceArmPrivateDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta int
 
 	eTag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
-	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.PTR, name, parameters, eTag, ifNoneMatch); err != nil {
-		return fmt.Errorf("Error creating/updating Private DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.PTR, resourceId.PTRName, parameters, eTag, ifNoneMatch); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.PTR, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Private DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Private DNS PTR Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsPtrRecordRead(d, meta)
 }
 
@@ -137,33 +125,30 @@ func resourceArmPrivateDnsPtrRecordRead(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.PtrRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["PTR"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.PTR, name)
+	resp, err := dnsClient.Get(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.PTR, id.PTRName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Private DNS PTR record %s: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("zone_name", zoneName)
+	d.Set("name", id.PTRName)
+	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
 	d.Set("ttl", resp.TTL)
 	d.Set("fqdn", resp.Fqdn)
 
 	if props := resp.RecordSetProperties; props != nil {
-		if err := d.Set("records", flattenAzureRmPrivateDnsPtrRecords(resp.PtrRecords)); err != nil {
-			return fmt.Errorf("Error setting `records`: %+v", err)
+		if err := d.Set("records", flattenAzureRmPrivateDnsPtrRecords(props.PtrRecords)); err != nil {
+			return fmt.Errorf("setting `records`: %+v", err)
 		}
 	}
 
@@ -175,18 +160,13 @@ func resourceArmPrivateDnsPtrRecordDelete(d *schema.ResourceData, meta interface
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.PtrRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["PTR"]
-	zoneName := id.Path["privateDnsZones"]
-
-	_, err = dnsClient.Delete(ctx, resGroup, zoneName, privatedns.PTR, name, "")
-	if err != nil {
-		return fmt.Errorf("Error deleting Private DNS PTR Record %s: %+v", name, err)
+	if _, err = dnsClient.Delete(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.PTR, id.PTRName, ""); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -119,7 +119,7 @@ func resourceArmPrivateDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta int
 		}
 
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_private_dns_srv_record", resourceId.ID(""))
+			return tf.ImportAsExistsError("azurerm_private_dns_srv_record", resourceId.ID())
 		}
 	}
 
@@ -139,7 +139,7 @@ func resourceArmPrivateDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsSrvRecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +24,10 @@ func resourceArmPrivateDnsSrvRecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsSrvRecordRead,
 		Update: resourceArmPrivateDnsSrvRecordCreateUpdate,
 		Delete: resourceArmPrivateDnsSrvRecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.SrvRecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -105,23 +105,21 @@ func resourceArmPrivateDnsSrvRecord() *schema.Resource {
 
 func resourceArmPrivateDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	zoneName := d.Get("zone_name").(string)
-
+	resourceId := parse.NewSrvRecordID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, zoneName, privatedns.SRV, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.SRV, resourceId.SRVName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Private DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+				return fmt.Errorf("checking for presence of %s: %+v", resourceId, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_private_dns_srv_record", *existing.ID)
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_private_dns_srv_record", resourceId.ID(""))
 		}
 	}
 
@@ -129,7 +127,7 @@ func resourceArmPrivateDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta int
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := privatedns.RecordSet{
-		Name: &name,
+		Name: utils.String(resourceId.SRVName),
 		RecordSetProperties: &privatedns.RecordSetProperties{
 			Metadata:   tags.Expand(t),
 			TTL:        &ttl,
@@ -137,21 +135,11 @@ func resourceArmPrivateDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta int
 		},
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.SRV, name, parameters, "", ""); err != nil {
-		return fmt.Errorf("Error creating/updating Private DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.PrivateDnsZoneName, privatedns.SRV, resourceId.SRVName, parameters, "", ""); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.SRV, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Private DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read Private DNS SRV Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsSrvRecordRead(d, meta)
 }
 
@@ -160,27 +148,24 @@ func resourceArmPrivateDnsSrvRecordRead(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.SrvRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["SRV"]
-	zoneName := id.Path["privateDnsZones"]
-
-	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.SRV, name)
+	resp, err := dnsClient.Get(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.SRV, id.SRVName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Private DNS SRV record %s: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("zone_name", zoneName)
+	d.Set("name", id.SRVName)
+	d.Set("zone_name", id.PrivateDnsZoneName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
 	d.Set("ttl", resp.TTL)
 	d.Set("fqdn", resp.Fqdn)
 
@@ -196,18 +181,13 @@ func resourceArmPrivateDnsSrvRecordDelete(d *schema.ResourceData, meta interface
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.SrvRecordID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["SRV"]
-	zoneName := id.Path["privateDnsZones"]
-
-	_, err = dnsClient.Delete(ctx, resGroup, zoneName, privatedns.SRV, name, "")
-	if err != nil {
-		return fmt.Errorf("Error deleting Private DNS SRV Record %s: %+v", name, err)
+	if _, err = dnsClient.Delete(ctx, id.ResourceGroup, id.PrivateDnsZoneName, privatedns.SRV, id.SRVName, ""); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_txt_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_txt_record_resource.go
@@ -102,7 +102,7 @@ func resourceArmPrivateDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta int
 		}
 
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_private_dns_txt_record", resourceId.ID(""))
+			return tf.ImportAsExistsError("azurerm_private_dns_txt_record", resourceId.ID())
 		}
 	}
 
@@ -119,7 +119,7 @@ func resourceArmPrivateDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsTxtRecordRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_txt_record_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_txt_record_resource.go
@@ -12,7 +12,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -23,9 +25,10 @@ func resourceArmPrivateDnsTxtRecord() *schema.Resource {
 		Read:   resourceArmPrivateDnsTxtRecordRead,
 		Update: resourceArmPrivateDnsTxtRecordCreateUpdate,
 		Delete: resourceArmPrivateDnsTxtRecordDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.TxtRecordID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_txt_record_resource_test.go
+++ b/azurerm/internal/services/privatedns/private_dns_txt_record_resource_test.go
@@ -242,7 +242,7 @@ resource "azurerm_private_dns_zone" "test" {
 }
 
 resource "azurerm_private_dns_txt_record" "test" {
-  name                = "test%d"
+  name                = "testacctxt%d"
   resource_group_name = azurerm_resource_group.test.name
   zone_name           = azurerm_private_dns_zone.test.name
   ttl                 = 300

--- a/azurerm/internal/services/privatedns/private_dns_zone_data_source.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_data_source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -62,6 +63,7 @@ func dataSourceArmPrivateDnsZone() *schema.Resource {
 
 func dataSourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.PrivateZonesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -94,10 +96,9 @@ func dataSourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) e
 		resourceGroup = zone.resourceGroup
 	}
 
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("retrieving Private DNS Zone %q (Resource Group %q)", name, resourceGroup)
-	}
-	d.SetId(*resp.ID)
+	resourceId := parse.NewPrivateDnsZoneID(subscriptionId, resourceGroup, name)
+	d.SetId(resourceId.ID(""))
+
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)
 

--- a/azurerm/internal/services/privatedns/private_dns_zone_data_source.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_data_source.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -133,14 +132,14 @@ func findPrivateZone(ctx context.Context, client *privatedns.PrivateZonesClient,
 			continue
 		}
 
-		id, err := azure.ParseAzureResourceID(*z.ID)
+		id, err := parse.PrivateDnsZoneID(*z.ID)
 		if err != nil {
 			continue
 		}
 
-		zone, err := client.Get(ctx, id.ResourceGroup, name)
+		zone, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
-			return nil, fmt.Errorf("Error retrieving Private DNS Zone %q in resource group %q: %+v", name, id.ResourceGroup, err)
+			return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
 		return &privateDnsZone{

--- a/azurerm/internal/services/privatedns/private_dns_zone_data_source.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_data_source.go
@@ -96,7 +96,7 @@ func dataSourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	resourceId := parse.NewPrivateDnsZoneID(subscriptionId, resourceGroup, name)
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)

--- a/azurerm/internal/services/privatedns/private_dns_zone_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_resource.go
@@ -164,7 +164,7 @@ func resourceArmPrivateDnsZoneCreateUpdate(d *schema.ResourceData, meta interfac
 		}
 
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_private_dns_zone", resourceId.ID(""))
+			return tf.ImportAsExistsError("azurerm_private_dns_zone", resourceId.ID())
 		}
 	}
 
@@ -208,7 +208,7 @@ func resourceArmPrivateDnsZoneCreateUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsZoneRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/private_dns_zone_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_resource.go
@@ -12,8 +12,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -24,9 +26,10 @@ func resourceArmPrivateDnsZone() *schema.Resource {
 		Read:   resourceArmPrivateDnsZoneRead,
 		Update: resourceArmPrivateDnsZoneCreateUpdate,
 		Delete: resourceArmPrivateDnsZoneDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.PrivateDnsZoneID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -147,22 +150,21 @@ func resourceArmPrivateDnsZone() *schema.Resource {
 func resourceArmPrivateDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).PrivateDns.PrivateZonesClient
 	recordSetsClient := meta.(*clients.Client).PrivateDns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-
+	resourceId := parse.NewPrivateDnsZoneID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, name)
+		existing, err := client.Get(ctx, resourceId.ResourceGroup, resourceId.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("error checking for presence of existing Private DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
+				return fmt.Errorf("checking for presence of existing Private DNS Zone %q (Resource Group %q): %+v", resourceId.Name, resourceId.ResourceGroup, err)
 			}
 		}
 
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_private_dns_zone", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_private_dns_zone", resourceId.ID(""))
 		}
 	}
 
@@ -176,45 +178,37 @@ func resourceArmPrivateDnsZoneCreateUpdate(d *schema.ResourceData, meta interfac
 
 	etag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
-	future, err := client.CreateOrUpdate(ctx, resGroup, name, parameters, etag, ifNoneMatch)
+	future, err := client.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.Name, parameters, etag, ifNoneMatch)
 	if err != nil {
-		return fmt.Errorf("error creating/updating Private DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
+		return fmt.Errorf("creating/updating Private DNS Zone %q (Resource Group %q): %s", resourceId.Name, resourceId.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("error waiting for Private DNS Zone %q to become available: %+v", name, err)
-	}
-
-	resp, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		return fmt.Errorf("error retrieving Private DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
+		return fmt.Errorf("waiting for create/update of Private DNS Zone %q (Resource Group %q): %+v", resourceId.Name, resourceId.ResourceGroup, err)
 	}
 
 	if v, ok := d.GetOk("soa_record"); ok {
-		soaRecord := v.([]interface{})[0].(map[string]interface{})
+		soaRecordRaw := v.([]interface{})[0].(map[string]interface{})
+		soaRecord := expandArmPrivateDNSZoneSOARecord(soaRecordRaw)
 		rsParameters := privatedns.RecordSet{
 			RecordSetProperties: &privatedns.RecordSetProperties{
-				TTL:       utils.Int64(int64(soaRecord["ttl"].(int))),
-				Metadata:  tags.Expand(soaRecord["tags"].(map[string]interface{})),
-				SoaRecord: expandArmPrivateDNSZoneSOARecord(soaRecord),
+				TTL:       utils.Int64(int64(soaRecordRaw["ttl"].(int))),
+				Metadata:  tags.Expand(soaRecordRaw["tags"].(map[string]interface{})),
+				SoaRecord: soaRecord,
 			},
 		}
 
-		if len(name+strings.TrimSuffix(*rsParameters.RecordSetProperties.SoaRecord.Email, ".")) > 253 {
-			return fmt.Errorf("`email` which is concatenated with Private DNS Zone `name` cannot exceed 253 characters excluding a trailing period")
+		val := fmt.Sprintf("%s%s", resourceId.Name, strings.TrimSuffix(*soaRecord.Email, "."))
+		if len(val) > 253 {
+			return fmt.Errorf("the value %q for `email` which is concatenated with Private DNS Zone `name` cannot exceed 253 characters excluding a trailing period", val)
 		}
 
-		if _, err := recordSetsClient.CreateOrUpdate(ctx, resGroup, name, privatedns.SOA, "@", rsParameters, etag, ifNoneMatch); err != nil {
-			return fmt.Errorf("creating/updating Private DNS SOA Record @ (Zone %q / Resource Group %q): %s", name, resGroup, err)
+		if _, err := recordSetsClient.CreateOrUpdate(ctx, resourceId.ResourceGroup, resourceId.Name, privatedns.SOA, "@", rsParameters, etag, ifNoneMatch); err != nil {
+			return fmt.Errorf("creating/updating Private DNS SOA Record @ (Zone %q / Resource Group %q): %s", resourceId.Name, resourceId.ResourceGroup, err)
 		}
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("cannot read Private DNS Zone %q (Resource Group %q) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
-
+	d.SetId(resourceId.ID(""))
 	return resourceArmPrivateDnsZoneRead(d, meta)
 }
 
@@ -224,25 +218,27 @@ func resourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.PrivateDnsZoneID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["privateDnsZones"]
-
-	resp, err := client.Get(ctx, resGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("error reading Private DNS Zone %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("retrieving Private DNS Zone %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
+	recordSetResp, err := recordSetsClient.Get(ctx, id.ResourceGroup, id.Name, privatedns.SOA, "@")
+	if err != nil {
+		return fmt.Errorf("reading DNS SOA record @: %v", err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 
 	if props := resp.PrivateZoneProperties; props != nil {
 		d.Set("number_of_record_sets", props.NumberOfRecordSets)
@@ -251,12 +247,7 @@ func resourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("max_number_of_virtual_network_links_with_registration", props.MaxNumberOfVirtualNetworkLinksWithRegistration)
 	}
 
-	rsResp, err := recordSetsClient.Get(ctx, id.ResourceGroup, name, privatedns.SOA, "@")
-	if err != nil {
-		return fmt.Errorf("reading DNS SOA record @: %v", err)
-	}
-
-	if err := d.Set("soa_record", flattenArmPrivateDNSZoneSOARecord(&rsResp)); err != nil {
+	if err := d.Set("soa_record", flattenArmPrivateDNSZoneSOARecord(&recordSetResp)); err != nil {
 		return fmt.Errorf("setting `soa_record`: %+v", err)
 	}
 
@@ -268,28 +259,25 @@ func resourceArmPrivateDnsZoneDelete(d *schema.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.PrivateDnsZoneID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resGroup := id.ResourceGroup
-	name := id.Path["privateDnsZones"]
-
 	etag := ""
-	future, err := client.Delete(ctx, resGroup, name, etag)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name, etag)
 	if err != nil {
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Private DNS Zone %s (resource group %s): %+v", name, resGroup, err)
+		return fmt.Errorf("error deleting Private DNS Zone %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
-		return fmt.Errorf("error deleting Private DNS Zone %s (resource group %s): %+v", name, resGroup, err)
+		return fmt.Errorf("error deleting Private DNS Zone %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
@@ -26,9 +28,10 @@ func resourceArmPrivateDnsZoneVirtualNetworkLink() *schema.Resource {
 		Read:   resourceArmPrivateDnsZoneVirtualNetworkLinkRead,
 		Update: resourceArmPrivateDnsZoneVirtualNetworkLinkCreateUpdate,
 		Delete: resourceArmPrivateDnsZoneVirtualNetworkLinkDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.VirtualNetworkLinkID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/azurerm/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -97,7 +97,7 @@ func resourceArmPrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *schema.ResourceD
 		}
 
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_private_dns_zone_virtual_network_link", resourceId.ID(""))
+			return tf.ImportAsExistsError("azurerm_private_dns_zone_virtual_network_link", resourceId.ID())
 		}
 	}
 
@@ -127,7 +127,7 @@ func resourceArmPrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *schema.ResourceD
 		return fmt.Errorf("waiting for Virtual Network Link %q (Private DNS Zone %q / Resource Group %q) to become available: %+v", resourceId.Name, resourceId.PrivateDnsZoneName, resourceId.ResourceGroup, err)
 	}
 
-	d.SetId(resourceId.ID(""))
+	d.SetId(resourceId.ID())
 	return resourceArmPrivateDnsZoneVirtualNetworkLinkRead(d, meta)
 }
 

--- a/azurerm/internal/services/privatedns/resourceids.go
+++ b/azurerm/internal/services/privatedns/resourceids.go
@@ -1,3 +1,12 @@
 package privatedns
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=PrivateDnsZone -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkLink -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/virtualNetworkLink1
+
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ARecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/eh1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AaaaRecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/eheh1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=CnameRecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/name1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=MxRecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/mx1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=PtrRecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/ptr1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SrvRecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/srv1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=TxtRecord -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/txt1

--- a/azurerm/internal/services/privatedns/validate/a_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/a_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func ARecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.ARecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/a_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/a_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestARecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing AName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for AName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/A/eh1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/A/EH1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ARecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/aaaa_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/aaaa_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func AaaaRecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.AaaaRecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/aaaa_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/aaaa_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestAaaaRecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing AAAAName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for AAAAName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/AAAA/eheh1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/AAAA/EHEH1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := AaaaRecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/cname_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/cname_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func CnameRecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.CnameRecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/cname_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/cname_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestCnameRecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing CNAMEName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for CNAMEName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/CNAME/name1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/CNAME/NAME1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := CnameRecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/mx_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/mx_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func MxRecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.MxRecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/mx_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/mx_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestMxRecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing MXName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for MXName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/MX/mx1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/MX/MX1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := MxRecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/ptr_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/ptr_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func PtrRecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.PtrRecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/ptr_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/ptr_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestPtrRecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing PTRName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PTRName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/PTR/ptr1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/PTR/PTR1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := PtrRecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/srv_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/srv_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func SrvRecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.SrvRecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/srv_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/srv_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestSrvRecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing SRVName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SRVName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/SRV/srv1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/SRV/SRV1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := SrvRecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/txt_record_id.go
+++ b/azurerm/internal/services/privatedns/validate/txt_record_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func TxtRecordID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.TxtRecordID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/txt_record_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/txt_record_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestTxtRecordID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing TXTName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for TXTName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/TXT/txt1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/TXT/TXT1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := TxtRecordID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/privatedns/validate/virtual_network_link_id.go
+++ b/azurerm/internal/services/privatedns/validate/virtual_network_link_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
+)
+
+func VirtualNetworkLinkID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.VirtualNetworkLinkID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/privatedns/validate/virtual_network_link_id_test.go
+++ b/azurerm/internal/services/privatedns/validate/virtual_network_link_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestVirtualNetworkLinkID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for PrivateDnsZoneName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/privateDnsZones/privateDnsZone1/virtualNetworkLinks/virtualNetworkLink1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/PRIVATEDNSZONES/PRIVATEDNSZONE1/VIRTUALNETWORKLINKS/VIRTUALNETWORKLINK1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := VirtualNetworkLinkID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
This PR converts the `privatedns` package over to using a Resource ID Formatter/Parser. It also adds Enhanced Import validation for the following resources:

* `azurerm_private_dns_zone`
* `azurerm_private_dns_a_record`
* `azurerm_private_dns_aaaa_record`
* `azurerm_private_dns_cname_record`
* `azurerm_private_dns_mx_record`
* `azurerm_private_dns_ptr_record`
* `azurerm_private_dns_srv_record`
* `azurerm_private_dns_txt_record`
* `azurerm_private_dns_zone_virtual_network_link`