### PR TITLE
key-vault/nested items: support for purging deleted items

### DIFF
--- a/azurerm/internal/services/keyvault/internal.go
+++ b/azurerm/internal/services/keyvault/internal.go
@@ -1,0 +1,121 @@
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type deleteAndPurgeNestedItem interface {
+	DeleteNestedItem(ctx context.Context) (autorest.Response, error)
+	NestedItemHasBeenDeleted(ctx context.Context) (autorest.Response, error)
+
+	PurgeNestedItem(ctx context.Context) (autorest.Response, error)
+	NestedItemHasBeenPurged(ctx context.Context) (autorest.Response, error)
+}
+
+func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPurge bool, helper deleteAndPurgeNestedItem) error {
+	timeout, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context is missing a timeout")
+	}
+
+	log.Printf("[DEBUG] Deleting %s..", description)
+	if resp, err := helper.DeleteNestedItem(ctx); err != nil {
+		if utils.ResponseWasNotFound(resp) {
+			return nil
+		}
+
+		return fmt.Errorf("deleting %s: %+v", description, err)
+	}
+	log.Printf("[DEBUG] Waiting for %s to finish deleting..", description)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"InProgress"},
+		Target:  []string{"NotFound"},
+		Refresh: func() (interface{}, string, error) {
+			item, err := helper.NestedItemHasBeenDeleted(ctx)
+			if err != nil {
+				if utils.ResponseWasNotFound(item) {
+					return item, "NotFound", nil
+				}
+
+				return nil, "Error", err
+			}
+
+			return item, "InProgress", nil
+		},
+		ContinuousTargetOccurence: 3,
+		PollInterval:              5 * time.Second,
+		Timeout:                   time.Until(timeout),
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("waiting for %s to be deleted: %+v", description, err)
+	}
+	log.Printf("[DEBUG] Deleted %s.", description)
+
+	if !shouldPurge {
+		log.Printf("[DEBUG] Skipping purging of %s as opted-out..", description)
+		return nil
+	}
+
+	log.Printf("[DEBUG] Purging %s..", description)
+	if _, err := helper.PurgeNestedItem(ctx); err != nil {
+		return fmt.Errorf("purging %s: %+v", description, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for %s to finish purging..", description)
+	stateConf = &resource.StateChangeConf{
+		Pending: []string{"InProgress"},
+		Target:  []string{"NotFound"},
+		Refresh: func() (interface{}, string, error) {
+			item, err := helper.NestedItemHasBeenPurged(ctx)
+			if err != nil {
+				if utils.ResponseWasNotFound(item) {
+					return item, "NotFound", nil
+				}
+
+				return nil, "Error", err
+			}
+
+			return item, "InProgress", nil
+		},
+		ContinuousTargetOccurence: 3,
+		PollInterval:              5 * time.Second,
+		Timeout:                   time.Until(timeout),
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("waiting for %s to finish purging: %+v", description, err)
+	}
+	log.Printf("[DEBUG] Purged %s.", description)
+
+	return nil
+}
+
+func keyVaultChildItemRefreshFunc(secretUri string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Checking to see if KeyVault Secret %q is available..", secretUri)
+
+		PTransport := &http.Transport{Proxy: http.ProxyFromEnvironment}
+
+		client := &http.Client{
+			Transport: PTransport,
+		}
+
+		conn, err := client.Get(secretUri)
+		if err != nil {
+			log.Printf("[DEBUG] Didn't find KeyVault secret at %q", secretUri)
+			return nil, "pending", fmt.Errorf("Error checking secret at %q: %s", secretUri, err)
+		}
+
+		defer conn.Body.Close()
+
+		log.Printf("[DEBUG] Found KeyVault Secret %q", secretUri)
+		return "available", "available", nil
+	}
+}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource.go
@@ -24,7 +24,7 @@ func resourceArmKeyVaultCertificateIssuer() *schema.Resource {
 		Read:   resourceArmKeyVaultCertificateIssuerRead,
 		Delete: resourceArmKeyVaultCertificateIssuerDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceArmKeyVaultChildResourceImporter,
+			State: nestedItemResourceImporter,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -215,6 +215,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 									"key_usage": {
 										Type:     schema.TypeList,
 										Required: true,
+										ForceNew: true,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -602,13 +602,73 @@ func resourceArmKeyVaultCertificateDelete(d *schema.ResourceData, meta interface
 		return nil
 	}
 
+	log.Printf("[DEBUG] Deleting Certificate %q (Key Vault %q)..", id.Name, id.KeyVaultBaseUrl)
 	resp, err := client.DeleteCertificate(ctx, id.KeyVaultBaseUrl, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting Certificate %q from Key Vault: %+v", id.Name, err)
+		return fmt.Errorf("deleting Certificate %q (Key Vault %q): %+v", id.Name, id.KeyVaultBaseUrl, err)
+	}
+	log.Printf("[DEBUG] Waiting for Certificate %q (Key Vault %q) to finish deleting", id.Name, id.KeyVaultBaseUrl)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"InProgress"},
+		Target:  []string{"NotFound"},
+		Refresh: func() (interface{}, string, error) {
+			key, err := client.GetCertificate(ctx, id.KeyVaultBaseUrl, id.Name, "")
+			if err != nil {
+				if utils.ResponseWasNotFound(key.Response) {
+					return key, "NotFound", nil
+				}
+
+				return nil, "Error", err
+			}
+
+			return key, "InProgress", nil
+		},
+		ContinuousTargetOccurence: 3,
+		PollInterval:              5 * time.Second,
+		Timeout:                   d.Timeout(schema.TimeoutDelete),
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("waiting for Certificate %q (Key Vault %q) to be deleted: %+v", id.Name, id.KeyVaultBaseUrl, err)
+	}
+	log.Printf("[DEBUG] Deleted Secret %q (Key Vault %q).", id.Name, id.KeyVaultBaseUrl)
+
+	shouldPurge := true // meta.(*clients.Client).Features.KeyVault.PurgeNestedItemsOnDestroy
+	if shouldPurge {
+		log.Printf("[DEBUG] Purging Certificate %q (Key Vault %q)..", id.Name, id.KeyVaultBaseUrl)
+		if _, err := client.PurgeDeletedCertificate(ctx, id.KeyVaultBaseUrl, id.Name); err != nil {
+			return fmt.Errorf("purging Certificate %q (Key Vault %q): %+v", id.Name, id.KeyVaultBaseUrl, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for Certificate %q (Key Vault %q) to finish purging..", id.Name, id.KeyVaultBaseUrl)
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"InProgress"},
+			Target:  []string{"NotFound"},
+			Refresh: func() (interface{}, string, error) {
+				key, err := client.GetDeletedCertificate(ctx, id.KeyVaultBaseUrl, id.Name)
+				if err != nil {
+					if utils.ResponseWasNotFound(key.Response) {
+						return key, "NotFound", nil
+					}
+
+					return nil, "Error", err
+				}
+
+				return key, "InProgress", nil
+			},
+			ContinuousTargetOccurence: 3,
+			PollInterval:              5 * time.Second,
+			Timeout:                   d.Timeout(schema.TimeoutDelete),
+		}
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf("waiting for Certificate %q (Key Vault %q) to finish purging: %+v", id.Name, id.KeyVaultBaseUrl, err)
+		}
+		log.Printf("[DEBUG] Purged Certificate %q (Key Vault %q).", id.Name, id.KeyVaultBaseUrl)
+	} else {
+		log.Printf("[DEBUG] Skipping purging of Certificate %q (Key Vault %q)..", id.Name, id.KeyVaultBaseUrl)
 	}
 
 	return nil

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -25,27 +25,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-// todo refactor and find a home for this wayward func
-func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client).KeyVault.VaultsClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	id, err := azure.ParseKeyVaultChildID(d.Id())
-	if err != nil {
-		return []*schema.ResourceData{d}, fmt.Errorf("Error Unable to parse ID (%s) for Key Vault Child import: %v", d.Id(), err)
-	}
-
-	kvid, err := azure.GetKeyVaultIDFromBaseUrl(ctx, client, id.KeyVaultBaseUrl)
-	if err != nil {
-		return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
-	}
-
-	d.Set("key_vault_id", kvid)
-
-	return []*schema.ResourceData{d}, nil
-}
-
 func resourceArmKeyVaultCertificate() *schema.Resource {
 	return &schema.Resource{
 		// TODO: support Updating once we have more information about what can be updated
@@ -54,7 +33,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 		Delete: resourceArmKeyVaultCertificateDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceArmKeyVaultChildResourceImporter,
+			State: nestedItemResourceImporter,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -934,6 +934,7 @@ resource "azurerm_key_vault_access_policy" "test" {
     "delete",
     "get",
     "purge",
+    "recover",
     "update",
   ]
 
@@ -1125,7 +1126,9 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "import",
       "purge",
+      "recover",
       "update",
     ]
 

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -916,13 +916,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
+  name                       = "acctestkeyvault%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -1014,13 +1014,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
+  name                       = "acctestkeyvault%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
@@ -1109,12 +1109,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
+  name                       = "acctestkeyvault%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -933,6 +933,7 @@ resource "azurerm_key_vault_access_policy" "test" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 
@@ -1032,6 +1033,7 @@ resource "azurerm_key_vault_access_policy" "test" {
     "delete",
     "get",
     "recover",
+    "purge",
     "update",
   ]
 
@@ -1122,6 +1124,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
       "update",
     ]
 

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -407,46 +407,13 @@ func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource
 }
 
 func testAccAzureRMKeyVaultCertificate_basicImportPFX(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "delete",
-      "import",
-      "get",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -474,7 +441,7 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_requiresImport(data acceptance.TestData) string {
@@ -512,51 +479,13 @@ resource "azurerm_key_vault_certificate" "import" {
 }
 
 func testAccAzureRMKeyVaultCertificate_basicGenerate(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-
-    storage_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -603,55 +532,17 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_basicGenerateUnknownIssuer(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-
-    storage_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -698,55 +589,17 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_basicGenerateSans(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-
-    storage_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -800,51 +653,17 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_basicGenerateTags(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -895,55 +714,17 @@ resource "azurerm_key_vault_certificate" "test" {
     "hello" = "world"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_basicExtendedKeyUsage(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-
-    storage_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -996,55 +777,17 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_emptyExtendedKeyUsage(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-
-    storage_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -1093,10 +836,11 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_softDeleteRecovery(data acceptance.TestData, purge bool) string {
+	template := testAccAzureRMKeyVaultCertificate_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -1107,48 +851,7 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-kvc-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  soft_delete_enabled = true
-
-  sku_name = "standard"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "create",
-      "delete",
-      "get",
-      "recover",
-      "update",
-    ]
-
-    key_permissions = [
-      "create",
-    ]
-
-    secret_permissions = [
-      "set",
-    ]
-
-    storage_permissions = [
-      "set",
-    ]
-  }
-}
+%s
 
 resource "azurerm_key_vault_certificate" "test" {
   name         = "acctestcert%s"
@@ -1195,7 +898,7 @@ resource "azurerm_key_vault_certificate" "test" {
     }
   }
 }
-`, purge, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, purge, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultCertificate_withExternalAccessPolicy(data acceptance.TestData) string {
@@ -1392,4 +1095,48 @@ resource "azurerm_key_vault_certificate" "test" {
   depends_on = [azurerm_key_vault_access_policy.test]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMKeyVaultCertificate_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkeyvault%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+    ]
+
+    key_permissions = [
+      "create",
+    ]
+
+    secret_permissions = [
+      "set",
+    ]
+
+    storage_permissions = [
+      "set",
+    ]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/keyvault/key_vault_key_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource.go
@@ -28,7 +28,7 @@ func resourceArmKeyVaultKey() *schema.Resource {
 		Update: resourceArmKeyVaultKeyUpdate,
 		Delete: resourceArmKeyVaultKeyDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceArmKeyVaultChildResourceImporter,
+			State: nestedItemResourceImporter,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
@@ -495,49 +495,13 @@ func testCheckAzureRMKeyVaultKeyDisappears(resourceName string) resource.TestChe
 }
 
 func testAccAzureRMKeyVaultKey_basicEC(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name         = "key-%s"
@@ -550,53 +514,17 @@ resource "azurerm_key_vault_key" "test" {
     "verify",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_basicECUpdatedExternally(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name            = "key-%s"
@@ -614,7 +542,7 @@ resource "azurerm_key_vault_key" "test" {
     Rick = "Morty"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_requiresImport(data acceptance.TestData) string {
@@ -637,49 +565,13 @@ resource "azurerm_key_vault_key" "import" {
 }
 
 func testAccAzureRMKeyVaultKey_basicRSA(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name         = "key-%s"
@@ -696,52 +588,17 @@ resource "azurerm_key_vault_key" "test" {
     "wrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_basicRSAHSM(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name         = "key-%s"
@@ -758,52 +615,17 @@ resource "azurerm_key_vault_key" "test" {
     "wrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_complete(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name            = "key-%s"
@@ -826,53 +648,17 @@ resource "azurerm_key_vault_key" "test" {
     "hello" = "world"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_basicUpdated(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-      "update",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name         = "key-%s"
@@ -888,52 +674,17 @@ resource "azurerm_key_vault_key" "test" {
     "wrapKey",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_curveEC(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name         = "key-%s"
@@ -946,52 +697,17 @@ resource "azurerm_key_vault_key" "test" {
     "verify",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_basicECHSM(data acceptance.TestData) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "delete",
-      "get",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name         = "key-%s"
@@ -1004,10 +720,11 @@ resource "azurerm_key_vault_key" "test" {
     "verify",
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_softDeleteRecovery(data acceptance.TestData, purge bool) string {
+	template := testAccAzureRMKeyVaultKey_template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -1018,45 +735,7 @@ provider "azurerm" {
   }
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-kvk-%d"
-  location = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  soft_delete_enabled = true
-
-  sku_name = "premium"
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-
-    key_permissions = [
-      "create",
-      "recover",
-      "delete",
-      "get",
-    ]
-
-    secret_permissions = [
-      "get",
-      "delete",
-      "set",
-    ]
-  }
-
-  tags = {
-    environment = "Production"
-  }
-}
+%s
 
 resource "azurerm_key_vault_key" "test" {
   name            = "key-%s"
@@ -1079,7 +758,7 @@ resource "azurerm_key_vault_key" "test" {
     "hello" = "world"
   }
 }
-`, purge, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, purge, template, data.RandomString)
 }
 
 func testAccAzureRMKeyVaultKey_withExternalAccessPolicy(data acceptance.TestData) string {
@@ -1097,12 +776,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "acctestkv-%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   tags = {
     environment = "accTest"
@@ -1118,6 +798,8 @@ resource "azurerm_key_vault_access_policy" "test" {
     "create",
     "delete",
     "get",
+    "purge",
+    "recover",
     "update",
   ]
 
@@ -1159,12 +841,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "acctestkv-%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "acctestkv-%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   tags = {
     environment = "accTest"
@@ -1181,6 +864,8 @@ resource "azurerm_key_vault_access_policy" "test" {
     "delete",
     "encrypt",
     "get",
+    "purge",
+    "recover",
     "update",
   ]
 
@@ -1205,4 +890,49 @@ resource "azurerm_key_vault_key" "test" {
   depends_on = [azurerm_key_vault_access_policy.test]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMKeyVaultKey_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv-%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "create",
+      "delete",
+      "get",
+      "purge",
+      "recover",
+      "update",
+    ]
+
+    secret_permissions = [
+      "get",
+      "delete",
+      "set",
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -103,7 +103,7 @@ func resourceArmKeyVault() *schema.Resource {
 						"application_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.IsUUID,
+							ValidateFunc: validate.IsUUIDOrEmpty,
 						},
 						"certificate_permissions": azure.SchemaKeyVaultCertificatePermissions(),
 						"key_permissions":         azure.SchemaKeyVaultKeyPermissions(),

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -631,12 +631,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -664,12 +665,13 @@ func testAccAzureRMKeyVault_requiresImport(data acceptance.TestData) string {
 %s
 
 resource "azurerm_key_vault" "import" {
-  name                = azurerm_key_vault.test.name
-  location            = azurerm_key_vault.test.location
-  resource_group_name = azurerm_key_vault.test.resource_group_name
-  tenant_id           = azurerm_key_vault.test.tenant_id
-
-  sku_name = "premium"
+  name                       = azurerm_key_vault.test.name
+  location                   = azurerm_key_vault.test.location
+  resource_group_name        = azurerm_key_vault.test.resource_group_name
+  tenant_id                  = azurerm_key_vault.test.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -732,12 +734,13 @@ func testAccAzureRMKeyVault_networkAcls(data acceptance.TestData) string {
 %s
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -767,12 +770,13 @@ func testAccAzureRMKeyVault_networkAclsUpdated(data acceptance.TestData) string 
 %s
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -803,12 +807,13 @@ func testAccAzureRMKeyVault_networkAclsAllowed(data acceptance.TestData) string 
 %s
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -846,12 +851,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -893,12 +899,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   enabled_for_deployment          = true
   enabled_for_disk_encryption     = true
@@ -927,12 +934,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy = []
 
@@ -963,12 +971,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id      = data.azurerm_client_config.current.tenant_id
@@ -1010,12 +1019,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -1052,12 +1062,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
-  sku_name = "premium"
   %s
 }
 
@@ -1227,7 +1239,6 @@ resource "azurerm_key_vault" "test" {
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
-
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -1247,12 +1258,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy = []
 }
@@ -1274,12 +1286,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -27,7 +27,7 @@ func resourceArmKeyVaultSecret() *schema.Resource {
 		Update: resourceArmKeyVaultSecretUpdate,
 		Delete: resourceArmKeyVaultSecretDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceArmKeyVaultChildResourceImporter,
+			State: nestedItemResourceImporter,
 		},
 
 		Timeouts: &schema.ResourceTimeout{

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -548,6 +548,8 @@ resource "azurerm_key_vault_access_policy" "test" {
     "set",
     "get",
     "delete",
+    "purge",
+    "recover"
   ]
 }
 
@@ -600,7 +602,8 @@ resource "azurerm_key_vault_access_policy" "test" {
     "set",
     "get",
     "delete",
-    "recover",
+    "purge",
+    "recover"
   ]
 }
 

--- a/azurerm/internal/services/keyvault/validate/uuid.go
+++ b/azurerm/internal/services/keyvault/validate/uuid.go
@@ -1,0 +1,26 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+// IsUUIDOrEmpty is a ValidateFunc that ensures a string can be parsed as UUID or is empty
+func IsUUIDOrEmpty(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" {
+		return
+	}
+
+	if _, err := uuid.ParseUUID(v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid UUID, got %v", k, v))
+	}
+
+	return warnings, errors
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -169,13 +169,13 @@ The `features` block supports the following:
 
 The `key_vault` block supports the following:
 
-* `recover_soft_deleted_key_vaults` - (Optional) Should the `azurerm_key_vault` resource recover a Key Vault which has previously been Soft Deleted? Defaults to `true`.
-
-* `purge_soft_delete_on_destroy` - (Optional) Should the `azurerm_key_vault` resource be permanently deleted (e.g. purged) when destroyed? Defaults to `true`.
-
-~> **Note:** When purge protection is enabled, a key vault or an object in the deleted state cannot be purged until the retention period(90 days) has passed.
+* `recover_soft_deleted_key_vaults` - (Optional) Should the `azurerm_key_vault`, `azurerm_key_vault_certificate`, `azurerm_key_vault_key` and `azurerm_key_vault_secret` resources recover a Soft-Deleted Key Vault/Item? Defaults to `true`.
 
 ~> **Note:** When recovering soft-deleted Key Vault items (Keys, Certificates, and Secrets) the Principal used by Terraform needs the `"recover"` permission.
+
+* `purge_soft_delete_on_destroy` - (Optional) Should the `azurerm_key_vault`, `azurerm_key_vault_certificate`, `azurerm_key_vault_key` and `azurerm_key_vault_secret` resources be permanently deleted (e.g. purged) when destroyed? Defaults to `true`.
+
+~> **Note:** When purge protection is enabled, a key vault or an object in the deleted state cannot be purged until the retention period (7-90 days) has passed.
 
 ---
 

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -17,32 +17,25 @@ Manages a Key Vault Access Policy.
 ## Example Usage
 
 ```hcl
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_resource_group" "example" {
-  name     = "resourceGroup1"
-  location = azurerm_resource_group.example.location
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "testvault"
+  name                = "examplekeyvault"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-
-  sku_name = "standard"
-
-  tenant_id = "22222222-2222-2222-2222-222222222222"
-
-  enabled_for_disk_encryption = true
-
-  tags = {
-    environment = "Production"
-  }
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "premium"
 }
 
 resource "azurerm_key_vault_access_policy" "example" {
   key_vault_id = azurerm_key_vault.example.id
-
-  tenant_id = "00000000-0000-0000-0000-000000000000"
-  object_id = "11111111-1111-1111-1111-111111111111"
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "get",

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -141,6 +141,7 @@ resource "azurerm_key_vault" "example" {
       "listissuers",
       "managecontacts",
       "manageissuers",
+      "purge",
       "setissuers",
       "update",
     ]

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -120,11 +120,13 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "examplekeyvault"
-  location            = azurerm_resource_group.example.location
-  resource_group_name = azurerm_resource_group.example.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  sku_name            = "premium"
+  name                       = "examplekeyvault"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -16,21 +16,19 @@ Manages a Key Vault Certificate.
 ~> **Note:** this example assumed the PFX file is located in the same directory at `certificate-to-import.pfx`.
 
 ```hcl
-data "azurerm_client_config" "current" {
-}
+data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "key-vault-certificate-example"
+  name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "keyvaultcertexample"
+  name                = "examplekeyvault"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -80,10 +78,6 @@ resource "azurerm_key_vault" "example" {
       "restore",
       "set",
     ]
-  }
-
-  tags = {
-    environment = "Production"
   }
 }
 
@@ -118,21 +112,19 @@ resource "azurerm_key_vault_certificate" "example" {
 ## Example Usage (Generating a new certificate)
 
 ```hcl
-data "azurerm_client_config" "current" {
-}
+data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "key-vault-certificate-example"
+  name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "keyvaultcertexample"
+  name                = "examplekeyvault"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "standard"
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -182,10 +174,6 @@ resource "azurerm_key_vault" "example" {
       "restore",
       "set",
     ]
-  }
-
-  tags = {
-    environment = "Production"
   }
 }
 
@@ -356,5 +344,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Key Vault Certificates can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_key_vault_certificate.examplehttps://example-keyvault.vault.azure.net/certificates/example/fdf067c93bbb4b22bff4d8b7a9a56217
+terraform import azurerm_key_vault_certificate.example https://example-keyvault.vault.azure.net/certificates/example/fdf067c93bbb4b22bff4d8b7a9a56217
 ```

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -344,5 +344,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Key Vault Certificates can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_key_vault_certificate.example https://example-keyvault.vault.azure.net/certificates/example/fdf067c93bbb4b22bff4d8b7a9a56217
+terraform import azurerm_key_vault_certificate.example "https://example-keyvault.vault.azure.net/certificates/example/fdf067c93bbb4b22bff4d8b7a9a56217"
 ```

--- a/website/docs/r/key_vault_certificate_issuer.html.markdown
+++ b/website/docs/r/key_vault_certificate_issuer.html.markdown
@@ -13,15 +13,15 @@ Manages a Key Vault Certificate Issuer.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "example" {
-  name     = "example-resources"
-  location = "West US"
-}
-
 data "azurerm_client_config" "current" {}
 
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
 resource "azurerm_key_vault" "example" {
-  name                = "example-key-vault"
+  name                = "examplekeyvault"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku_name            = "standard"

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -109,5 +109,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Key Vault Key which is Enabled can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_key_vault_key.example https://example-keyvault.vault.azure.net/keys/example/fdf067c93bbb4b22bff4d8b7a9a56217
+terraform import azurerm_key_vault_key.example "https://example-keyvault.vault.azure.net/keys/example/fdf067c93bbb4b22bff4d8b7a9a56217"
 ```

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -14,29 +14,19 @@ Manages a Key Vault Key.
 ## Example Usage
 
 ```hcl
-data "azurerm_client_config" "current" {
-}
+data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "my-resource-group"
-  location = "West US"
-}
-
-resource "random_id" "server" {
-  keepers = {
-    ami_id = 1
-  }
-
-  byte_length = 8
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "keyvaultkeyexample"
+  name                = "examplekeyvault"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -50,10 +40,6 @@ resource "azurerm_key_vault" "example" {
     secret_permissions = [
       "set",
     ]
-  }
-
-  tags = {
-    environment = "Production"
   }
 }
 
@@ -123,5 +109,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Key Vault Key which is Enabled can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_key_vault_key.examplehttps://example-keyvault.vault.azure.net/keys/example/fdf067c93bbb4b22bff4d8b7a9a56217
+terraform import azurerm_key_vault_key.example https://example-keyvault.vault.azure.net/keys/example/fdf067c93bbb4b22bff4d8b7a9a56217
 ```

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -22,11 +22,13 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "examplekeyvault"
-  location            = azurerm_resource_group.example.location
-  resource_group_name = azurerm_resource_group.example.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  sku_name            = "premium"
+  name                       = "examplekeyvault"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -35,6 +37,8 @@ resource "azurerm_key_vault" "example" {
     key_permissions = [
       "create",
       "get",
+      "purge",
+      "recover"
     ]
 
     secret_permissions = [

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -25,11 +25,13 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = "examplekeyvault"
-  location            = azurerm_resource_group.example.location
-  resource_group_name = azurerm_resource_group.example.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  sku_name            = "premium"
+  name                       = "examplekeyvault"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -44,6 +46,8 @@ resource "azurerm_key_vault" "example" {
       "set",
       "get",
       "delete",
+      "purge",
+      "recover"
     ]
   }
 }

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -17,29 +17,19 @@ Manages a Key Vault Secret.
 ## Example Usage
 
 ```hcl
-data "azurerm_client_config" "current" {
-}
+data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "my-resource-group"
-  location = "West US"
-}
-
-resource "random_id" "server" {
-  keepers = {
-    ami_id = 1
-  }
-
-  byte_length = 8
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_key_vault" "example" {
-  name                = format("%s%s", "kv", random_id.server.hex)
+  name                = "examplekeyvault"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name = "premium"
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -56,20 +46,12 @@ resource "azurerm_key_vault" "example" {
       "delete",
     ]
   }
-
-  tags = {
-    environment = "Production"
-  }
 }
 
 resource "azurerm_key_vault_secret" "example" {
   name         = "secret-sauce"
   value        = "szechuan"
   key_vault_id = azurerm_key_vault.example.id
-
-  tags = {
-    environment = "Production"
-  }
 }
 ```
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -98,5 +98,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Key Vault Secrets which are Enabled can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_key_vault_secret.example https://example-keyvault.vault.azure.net/secrets/example/fdf067c93bbb4b22bff4d8b7a9a56217
+terraform import azurerm_key_vault_secret.example "https://example-keyvault.vault.azure.net/secrets/example/fdf067c93bbb4b22bff4d8b7a9a56217"
 ```


### PR DESCRIPTION
This PR introduces Purging for Nested Items (e.g. Certificates, Keys and Secrets) during deletion - like we do for the Key Vaults themselves. This behaviour can be opted-out of using the `purge_soft_delete_on_destroy` flag (which is reused in the same way that the `recover_soft_deleted_key_vaults` flag is reused between Key Vaults and Nested Items)

This also fixes an issue where the Key Vault Data Plane API is eventually consistent, by polling to ensure the Nested Item is fully deleted (and subsequently fully purged, if we're opted-into that) during the Delete function.

This change is necessary to workaround an upcoming breaking change happening on December 31st where all Key Vaults get Soft-Delete force-enabled by default and have no means of disabling that - as such to retain the same behaviour as exists today Nested Items must (presuming the users opted in) now be purged during deletion (since users have already confirmed they want to delete these items via approving the `terraform plan`).

Fixes #5659