### PR TITLE
`azurerm_synapse_workspace` - Add support for `managed_resource_group_name`

### DIFF
--- a/azurerm/internal/services/synapse/synapse_workspace_resource.go
+++ b/azurerm/internal/services/synapse/synapse_workspace_resource.go
@@ -139,8 +139,11 @@ func resourceSynapseWorkspace() *schema.Resource {
 			},
 
 			"managed_resource_group_name": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.ManagedResourceGroupName(),
 			},
 
 			"tags": tags.Schema(),
@@ -179,6 +182,7 @@ func resourceSynapseWorkspaceCreate(d *schema.ResourceData, meta interface{}) er
 			ManagedVirtualNetwork:         utils.String(managedVirtualNetwork),
 			SQLAdministratorLogin:         utils.String(d.Get("sql_administrator_login").(string)),
 			SQLAdministratorLoginPassword: utils.String(d.Get("sql_administrator_login_password").(string)),
+			ManagedResourceGroupName:      utils.String(d.Get("managed_resource_group_name").(string)),
 		},
 		Identity: &synapse.ManagedIdentity{
 			Type: synapse.ResourceIdentityTypeSystemAssigned,

--- a/azurerm/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/azurerm/internal/services/synapse/synapse_workspace_resource_test.go
@@ -25,6 +25,7 @@ func TestAccSynapseWorkspace_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_resource_group_name").Exists(),
 			),
 		},
 		data.ImportStep("sql_administrator_login_password"),
@@ -55,6 +56,7 @@ func TestAccSynapseWorkspace_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_resource_group_name").HasValue(fmt.Sprintf("acctest-ManagedSynapse-%d", data.RandomInteger)),
 			),
 		},
 		data.ImportStep("sql_administrator_login_password"),
@@ -151,12 +153,13 @@ resource "azurerm_synapse_workspace" "test" {
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
   managed_virtual_network_enabled      = true
+  managed_resource_group_name          = "acctest-ManagedSynapse-%d"
 
   tags = {
     ENV = "Test"
   }
 }
-`, template, data.RandomInteger)
+`, template, data.RandomInteger, data.RandomInteger)
 }
 
 func (r SynapseWorkspaceResource) withUpdateFields(data acceptance.TestData) string {

--- a/azurerm/internal/services/synapse/validate/managed_resource_group_name.go
+++ b/azurerm/internal/services/synapse/validate/managed_resource_group_name.go
@@ -1,0 +1,14 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func ManagedResourceGroupName() schema.SchemaValidateFunc {
+	return validation.StringMatch(
+		regexp.MustCompile("^[-\\w\\._\\(\\)]{0,89}[-\\w_\\(\\)]$"),
+		"The resource group name must be no longer than 90 characters long, and must be alphanumeric characters and '-', '_', '(', ')' and'.'. Note that the name cannot end with '.'")
+}

--- a/azurerm/internal/services/synapse/validate/managed_resource_group_name.go
+++ b/azurerm/internal/services/synapse/validate/managed_resource_group_name.go
@@ -9,6 +9,6 @@ import (
 
 func ManagedResourceGroupName() schema.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile("^[-\\w\\._\\(\\)]{0,89}[-\\w_\\(\\)]$"),
+		regexp.MustCompile(`^[-\w\._\(\)]{0,89}[-\w_\(\)]$`),
 		"The resource group name must be no longer than 90 characters long, and must be alphanumeric characters and '-', '_', '(', ')' and'.'. Note that the name cannot end with '.'")
 }

--- a/azurerm/internal/services/synapse/validate/managed_resource_group_name_test.go
+++ b/azurerm/internal/services/synapse/validate/managed_resource_group_name_test.go
@@ -1,0 +1,77 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestManagedResourceGroupName(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+			Valid: false,
+		},
+		{
+			Input: "a",
+			Valid: true,
+		},
+		{
+			Input: "1",
+			Valid: true,
+		},
+		{
+			Input: "hello",
+			Valid: true,
+		},
+		{
+			Input: "Hello",
+			Valid: true,
+		},
+		{
+			Input: "hello-world",
+			Valid: true,
+		},
+		{
+			Input: "Hello_World",
+			Valid: true,
+		},
+		{
+			Input: "HelloWithNumbers12345",
+			Valid: true,
+		},
+		{
+			Input: "(Did)You(Know)That(Brackets)Are(Allowed)In(Resource)Group(Names)",
+			Valid: true,
+		},
+		{
+			Input: "EndingWithAPeriod.",
+			Valid: false,
+		},
+		{
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo",
+			Valid: false,
+		},
+		{
+			Input: acctest.RandString(90),
+			Valid: true,
+		},
+		{
+			Input: acctest.RandString(91),
+			Valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ManagedResourceGroupName()(tc.Input, "name")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `managed_virtual_network_enabled` - (Optional) Is Virtual Network enabled for all computes in this workspace. Changing this forces a new resource to be created.
 
+* `managed_resource_group_name` - Workspace managed resource group.
+
 * `aad_admin` - (Optional) An `aad_admin` block as defined below.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Workspace.
@@ -92,8 +94,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `id` - The ID of the synapse Workspace.
 
 * `connectivity_endpoints` - A list of Connectivity endpoints for this Synapse Workspace.
-
-* `managed_resource_group_name` - Workspace managed resource group.
 
 * `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this Synapse Workspace.
 


### PR DESCRIPTION
`managed_resource_group_name` is a field already computed on `azurerm_synapse_workspace`.
Now ([CHANGELOG.md](https://github.com/Azure/azure-sdk-for-go/blob/1a7479afb19f08212018f3572c768b37fdc582e7/services/preview/synapse/2019-06-01-preview/artifacts/CHANGELOG.md)) we can set this property at creation time of Synapse workspaces.