### PR TITLE
Adding description to ADF managed IR docs

### DIFF
--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `vnet_integration` - (Optional) A `vnet_integration` block as defined below.
 
+* `description` - (Optional) Integration runtime description.
+
 ---
 
 A `catalog_info` block supports the following:


### PR DESCRIPTION
The field `description` of `azurerm_data_factory_integration_runtime_managed` is already implemented but was missing on the resource docs:

https://github.com/terraform-providers/terraform-provider-azurerm/blob/50bf34b6e5e2cdb72727cce32c92ed6e0afa6791/azurerm/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go#L47-L50