### PR TITLE
Add TC to support recreating vhub connection with same name

### DIFF
--- a/azurerm/internal/services/network/tests/virtual_hub_connection_resource_test.go
+++ b/azurerm/internal/services/network/tests/virtual_hub_connection_resource_test.go
@@ -135,6 +135,8 @@ func TestAccAzureRMVirtualHubConnection_enableInternetSecurity(t *testing.T) {
 func TestAccAzureRMVirtualHubConnection_recreateWithSameConnectionName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_connection", "test")
 
+	vhubData := data
+	vhubData.ResourceName = "azurerm_virtual_hub.test"
 	resourceGroupName := fmt.Sprintf("acctestRG-vhub-%d", data.RandomInteger)
 	vhubName := fmt.Sprintf("acctest-VHUB-%d", data.RandomInteger)
 	vhubConnectionName := fmt.Sprintf("acctestbasicvhubconn-%d", data.RandomInteger)
@@ -154,7 +156,7 @@ func TestAccAzureRMVirtualHubConnection_recreateWithSameConnectionName(t *testin
 			{
 				Config: testAccAzureRMVirtualHubConnection_template(data),
 				Check: resource.ComposeTestCheckFunc(
-					data.CheckWithClient(checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName)),
+					vhubData.CheckWithClient(checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName)),
 				),
 			},
 			{

--- a/azurerm/internal/services/network/tests/virtual_hub_connection_resource_test.go
+++ b/azurerm/internal/services/network/tests/virtual_hub_connection_resource_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -153,7 +154,7 @@ func TestAccAzureRMVirtualHubConnection_recreateWithSameConnectionName(t *testin
 			{
 				Config: testAccAzureRMVirtualHubConnection_template(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName),
+					data.CheckWithClient(checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName)),
 				),
 			},
 			{
@@ -293,12 +294,9 @@ func testCheckAzureRMVirtualHubConnectionExists(resourceName string) resource.Te
 	}
 }
 
-func testCheckAzureRMVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.HubVirtualNetworkConnectionClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		if resp, err := client.Get(ctx, resourceGroupName, vhubName, vhubConnectionName); err != nil {
+func checkVirtualHubConnectionDoesNotExist(resourceGroupName, vhubName, vhubConnectionName string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+		if resp, err := clients.Network.HubVirtualNetworkConnectionClient.Get(ctx, resourceGroupName, vhubName, vhubConnectionName); err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return nil
 			}


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/7284

The above issue has been fixed after tested. But there is no tc to cover the scenario recreating vhub connection with same name. So I submitted this PR to cover it.

--- PASS: TestAccAzureRMVirtualHubConnection_basic (1866.65s)
--- PASS: TestAccAzureRMVirtualHubConnection_requiresImport (1900.41s)
--- PASS: TestAccAzureRMVirtualHubConnection_recreateWithSameConnectionName (2236.64s)
--- PASS: TestAccAzureRMVirtualHubConnection_removePropagatedRouteTable (1947.74s)
--- PASS: TestAccAzureRMVirtualHubConnection_updateRoutingConfiguration (2016.10s)
--- PASS: TestAccAzureRMVirtualHubConnection_removeVnetStaticRoute (2019.56s)
--- PASS: TestAccAzureRMVirtualHubConnection_complete (2163.34s)
--- PASS: TestAccAzureRMVirtualHubConnection_removeRoutingConfiguration (2210.92s)
--- PASS: TestAccAzureRMVirtualHubConnection_enableInternetSecurity (2316.13s)
--- PASS: TestAccAzureRMVirtualHubConnection_update (2487.00s)
