### PR TITLE
azurerm_monitor_diagnostic_setting name validation

### DIFF
--- a/azurerm/helpers/validate/monitor_diagnostic_setting.go
+++ b/azurerm/helpers/validate/monitor_diagnostic_setting.go
@@ -1,0 +1,24 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func MonitorDiagnosticSettingName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+	if regexp.MustCompile(`[<>*%&:\\?+\/]+`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"characters <, >, *, %%, &, :, \\, ?, +, / are not allowed in %q: %q", k, value))
+	}
+
+	if len(value) < 1 {
+		errors = append(errors, fmt.Errorf("%q must be longer than 0 characters: %q %d", k, value, len(value)))
+	}
+
+	if len(value) > 260 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 260 characters: %q %d", k, value, len(value)))
+	}
+
+	return warnings, errors
+}

--- a/azurerm/helpers/validate/monitor_diagnostic_setting.go
+++ b/azurerm/helpers/validate/monitor_diagnostic_setting.go
@@ -12,12 +12,9 @@ func MonitorDiagnosticSettingName(v interface{}, k string) (warnings []string, e
 			"characters <, >, *, %%, &, :, \\, ?, +, / are not allowed in %q: %q", k, value))
 	}
 
-	if len(value) < 1 {
-		errors = append(errors, fmt.Errorf("%q must be longer than 0 characters: %q %d", k, value, len(value)))
-	}
-
-	if len(value) > 260 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 260 characters: %q %d", k, value, len(value)))
+	if len(value) < 1 || len(value) > 260 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be between 1 and 260 characters: %q", k, value))
 	}
 
 	return warnings, errors

--- a/azurerm/helpers/validate/monitor_diagnostic_setting_test.go
+++ b/azurerm/helpers/validate/monitor_diagnostic_setting_test.go
@@ -2,6 +2,8 @@ package validate
 
 import (
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
 func TestMonitorDiagnosticSettingName(t *testing.T) {
@@ -18,7 +20,7 @@ func TestMonitorDiagnosticSettingName(t *testing.T) {
 			Errors: 1,
 		},
 		{
-			Name:   "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghija",
+			Name:   acctest.RandString(261),
 			Errors: 1,
 		},
 		{

--- a/azurerm/helpers/validate/monitor_diagnostic_setting_test.go
+++ b/azurerm/helpers/validate/monitor_diagnostic_setting_test.go
@@ -1,0 +1,75 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestMonitorDiagnosticSettingName(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Errors int
+	}{
+		{
+			Name:   "somename",
+			Errors: 0,
+		},
+		{
+			Name:   "",
+			Errors: 1,
+		},
+		{
+			Name:   "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghija",
+			Errors: 1,
+		},
+		{
+			Name:   "some<name",
+			Errors: 1,
+		},
+		{
+			Name:   "some>name",
+			Errors: 1,
+		},
+		{
+			Name:   "some*name",
+			Errors: 1,
+		},
+		{
+			Name:   "some%name",
+			Errors: 1,
+		},
+		{
+			Name:   "some&name",
+			Errors: 1,
+		},
+		{
+			Name:   "some:name",
+			Errors: 1,
+		},
+		{
+			Name:   "some\\name",
+			Errors: 1,
+		},
+		{
+			Name:   "some?name",
+			Errors: 1,
+		},
+		{
+			Name:   "some+name",
+			Errors: 1,
+		},
+		{
+			Name:   "some/name",
+			Errors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, errors := MonitorDiagnosticSettingName(tc.Name, "test")
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected Name to return %d error(s) not %d", tc.Errors, len(errors))
+			}
+		})
+	}
+}

--- a/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -39,12 +40,10 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				// NOTE: there's no validation requirements listed for this
-				// so we're intentionally doing the minimum we can here
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.MonitorDiagnosticSettingName,
 			},
 
 			"target_resource_id": {


### PR DESCRIPTION
Fixes #9083

I used the validation rules presented in the portal:

- `The alert name can contain any characters, but the following characters: <, >, *, %, &, :, \, ?, +, /`
- `Required`
- `Max 260 characters long`