### PR TITLE
r/devspace_controller: disabling the tests & highlighting this'll be removed in 3.0

### DIFF
--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -28,7 +28,6 @@ var services = mapOf(
         "databasemigration" to "Database Migration",
         "desktopvirtualization" to "Desktop Virtualization",
         "devtestlabs" to "Dev Test",
-        "devspace" to "DevSpaces",
         "digitaltwins" to "Digital Twins",
         "eventgrid" to "EventGrid",
         "eventhub" to "EventHub",

--- a/azurerm/internal/services/devspace/devspace_controller_resource.go
+++ b/azurerm/internal/services/devspace/devspace_controller_resource.go
@@ -38,6 +38,10 @@ func resourceDevSpaceController() *schema.Resource {
 			return err
 		}),
 
+		DeprecationMessage: `DevSpace Controllers are deprecated and will be retired on 31 October 2023 - at this time the Azure API does not allow new Controllers to be provisioned, but existing DevSpace Controllers can continue to be used.
+
+Since these are deprecated and can no longer be provisioned, version 3.0 of the Azure Provider will remove support for DevSpace Controllers.`,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/azurerm/internal/services/devspace/devspace_controller_resource_test.go
+++ b/azurerm/internal/services/devspace/devspace_controller_resource_test.go
@@ -19,6 +19,8 @@ type DevSpaceControllerResource struct {
 }
 
 func TestAccDevSpaceController_basic(t *testing.T) {
+	t.Skip("A breaking API change has means new DevSpace Controllers cannot be provisioned, so skipping..")
+
 	data := acceptance.BuildTestData(t, "azurerm_devspace_controller", "test")
 	r := DevSpaceControllerResource{}
 	clientId := os.Getenv("ARM_CLIENT_ID")
@@ -36,6 +38,8 @@ func TestAccDevSpaceController_basic(t *testing.T) {
 }
 
 func TestAccDevSpaceController_requiresImport(t *testing.T) {
+	t.Skip("A breaking API change has means new DevSpace Controllers cannot be provisioned, so skipping..")
+
 	data := acceptance.BuildTestData(t, "azurerm_devspace_controller", "test")
 	r := DevSpaceControllerResource{}
 	clientId := os.Getenv("ARM_CLIENT_ID")

--- a/azurerm/internal/services/devspace/devspace_controller_resource_test.go
+++ b/azurerm/internal/services/devspace/devspace_controller_resource_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+// temporarily works around the unused test, since the tests are skipped
+var _ interface{} = DevSpaceControllerResource{}
+var _ interface{} = DevSpaceControllerResource{}.basic(acceptance.TestData{}, "", "")
+var _ interface{} = DevSpaceControllerResource{}.requiresImport(acceptance.TestData{}, "", "")
+
 type DevSpaceControllerResource struct {
 }
 

--- a/azurerm/internal/services/devspace/registration.go
+++ b/azurerm/internal/services/devspace/registration.go
@@ -2,6 +2,7 @@ package devspace
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 // TODO: this can be moved into Container
@@ -27,6 +28,11 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
+	if features.ThreePointOh() {
+		return map[string]*schema.Resource{}
+	}
+
+	// TODO: remove this entire package in 3.0
 	return map[string]*schema.Resource{
 		"azurerm_devspace_controller": resourceDevSpaceController(),
 	}

--- a/azurerm/internal/tools/generator-services/main.go
+++ b/azurerm/internal/tools/generator-services/main.go
@@ -12,6 +12,12 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
 
+// Packages in this list are deprecated and cannot be run due to breaking API changes
+// this should only be used as a last resort - since all acctests should run nightly.
+var packagesToSkip = map[string]struct{}{
+	"devspace": {},
+}
+
 func main() {
 	filePath := flag.String("path", "", "The relative path to the root directory")
 	showHelp := flag.Bool("help", false, "Display this message")
@@ -29,7 +35,7 @@ func main() {
 	}
 	for _, value := range generators {
 		outputFile := value.outputPath(*filePath)
-		if err := value.run(outputFile); err != nil {
+		if err := value.run(outputFile, packagesToSkip); err != nil {
 			panic(err)
 		}
 	}
@@ -37,7 +43,7 @@ func main() {
 
 type generator interface {
 	outputPath(rootDirectory string) string
-	run(outputFileName string) error
+	run(outputFileName string, packagesToSkip map[string]struct{}) error
 }
 
 type teamCityServicesListGenerator struct{}
@@ -46,7 +52,7 @@ func (teamCityServicesListGenerator) outputPath(rootDirectory string) string {
 	return fmt.Sprintf("%s/.teamcity/components/generated/services.kt", rootDirectory)
 }
 
-func (teamCityServicesListGenerator) run(outputFileName string) error {
+func (teamCityServicesListGenerator) run(outputFileName string, packagesToSkip map[string]struct{}) error {
 	template := `// NOTE: this is Generated from the Service Definitions - manual changes will be lost
 //       to re-generate this file, run 'make generate' in the root of the repository
 var services = mapOf(
@@ -91,6 +97,10 @@ var services = mapOf(
 	sort.Strings(serviceNames)
 	for _, serviceName := range serviceNames {
 		packageName := services[serviceName]
+		if _, shouldSkip := packagesToSkip[packageName]; shouldSkip {
+			continue
+		}
+
 		item := fmt.Sprintf("        %q to %q", packageName, serviceName)
 		items = append(items, item)
 	}
@@ -105,7 +115,7 @@ func (websiteCategoriesGenerator) outputPath(rootDirectory string) string {
 	return fmt.Sprintf("%s/website/allowed-subcategories", rootDirectory)
 }
 
-func (websiteCategoriesGenerator) run(outputFileName string) error {
+func (websiteCategoriesGenerator) run(outputFileName string, _ map[string]struct{}) error {
 	websiteCategories := make([]string, 0)
 
 	// get a distinct list

--- a/website/docs/r/devspace_controller.html.markdown
+++ b/website/docs/r/devspace_controller.html.markdown
@@ -12,6 +12,8 @@ Manages a DevSpace Controller.
 
 ~> **NOTE:** Microsoft will be retiring Azure Dev Spaces on 31 October 2023, please see the product [documentation](https://azure.microsoft.com/en-us/updates/azure-dev-spaces-is-retiring-on-31-october-2023/) for more information.
 
+!> **NOTE:** The Azure API no longer allows provisioning new DevSpace Controllers - as such this resource exists only to allow existing users to continue managing these in Terraform at this time. Support for the `azurerm_devspace_controller` resource will be removed in version 3.0 of the Azure Provider.
+
 ## Example Usage
 
 ```hcl
@@ -57,6 +59,8 @@ resource "azurerm_devspace_controller" "example" {
 
 ## Argument Reference
 
+!> **NOTE:** The Azure API no longer allows provisioning new DevSpace Controllers - as such this resource exists only to allow existing users to continue managing these in Terraform at this time. Support for the `azurerm_devspace_controller` resource will be removed in version 3.0 of the Azure Provider.
+
 The following arguments are supported:  
 
 * `name` - (Required) Specifies the name of the DevSpace Controller. Changing this forces a new resource to be created.
@@ -85,8 +89,6 @@ The following attributes are exported:
 * `host_suffix` - The host suffix for the DevSpace Controller.
 
 ## Timeouts
-
-
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 


### PR DESCRIPTION
There's a breaking behavioural change in the API where provisioning new instances returns:

> Azure Dev Spaces Controller creation is blocked because Azure Dev Spaces is being retired. Bridge to Kubernetes is an improved alternative to many of the Azure Dev Spaces development scenarios. Learn more here: https://aka.ms/migrate-to-bridge.

As such, there's no point running these tests since they're going to fail - but this resource will continue to be usable for existing users, albeit we can no longer test it.

This PR introduces a deprecation message for this resource - and prepares it to be removed in 3.0.