### PR TITLE
CDN endpoint: Test for Premium_Verizon, optional values fix

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -469,18 +469,14 @@ func resourceCdnEndpointRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 
-		if _, ok := d.GetOk("content_types_to_compress"); ok {
-			contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)
-			if err := d.Set("content_types_to_compress", contentTypes); err != nil {
-				return fmt.Errorf("Error setting `content_types_to_compress`: %+v", err)
-			}
+		contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)
+		if err := d.Set("content_types_to_compress", contentTypes); err != nil {
+			return fmt.Errorf("Error setting `content_types_to_compress`: %+v", err)
 		}
 
-		if _, ok := d.GetOk("geo_filter"); ok {
-			geoFilters := flattenCdnEndpointGeoFilters(props.GeoFilters)
-			if err := d.Set("geo_filter", geoFilters); err != nil {
-				return fmt.Errorf("Error setting `geo_filter`: %+v", err)
-			}
+		geoFilters := flattenCdnEndpointGeoFilters(props.GeoFilters)
+		if err := d.Set("geo_filter", geoFilters); err != nil {
+			return fmt.Errorf("Error setting `geo_filter`: %+v", err)
 		}
 
 		origins := flattenAzureRMCdnEndpointOrigin(props.Origins)

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -300,13 +300,14 @@ func resourceCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error expanding `global_delivery_rule` or `delivery_rule`: %s", err)
 		}
 
-		if deliveryPolicy != nil {
-			if profile.Sku.Name != cdn.StandardMicrosoft && len(*deliveryPolicy.Rules) > 0 {
-				return fmt.Errorf("`global_delivery_policy` and `delivery_rule` are only allowed when `Standard_Microsoft` sku is used. Profile sku:  %s", profile.Sku.Name)
-			}
+		if profile.Sku.Name != cdn.StandardMicrosoft && len(*deliveryPolicy.Rules) > 0 {
+			return fmt.Errorf("`global_delivery_rule` and `delivery_rule` are only allowed when `Standard_Microsoft` sku is used. Profile sku:  %s", profile.Sku.Name)
+		}
 
+		if profile.Sku.Name == cdn.StandardMicrosoft {
 			endpoint.EndpointProperties.DeliveryPolicy = deliveryPolicy
 		}
+
 	}
 
 	future, err := endpointsClient.Create(ctx, resourceGroup, profileName, name, endpoint)
@@ -402,13 +403,14 @@ func resourceCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error expanding `global_delivery_rule` or `delivery_rule`: %s", err)
 		}
 
-		if deliveryPolicy != nil {
-			if profile.Sku.Name != cdn.StandardMicrosoft && len(*deliveryPolicy.Rules) > 0 {
-				return fmt.Errorf("`global_delivery_policy` and `delivery_rule` are only allowed when `Standard_Microsoft` sku is used. Profile sku:  %s", profile.Sku.Name)
-			}
+		if profile.Sku.Name != cdn.StandardMicrosoft && len(*deliveryPolicy.Rules) > 0 {
+			return fmt.Errorf("`global_delivery_rule` and `delivery_rule` are only allowed when `Standard_Microsoft` sku is used. Profile sku:  %s", profile.Sku.Name)
+		}
 
+		if profile.Sku.Name == cdn.StandardMicrosoft {
 			endpoint.EndpointPropertiesUpdateParameters.DeliveryPolicy = deliveryPolicy
 		}
+
 	}
 
 	future, err := endpointsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.Name, endpoint)
@@ -678,10 +680,6 @@ func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []interface
 }
 
 func expandArmCdnEndpointDeliveryPolicy(globalRulesRaw []interface{}, deliveryRulesRaw []interface{}) (*cdn.EndpointPropertiesUpdateParametersDeliveryPolicy, error) {
-	if len(globalRulesRaw) == 0 && len(deliveryRulesRaw) == 0 {
-		return nil, nil
-	}
-
 	deliveryRules := make([]cdn.DeliveryRule, 0)
 	deliveryPolicy := cdn.EndpointPropertiesUpdateParametersDeliveryPolicy{
 		Description: utils.String(""),

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -307,7 +307,6 @@ func resourceCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 		if profile.Sku.Name == cdn.StandardMicrosoft {
 			endpoint.EndpointProperties.DeliveryPolicy = deliveryPolicy
 		}
-
 	}
 
 	future, err := endpointsClient.Create(ctx, resourceGroup, profileName, name, endpoint)
@@ -410,7 +409,6 @@ func resourceCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 		if profile.Sku.Name == cdn.StandardMicrosoft {
 			endpoint.EndpointPropertiesUpdateParameters.DeliveryPolicy = deliveryPolicy
 		}
-
 	}
 
 	future, err := endpointsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.Name, endpoint)

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -1112,12 +1112,12 @@ resource "azurerm_cdn_profile" "test" {
 }
 
 resource "azurerm_cdn_endpoint" "test" {
-  name                = "acctestcdnend%d"
-  profile_name        = azurerm_cdn_profile.test.name
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  is_http_allowed     = false
-  is_https_allowed    = true
+  name                          = "acctestcdnend%d"
+  profile_name                  = azurerm_cdn_profile.test.name
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  is_http_allowed               = false
+  is_https_allowed              = true
   querystring_caching_behaviour = "NotSet"
 
   origin {

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -283,6 +283,21 @@ func TestAccCdnEndpoint_dnsAlias(t *testing.T) {
 	})
 }
 
+func TestAccCdnEndpoint_PremiumVerizon(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_endpoint", "test")
+	r := CdnEndpointResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.PremiumVerizon(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CdnEndpointResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.EndpointID(state.ID)
 	if err != nil {
@@ -1076,4 +1091,41 @@ resource "azurerm_dns_a_record" "test" {
   target_resource_id  = azurerm_cdn_endpoint.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnEndpointResource) PremiumVerizon(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Premium_Verizon"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+  name                = "acctestcdnend%d"
+  profile_name        = azurerm_cdn_profile.test.name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  is_http_allowed     = false
+  is_https_allowed    = true
+  querystring_caching_behaviour = "NotSet"
+
+  origin {
+    name       = "acceptanceTestCdnOrigin1"
+    host_name  = "www.contoso.com"
+    https_port = 443
+    http_port  = 80
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
* Added test for "Premium_Verizon" SKU for azurerm_cdn_profile
* Assigning the parameters `EndpointProperties.ContentTypesToCompress`, `EndpointProperties.GeoFilters` only when values are set for `content_types_to_compress`, `geo_filter`.
* Assigning the parameter `EndpointProperties.DeliveryPolicy` only when SKU set to `Microsoft_Standard`.

 Fixes #9895 