### PR TITLE
r/role_definition: fixing a crash when `permissions` is nil & making permissions optional

### DIFF
--- a/azurerm/internal/services/authorization/azuresdkhacks/definitions.go
+++ b/azurerm/internal/services/authorization/azuresdkhacks/definitions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2020-04-01-preview/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )

--- a/azurerm/internal/services/authorization/azuresdkhacks/definitions.go
+++ b/azurerm/internal/services/authorization/azuresdkhacks/definitions.go
@@ -1,0 +1,154 @@
+package azuresdkhacks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type RoleDefinitionsWorkaroundClient struct {
+	sdkClient *authorization.RoleDefinitionsClient
+}
+
+func NewRoleDefinitionsWorkaroundClient(client *authorization.RoleDefinitionsClient) RoleDefinitionsWorkaroundClient {
+	return RoleDefinitionsWorkaroundClient{
+		sdkClient: client,
+	}
+}
+
+// CreateOrUpdate creates or updates a role definition.
+// Parameters:
+// scope - the scope of the role definition.
+// roleDefinitionID - the ID of the role definition.
+// roleDefinition - the values for the role definition.
+func (client RoleDefinitionsWorkaroundClient) CreateOrUpdate(ctx context.Context, scope string, roleDefinitionID string, roleDefinition authorization.RoleDefinition) (result RoleDefinitionUpdateResponse, err error) {
+	req, err := client.sdkClient.CreateOrUpdatePreparer(ctx, scope, roleDefinitionID, roleDefinition)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.sdkClient.CreateOrUpdateSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "CreateOrUpdate", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "CreateOrUpdate", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// CreateOrUpdateResponder handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (client RoleDefinitionsWorkaroundClient) CreateOrUpdateResponder(resp *http.Response) (result RoleDefinitionUpdateResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// Get get role definition by name (GUID).
+// Parameters:
+// scope - the scope of the role definition.
+// roleDefinitionID - the ID of the role definition.
+func (client RoleDefinitionsWorkaroundClient) Get(ctx context.Context, scope string, roleDefinitionID string) (result RoleDefinitionGetResponse, err error) {
+	req, err := client.sdkClient.GetPreparer(ctx, scope, roleDefinitionID)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.sdkClient.GetSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "Get", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "Get", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// GetResponder handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (client RoleDefinitionsWorkaroundClient) GetResponder(resp *http.Response) (result RoleDefinitionGetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}
+
+// RoleDefinition role definition.
+type RoleDefinitionGetResponse struct {
+	autorest.Response `json:"-"`
+	// ID - READ-ONLY; The role definition ID.
+	ID *string `json:"id,omitempty"`
+	// Name - READ-ONLY; The role definition name.
+	Name *string `json:"name,omitempty"`
+	// Type - READ-ONLY; The role definition type.
+	Type *string `json:"type,omitempty"`
+	// RoleDefinitionProperties - Role definition properties.
+	*RoleDefinitionProperties `json:"properties,omitempty"`
+}
+
+type RoleDefinitionUpdateResponse struct {
+	autorest.Response `json:"-"`
+	// ID - READ-ONLY; The role definition ID.
+	ID *string `json:"id,omitempty"`
+	// Name - READ-ONLY; The role definition name.
+	Name *string `json:"name,omitempty"`
+	// Type - READ-ONLY; The role definition type.
+	Type *string `json:"type,omitempty"`
+	// RoleDefinitionProperties - Role definition properties.
+	*RoleDefinitionProperties `json:"properties,omitempty"`
+}
+
+// RoleDefinitionProperties role definition properties.
+type RoleDefinitionProperties struct {
+	// RoleName - The role name.
+	RoleName *string `json:"roleName,omitempty"`
+	// Description - The role definition description.
+	Description *string `json:"description,omitempty"`
+	// RoleType - The role type.
+	RoleType *string `json:"type,omitempty"`
+	// Permissions - Role definition permissions.
+	Permissions *[]Permission `json:"permissions,omitempty"`
+	// AssignableScopes - Role definition assignable scopes.
+	AssignableScopes *[]string `json:"assignableScopes,omitempty"`
+
+	// not exposed in the sdk
+	CreatedOn *string `json:"createdOn,omitempty"`
+	UpdatedOn *string `json:"updatedOn,omitempty"`
+	CreatedBy *string `json:"createdBy,omitempty"`
+	UpdatedBy *string `json:"updatedBy,omitempty"`
+}
+
+// Permission role definition permissions.
+type Permission struct {
+	// Actions - Allowed actions.
+	Actions *[]string `json:"actions,omitempty"`
+	// NotActions - Denied actions.
+	NotActions *[]string `json:"notActions,omitempty"`
+	// DataActions - Allowed Data actions.
+	DataActions *[]string `json:"dataActions,omitempty"`
+	// NotDataActions - Denied Data actions.
+	NotDataActions *[]string `json:"notDataActions,omitempty"`
+}

--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -374,8 +374,20 @@ func roleDefinitionEventualConsistencyUpdate(ctx context.Context, client azuresd
 		}
 
 		updateRequestTime, err := time.Parse(time.RFC3339, updateRequestDate)
-		respCreatedOn, _ := time.Parse(time.RFC3339, *resp.RoleDefinitionProperties.CreatedOn)
-		respUpdatedOn, _ := time.Parse(time.RFC3339, *resp.RoleDefinitionProperties.UpdatedOn)
+		if err != nil {
+			return nil, "", fmt.Errorf("error parsing time from update request: %+v", err)
+		}
+
+		respCreatedOn, err := time.Parse(time.RFC3339, *resp.RoleDefinitionProperties.CreatedOn)
+		if err != nil {
+			return nil, "", fmt.Errorf("error parsing time for createdOn from update request: %+v", err)
+		}
+
+		respUpdatedOn, err := time.Parse(time.RFC3339, *resp.RoleDefinitionProperties.UpdatedOn)
+		if err != nil {
+			return nil, "", fmt.Errorf("error parsing time for updatedOn from update request: %+v", err)
+		}
+
 		if respCreatedOn.Equal(updateRequestTime) {
 			// a new role definition is created and eventually (~5s) reconciled
 			return resp, "Pending", nil

--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -300,6 +300,10 @@ func expandRoleDefinitionPermissions(input []interface{}) []authorization.Permis
 	}
 
 	for _, v := range input {
+		if v == nil {
+			continue
+		}
+
 		input := v.(map[string]interface{})
 		permission := authorization.Permission{}
 

--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -401,6 +401,9 @@ func expandRoleDefinitionPermissions(input []interface{}) []authorization.Permis
 		actionsOutput := make([]string, 0)
 		actions := raw["actions"].([]interface{})
 		for _, a := range actions {
+			if a == nil {
+				continue
+			}
 			actionsOutput = append(actionsOutput, a.(string))
 		}
 		permission.Actions = &actionsOutput
@@ -408,6 +411,9 @@ func expandRoleDefinitionPermissions(input []interface{}) []authorization.Permis
 		dataActionsOutput := make([]string, 0)
 		dataActions := raw["data_actions"].(*schema.Set)
 		for _, a := range dataActions.List() {
+			if a == nil {
+				continue
+			}
 			dataActionsOutput = append(dataActionsOutput, a.(string))
 		}
 		permission.DataActions = &dataActionsOutput
@@ -415,6 +421,9 @@ func expandRoleDefinitionPermissions(input []interface{}) []authorization.Permis
 		notActionsOutput := make([]string, 0)
 		notActions := raw["not_actions"].([]interface{})
 		for _, a := range notActions {
+			if a == nil {
+				continue
+			}
 			notActionsOutput = append(notActionsOutput, a.(string))
 		}
 		permission.NotActions = &notActionsOutput
@@ -422,6 +431,9 @@ func expandRoleDefinitionPermissions(input []interface{}) []authorization.Permis
 		notDataActionsOutput := make([]string, 0)
 		notDataActions := raw["not_data_actions"].(*schema.Set)
 		for _, a := range notDataActions.List() {
+			if a == nil {
+				continue
+			}
 			notDataActionsOutput = append(notDataActionsOutput, a.(string))
 		}
 		permission.NotDataActions = &notDataActionsOutput

--- a/azurerm/internal/services/authorization/role_definition_resource_test.go
+++ b/azurerm/internal/services/authorization/role_definition_resource_test.go
@@ -126,7 +126,7 @@ func TestAccRoleDefinition_emptyName(t *testing.T) {
 	})
 }
 
-func testAccRoleDefinition_emptyPermissions(t *testing.T) {
+func TestAccRoleDefinition_emptyPermissions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -141,7 +141,7 @@ func testAccRoleDefinition_emptyPermissions(t *testing.T) {
 	})
 }
 
-func testAccRoleDefinition_managementGroup(t *testing.T) {
+func TestAccRoleDefinition_managementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 

--- a/azurerm/internal/services/authorization/role_definition_resource_test.go
+++ b/azurerm/internal/services/authorization/role_definition_resource_test.go
@@ -16,7 +16,7 @@ import (
 
 type RoleDefinitionResource struct{}
 
-func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
+func TestAccRoleDefinition_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -31,7 +31,7 @@ func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_requiresImport(t *testing.T) {
+func TestAccRoleDefinition_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	id := uuid.New().String()
 
@@ -50,7 +50,7 @@ func TestAccAzureRMRoleDefinition_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_complete(t *testing.T) {
+func TestAccRoleDefinition_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -65,7 +65,7 @@ func TestAccAzureRMRoleDefinition_complete(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_update(t *testing.T) {
+func TestAccRoleDefinition_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 	id := uuid.New().String()
@@ -88,7 +88,7 @@ func TestAccAzureRMRoleDefinition_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_updateEmptyId(t *testing.T) {
+func TestAccRoleDefinition_updateEmptyId(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 
 	r := RoleDefinitionResource{}
@@ -111,7 +111,7 @@ func TestAccAzureRMRoleDefinition_updateEmptyId(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_emptyName(t *testing.T) {
+func TestAccRoleDefinition_emptyName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -126,7 +126,22 @@ func TestAccAzureRMRoleDefinition_emptyName(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_managementGroup(t *testing.T) {
+func TestAccRoleDefinition_emptyPermissions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
+	r := RoleDefinitionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.emptyPermissions(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRoleDefinition_managementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -141,7 +156,7 @@ func TestAccAzureRMRoleDefinition_managementGroup(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_assignToSmallerScope(t *testing.T) {
+func TestAccRoleDefinition_assignToSmallerScope(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -156,7 +171,7 @@ func TestAccAzureRMRoleDefinition_assignToSmallerScope(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMRoleDefinition_noAssignableScope(t *testing.T) {
+func TestAccRoleDefinition_noAssignableScope(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 
 	r := RoleDefinitionResource{}
@@ -339,6 +354,28 @@ resource "azurerm_role_definition" "test" {
   ]
 }
 `, data.RandomInteger)
+}
+
+func (r RoleDefinitionResource) emptyPermissions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_subscription" "primary" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = %q
+}
+
+resource "azurerm_role_definition" "test" {
+  name              = "acctestrd-%d"
+  scope             = azurerm_resource_group.test.id
+  assignable_scopes = [azurerm_resource_group.test.id]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RoleDefinitionResource) managementGroup(id string, data acceptance.TestData) string {

--- a/azurerm/internal/services/authorization/role_definition_resource_test.go
+++ b/azurerm/internal/services/authorization/role_definition_resource_test.go
@@ -126,7 +126,7 @@ func TestAccRoleDefinition_emptyName(t *testing.T) {
 	})
 }
 
-func TestAccRoleDefinition_emptyPermissions(t *testing.T) {
+func testAccRoleDefinition_emptyPermissions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 
@@ -141,7 +141,7 @@ func TestAccRoleDefinition_emptyPermissions(t *testing.T) {
 	})
 }
 
-func TestAccRoleDefinition_managementGroup(t *testing.T) {
+func testAccRoleDefinition_managementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleDefinitionResource{}
 

--- a/azurerm/internal/services/authorization/role_definition_resource_test.go
+++ b/azurerm/internal/services/authorization/role_definition_resource_test.go
@@ -292,7 +292,7 @@ resource "azurerm_role_definition" "test" {
   role_definition_id = "%s"
   name               = "acctestrd-%d"
   scope              = data.azurerm_subscription.primary.id
-  description        = "Acceptance Test Role Definition"
+  description        = "Acceptance Test Role Definition Updated"
 
   permissions {
     actions     = ["*"]

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2019-06-01-preview/templatespecs/CHANGELOG.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2019-06-01-preview/templatespecs/CHANGELOG.md
@@ -1,5 +1,5 @@
 Generated from https://github.com/Azure/azure-rest-api-specs/tree/b08824e05817297a4b2874d8db5e6fc8c29349c9//specification/resources/resource-manager/readme.md tag: `package-templatespecs-2019-06-preview`
 
-Code generator @microsoft.azure/autorest.go@2.1.171
+Code generator @microsoft.azure/autorest.go@2.1.175
 
 

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -45,11 +45,13 @@ The following arguments are supported:
 
 * `description` - (Optional) A description of the Role Definition.
 
-* `permissions` - (Required) A `permissions` block as defined below.
+* `permissions` - (Optional) A `permissions` block as defined below.
 
 * `assignable_scopes` - (Optional) One or more assignable scopes for this Role Definition, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`.
 
 ~> **NOTE:** The value for `scope` is automatically included in this list if no other values supplied.
+
+---
 
 A `permissions` block as the following properties:
 


### PR DESCRIPTION
In testing it appears this block can be left empty (e.g. `[]`) - since the API will transform an empty permissions block into `[]`

Fixes #9815
Fixes #440
Fixes #3732