### PR TITLE
Acceptance tests: fix CheckDestroyedFunc

### DIFF
--- a/azurerm/internal/acceptance/helpers/check_destroyed.go
+++ b/azurerm/internal/acceptance/helpers/check_destroyed.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CheckDestroyedFunc returns a TestCheckFunc which validates the resource no longer exists
-func CheckDestroyedFunc(client *clients.Client, testResource types.TestResource, resourceType, resourceLabel string) func(state *terraform.State) error {
+func CheckDestroyedFunc(client *clients.Client, testResource types.TestResource, resourceType, resourceName string) func(state *terraform.State) error {
 	return func(state *terraform.State) error {
 		ctx := client.StopContext
 
@@ -17,17 +17,17 @@ func CheckDestroyedFunc(client *clients.Client, testResource types.TestResource,
 			if resourceState.Type != resourceType {
 				continue
 			}
-			if label != resourceLabel {
+			if label != resourceName {
 				continue
 			}
 
 			// Destroy is unconcerned with an error checking the status, since this is going to be "not found"
 			result, err := testResource.Exists(ctx, client, resourceState.Primary)
-			if result == nil && err != nil {
-				return fmt.Errorf("should have either an error or a result when checking if \"%s.%s\" has been destroyed", resourceType, resourceLabel)
+			if result == nil && err == nil {
+				return fmt.Errorf("should have either an error or a result when checking if %q has been destroyed", resourceName)
 			}
 			if result != nil && *result {
-				return fmt.Errorf("\"%s.%s\" still exists", resourceType, resourceLabel)
+				return fmt.Errorf("%q still exists", resourceName)
 			}
 		}
 

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -32,7 +32,7 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 		PreCheck: func() { PreCheck(t) },
 		CheckDestroy: func(s *terraform.State) error {
 			client := buildClient()
-			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.resourceLabel)(s)
+			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.ResourceName)(s)
 		},
 		Steps: steps,
 	}


### PR DESCRIPTION
- state.RootModule().Resources uses full notation for key values
- Using Exists() for destroy check should fail when err == nil