### PR TITLE
Broken link in AzureAD migration guide

### DIFF
--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -201,4 +201,4 @@ configuration and real physical resources that exist. As a result, no
 actions need to be performed.
 ```
 
-At this point, you've switched over to using [the new Azure Active Directory provider](http://terraform.io/docs/providers/azuread/index.html)! You can stay up to date with Releases (and file Feature Requests/Bugs) [on the Github repository](https://github.com/terraform-providers/terraform-provider-azuread).
+At this point, you've switched over to using [the new Azure Active Directory provider](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs)! You can stay up to date with Releases (and file Feature Requests/Bugs) [on the Github repository](https://github.com/terraform-providers/terraform-provider-azuread).


### PR DESCRIPTION
Fixed link to AzureAD provider documentation on registry.terraform.io.