### PR TITLE
Function app example: Replace storage account connection string with name/access key

### DIFF
--- a/examples/app-service/function-basic/main.tf
+++ b/examples/app-service/function-basic/main.tf
@@ -39,7 +39,8 @@ resource "azurerm_function_app" "main" {
   resource_group_name       = azurerm_resource_group.main.name
   location                  = azurerm_resource_group.main.location
   app_service_plan_id       = azurerm_app_service_plan.main.id
-  storage_connection_string = azurerm_storage_account.main.primary_connection_string
+  storage_account_name      = azurerm_storage_account.main.name
+  storage_account_access_key = azurerm_storage_account.main.primary_access_key
 
   app_settings = {
     AppInsights_InstrumentationKey = azurerm_application_insights.main.instrumentation_key


### PR DESCRIPTION
The storage_connection_string argument for the azurerm_function_app resource is being deprecated in favor of the storage_account_name and storage_account_access_key arguments. This PR replaces the argument to remove the warning.

```
Warning: "storage_connection_string": [DEPRECATED] Deprecated in favour of `storage_account_name` and `storage_account_access_key`
```