### PR TITLE
`azurerm_linux_virtual_machine` - Normalise SSH keys 

### DIFF
--- a/azurerm/helpers/azure/ssh_key.go
+++ b/azurerm/helpers/azure/ssh_key.go
@@ -14,15 +14,17 @@ func NormaliseSSHKey(input string) (*string, error) {
 		return nil, fmt.Errorf("empty string supplied")
 	}
 
-	// Strip the Azure generated multiline wrapper
-	Normalised := strings.ReplaceAll(input, "<<~EOT\r\n", "")
-	Normalised = strings.ReplaceAll(Normalised, "EOT", "")
+	output := input
+	output = strings.ReplaceAll(output, "<<~EOT", "")
+	output = strings.ReplaceAll(output, "EOT", "")
+	output = strings.ReplaceAll(output, "\r", "")
 
-	// strip Windows flavour new-lines
-	Normalised = strings.ReplaceAll(Normalised, "\r\n", "")
+	lines := make([]string, 0)
+	for _, line := range strings.Split(output, "\n") {
+		lines = append(lines, strings.TrimSpace(line))
+	}
 
-	// strip Linux flavour nee lines
-	Normalised = strings.ReplaceAll(Normalised, "\n", "")
+	normalised := strings.Join(lines, "")
 
-	return utils.String(Normalised), nil
+	return utils.String(normalised), nil
 }

--- a/azurerm/helpers/azure/ssh_key.go
+++ b/azurerm/helpers/azure/ssh_key.go
@@ -1,0 +1,28 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+// NormaliseSSHKey attempts to remove invalid formatting and line breaks that can be present in some cases
+// when querying the Azure APIs
+func NormaliseSSHKey(input string) (*string, error) {
+	if input == "" {
+		return nil, fmt.Errorf("empty string supplied")
+	}
+
+	// Strip the Azure generated multiline wrapper
+	Normalised := strings.ReplaceAll(input, "<<~EOT\r\n", "")
+	Normalised = strings.ReplaceAll(Normalised, "EOT", "")
+
+	// strip Windows flavour new-lines
+	Normalised = strings.ReplaceAll(Normalised, "\r\n", "")
+
+	// strip Linux flavour nee lines
+	Normalised = strings.ReplaceAll(Normalised, "\n", "")
+
+	return utils.String(Normalised), nil
+}

--- a/azurerm/helpers/azure/ssk_key_test.go
+++ b/azurerm/helpers/azure/ssk_key_test.go
@@ -68,6 +68,38 @@ func TestNormaliseSSHKey(t *testing.T) {
 				"3w== generated-by-azure",
 			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
 		},
+		{
+			// Valid 4096 - multiline Windows Wrapped
+			Input: "<<~EOT\r\n" +
+				"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wz\r\n" +
+				"Qn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB\r\n" +
+				"85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGK\r\n" +
+				"H3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x\r\n" +
+				"6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayI\r\n" +
+				"oiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5\r\n" +
+				"y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpm\r\n" +
+				"rJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6\r\n" +
+				"Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a\r\n" +
+				"3w== generated-by-azure" +
+				"EOT",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
+		},
+		{
+			// Valid 4096 - multiline Windows Wrapped with whitespace
+			Input: "<<~EOT\r\n" +
+				"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wz\r\n  " +
+				"Qn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB\r\n  " +
+				"85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGK\r\n" +
+				"  H3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x\r\n" +
+				"6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayI\r\n" +
+				"oiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5\r\n" +
+				"y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpm\r\n" +
+				" rJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6\r\n" +
+				"    Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a\r\n    " +
+				"3w== generated-by-azure" +
+				"EOT",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
+		},
 	}
 
 	for _, tc := range cases {

--- a/azurerm/helpers/azure/ssk_key_test.go
+++ b/azurerm/helpers/azure/ssk_key_test.go
@@ -1,0 +1,86 @@
+package azure
+
+import "testing"
+
+func TestNormaliseSSHKey(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Error    bool
+		Expected string
+	}{
+		{
+			Input: "",
+			Error: true,
+		},
+		{
+			// Valid 2048 - no modification needed
+			Input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSNTSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVqXn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0yyiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh generated-by-azure",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSNTSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVqXn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0yyiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh generated-by-azure",
+		},
+		{
+			// Valid 2048 - multiline, as per ARM Template Cache
+			Input: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSN\r\n" +
+				"TSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVq\r\n" +
+				"Xn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh\r\n" +
+				"3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0y\r\n" +
+				"yiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh generated-by-azure",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSNTSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVqXn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0yyiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh generated-by-azure",
+		},
+		{
+			// Valid 2048 - multiline, as per ARM Template Cache Linux newlines
+			Input: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSN\n" +
+				"TSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVq\n" +
+				"Xn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh\n" +
+				"3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0y\n" +
+				"yiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh generated-by-azure",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSNTSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVqXn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0yyiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh generated-by-azure",
+		},
+		{
+			// Valid 4096 - not modification required
+			Input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
+		},
+		{
+			// Valid 4096 - multiline Windows
+			Input: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wz\r\n" +
+				"Qn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB\r\n" +
+				"85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGK\r\n" +
+				"H3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x\r\n" +
+				"6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayI\r\n" +
+				"oiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5\r\n" +
+				"y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpm\r\n" +
+				"rJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6\r\n" +
+				"Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a\r\n" +
+				"3w== generated-by-azure",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
+		},
+		{
+			// Valid 4096 - multiline Linux newlines
+			Input: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wz\n" +
+				"Qn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB\n" +
+				"85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGK\n" +
+				"H3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x\n" +
+				"6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayI\n" +
+				"oiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5\n" +
+				"y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpm\n" +
+				"rJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6\n" +
+				"Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a\n" +
+				"3w== generated-by-azure",
+			Expected: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w== generated-by-azure",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Input, func(t *testing.T) {
+			output, err := NormaliseSSHKey(tc.Input)
+			if err != nil {
+				if !tc.Error {
+					t.Fatalf("expected NormaliseSSHKey to error")
+				}
+			}
+			if output != nil && *output != tc.Expected {
+				t.Fatalf("Expected %q, got %q", tc.Expected, *output)
+			}
+		})
+	}
+}

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -605,7 +605,7 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 			if err != nil {
 				return fmt.Errorf("flattening `admin_ssh_key`: %+v", err)
 			}
-			if err := d.Set("admin_ssh_key", flattenedSSHKeys); err != nil {
+			if err := d.Set("admin_ssh_key", schema.NewSet(SSHKeySchemaHash, *flattenedSSHKeys)); err != nil {
 				return fmt.Errorf("setting `admin_ssh_key`: %+v", err)
 			}
 		}

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -951,7 +951,7 @@ func resourceArmLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta int
 				if err != nil {
 					return fmt.Errorf("Error flattening `admin_ssh_key`: %+v", err)
 				}
-				if err := d.Set("admin_ssh_key", flattenedSshKeys); err != nil {
+				if err := d.Set("admin_ssh_key", schema.NewSet(SSHKeySchemaHash, *flattenedSshKeys)); err != nil {
 					return fmt.Errorf("Error setting `admin_ssh_key`: %+v", err)
 				}
 			}

--- a/azurerm/internal/services/compute/ssh_keys.go
+++ b/azurerm/internal/services/compute/ssh_keys.go
@@ -186,7 +186,7 @@ func SSHKeySchemaHash(v interface{}) int {
 	if m, ok := v.(map[string]interface{}); ok {
 		normalisedKey, _ := azure.NormaliseSSHKey(m["public_key"].(string))
 		buf.WriteString(fmt.Sprintf("%s-", *normalisedKey))
-		buf.WriteString(fmt.Sprintf("%s", m["username"].(string)))
+		buf.WriteString(fmt.Sprintf("%s", m["username"]))
 	}
 
 	return hashcode.String(buf.String())


### PR DESCRIPTION
Fixes #9238 

Background: When VM's are created via the Portal with "Generate new key" the API response contains a broken representation of the public key including newline character codes which needs to be normalised before it can be used via `terraform import`. 

Tested manually:
```
➜  terraform state show azurerm_linux_virtual_machine.import
# azurerm_linux_virtual_machine.import:
resource "azurerm_linux_virtual_machine" "import" {
    admin_username                  = "azureuser"
    allow_extension_operations      = true
    computer_name                   = "stedev-ssh-test"
    disable_password_authentication = true
    encryption_at_host_enabled      = false
    extensions_time_budget          = "PT1H30M"
    id                              = "/subscriptions/******/resourcegroups/stedev-20201216/providers/Microsoft.Compute/virtualMachines/stedev-ssh-test"
    location                        = "westeurope"
    max_bid_price                   = -1
    name                            = "stedev-ssh-test"
    network_interface_ids           = [
        "/subscriptions/******/resourceGroups/stedev-20201216/providers/Microsoft.Network/networkInterfaces/stedev-ssh-test842",
    ]
    priority                        = "Regular"
    private_ip_address              = "10.1.1.4"
    private_ip_addresses            = [
        "10.1.1.4",
    ]
    provision_vm_agent              = true
    public_ip_address               = "20.73.65.79"
    public_ip_addresses             = [
        "20.73.65.79",
    ]
    resource_group_name             = "stedev-20201216"
    size                            = "Standard_B1ls"
    tags                            = {}
    virtual_machine_id              = "7bd30006-3bba-4731-a066-68aadcbe41c9"

    admin_ssh_key {
        public_key = <<~EOT
            ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC5UO2NUzb5G/Lcis/hc/VzKgUn
            VbHjiZAUIlNcQg+3yL6Xj5Fg2jF7gO/hWdZK5VS4cGp38ryuS67bvrApwxslmFe2
            6qpd8203RLAF1wUjiSugOPCqPSFD4PKRTUoLmwtECcnhhAV0RkCRmikdjuDRN4bq
            D0jgABfgabIvWbvJ5T9ea/qf7SInIQpGtd4HTEpSyTohIXg/Wdsk+9CulJfcQSou
            a3C/elw9ssnEBh4aXmty+Yc+dF2oWzDSgcb5ic4eB6lwnP9LAr7NsEr4b6wPM0dh
            rn6QO2Q2xReG7ESgrEPDY6Sb1g6PPNZbnV7x1b3nwIPtM9rW/AQ1OOmUX43v32n2
            AIMo0/egkCZcxIskvp2WNnd5I/tmUsc3TuiPF5YXT0/1UMyR/bnwlJbLSp4xY0Zm
            qI1xXDaWzGiDrP103A75iIP9ps5Eq+mmJIjr/w38x/8kJBiU69dSklokBFS9AE2m
            cT8SKpPespdqC9WaXuXNurxN0uOmfYT0F4KWfYc= generated-by-azure
        EOT
        username   = "azureuser"
    }

    boot_diagnostics {}

    os_disk {
        caching                   = "ReadWrite"
        disk_size_gb              = 30
        name                      = "stedev-ssh-test_disk1_4891a3883e7b4638a1c56ff7997d936f"
        storage_account_type      = "Standard_LRS"
        write_accelerator_enabled = false
    }

    source_image_reference {
        offer     = "UbuntuServer"
        publisher = "Canonical"
        sku       = "18.04-LTS"
        version   = "latest"
    }

    timeouts {}
}
```
Config:
```
provider "azurerm" {
  features {}
}

resource "azurerm_linux_virtual_machine" "import" {
  name                = "stedev-ssh-test"
  location            = "westeurope"
  resource_group_name = "stedev-20201216"
  size                = "Standard_B1ls"
  network_interface_ids = [
    "/subscriptions/******/resourceGroups/stedev-20201216/providers/Microsoft.Network/networkInterfaces/stedev-ssh-test842",
  ]
  os_disk {
    caching                   = "ReadWrite"
    disk_size_gb              = 30
    name                      = "stedev-ssh-test_disk1_4891a3883e7b4638a1c56ff7997d936f"
    storage_account_type      = "Standard_LRS"
    write_accelerator_enabled = false
  }
  admin_username = "azureuser"

  admin_ssh_key {
    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC5UO2NUzb5G/Lcis/hc/VzKgUnVbHjiZAUIlNcQg+3yL6Xj5Fg2jF7gO/hWdZK5VS4cGp38ryuS67bvrApwxslmFe26qpd8203RLAF1wUjiSugOPCqPSFD4PKRTUoLmwtECcnhhAV0RkCRmikdjuDRN4bqD0jgABfgabIvWbvJ5T9ea/qf7SInIQpGtd4HTEpSyTohIXg/Wdsk+9CulJfcQSoua3C/elw9ssnEBh4aXmty+Yc+dF2oWzDSgcb5ic4eB6lwnP9LAr7NsEr4b6wPM0dhrn6QO2Q2xReG7ESgrEPDY6Sb1g6PPNZbnV7x1b3nwIPtM9rW/AQ1OOmUX43v32n2AIMo0/egkCZcxIskvp2WNnd5I/tmUsc3TuiPF5YXT0/1UMyR/bnwlJbLSp4xY0ZmqI1xXDaWzGiDrP103A75iIP9ps5Eq+mmJIjr/w38x/8kJBiU69dSklokBFS9AE2mcT8SKpPespdqC9WaXuXNurxN0uOmfYT0F4KWfYc= generated-by-azure"
    username   = "azureuser"
  }

  source_image_reference {
    offer     = "UbuntuServer"
    publisher = "Canonical"
    sku       = "18.04-LTS"
    version   = "latest"
  }

  boot_diagnostics {}
  
}
```
Plan: 
```
➜  terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_linux_virtual_machine.import: Refreshing state... [id=/subscriptions/******/resourcegroups/stedev-20201216/providers/Microsoft.Compute/virtualMachines/stedev-ssh-test]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```