### PR TITLE
`azurerm_traffic_manager_profile` - add traffic view support

### DIFF
--- a/azurerm/internal/services/trafficmanager/traffic_manager_profile_data_source.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_profile_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2018-04-01/trafficmanager"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -160,7 +161,7 @@ func dataSourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interfa
 
 		d.Set("dns_config", flattenAzureRMTrafficManagerProfileDNSConfig(profile.DNSConfig))
 		d.Set("monitor_config", flattenAzureRMTrafficManagerProfileMonitorConfig(profile.MonitorConfig))
-		d.Set("traffic_view_enabled", flattenArmTrafficManagerTrafficView(profile.TrafficViewEnrollmentStatus))
+		d.Set("traffic_view_enabled", profile.TrafficViewEnrollmentStatus == trafficmanager.TrafficViewEnrollmentStatusEnabled)
 
 		// fqdn is actually inside DNSConfig, inlined for simpler reference
 		if dns := profile.DNSConfig; dns != nil {

--- a/azurerm/internal/services/trafficmanager/traffic_manager_profile_data_source.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_profile_data_source.go
@@ -126,6 +126,11 @@ func dataSourceArmTrafficManagerProfile() *schema.Resource {
 				Computed: true,
 			},
 
+			"traffic_view_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -155,6 +160,7 @@ func dataSourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interfa
 
 		d.Set("dns_config", flattenAzureRMTrafficManagerProfileDNSConfig(profile.DNSConfig))
 		d.Set("monitor_config", flattenAzureRMTrafficManagerProfileMonitorConfig(profile.MonitorConfig))
+		d.Set("traffic_view_enabled", flattenArmTrafficManagerTrafficView(profile.TrafficViewEnrollmentStatus))
 
 		// fqdn is actually inside DNSConfig, inlined for simpler reference
 		if dns := profile.DNSConfig; dns != nil {

--- a/azurerm/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -282,7 +282,7 @@ func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface
 
 		d.Set("dns_config", flattenAzureRMTrafficManagerProfileDNSConfig(profile.DNSConfig))
 		d.Set("monitor_config", flattenAzureRMTrafficManagerProfileMonitorConfig(profile.MonitorConfig))
-		d.Set("traffic_view_enabled", flattenArmTrafficManagerTrafficView(profile.TrafficViewEnrollmentStatus))
+		d.Set("traffic_view_enabled", profile.TrafficViewEnrollmentStatus == trafficmanager.TrafficViewEnrollmentStatusEnabled)
 
 		// fqdn is actually inside DNSConfig, inlined for simpler reference
 		if dns := profile.DNSConfig; dns != nil {
@@ -493,13 +493,6 @@ func flattenAzureRMTrafficManagerProfileMonitorConfig(cfg *trafficmanager.Monito
 	}
 
 	return []interface{}{result}
-}
-
-func flattenArmTrafficManagerTrafficView(s trafficmanager.TrafficViewEnrollmentStatus) bool {
-	if s == trafficmanager.TrafficViewEnrollmentStatusEnabled {
-		return true
-	}
-	return false
 }
 
 func validateTrafficManagerProfileStatusCodeRange(i interface{}, k string) (warnings []string, errors []error) {

--- a/azurerm/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -181,6 +181,11 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 8),
 			},
 
+			"traffic_view_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -224,6 +229,10 @@ func resourceArmTrafficManagerProfileCreate(d *schema.ResourceData, meta interfa
 
 	if status, ok := d.GetOk("profile_status"); ok {
 		profile.ProfileStatus = trafficmanager.ProfileStatus(status.(string))
+	}
+
+	if trafficViewStatus, ok := d.GetOk("traffic_view_enabled"); ok {
+		profile.TrafficViewEnrollmentStatus = expandArmTrafficManagerTrafficView(trafficViewStatus.(bool))
 	}
 
 	if profile.ProfileProperties.TrafficRoutingMethod == trafficmanager.MultiValue &&
@@ -273,6 +282,7 @@ func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface
 
 		d.Set("dns_config", flattenAzureRMTrafficManagerProfileDNSConfig(profile.DNSConfig))
 		d.Set("monitor_config", flattenAzureRMTrafficManagerProfileMonitorConfig(profile.MonitorConfig))
+		d.Set("traffic_view_enabled", flattenArmTrafficManagerTrafficView(profile.TrafficViewEnrollmentStatus))
 
 		// fqdn is actually inside DNSConfig, inlined for simpler reference
 		if dns := profile.DNSConfig; dns != nil {
@@ -319,6 +329,12 @@ func resourceArmTrafficManagerProfileUpdate(d *schema.ResourceData, meta interfa
 
 	if d.HasChange("monitor_config") {
 		update.ProfileProperties.MonitorConfig = expandArmTrafficManagerMonitorConfig(d)
+	}
+
+	if d.HasChange("traffic_view_enabled") {
+		if trafficViewStatus, ok := d.GetOk("traffic_view_enabled"); ok {
+			update.ProfileProperties.TrafficViewEnrollmentStatus = expandArmTrafficManagerTrafficView(trafficViewStatus.(bool))
+		}
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.Name, update); err != nil {
@@ -433,6 +449,13 @@ func expandArmTrafficManagerDNSConfig(d *schema.ResourceData) *trafficmanager.DN
 	}
 }
 
+func expandArmTrafficManagerTrafficView(s bool) trafficmanager.TrafficViewEnrollmentStatus {
+	if s {
+		return trafficmanager.TrafficViewEnrollmentStatusEnabled
+	}
+	return trafficmanager.TrafficViewEnrollmentStatusDisabled
+}
+
 func flattenAzureRMTrafficManagerProfileDNSConfig(dns *trafficmanager.DNSConfig) []interface{} {
 	result := make(map[string]interface{})
 
@@ -470,6 +493,13 @@ func flattenAzureRMTrafficManagerProfileMonitorConfig(cfg *trafficmanager.Monito
 	}
 
 	return []interface{}{result}
+}
+
+func flattenArmTrafficManagerTrafficView(s trafficmanager.TrafficViewEnrollmentStatus) bool {
+	if s == trafficmanager.TrafficViewEnrollmentStatusEnabled {
+		return true
+	}
+	return false
 }
 
 func validateTrafficManagerProfileStatusCodeRange(i interface{}, k string) (warnings []string, errors []error) {

--- a/azurerm/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
+++ b/azurerm/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
@@ -585,22 +585,22 @@ func (r TrafficManagerProfileResource) withTrafficView(data acceptance.TestData,
 %s
 
 resource "azurerm_traffic_manager_profile" "test" {
-	name                   = "acctest-TMP-%d"
-	resource_group_name    = azurerm_resource_group.test.name
-	traffic_routing_method = "Geographic"
-  
-	dns_config {
-	  relative_name = "acctest-tmp-%d"
-	  ttl           = 30
-	}
-  
-	monitor_config {
-	  protocol = "https"
-	  port     = 443
-	  path     = "/"
-	}
-	traffic_view_enabled = %t
+  name                   = "acctest-TMP-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  traffic_routing_method = "Geographic"
+
+  dns_config {
+    relative_name = "acctest-tmp-%d"
+    ttl           = 30
   }
+
+  monitor_config {
+    protocol = "https"
+    port     = 443
+    path     = "/"
+  }
+  traffic_view_enabled = %t
+}
   `, template, data.RandomInteger, data.RandomInteger, enabled)
 }
 

--- a/website/docs/d/traffic_manager_profile.html.markdown
+++ b/website/docs/d/traffic_manager_profile.html.markdown
@@ -42,6 +42,8 @@ output "traffic_routing_method" {
 
 * `traffic_routing_method` - Specifies the algorithm used to route traffic.
 
+* `traffic_view_enabled` - Indicates whether Traffic View is enabled for the Traffic Manager profile.
+
 * `dns_config` - This block specifies the DNS configuration of the Profile.
 
 * `monitor_config` - This block specifies the Endpoint monitoring configuration for the Profile.

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -70,6 +70,8 @@ The following arguments are supported:
   * `Subnet` - Traffic is routed based on a mapping of sets of end-user IP address ranges to a specific Endpoint within a Traffic Manager profile.
   * `Weighted` - Traffic is spread across Endpoints proportional to their `weight` value.
 
+* `traffic_view_enabled` - (Optional) Indicates whether Traffic View is enabled for the Traffic Manager profile.
+
 * `dns_config` - (Required) This block specifies the DNS configuration of the Profile, it supports the fields documented below.
 
 * `monitor_config` - (Required) This block specifies the Endpoint monitoring configuration for the Profile, it supports the fields documented below.


### PR DESCRIPTION
adds `traffic_view_enabled` to both traffic manager profile resource and data source.