### PR TITLE
web/app-service: fixing the Exists function

### DIFF
--- a/azurerm/internal/services/web/app_service_plan_resource_test.go
+++ b/azurerm/internal/services/web/app_service_plan_resource_test.go
@@ -230,6 +230,11 @@ func (r AppServicePlanResource) Exists(ctx context.Context, client *clients.Clie
 		return nil, fmt.Errorf("retrieving App Service Plan %q (Resource Group %q): %+v", id.ServerfarmName, id.ResourceGroup, err)
 	}
 
+	// The SDK defines 404 as an "ok" status code..
+	if utils.ResponseWasNotFound(resp.Response) {
+		return utils.Bool(false), nil
+	}
+
 	return utils.Bool(true), nil
 }
 

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -1695,6 +1695,12 @@ func (r AppServiceResource) Exists(ctx context.Context, client *clients.Client, 
 		}
 		return nil, fmt.Errorf("retrieving App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
+
+	// The SDK defines 404 as an "ok" status code..
+	if utils.ResponseWasNotFound(resp.Response) {
+		return utils.Bool(false), nil
+	}
+
 	return utils.Bool(true), nil
 }
 

--- a/azurerm/internal/services/web/app_service_slot_resource_test.go
+++ b/azurerm/internal/services/web/app_service_slot_resource_test.go
@@ -1142,6 +1142,11 @@ func (r AppServiceSlotResource) Exists(ctx context.Context, client *clients.Clie
 		return nil, fmt.Errorf("retrieving Slot %q (App Service %q / Resource Group %q): %+v", id.SlotName, id.SiteName, id.ResourceGroup, err)
 	}
 
+	// The SDK defines 404 as an "ok" status code..
+	if utils.ResponseWasNotFound(resp.Response) {
+		return utils.Bool(false), nil
+	}
+
 	return utils.Bool(true), nil
 }
 

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -839,6 +839,11 @@ func (r FunctionAppResource) Exists(ctx context.Context, client *clients.Client,
 		return nil, fmt.Errorf("retrieving Function App %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
 
+	// The SDK defines 404 as an "ok" status code..
+	if utils.ResponseWasNotFound(resp.Response) {
+		return utils.Bool(false), nil
+	}
+
 	return utils.Bool(true), nil
 }
 

--- a/azurerm/internal/services/web/function_app_slot_resource_test.go
+++ b/azurerm/internal/services/web/function_app_slot_resource_test.go
@@ -594,6 +594,12 @@ func (r FunctionAppSlotResource) Exists(ctx context.Context, client *clients.Cli
 		}
 		return nil, fmt.Errorf("retrieving Function App Slot %q (Function App %q / Resource Group %q): %+v", id.SlotName, id.SiteName, id.ResourceGroup, err)
 	}
+
+	// The SDK defines 404 as an "ok" status code..
+	if utils.ResponseWasNotFound(resp.Response) {
+		return utils.Bool(false), nil
+	}
+
 	return utils.Bool(true), nil
 }
 


### PR DESCRIPTION
The App Service API has "404" as an "ok" status code.. so this doesn't return an error. This PR fixing the Exists function used in the tests to account for this - these provision fine otherwise.