### PR TITLE
new resource "azurerm_spring_cloud_java_deployment" and "azurerm_spring_cloud_active_deployment"

### DIFF
--- a/azurerm/internal/services/springcloud/client/client.go
+++ b/azurerm/internal/services/springcloud/client/client.go
@@ -10,6 +10,7 @@ type Client struct {
 	CertificatesClient       *appplatform.CertificatesClient
 	ConfigServersClient      *appplatform.ConfigServersClient
 	MonitoringSettingsClient *appplatform.MonitoringSettingsClient
+	DeploymentsClient        *appplatform.DeploymentsClient
 	ServicesClient           *appplatform.ServicesClient
 }
 
@@ -23,6 +24,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	configServersClient := appplatform.NewConfigServersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&configServersClient.Client, o.ResourceManagerAuthorizer)
 
+	deploymentsClient := appplatform.NewDeploymentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&deploymentsClient.Client, o.ResourceManagerAuthorizer)
+
 	monitoringSettingsClient := appplatform.NewMonitoringSettingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&monitoringSettingsClient.Client, o.ResourceManagerAuthorizer)
 
@@ -33,6 +37,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		AppsClient:               &appsClient,
 		CertificatesClient:       &certificatesClient,
 		ConfigServersClient:      &configServersClient,
+		DeploymentsClient:        &deploymentsClient,
 		MonitoringSettingsClient: &monitoringSettingsClient,
 		ServicesClient:           &servicesClient,
 	}

--- a/azurerm/internal/services/springcloud/parse/spring_cloud_deployment.go
+++ b/azurerm/internal/services/springcloud/parse/spring_cloud_deployment.go
@@ -1,0 +1,81 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type SpringCloudDeploymentId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	SpringName     string
+	AppName        string
+	DeploymentName string
+}
+
+func NewSpringCloudDeploymentID(subscriptionId, resourceGroup, springName, appName, deploymentName string) SpringCloudDeploymentId {
+	return SpringCloudDeploymentId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		SpringName:     springName,
+		AppName:        appName,
+		DeploymentName: deploymentName,
+	}
+}
+
+func (id SpringCloudDeploymentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Deployment Name %q", id.DeploymentName),
+		fmt.Sprintf("App Name %q", id.AppName),
+		fmt.Sprintf("Spring Name %q", id.SpringName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Spring Cloud Deployment", segmentsStr)
+}
+
+func (id SpringCloudDeploymentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AppPlatform/Spring/%s/apps/%s/deployments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
+}
+
+// SpringCloudDeploymentID parses a SpringCloudDeployment ID into an SpringCloudDeploymentId struct
+func SpringCloudDeploymentID(input string) (*SpringCloudDeploymentId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := SpringCloudDeploymentId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.SpringName, err = id.PopSegment("Spring"); err != nil {
+		return nil, err
+	}
+	if resourceId.AppName, err = id.PopSegment("apps"); err != nil {
+		return nil, err
+	}
+	if resourceId.DeploymentName, err = id.PopSegment("deployments"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/springcloud/parse/spring_cloud_deployment_test.go
+++ b/azurerm/internal/services/springcloud/parse/spring_cloud_deployment_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = SpringCloudDeploymentId{}
+
+func TestSpringCloudDeploymentIDFormatter(t *testing.T) {
+	actual := NewSpringCloudDeploymentID("12345678-1234-9876-4563-123456789012", "resGroup1", "spring1", "app1", "deploy1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/deployments/deploy1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestSpringCloudDeploymentID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SpringCloudDeploymentId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing SpringName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/",
+			Error: true,
+		},
+
+		{
+			// missing value for SpringName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/",
+			Error: true,
+		},
+
+		{
+			// missing AppName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/",
+			Error: true,
+		},
+
+		{
+			// missing value for AppName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/",
+			Error: true,
+		},
+
+		{
+			// missing DeploymentName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/",
+			Error: true,
+		},
+
+		{
+			// missing value for DeploymentName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/deployments/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/deployments/deploy1",
+			Expected: &SpringCloudDeploymentId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				SpringName:     "spring1",
+				AppName:        "app1",
+				DeploymentName: "deploy1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.APPPLATFORM/SPRING/SPRING1/APPS/APP1/DEPLOYMENTS/DEPLOY1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := SpringCloudDeploymentID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.SpringName != v.Expected.SpringName {
+			t.Fatalf("Expected %q but got %q for SpringName", v.Expected.SpringName, actual.SpringName)
+		}
+		if actual.AppName != v.Expected.AppName {
+			t.Fatalf("Expected %q but got %q for AppName", v.Expected.AppName, actual.AppName)
+		}
+		if actual.DeploymentName != v.Expected.DeploymentName {
+			t.Fatalf("Expected %q but got %q for DeploymentName", v.Expected.DeploymentName, actual.DeploymentName)
+		}
+	}
+}

--- a/azurerm/internal/services/springcloud/registration.go
+++ b/azurerm/internal/services/springcloud/registration.go
@@ -28,8 +28,10 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_spring_cloud_app":         resourceSpringCloudApp(),
-		"azurerm_spring_cloud_certificate": resourceSpringCloudCertificate(),
-		"azurerm_spring_cloud_service":     resourceSpringCloudService(),
+		"azurerm_spring_cloud_active_deployment": resourceSpringCloudActiveDeployment(),
+		"azurerm_spring_cloud_app":               resourceSpringCloudApp(),
+		"azurerm_spring_cloud_certificate":       resourceSpringCloudCertificate(),
+		"azurerm_spring_cloud_java_deployment":   resourceSpringCloudJavaDeployment(),
+		"azurerm_spring_cloud_service":           resourceSpringCloudService(),
 	}
 }

--- a/azurerm/internal/services/springcloud/resourceids.go
+++ b/azurerm/internal/services/springcloud/resourceids.go
@@ -1,5 +1,6 @@
 package springcloud
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SpringCloudApp -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SpringCloudDeployment -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/deployments/deploy1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SpringCloudCertificate -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/certificates/cert1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SpringCloudService -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1

--- a/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
@@ -69,10 +69,8 @@ func resourceSpringCloudActiveDeploymentCreate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("making Read request on AzureRM Spring Cloud App %q (Spring Cloud service %q / resource group %q): %+v", appId.AppName, appId.SpringName, appId.ResourceGroup, err)
 	}
 
-	if d.IsNewResource() {
-		if existing.Properties != nil && existing.Properties.ActiveDeploymentName != nil {
-			return tf.ImportAsExistsError("azurerm_spring_cloud_active_deployment", resourceId)
-		}
+	if existing.Properties != nil && existing.Properties.ActiveDeploymentName != nil && *existing.Properties.ActiveDeploymentName != "" {
+		return tf.ImportAsExistsError("azurerm_spring_cloud_active_deployment", resourceId)
 	}
 
 	if existing.Properties == nil {
@@ -113,11 +111,11 @@ func resourceSpringCloudActiveDeploymentUpdate(d *schema.ResourceData, meta inte
 
 	future, err := client.Update(ctx, id.ResourceGroup, id.SpringName, id.AppName, app)
 	if err != nil {
-		return fmt.Errorf("swapping active deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", deploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("updating Active Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", deploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for swapping active deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", deploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for Update of Active Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", deploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
 	return resourceSpringCloudActiveDeploymentRead(d, meta)
@@ -173,7 +171,7 @@ func resourceSpringCloudActiveDeploymentDelete(d *schema.ResourceData, meta inte
 
 	future, err := client.Update(ctx, id.ResourceGroup, id.SpringName, id.AppName, app)
 	if err != nil {
-		return fmt.Errorf("deleting active deployment (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("deleting Active Deployment (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {

--- a/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
@@ -1,0 +1,148 @@
+package springcloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceSpringCloudActiveDeployment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSpringCloudActiveDeploymentCreateUpdate,
+		Read:   resourceSpringCloudActiveDeploymentRead,
+		Update: resourceSpringCloudActiveDeploymentCreateUpdate,
+		Delete: resourceSpringCloudActiveDeploymentDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.SpringCloudAppID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"spring_cloud_app_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.SpringCloudAppID,
+			},
+
+			"deployment_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.SpringCloudDeploymentName,
+			},
+		},
+	}
+}
+
+func resourceSpringCloudActiveDeploymentCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.AppsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	deploymentName := d.Get("deployment_name").(string)
+	appId, err := parse.SpringCloudAppID(d.Get("spring_cloud_app_id").(string))
+	if err != nil {
+		return err
+	}
+
+	resourceId := parse.NewSpringCloudAppID(appId.SubscriptionId, appId.ResourceGroup, appId.SpringName, appId.AppName).ID()
+	existing, err := client.Get(ctx, appId.ResourceGroup, appId.SpringName, appId.AppName, "")
+	if err != nil {
+		return fmt.Errorf("making Read request on AzureRM Spring Cloud App %q (Spring Cloud service %q / resource group %q): %+v", appId.AppName, appId.SpringName, appId.ResourceGroup, err)
+	}
+
+	if d.IsNewResource() {
+		if existing.Properties != nil && existing.Properties.ActiveDeploymentName != nil {
+			return tf.ImportAsExistsError("azurerm_spring_cloud_active_deployment", resourceId)
+		}
+	}
+
+	if existing.Properties == nil {
+		existing.Properties = &appplatform.AppResourceProperties{}
+	}
+	existing.Properties.ActiveDeploymentName = &deploymentName
+	future, err := client.CreateOrUpdate(ctx, appId.ResourceGroup, appId.SpringName, appId.AppName, existing)
+	if err != nil {
+		return fmt.Errorf("swapping active deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", deploymentName, appId.SpringName, appId.AppName, appId.ResourceGroup, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for swapping active deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", deploymentName, appId.SpringName, appId.AppName, appId.ResourceGroup, err)
+	}
+	d.SetId(resourceId)
+	return resourceSpringCloudActiveDeploymentRead(d, meta)
+}
+
+func resourceSpringCloudActiveDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.AppsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.SpringCloudAppID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Spring Cloud App %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading Spring Cloud App %q (Spring Cloud Service %q / resource Group %q): %+v", id.AppName, id.SpringName, id.ResourceGroup, err)
+	}
+
+	if resp.Properties == nil || resp.Properties.ActiveDeploymentName == nil {
+		log.Printf("[DEBUG] Spring Cloud App %q (Spring Cloud Service %q / Resource Group %q) doesn't have Active Deployment - removing from state!", id.AppName, id.SpringName, id.ResourceGroup)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("spring_cloud_app_id", id.ID())
+	d.Set("deployment_name", resp.Properties.ActiveDeploymentName)
+
+	return nil
+}
+
+func resourceSpringCloudActiveDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.AppsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.SpringCloudAppID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	app := appplatform.AppResource{
+		Properties: &appplatform.AppResourceProperties{
+			ActiveDeploymentName: utils.String(""),
+		},
+	}
+	future, err := client.Update(ctx, id.ResourceGroup, id.SpringName, id.AppName, app)
+	if err != nil {
+		return fmt.Errorf("deleting active deployment (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.SpringName, id.AppName, id.ResourceGroup, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deleting active deployment (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.SpringName, id.AppName, id.ResourceGroup, err)
+	}
+	return nil
+}

--- a/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform"
+	"github.com/Azure/azure-sdk-for-go/services/appplatform/mgmt/2020-07-01/appplatform"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"

--- a/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource.go
@@ -45,7 +45,7 @@ func resourceSpringCloudActiveDeployment() *schema.Resource {
 
 			"deployment_name": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ValidateFunc: validate.SpringCloudDeploymentName,
 			},
 		},

--- a/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource_test.go
@@ -47,7 +47,7 @@ func TestAccSpringCloudActiveDeployment_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccSpringCloudActiveDeployment_swap(t *testing.T) {
+func TestAccSpringCloudActiveDeployment_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_active_deployment", "test")
 	r := SpringCloudActiveDeploymentResource{}
 
@@ -60,7 +60,7 @@ func TestAccSpringCloudActiveDeployment_swap(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.swap(data),
+			Config: r.update(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -105,7 +105,7 @@ resource "azurerm_spring_cloud_active_deployment" "import" {
 `, r.basic(data))
 }
 
-func (r SpringCloudActiveDeploymentResource) swap(data acceptance.TestData) string {
+func (r SpringCloudActiveDeploymentResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_active_deployment_resource_test.go
@@ -1,0 +1,152 @@
+package springcloud_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type SpringCloudActiveDeploymentResource struct {
+}
+
+func TestAccSpringCloudActiveDeployment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_active_deployment", "test")
+	r := SpringCloudActiveDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSpringCloudActiveDeployment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_active_deployment", "test")
+	r := SpringCloudActiveDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccSpringCloudActiveDeployment_swap(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_active_deployment", "test")
+	r := SpringCloudActiveDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.swap(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r SpringCloudActiveDeploymentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.SpringCloudAppID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.AppPlatform.AppsClient.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, "")
+	if err != nil {
+		return nil, fmt.Errorf("reading Spring Cloud App %q (Spring Cloud Service %q / Resource Group %q): %+v", id.AppName, id.SpringName, id.ResourceGroup, err)
+	}
+
+	return utils.Bool(resp.Properties != nil && resp.Properties.ActiveDeploymentName != nil), nil
+}
+
+func (r SpringCloudActiveDeploymentResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_active_deployment" "test" {
+  spring_cloud_app_id = azurerm_spring_cloud_app.test.id
+  deployment_name     = azurerm_spring_cloud_java_deployment.test.name
+}
+`, r.template(data))
+}
+
+func (r SpringCloudActiveDeploymentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_active_deployment" "import" {
+  spring_cloud_app_id = azurerm_spring_cloud_active_deployment.test.spring_cloud_app_id
+  deployment_name     = azurerm_spring_cloud_active_deployment.test.deployment_name
+}
+`, r.basic(data))
+}
+
+func (r SpringCloudActiveDeploymentResource) swap(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_java_deployment" "test2" {
+  name                = "acctest-scjd2%s"
+  spring_cloud_app_id = azurerm_spring_cloud_app.test.id
+}
+
+resource "azurerm_spring_cloud_active_deployment" "test" {
+  spring_cloud_app_id = azurerm_spring_cloud_app.test.id
+  deployment_name     = azurerm_spring_cloud_java_deployment.test2.name
+}
+`, r.template(data), data.RandomString)
+}
+
+func (SpringCloudActiveDeploymentResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-spring-%d"
+  location = "%s"
+}
+
+resource "azurerm_spring_cloud_service" "test" {
+  name                = "acctest-sc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_spring_cloud_app" "test" {
+  name                = "acctest-sca-%d"
+  resource_group_name = azurerm_spring_cloud_service.test.resource_group_name
+  service_name        = azurerm_spring_cloud_service.test.name
+}
+
+resource "azurerm_spring_cloud_java_deployment" "test" {
+  name                = "acctest-scjd%s"
+  spring_cloud_app_id = azurerm_spring_cloud_app.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString)
+}

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -58,11 +58,12 @@ func resourceSpringCloudJavaDeployment() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 4),
 			},
 
-			"memory_in_gb": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      1,
-				ValidateFunc: validation.IntBetween(1, 8),
+			"environment_variables": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 
 			"instance_count": {
@@ -77,12 +78,11 @@ func resourceSpringCloudJavaDeployment() *schema.Resource {
 				Optional: true,
 			},
 
-			"env": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+			"memory_in_gb": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(1, 8),
 			},
 
 			"runtime_version": {
@@ -91,7 +91,7 @@ func resourceSpringCloudJavaDeployment() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(appplatform.Java8),
 					string(appplatform.Java11),
-				}, true),
+				}, false),
 				Default: string(appplatform.Java8),
 			},
 		},
@@ -134,7 +134,7 @@ func resourceSpringCloudJavaDeploymentCreateUpdate(d *schema.ResourceData, meta 
 				MemoryInGB:           utils.Int32(int32(d.Get("memory_in_gb").(int))),
 				JvmOptions:           utils.String(d.Get("jvm_options").(string)),
 				InstanceCount:        utils.Int32(int32(d.Get("instance_count").(int))),
-				EnvironmentVariables: expandSpringCloudDeploymentEnv(d.Get("env").(map[string]interface{})),
+				EnvironmentVariables: expandSpringCloudDeploymentEnvironmentVariables(d.Get("environment_variables").(map[string]interface{})),
 				RuntimeVersion:       appplatform.RuntimeVersion(d.Get("runtime_version").(string)),
 			},
 		},
@@ -179,7 +179,7 @@ func resourceSpringCloudJavaDeploymentRead(d *schema.ResourceData, meta interfac
 		d.Set("memory_in_gb", settings.MemoryInGB)
 		d.Set("instance_count", settings.InstanceCount)
 		d.Set("jvm_options", settings.JvmOptions)
-		d.Set("env", flattenSpringCloudDeploymentEnv(settings.EnvironmentVariables))
+		d.Set("environment_variables", flattenSpringCloudDeploymentEnvironmentVariables(settings.EnvironmentVariables))
 		d.Set("runtime_version", settings.RuntimeVersion)
 	}
 
@@ -203,7 +203,7 @@ func resourceSpringCloudJavaDeploymentDelete(d *schema.ResourceData, meta interf
 	return nil
 }
 
-func expandSpringCloudDeploymentEnv(envMap map[string]interface{}) map[string]*string {
+func expandSpringCloudDeploymentEnvironmentVariables(envMap map[string]interface{}) map[string]*string {
 	output := make(map[string]*string, len(envMap))
 
 	for k, v := range envMap {
@@ -213,7 +213,7 @@ func expandSpringCloudDeploymentEnv(envMap map[string]interface{}) map[string]*s
 	return output
 }
 
-func flattenSpringCloudDeploymentEnv(envMap map[string]*string) map[string]interface{} {
+func flattenSpringCloudDeploymentEnvironmentVariables(envMap map[string]*string) map[string]interface{} {
 	output := make(map[string]interface{}, len(envMap))
 	for i, v := range envMap {
 		if v == nil {

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -1,0 +1,225 @@
+package springcloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/appplatform/mgmt/2019-05-01-preview/appplatform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceSpringCloudJavaDeployment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSpringCloudJavaDeploymentCreateUpdate,
+		Read:   resourceSpringCloudJavaDeploymentRead,
+		Update: resourceSpringCloudJavaDeploymentCreateUpdate,
+		Delete: resourceSpringCloudJavaDeploymentDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.SpringCloudDeploymentID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.SpringCloudDeploymentName,
+			},
+
+			"spring_cloud_app_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.SpringCloudAppID,
+			},
+
+			"cpu": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(1, 4),
+			},
+
+			"memory_in_gb": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(1, 8),
+			},
+
+			"instance_count": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(1, 500),
+			},
+
+			"jvm_options": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"env": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"runtime_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(appplatform.Java8),
+					string(appplatform.Java11),
+				}, true),
+				Default: string(appplatform.Java8),
+			},
+		},
+	}
+}
+
+func resourceSpringCloudJavaDeploymentCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.DeploymentsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	appId, err := parse.SpringCloudAppID(d.Get("spring_cloud_app_id").(string))
+	if err != nil {
+		return err
+	}
+
+	resourceId := parse.NewSpringCloudDeploymentID(subscriptionId, appId.ResourceGroup, appId.SpringName, appId.AppName, name).ID()
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, appId.ResourceGroup, appId.SpringName, appId.AppName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", name, appId.SpringName, appId.AppName, appId.ResourceGroup, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_spring_cloud_java_deployment", resourceId)
+		}
+	}
+
+	deployment := appplatform.DeploymentResource{
+		Properties: &appplatform.DeploymentResourceProperties{
+			Source: &appplatform.UserSourceInfo{
+				Type:         appplatform.Jar,
+				RelativePath: utils.String("<default>"),
+			},
+			DeploymentSettings: &appplatform.DeploymentSettings{
+				CPU:                  utils.Int32(int32(d.Get("cpu").(int))),
+				MemoryInGB:           utils.Int32(int32(d.Get("memory_in_gb").(int))),
+				JvmOptions:           utils.String(d.Get("jvm_options").(string)),
+				InstanceCount:        utils.Int32(int32(d.Get("instance_count").(int))),
+				EnvironmentVariables: expandSpringCloudDeploymentEnv(d.Get("env").(map[string]interface{})),
+				RuntimeVersion:       appplatform.RuntimeVersion(d.Get("runtime_version").(string)),
+			},
+		},
+	}
+	future, err := client.CreateOrUpdate(ctx, appId.ResourceGroup, appId.SpringName, appId.AppName, name, deployment)
+	if err != nil {
+		return fmt.Errorf("creating/update Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", name, appId.SpringName, appId.AppName, appId.ResourceGroup, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", name, appId.SpringName, appId.AppName, appId.ResourceGroup, err)
+	}
+
+	d.SetId(resourceId)
+	return resourceSpringCloudJavaDeploymentRead(d, meta)
+}
+
+func resourceSpringCloudJavaDeploymentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.DeploymentsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.SpringCloudDeploymentID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Spring Cloud deployment %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+	}
+
+	d.Set("name", id.DeploymentName)
+	d.Set("spring_cloud_app_id", parse.NewSpringCloudAppID(id.SubscriptionId, id.ResourceGroup, id.SpringName, id.AppName).ID())
+	if resp.Properties != nil && resp.Properties.DeploymentSettings != nil {
+		settings := resp.Properties.DeploymentSettings
+		d.Set("cpu", settings.CPU)
+		d.Set("memory_in_gb", settings.MemoryInGB)
+		d.Set("instance_count", settings.InstanceCount)
+		d.Set("jvm_options", settings.JvmOptions)
+		d.Set("env", flattenSpringCloudDeploymentEnv(settings.EnvironmentVariables))
+		d.Set("runtime_version", settings.RuntimeVersion)
+	}
+
+	return nil
+}
+
+func resourceSpringCloudJavaDeploymentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.DeploymentsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.SpringCloudDeploymentID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName); err != nil {
+		return fmt.Errorf("deleting Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+	}
+
+	return nil
+}
+
+func expandSpringCloudDeploymentEnv(envMap map[string]interface{}) map[string]*string {
+	output := make(map[string]*string, len(envMap))
+
+	for k, v := range envMap {
+		output[k] = utils.String(v.(string))
+	}
+
+	return output
+}
+
+func flattenSpringCloudDeploymentEnv(envMap map[string]*string) map[string]interface{} {
+	output := make(map[string]interface{}, len(envMap))
+	for i, v := range envMap {
+		if v == nil {
+			continue
+		}
+		output[i] = *v
+	}
+	return output
+}

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
@@ -140,7 +140,8 @@ resource "azurerm_spring_cloud_java_deployment" "test" {
   jvm_options         = "-XX:+PrintGC"
   runtime_version     = "Java_8"
 
-  env = {
+  environment_variables = {
+    "Foo" : "Bar"
     "Env" : "Staging"
   }
 }

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
@@ -138,7 +138,7 @@ resource "azurerm_spring_cloud_java_deployment" "test" {
   memory_in_gb        = 4
   instance_count      = 2
   jvm_options         = "-XX:+PrintGC"
-  runtime_version     = "Java_8"
+  runtime_version     = "Java_11"
 
   environment_variables = {
     "Foo" : "Bar"

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
@@ -1,0 +1,173 @@
+package springcloud_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type SpringCloudJavaDeploymentResource struct {
+}
+
+func TestAccSpringCloudJavaDeployment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_java_deployment", "test")
+	r := SpringCloudJavaDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSpringCloudJavaDeployment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_java_deployment", "test")
+	r := SpringCloudJavaDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccSpringCloudJavaDeployment_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_java_deployment", "test")
+	r := SpringCloudJavaDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSpringCloudJavaDeployment_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_java_deployment", "test")
+	r := SpringCloudJavaDeploymentResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r SpringCloudJavaDeploymentResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.SpringCloudDeploymentID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.AppPlatform.DeploymentsClient.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
+	if err != nil {
+		return nil, fmt.Errorf("reading Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+	}
+
+	return utils.Bool(resp.Properties != nil), nil
+}
+
+func (r SpringCloudJavaDeploymentResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_java_deployment" "test" {
+  name                = "acctest-scjd%s"
+  spring_cloud_app_id = azurerm_spring_cloud_app.test.id
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r SpringCloudJavaDeploymentResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_java_deployment" "import" {
+  name                = azurerm_spring_cloud_java_deployment.test.name
+  spring_cloud_app_id = azurerm_spring_cloud_java_deployment.test.spring_cloud_app_id
+}
+`, r.basic(data))
+}
+
+func (r SpringCloudJavaDeploymentResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_java_deployment" "test" {
+  name                = "acctest-scjd%s"
+  spring_cloud_app_id = azurerm_spring_cloud_app.test.id
+  cpu                 = 2
+  memory_in_gb        = 4
+  instance_count      = 2
+  jvm_options         = "-XX:+PrintGC"
+  runtime_version     = "Java_8"
+
+  env = {
+    "Env" : "Staging"
+  }
+}
+`, r.template(data), data.RandomString)
+}
+
+func (SpringCloudJavaDeploymentResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-spring-%d"
+  location = "%s"
+}
+
+resource "azurerm_spring_cloud_service" "test" {
+  name                = "acctest-sc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_spring_cloud_app" "test" {
+  name                = "acctest-sca-%d"
+  resource_group_name = azurerm_spring_cloud_service.test.resource_group_name
+  service_name        = azurerm_spring_cloud_service.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_id.go
+++ b/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/parse"
+)
+
+func SpringCloudDeploymentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.SpringCloudDeploymentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_id_test.go
+++ b/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_id_test.go
@@ -1,0 +1,100 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestSpringCloudDeploymentID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing SpringName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SpringName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/",
+			Valid: false,
+		},
+
+		{
+			// missing AppName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for AppName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/",
+			Valid: false,
+		},
+
+		{
+			// missing DeploymentName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for DeploymentName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/deployments/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/deployments/deploy1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.APPPLATFORM/SPRING/SPRING1/APPS/APP1/DEPLOYMENTS/DEPLOY1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := SpringCloudDeploymentID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_name.go
+++ b/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_name.go
@@ -1,0 +1,25 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func SpringCloudDeploymentName(i interface{}, k string) (_ []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, append(errors, fmt.Errorf("expected type of %s to be string", k))
+	}
+
+	// The name attribute rules are :
+	// 1. can contain only lowercase letters, numbers and hyphens.
+	// 2. The first character must be a letter.
+	// 3. The last character must be a letter or number
+	// 4. The value must be between 4 and 32 characters long
+
+	if !regexp.MustCompile(`^([a-z])([a-z\d-]{2,30})([a-z\d])$`).MatchString(v) {
+		errors = append(errors, fmt.Errorf("%s must begin with a letter, end with a letter or number, contain only lowercase letters, numbers and hyphens. The value must be between 4 and 32 characters long.", k))
+	}
+
+	return nil, errors
+}

--- a/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_name_test.go
+++ b/azurerm/internal/services/springcloud/validate/spring_cloud_deployment_name_test.go
@@ -1,0 +1,61 @@
+package validate
+
+import "testing"
+
+func TestSpringCloudDeploymentName(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// basic example
+			input:    "ab-c",
+			expected: true,
+		},
+		{
+			// can't start with a number
+			input:    "1abc",
+			expected: false,
+		},
+		{
+			// can't contain underscore
+			input:    "ab_c",
+			expected: false,
+		},
+		{
+			// can't end with hyphen
+			input:    "abc-",
+			expected: false,
+		},
+		{
+			// can not short than 4 characters
+			input:    "abc",
+			expected: false,
+		},
+		{
+			// 32 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdef",
+			expected: true,
+		},
+		{
+			// 33 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefg",
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+
+		_, errors := SpringCloudDeploymentName(v.input, "name")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -968,11 +968,19 @@
               <a href="#">Spring Cloud</a>
               <ul class="nav">
                 <li>
+                  <a href="/docs/providers/azurerm/r/spring_cloud_active_deployment.html">azurerm_spring_cloud_active_deployment</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/spring_cloud_app.html">azurerm_spring_cloud_app</a>
                 </li>
 
                 <li>
                   <a href="/docs/providers/azurerm/r/spring_cloud_certificate.html">azurerm_spring_cloud_certificate</a>
+                </li>
+
+                <li>
+                  <a href="/docs/providers/azurerm/r/spring_cloud_java_deployment.html">azurerm_spring_cloud_java_deployment</a>
                 </li>
 
                 <li>

--- a/website/docs/r/spring_cloud_active_deployment.html.markdown
+++ b/website/docs/r/spring_cloud_active_deployment.html.markdown
@@ -1,0 +1,90 @@
+---
+subcategory: "Spring Cloud"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_spring_cloud_active_deployment"
+description: |-
+  Manage an Active Azure Spring Cloud Deployment.
+---
+
+# azurerm_spring_cloud_active_deployment
+
+Manage an Active Azure Spring Cloud Deployment.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_spring_cloud_service" "example" {
+  name                = "example-springcloud"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_spring_cloud_app" "example" {
+  name                = "example-springcloudapp"
+  resource_group_name = azurerm_resource_group.example.name
+  service_name        = azurerm_spring_cloud_service.example.name
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_spring_cloud_java_deployment" "example" {
+  name                = "deploy1"
+  spring_cloud_app_id = azurerm_spring_cloud_app.example.id
+  cpu                 = 2
+  memory_in_gb        = 4
+  instance_count      = 2
+  jvm_options         = "-XX:+PrintGC"
+  runtime_version     = "Java_8"
+
+  env = {
+    "Env" : "Staging"
+  }
+}
+
+resource "azurerm_spring_cloud_active_deployment" "test" {
+  spring_cloud_app_id = azurerm_spring_cloud_app.example.id
+  deployment_name     = azurerm_spring_cloud_java_deployment.example.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `spring_cloud_app_id` - (Required) Specifies the id of the Spring Cloud Application. Changing this forces a new resource to be created.
+
+* `deployment_name` - (Required) Specifies the name of Spring Cloud Deployment which is going to be active.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Spring Cloud Active Deployment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Spring Cloud Active Deployment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Spring Cloud Active Deployment.
+* `update` - (Defaults to 30 minutes) Used when updating the Spring Cloud Active Deployment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Spring Cloud Active Deployment.
+
+## Import
+
+Spring Cloud Active Deployment can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_spring_cloud_active_deployment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourcegroup1/providers/Microsoft.AppPlatform/Spring/service1/apps/app1
+```

--- a/website/docs/r/spring_cloud_active_deployment.html.markdown
+++ b/website/docs/r/spring_cloud_active_deployment.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Spring Cloud"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_spring_cloud_active_deployment"
 description: |-
-  Manage an Active Azure Spring Cloud Deployment.
+  Manages an Active Azure Spring Cloud Deployment.
 ---
 
 # azurerm_spring_cloud_active_deployment
 
-Manage an Active Azure Spring Cloud Deployment.
+Manages an Active Azure Spring Cloud Deployment.
 
 ## Example Usage
 
@@ -45,14 +45,14 @@ resource "azurerm_spring_cloud_java_deployment" "example" {
   memory_in_gb        = 4
   instance_count      = 2
   jvm_options         = "-XX:+PrintGC"
-  runtime_version     = "Java_8"
+  runtime_version     = "Java_11"
 
-  env = {
+  environment_variables = {
     "Env" : "Staging"
   }
 }
 
-resource "azurerm_spring_cloud_active_deployment" "test" {
+resource "azurerm_spring_cloud_active_deployment" "example" {
   spring_cloud_app_id = azurerm_spring_cloud_app.example.id
   deployment_name     = azurerm_spring_cloud_java_deployment.example.name
 }

--- a/website/docs/r/spring_cloud_java_deployment.html.markdown
+++ b/website/docs/r/spring_cloud_java_deployment.html.markdown
@@ -1,0 +1,97 @@
+---
+subcategory: "Spring Cloud"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_spring_cloud_java_deployment"
+description: |-
+  Manage an Azure Spring Cloud Deployment which runtime is Java.
+---
+
+# azurerm_spring_cloud_java_deployment
+
+Manage an Azure Spring Cloud Deployment which runtime is Java.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_spring_cloud_service" "example" {
+  name                = "example-springcloud"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_spring_cloud_app" "example" {
+  name                = "example-springcloudapp"
+  resource_group_name = azurerm_resource_group.example.name
+  service_name        = azurerm_spring_cloud_service.example.name
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_spring_cloud_java_deployment" "example" {
+  name                = "deploy1"
+  spring_cloud_app_id = azurerm_spring_cloud_app.example.id
+  cpu                 = 2
+  memory_in_gb        = 4
+  instance_count      = 2
+  jvm_options         = "-XX:+PrintGC"
+  runtime_version     = "Java_8"
+
+  env = {
+    "Env" : "Staging"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Spring Cloud Deployment. Changing this forces a new resource to be created.
+
+* `spring_cloud_app_id` - (Required) Specifies the id of the Spring Cloud Application in which to create the Deployment. Changing this forces a new resource to be created.
+
+* `cpu` - (Optional) Specifies the required cpu of the Spring Cloud Deployment. Possible Values are between `1` and `4`.
+
+* `memory_in_gb` - (Optional) Specifies the required memory size of the Spring Cloud Deployment. Possible Values are between `1` and `8`.
+
+* `instance_count` - (Optional) Specifies the required instance count of the Spring Cloud Deployment. Possible Values are between `1` and `500`.
+
+* `jvm_options` - (Optional) Specifies the jvm option of the Spring Cloud Deployment.
+
+* `runtime_version` - (Optional) Specifies the runtime version of the Spring Cloud Deployment. Possible Values are `Java_8` and `Java_11`. Defaults to `Java_8`.
+
+* `env` - (Optional) Specifies the environment variables of the Spring Cloud Deployment.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Spring Cloud Deployment.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Spring Cloud Deployment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Spring Cloud Deployment.
+* `update` - (Defaults to 30 minutes) Used when updating the Spring Cloud Deployment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Spring Cloud Deployment.
+
+## Import
+
+Spring Cloud Deployment can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_spring_cloud_java_deployment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourcegroup1/providers/Microsoft.AppPlatform/Spring/service1/apps/app1/deployments/deploy1
+```

--- a/website/docs/r/spring_cloud_java_deployment.html.markdown
+++ b/website/docs/r/spring_cloud_java_deployment.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Spring Cloud"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_spring_cloud_java_deployment"
 description: |-
-  Manage an Azure Spring Cloud Deployment which runtime is Java.
+  Manages an Azure Spring Cloud Deployment which runtime is Java.
 ---
 
 # azurerm_spring_cloud_java_deployment
 
-Manage an Azure Spring Cloud Deployment which runtime is Java.
+Manages an Azure Spring Cloud Deployment which runtime is Java.
 
 ## Example Usage
 
@@ -42,12 +42,13 @@ resource "azurerm_spring_cloud_java_deployment" "example" {
   name                = "deploy1"
   spring_cloud_app_id = azurerm_spring_cloud_app.example.id
   cpu                 = 2
-  memory_in_gb        = 4
   instance_count      = 2
   jvm_options         = "-XX:+PrintGC"
-  runtime_version     = "Java_8"
+  memory_in_gb        = 4
+  runtime_version     = "Java_11"
 
-  env = {
+  environment_variables = {
+    "Foo" : "Bar"
     "Env" : "Staging"
   }
 }
@@ -61,17 +62,17 @@ The following arguments are supported:
 
 * `spring_cloud_app_id` - (Required) Specifies the id of the Spring Cloud Application in which to create the Deployment. Changing this forces a new resource to be created.
 
-* `cpu` - (Optional) Specifies the required cpu of the Spring Cloud Deployment. Possible Values are between `1` and `4`.
+* `cpu` - (Optional) Specifies the required cpu of the Spring Cloud Deployment. Possible Values are between `1` and `4`. Defaults to `1` if not specified.
 
-* `memory_in_gb` - (Optional) Specifies the required memory size of the Spring Cloud Deployment. Possible Values are between `1` and `8`.
+* `environment_variables` - (Optional) Specifies the environment variables of the Spring Cloud Deployment as a map of key-value pairs.
 
-* `instance_count` - (Optional) Specifies the required instance count of the Spring Cloud Deployment. Possible Values are between `1` and `500`.
+* `instance_count` - (Optional) Specifies the required instance count of the Spring Cloud Deployment. Possible Values are between `1` and `500`. Defaults to `1` if not specified.
 
 * `jvm_options` - (Optional) Specifies the jvm option of the Spring Cloud Deployment.
 
-* `runtime_version` - (Optional) Specifies the runtime version of the Spring Cloud Deployment. Possible Values are `Java_8` and `Java_11`. Defaults to `Java_8`.
+* `memory_in_gb` - (Optional) Specifies the required memory size of the Spring Cloud Deployment. Possible Values are between `1` and `8`. Defaults to `1` if not specified.
 
-* `env` - (Optional) Specifies the environment variables of the Spring Cloud Deployment.
+* `runtime_version` - (Optional) Specifies the runtime version of the Spring Cloud Deployment. Possible Values are `Java_8` and `Java_11`. Defaults to `Java_8`.
 
 ## Attributes Reference
 

--- a/website/docs/r/spring_cloud_java_deployment.html.markdown
+++ b/website/docs/r/spring_cloud_java_deployment.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Spring Cloud"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_spring_cloud_java_deployment"
 description: |-
-  Manages an Azure Spring Cloud Deployment which runtime is Java.
+  Manages an Azure Spring Cloud Deployment with a Java runtime.
 ---
 
 # azurerm_spring_cloud_java_deployment
 
-Manages an Azure Spring Cloud Deployment which runtime is Java.
+Manages an Azure Spring Cloud Deployment with a Java runtime.
 
 ## Example Usage
 


### PR DESCRIPTION
The service team has refactored the API design, active deployment could be deleted now.

now spring cloud deployment could support different runtime: java and dotnet. We are going to split it into different resources and support java deployment first

this PR adds two resources: `azurerm_spring_cloud_java_deployment` and `azurerm_spring_cloud_active_deployment`

![image](https://user-images.githubusercontent.com/2786738/102762561-6c4b1900-43b3-11eb-914c-7c5dfe64bbec.png)
