### PR TITLE
New Resource: `azurerm_data_factory_linked_service_synapse`

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory.go
+++ b/azurerm/internal/services/datafactory/data_factory.go
@@ -227,3 +227,41 @@ func serializeDataFactoryPipelineActivities(activities *[]datafactory.BasicActiv
 func suppressJsonOrderingDifference(_, old, new string, _ *schema.ResourceData) bool {
 	return utils.NormalizeJson(old) == utils.NormalizeJson(new)
 }
+
+func expandAzureKeyVaultPasswordReference(input []interface{}) *datafactory.AzureKeyVaultSecretReference {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	config := input[0].(map[string]interface{})
+
+	keyVaultLinkedServiceName := config["linked_service_name"].(string)
+	keyVaultPasswordSecretName := config["password_secret_name"].(string)
+	linkedServiceType := "LinkedServiceReference"
+
+	return &datafactory.AzureKeyVaultSecretReference{
+		SecretName: keyVaultPasswordSecretName,
+		Store: &datafactory.LinkedServiceReference{
+			Type:          &linkedServiceType,
+			ReferenceName: &keyVaultLinkedServiceName,
+		},
+	}
+}
+
+func flattenAzureKeyVaultPasswordReference(secretReference *datafactory.AzureKeyVaultSecretReference) []interface{} {
+	if secretReference == nil {
+		return nil
+	}
+
+	parameters := make(map[string]interface{})
+
+	if store := secretReference.Store; store != nil {
+		if store.ReferenceName != nil {
+			parameters["linked_service_name"] = *store.ReferenceName
+		}
+	}
+
+	parameters["password_secret_name"] = secretReference.SecretName
+
+	return []interface{}{parameters}
+}

--- a/azurerm/internal/services/datafactory/data_factory.go
+++ b/azurerm/internal/services/datafactory/data_factory.go
@@ -228,27 +228,23 @@ func suppressJsonOrderingDifference(_, old, new string, _ *schema.ResourceData) 
 	return utils.NormalizeJson(old) == utils.NormalizeJson(new)
 }
 
-func expandAzureKeyVaultPasswordReference(input []interface{}) *datafactory.AzureKeyVaultSecretReference {
+func expandAzureKeyVaultPassword(input []interface{}) *datafactory.AzureKeyVaultSecretReference {
 	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 
 	config := input[0].(map[string]interface{})
 
-	keyVaultLinkedServiceName := config["linked_service_name"].(string)
-	keyVaultPasswordSecretName := config["password_secret_name"].(string)
-	linkedServiceType := "LinkedServiceReference"
-
 	return &datafactory.AzureKeyVaultSecretReference{
-		SecretName: keyVaultPasswordSecretName,
+		SecretName: config["secret_name"].(string),
 		Store: &datafactory.LinkedServiceReference{
-			Type:          &linkedServiceType,
-			ReferenceName: &keyVaultLinkedServiceName,
+			Type:          utils.String("LinkedServiceReference"),
+			ReferenceName: utils.String(config["linked_service_name"].(string)),
 		},
 	}
 }
 
-func flattenAzureKeyVaultPasswordReference(secretReference *datafactory.AzureKeyVaultSecretReference) []interface{} {
+func flattenAzureKeyVaultPassword(secretReference *datafactory.AzureKeyVaultSecretReference) []interface{} {
 	if secretReference == nil {
 		return nil
 	}
@@ -261,7 +257,7 @@ func flattenAzureKeyVaultPasswordReference(secretReference *datafactory.AzureKey
 		}
 	}
 
-	parameters["password_secret_name"] = secretReference.SecretName
+	parameters["secret_name"] = secretReference.SecretName
 
 	return []interface{}{parameters}
 }

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
@@ -1,0 +1,329 @@
+package datafactory
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDataFactoryLinkedServiceSynapseCreateUpdate,
+		Read:   resourceArmDataFactoryLinkedServiceSynapseRead,
+		Update: resourceArmDataFactoryLinkedServiceSynapseCreateUpdate,
+		Delete: resourceArmDataFactoryLinkedServiceSynapseDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAzureRMDataFactoryLinkedServiceDatasetName,
+			},
+
+			"data_factory_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataFactoryName(),
+			},
+
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			"connection_string": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: azureRmDataFactoryLinkedServiceConnectionStringDiff,
+				ValidateFunc:     validation.StringIsNotEmpty,
+			},
+
+			"key_vault_password_reference": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_vault_linked_service_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"key_vault_password_secret_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"integration_runtime_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"annotations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"additional_properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceArmDataFactoryLinkedServiceSynapseCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	dataFactoryName := d.Get("data_factory_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Data Factory Linked Service Synapse%q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_data_factory_linked_service_synapse", *existing.ID)
+		}
+	}
+
+	passwordReferenceProps := d.Get("key_vault_password_reference").([]interface{})
+
+	sqlDWProperties := &datafactory.AzureSQLDWLinkedServiceTypeProperties{
+		ConnectionString: d.Get("connection_string").(string),
+		Password:         expandAzureKeyVaultSecretReference(passwordReferenceProps),
+	}
+
+	description := d.Get("description").(string)
+
+	sqlDWLinkedService := &datafactory.AzureSQLDWLinkedService{
+		Description:                           &description,
+		AzureSQLDWLinkedServiceTypeProperties: sqlDWProperties,
+		Type:                                  datafactory.TypeAzureSQLDW,
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		sqlDWLinkedService.Parameters = expandDataFactoryParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("integration_runtime_name"); ok {
+		sqlDWLinkedService.ConnectVia = expandDataFactoryLinkedServiceIntegrationRuntime(v.(string))
+	}
+
+	if v, ok := d.GetOk("additional_properties"); ok {
+		sqlDWLinkedService.AdditionalProperties = v.(map[string]interface{})
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		annotations := v.([]interface{})
+		sqlDWLinkedService.Annotations = &annotations
+	}
+
+	linkedService := datafactory.LinkedServiceResource{
+		Properties: sqlDWLinkedService,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, dataFactoryName, name, linkedService, ""); err != nil {
+		return fmt.Errorf("Error creating/updating Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmDataFactoryLinkedServiceSynapseRead(d, meta)
+}
+
+func resourceArmDataFactoryLinkedServiceSynapseRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("data_factory_name", dataFactoryName)
+
+	sqlDW, ok := resp.Properties.AsAzureSQLDWLinkedService()
+	if !ok {
+		return fmt.Errorf("Error classifiying Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", name, dataFactoryName, resourceGroup, datafactory.TypeAzureSQLDW, *resp.Type)
+	}
+
+	d.Set("additional_properties", sqlDW.AdditionalProperties)
+	d.Set("description", sqlDW.Description)
+
+	annotations := flattenDataFactoryAnnotations(sqlDW.Annotations)
+	if err := d.Set("annotations", annotations); err != nil {
+		return fmt.Errorf("Error setting `annotations`: %+v", err)
+	}
+
+	parameters := flattenDataFactoryParameters(sqlDW.Parameters)
+	if err := d.Set("parameters", parameters); err != nil {
+		return fmt.Errorf("Error setting `parameters`: %+v", err)
+	}
+
+	if connectVia := sqlDW.ConnectVia; connectVia != nil {
+		if connectVia.ReferenceName != nil {
+			d.Set("integration_runtime_name", connectVia.ReferenceName)
+		}
+	}
+
+	if properties := sqlDW.AzureSQLDWLinkedServiceTypeProperties; properties != nil {
+		if properties.ConnectionString != nil {
+			if val, ok := properties.ConnectionString.(string); ok {
+				d.Set("connection_string", val)
+			} else {
+				d.Set("connection_string", "")
+				log.Printf("[DEBUG] Skipping connection string %q since it's not a string", val)
+			}
+		}
+
+		if err := d.Set("key_vault_password_reference", flattenAzureKeyVaultSecretReference(properties.Password)); err != nil {
+			return fmt.Errorf("setting `custom_parameters`: %+v", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceArmDataFactoryLinkedServiceSynapseDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	response, err := client.Delete(ctx, resourceGroup, dataFactoryName, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(response) {
+			return fmt.Errorf("Error deleting Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}
+
+func expandAzureKeyVaultSecretReference(input []interface{}) *datafactory.AzureKeyVaultSecretReference {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	config := input[0].(map[string]interface{})
+
+	keyVaultLinkedServiceName := config["key_vault_linked_service_name"].(string)
+	keyVaultPasswordSecretName := config["key_vault_password_secret_name"].(string)
+	linkedServiceType := "LinkedServiceReference"
+
+	return &datafactory.AzureKeyVaultSecretReference{
+		SecretName: keyVaultPasswordSecretName,
+		Store: &datafactory.LinkedServiceReference{
+			Type:          &linkedServiceType,
+			ReferenceName: &keyVaultLinkedServiceName,
+		},
+	}
+}
+
+func flattenAzureKeyVaultSecretReference(secretReference *datafactory.AzureKeyVaultSecretReference) []interface{} {
+	if secretReference == nil {
+		return nil
+	}
+
+	parameters := make(map[string]interface{})
+
+	if store := secretReference.Store; store != nil {
+		if store.ReferenceName != nil {
+			parameters["key_vault_linked_service_name"] = *store.ReferenceName
+		}
+	}
+
+	if secretName := secretReference.SecretName; secretName != nil {
+		parameters["key_vault_password_secret_name"] = secretName
+	}
+
+	return []interface{}{parameters}
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
@@ -61,7 +61,7 @@ func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
 				ValidateFunc:     validation.StringIsNotEmpty,
 			},
 
-			"key_vault_password_reference": {
+			"key_vault_password": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -73,7 +73,7 @@ func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
-						"password_secret_name": {
+						"secret_name": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
@@ -146,13 +146,13 @@ func resourceArmDataFactoryLinkedServiceSynapseCreateUpdate(d *schema.ResourceDa
 		}
 	}
 
-	passwordReference := d.Get("key_vault_password_reference").([]interface{})
+	password := d.Get("key_vault_password").([]interface{})
 
 	sqlDWLinkedService := &datafactory.AzureSQLDWLinkedService{
 		Description: utils.String(d.Get("description").(string)),
 		AzureSQLDWLinkedServiceTypeProperties: &datafactory.AzureSQLDWLinkedServiceTypeProperties{
 			ConnectionString: d.Get("connection_string").(string),
-			Password:         expandAzureKeyVaultPasswordReference(passwordReference),
+			Password:         expandAzureKeyVaultPassword(password),
 		},
 		Type: datafactory.TypeAzureSQLDW,
 	}
@@ -254,8 +254,8 @@ func resourceArmDataFactoryLinkedServiceSynapseRead(d *schema.ResourceData, meta
 			}
 		}
 
-		if err := d.Set("key_vault_password_reference", flattenAzureKeyVaultPasswordReference(properties.Password)); err != nil {
-			return fmt.Errorf("setting `key_vault_password_reference`: %+v", err)
+		if err := d.Set("key_vault_password", flattenAzureKeyVaultPassword(properties.Password)); err != nil {
+			return fmt.Errorf("setting `key_vault_password`: %+v", err)
 		}
 	}
 

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -97,7 +98,8 @@ func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 
@@ -105,7 +107,8 @@ func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 
@@ -113,7 +116,8 @@ func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 		},
@@ -144,17 +148,13 @@ func resourceArmDataFactoryLinkedServiceSynapseCreateUpdate(d *schema.ResourceDa
 
 	passwordReference := d.Get("key_vault_password_reference").([]interface{})
 
-	sqlDWProperties := &datafactory.AzureSQLDWLinkedServiceTypeProperties{
-		ConnectionString: d.Get("connection_string").(string),
-		Password:         expandAzureKeyVaultPasswordReference(passwordReference),
-	}
-
-	description := d.Get("description").(string)
-
 	sqlDWLinkedService := &datafactory.AzureSQLDWLinkedService{
-		Description:                           &description,
-		AzureSQLDWLinkedServiceTypeProperties: sqlDWProperties,
-		Type:                                  datafactory.TypeAzureSQLDW,
+		Description: utils.String(d.Get("description").(string)),
+		AzureSQLDWLinkedServiceTypeProperties: &datafactory.AzureSQLDWLinkedServiceTypeProperties{
+			ConnectionString: d.Get("connection_string").(string),
+			Password:         expandAzureKeyVaultPasswordReference(passwordReference),
+		},
+		Type: datafactory.TypeAzureSQLDW,
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
@@ -201,31 +201,28 @@ func resourceArmDataFactoryLinkedServiceSynapseRead(d *schema.ResourceData, meta
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.LinkedServiceID(d.Id())
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.ResourceGroup
-	dataFactoryName := id.Path["factories"]
-	name := id.Path["linkedservices"]
 
-	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	resp, err := client.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", id.Name, id.FactoryName, id.ResourceGroup, err)
 	}
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("data_factory_name", dataFactoryName)
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("data_factory_name", id.FactoryName)
 
 	sqlDW, ok := resp.Properties.AsAzureSQLDWLinkedService()
 	if !ok {
-		return fmt.Errorf("Error classifiying Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", name, dataFactoryName, resourceGroup, datafactory.TypeAzureSQLDW, *resp.Type)
+		return fmt.Errorf("Error classifying Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", id.Name, id.FactoryName, id.ResourceGroup, datafactory.TypeAzureSQLDW, *resp.Type)
 	}
 
 	d.Set("additional_properties", sqlDW.AdditionalProperties)
@@ -270,18 +267,15 @@ func resourceArmDataFactoryLinkedServiceSynapseDelete(d *schema.ResourceData, me
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.LinkedServiceID(d.Id())
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.ResourceGroup
-	dataFactoryName := id.Path["factories"]
-	name := id.Path["linkedservices"]
 
-	response, err := client.Delete(ctx, resourceGroup, dataFactoryName, name)
+	response, err := client.Delete(ctx, id.ResourceGroup, id.FactoryName, id.Name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(response) {
-			return fmt.Errorf("Error deleting Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+			return fmt.Errorf("Error deleting Data Factory Linked Service Synapse %q (Data Factory %q / Resource Group %q): %+v", id.Name, id.FactoryName, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource.go
@@ -66,13 +66,13 @@ func resourceArmDataFactoryLinkedServiceSynapse() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key_vault_linked_service_name": {
+						"linked_service_name": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
-						"key_vault_password_secret_name": {
+						"password_secret_name": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
@@ -295,8 +295,8 @@ func expandAzureKeyVaultSecretReference(input []interface{}) *datafactory.AzureK
 
 	config := input[0].(map[string]interface{})
 
-	keyVaultLinkedServiceName := config["key_vault_linked_service_name"].(string)
-	keyVaultPasswordSecretName := config["key_vault_password_secret_name"].(string)
+	keyVaultLinkedServiceName := config["linked_service_name"].(string)
+	keyVaultPasswordSecretName := config["password_secret_name"].(string)
 	linkedServiceType := "LinkedServiceReference"
 
 	return &datafactory.AzureKeyVaultSecretReference{
@@ -317,12 +317,12 @@ func flattenAzureKeyVaultSecretReference(secretReference *datafactory.AzureKeyVa
 
 	if store := secretReference.Store; store != nil {
 		if store.ReferenceName != nil {
-			parameters["key_vault_linked_service_name"] = *store.ReferenceName
+			parameters["linked_service_name"] = *store.ReferenceName
 		}
 	}
 
 	if secretName := secretReference.SecretName; secretName != nil {
-		parameters["key_vault_password_secret_name"] = secretName
+		parameters["password_secret_name"] = secretName
 	}
 
 	return []interface{}{parameters}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -53,8 +53,8 @@ func TestAccDataFactoryLinkedServiceSynapse_KeyVaultReference(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "additional_properties.%", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "test description"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "connection_string"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "key_vault_password_reference.0.linked_service_name"),
-					resource.TestCheckResourceAttr(data.ResourceName, "key_vault_password_reference.0.password_secret_name", "secret"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "key_vault_password.0.linked_service_name"),
+					resource.TestCheckResourceAttr(data.ResourceName, "key_vault_password.0.secret_name", "secret"),
 				),
 			},
 			data.ImportStep(),
@@ -199,9 +199,9 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
   data_factory_name   = azurerm_data_factory.test.name
 
   connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
-  key_vault_password_reference {
+  key_vault_password {
     linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
-    password_secret_name = "secret"
+    secret_name = "secret"
   }
 
   annotations = ["test1", "test2", "test3"]

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -1,0 +1,221 @@
+package datafactory_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMDataFactoryLinkedServiceSynapse_ConnectionString(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_synapse", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataFactoryLinkedServiceSynapse_connection_string(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataFactoryLinkedServiceSynapseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "annotations.#", "3"),
+					resource.TestCheckResourceAttr(data.ResourceName, "additional_properties.%", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "description", "test description"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "connection_string"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDataFactoryLinkedServiceSynapse_KeyVaultReference(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_synapse", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataFactoryLinkedServiceSynapse_key_vault_reference(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataFactoryLinkedServiceSynapseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "parameters.%", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "annotations.#", "3"),
+					resource.TestCheckResourceAttr(data.ResourceName, "additional_properties.%", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "description", "test description"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "connection_string"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "key_vault_password_reference.0.key_vault_linked_service_name"),
+					resource.TestCheckResourceAttr(data.ResourceName, "key_vault_password_reference.0.key_vault_password_secret_name", "secret"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testCheckAzureRMDataFactoryLinkedServiceSynapseExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).DataFactory.LinkedServiceClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		dataFactoryName := rs.Primary.Attributes["data_factory_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for Data Factory: %s", name)
+		}
+
+		resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on dataFactoryLinkedServiceClient: %+v", err)
+		}
+
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Bad: Data Factory Linked Service Synapse %q (data factory name: %q / resource group: %q) does not exist", name, dataFactoryName, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).DataFactory.LinkedServiceClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_data_factory_linked_service_synapse" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		dataFactoryName := rs.Primary.Attributes["data_factory_name"]
+
+		resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Data Factory Linked Service Synapse still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMDataFactoryLinkedServiceSynapse_connection_string(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_synapse" "test" {
+  name                = "acctestlssql%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+
+  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;Password=test"
+  
+  annotations         = ["test1", "test2", "test3"]
+  description         = "test description"
+
+  parameters = {
+    foo = "test1"
+    bar = "test2"
+  }
+
+  additional_properties = {
+    foo = "test1"
+    bar = "test2"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMDataFactoryLinkedServiceSynapse_key_vault_reference(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctkv%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+  name                = "linkkv"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  key_vault_id        = azurerm_key_vault.test.id
+}
+
+resource "azurerm_data_factory_linked_service_synapse" "test" {
+  name                = "linksynapse"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  
+  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
+  key_vault_password_reference {
+	key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
+	key_vault_password_secret_name = "secret"
+  }
+
+  annotations         = ["test1", "test2", "test3"]
+  description         = "test description"
+
+  parameters = {
+    foo = "test1"
+    bar = "test2"
+  }
+
+  additional_properties = {
+    foo = "test1"
+    bar = "test2"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -141,10 +141,10 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
   resource_group_name = azurerm_resource_group.test.name
   data_factory_name   = azurerm_data_factory.test.name
 
-  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;Password=test"
-  
-  annotations         = ["test1", "test2", "test3"]
-  description         = "test description"
+  connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;Password=test"
+
+  annotations = ["test1", "test2", "test3"]
+  description = "test description"
 
   parameters = {
     foo = "test1"
@@ -197,15 +197,15 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
   name                = "linksynapse"
   resource_group_name = azurerm_resource_group.test.name
   data_factory_name   = azurerm_data_factory.test.name
-  
-  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
+
+  connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
   key_vault_password_reference {
-	key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
-	key_vault_password_secret_name = "secret"
+    key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
+    key_vault_password_secret_name = "secret"
   }
 
-  annotations         = ["test1", "test2", "test3"]
-  description         = "test description"
+  annotations = ["test1", "test2", "test3"]
+  description = "test description"
 
   parameters = {
     foo = "test1"

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -53,8 +53,8 @@ func TestAccAzureRMDataFactoryLinkedServiceSynapse_KeyVaultReference(t *testing.
 					resource.TestCheckResourceAttr(data.ResourceName, "additional_properties.%", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "test description"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "connection_string"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "key_vault_password_reference.0.key_vault_linked_service_name"),
-					resource.TestCheckResourceAttr(data.ResourceName, "key_vault_password_reference.0.key_vault_password_secret_name", "secret"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "key_vault_password_reference.0.linked_service_name"),
+					resource.TestCheckResourceAttr(data.ResourceName, "key_vault_password_reference.0.password_secret_name", "secret"),
 				),
 			},
 			data.ImportStep(),
@@ -200,8 +200,8 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
 
   connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
   key_vault_password_reference {
-    key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
-    key_vault_password_secret_name = "secret"
+    linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
+    password_secret_name = "secret"
   }
 
   annotations = ["test1", "test2", "test3"]

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -200,8 +200,8 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
 
   connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
   key_vault_password {
-    linked_service_name  = azurerm_data_factory_linked_service_key_vault.test.name
-    secret_name = "secret"
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "secret"
   }
 
   annotations = ["test1", "test2", "test3"]

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -137,7 +137,7 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_linked_service_synapse" "test" {
-  name                = "acctestlssql%d"
+  name                = "linksynapse"
   resource_group_name = azurerm_resource_group.test.name
   data_factory_name   = azurerm_data_factory.test.name
 
@@ -156,7 +156,7 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
     bar = "test2"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func testAccAzureRMDataFactoryLinkedServiceSynapse_key_vault_reference(data acceptance.TestData) string {

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_synapse_resource_test.go
@@ -12,18 +12,18 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMDataFactoryLinkedServiceSynapse_ConnectionString(t *testing.T) {
+func TestAccDataFactoryLinkedServiceSynapse_ConnectionString(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_synapse", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy,
+		CheckDestroy: testCheckDataFactoryLinkedServiceSynapseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMDataFactoryLinkedServiceSynapse_connection_string(data),
+				Config: testAccDataFactoryLinkedServiceSynapse_connection_string(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMDataFactoryLinkedServiceSynapseExists(data.ResourceName),
+					testCheckDataFactoryLinkedServiceSynapseExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "parameters.%", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "annotations.#", "3"),
 					resource.TestCheckResourceAttr(data.ResourceName, "additional_properties.%", "2"),
@@ -36,18 +36,18 @@ func TestAccAzureRMDataFactoryLinkedServiceSynapse_ConnectionString(t *testing.T
 	})
 }
 
-func TestAccAzureRMDataFactoryLinkedServiceSynapse_KeyVaultReference(t *testing.T) {
+func TestAccDataFactoryLinkedServiceSynapse_KeyVaultReference(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_synapse", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy,
+		CheckDestroy: testCheckDataFactoryLinkedServiceSynapseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMDataFactoryLinkedServiceSynapse_key_vault_reference(data),
+				Config: testAccDataFactoryLinkedServiceSynapse_key_vault_reference(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMDataFactoryLinkedServiceSynapseExists(data.ResourceName),
+					testCheckDataFactoryLinkedServiceSynapseExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "parameters.%", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "annotations.#", "3"),
 					resource.TestCheckResourceAttr(data.ResourceName, "additional_properties.%", "2"),
@@ -62,7 +62,7 @@ func TestAccAzureRMDataFactoryLinkedServiceSynapse_KeyVaultReference(t *testing.
 	})
 }
 
-func testCheckAzureRMDataFactoryLinkedServiceSynapseExists(name string) resource.TestCheckFunc {
+func testCheckDataFactoryLinkedServiceSynapseExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).DataFactory.LinkedServiceClient
 		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -93,7 +93,7 @@ func testCheckAzureRMDataFactoryLinkedServiceSynapseExists(name string) resource
 	}
 }
 
-func testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy(s *terraform.State) error {
+func testCheckDataFactoryLinkedServiceSynapseDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).DataFactory.LinkedServiceClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
 
@@ -119,7 +119,7 @@ func testCheckAzureRMDataFactoryLinkedServiceSynapseDestroy(s *terraform.State) 
 	return nil
 }
 
-func testAccAzureRMDataFactoryLinkedServiceSynapse_connection_string(data acceptance.TestData) string {
+func testAccDataFactoryLinkedServiceSynapse_connection_string(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -159,7 +159,7 @@ resource "azurerm_data_factory_linked_service_synapse" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMDataFactoryLinkedServiceSynapse_key_vault_reference(data acceptance.TestData) string {
+func testAccDataFactoryLinkedServiceSynapse_key_vault_reference(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -50,6 +50,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_data_factory_linked_service_postgresql":             resourceArmDataFactoryLinkedServicePostgreSQL(),
 		"azurerm_data_factory_linked_service_sftp":                   resourceArmDataFactoryLinkedServiceSFTP(),
 		"azurerm_data_factory_linked_service_sql_server":             resourceArmDataFactoryLinkedServiceSQLServer(),
+		"azurerm_data_factory_linked_service_synapse":                resourceArmDataFactoryLinkedServiceSynapse(),
 		"azurerm_data_factory_linked_service_web":                    resourceArmDataFactoryLinkedServiceWeb(),
 		"azurerm_data_factory_pipeline":                              resourceArmDataFactoryPipeline(),
 		"azurerm_data_factory_trigger_schedule":                      resourceArmDataFactoryTriggerSchedule(),

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -103,13 +103,13 @@ The following supported arguments are specific to Data Factory Synapse Linked Se
 
 * `connection_string` - (Required) The connection string in which to authenticate with the Synapse.
 
-* `key_vault_password_reference` - (Optional) A `key_vault_password_reference` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Data Factory linked service to Key Vault.
+* `key_vault_password_reference` - (Optional) A `key_vault_password_reference` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
 
 ---
 
 A `key_vault_password_reference` block supports the following:
 
-* `key_vault_linked_service_name` - (Required) Specifies the existing Data Factory linked service to Key Vault.
+* `key_vault_linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
 
 * `key_vault_password_secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores Synapse password.
 

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -73,8 +73,8 @@ resource "azurerm_data_factory_linked_service_synapse" "example" {
 
   connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
   key_vault_password_reference {
-    key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.example.name
-    key_vault_password_secret_name = "secret"
+    linked_service_name  = azurerm_data_factory_linked_service_key_vault.example.name
+    password_secret_name = "secret"
   }
 }
 ```
@@ -109,9 +109,9 @@ The following supported arguments are specific to Data Factory Synapse Linked Se
 
 A `key_vault_password_reference` block supports the following:
 
-* `key_vault_linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
+* `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
 
-* `key_vault_password_secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores Synapse password.
+* `password_secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores Synapse password.
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_data_factory_linked_service_synapse" "example" {
   resource_group_name = azurerm_resource_group.example.name
   data_factory_name   = azurerm_data_factory.example.name
 
-  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;Password=test"
+  connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;Password=test"
 }
 ```
 
@@ -71,7 +71,7 @@ resource "azurerm_data_factory_linked_service_synapse" "example" {
   resource_group_name = azurerm_resource_group.example.name
   data_factory_name   = azurerm_data_factory.example.name
 
-  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
+  connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
   key_vault_password_reference {
     key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.example.name
     key_vault_password_secret_name = "secret"

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -81,17 +81,13 @@ resource "azurerm_data_factory_linked_service_synapse" "example" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following supported arguments are common across all Azure Data Factory Linked Services:
 
 * `name` - (Required) Specifies the name of the Data Factory Linked Service Synapse. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service Synapse. Changing this forces a new resource
 
 * `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
-
-* `connection_string` - (Required) The connection string in which to authenticate with the Synapse.
-
-* `key_vault_password_reference` - (Optional) A `key_vault_password_reference` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Data Factory linked service to Key Vault.
 
 * `description` - (Optional) The description for the Data Factory Linked Service Synapse.
 
@@ -102,6 +98,12 @@ The following arguments are supported:
 * `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service Synapse.
 
 * `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service Synapse.
+
+The following supported arguments are specific to Azure File Storage Linked Service:
+
+* `connection_string` - (Required) The connection string in which to authenticate with the Synapse.
+
+* `key_vault_password_reference` - (Optional) A `key_vault_password_reference` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Data Factory linked service to Key Vault.
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -73,8 +73,8 @@ resource "azurerm_data_factory_linked_service_synapse" "example" {
 
   connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
   key_vault_password {
-    linked_service_name  = azurerm_data_factory_linked_service_key_vault.example.name
-    secret_name = "secret"
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.example.name
+    secret_name         = "secret"
   }
 }
 ```

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -72,9 +72,9 @@ resource "azurerm_data_factory_linked_service_synapse" "example" {
   data_factory_name   = azurerm_data_factory.example.name
 
   connection_string = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
-  key_vault_password_reference {
+  key_vault_password {
     linked_service_name  = azurerm_data_factory_linked_service_key_vault.example.name
-    password_secret_name = "secret"
+    secret_name = "secret"
   }
 }
 ```
@@ -103,15 +103,15 @@ The following supported arguments are specific to Data Factory Synapse Linked Se
 
 * `connection_string` - (Required) The connection string in which to authenticate with the Synapse.
 
-* `key_vault_password_reference` - (Optional) A `key_vault_password_reference` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
+* `key_vault_password` - (Optional) A `key_vault_password` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
 
 ---
 
-A `key_vault_password_reference` block supports the following:
+A `key_vault_password` block supports the following:
 
 * `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
 
-* `password_secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores Synapse password.
+* `secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores Synapse password.
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -99,7 +99,7 @@ The following supported arguments are common across all Azure Data Factory Linke
 
 * `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service Synapse.
 
-The following supported arguments are specific to Azure File Storage Linked Service:
+The following supported arguments are specific to Data Factory Synapse Linked Service:
 
 * `connection_string` - (Required) The connection string in which to authenticate with the Synapse.
 

--- a/website/docs/r/data_factory_linked_service_synapse.html.markdown
+++ b/website/docs/r/data_factory_linked_service_synapse.html.markdown
@@ -1,0 +1,137 @@
+---
+subcategory: "Data Factory"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_synapse"
+description: |-
+  Manages a Linked Service (connection) between Synapse and Azure Data Factory.
+---
+
+# azurerm_data_factory_linked_service_synapse
+
+Manages a Linked Service (connection) between Synapse and Azure Data Factory.
+
+~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "northeurope"
+}
+
+resource "azurerm_data_factory" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_data_factory_linked_service_synapse" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  data_factory_name   = azurerm_data_factory.example.name
+
+  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;Password=test"
+}
+```
+
+## Example Usage with Password in Key Vault
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "northeurope"
+}
+
+resource "azurerm_key_vault" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_data_factory" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_data_factory_linked_service_key_vault" "example" {
+  name                = "kvlink"
+  resource_group_name = azurerm_resource_group.example.name
+  data_factory_name   = azurerm_data_factory.example.name
+  key_vault_id        = azurerm_key_vault.example.id
+}
+
+resource "azurerm_data_factory_linked_service_synapse" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  data_factory_name   = azurerm_data_factory.example.name
+
+  connection_string   = "Integrated Security=False;Data Source=test;Initial Catalog=test;User ID=test;"
+  key_vault_password_reference {
+    key_vault_linked_service_name  = azurerm_data_factory_linked_service_key_vault.example.name
+    key_vault_password_secret_name = "secret"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Data Factory Linked Service Synapse. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service Synapse. Changing this forces a new resource
+
+* `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
+
+* `connection_string` - (Required) The connection string in which to authenticate with the Synapse.
+
+* `key_vault_password_reference` - (Optional) A `key_vault_password_reference` block as defined below. Use this argument to store Synapse password in an existing Key Vault. It needs an existing Data Factory linked service to Key Vault.
+
+* `description` - (Optional) The description for the Data Factory Linked Service Synapse.
+
+* `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service Synapse.
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service Synapse.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service Synapse.
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service Synapse.
+
+---
+
+A `key_vault_password_reference` block supports the following:
+
+* `key_vault_linked_service_name` - (Required) Specifies the existing Data Factory linked service to Key Vault.
+
+* `key_vault_password_secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores Synapse password.
+
+---
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Data Factory Synapse Linked Service.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Synapse Linked Service.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Synapse Linked Service.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Synapse Linked Service.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Synapse Linked Service.
+
+## Import
+
+Data Factory Synapse Linked Service's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_factory_linked_service_synapse.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+```


### PR DESCRIPTION
fix #9919 

This PR introduces the new resource `azurerm_data_factory_linked_service_synapse`.

You can use a connection string with password:
```hcl
resource "azurerm_data_factory_linked_service_synapse" "example" {
  name = "adf-link-synapse"
  resource_group_name = azurerm_resource_group.example.name
  data_factory_name = azurerm_data_factory.example.name

  connection_string = "data source=serverhostname;initial catalog=master;user id=testUser;Password=...;Timeout=30;"
}
```

or use a key vault linked service to store the password:

```hcl
resource "azurerm_data_factory_linked_service_synapse" "example" {
  name                = "adf-link-synapse"
  resource_group_name = azurerm_resource_group.example.name
  data_factory_name   = azurerm_data_factory.example.name

  connection_string = "data source=serverhostname;initial catalog=master;user id=testUser;Timeout=30;"
  key_vault_password_reference {
    linked_service_name  = "adf-link-key-vault"
    password_secret_name = "synapse-connection-string"
  }
}
```