### PR TITLE
docs(virtual-machines): fix link vm sizing doc

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -111,7 +111,7 @@ The following arguments are supported:
 
 * `os_profile_windows_config` - (Required, when a Windows machine) A `os_profile_windows_config` block.
 
-* `vm_size` - (Required) Specifies the [size of the Virtual Machine](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-size-specs/).
+* `vm_size` - (Required) Specifies the [size of the Virtual Machine](https://docs.microsoft.com/azure/virtual-machines/sizes-general). See also [Azure VM Naming Conventions](https://docs.microsoft.com/azure/virtual-machines/vm-naming-conventions).
 
 ---
 


### PR DESCRIPTION
- Updated the link to the current VM sizing overview page.
- Added link to naming conventions page that describes `[Family] + [Sub-family]* + [# of vCPUs] + [Additive Features] + [Accelerator Type]* + [Version]` formula to figure out needed string value for a VM size.
