### PR TITLE
batch: fixing broken tests

### DIFF
--- a/azurerm/internal/services/batch/batch_certificate_resource_test.go
+++ b/azurerm/internal/services/batch/batch_certificate_resource_test.go
@@ -3,7 +3,6 @@ package batch_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -22,15 +21,12 @@ type BatchCertificateResource struct {
 func TestAccBatchCertificate_Pfx(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_certificate", "test")
 	r := BatchCertificateResource{}
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
-	certificateID := fmt.Sprintf("/subscriptions/%s/resourceGroups/testacc-batch-%d/providers/Microsoft.Batch/batchAccounts/testaccbatch%s/certificates/sha1-42c107874fd0e4a9583292a2f1098e8fe4b2edda", subscriptionID, data.RandomInteger, data.RandomString)
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config: r.pfx(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("id").HasValue(certificateID),
 				check.That(data.ResourceName).Key("format").HasValue("Pfx"),
 				check.That(data.ResourceName).Key("thumbprint").HasValue("42c107874fd0e4a9583292a2f1098e8fe4b2edda"),
 				check.That(data.ResourceName).Key("thumbprint_algorithm").HasValue("sha1"),
@@ -55,15 +51,12 @@ func TestAccBatchCertificate_PfxWithoutPassword(t *testing.T) {
 func TestAccBatchCertificate_Cer(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_certificate", "test")
 	r := BatchCertificateResource{}
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
-	certificateID := fmt.Sprintf("/subscriptions/%s/resourceGroups/testacc-batch-%d/providers/Microsoft.Batch/batchAccounts/testaccbatch%s/certificates/sha1-312d31a79fa0cef49c00f769afc2b73e9f4edf34", subscriptionID, data.RandomInteger, data.RandomString)
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config: r.cer(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("id").HasValue(certificateID),
 				check.That(data.ResourceName).Key("format").HasValue("Cer"),
 				check.That(data.ResourceName).Key("thumbprint").HasValue("312d31a79fa0cef49c00f769afc2b73e9f4edf34"),
 				check.That(data.ResourceName).Key("thumbprint_algorithm").HasValue("sha1"),

--- a/azurerm/internal/services/batch/batch_pool.go
+++ b/azurerm/internal/services/batch/batch_pool.go
@@ -583,6 +583,10 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*batch.NetworkConf
 
 	if v, ok := networkConfigValue["public_ips"]; ok {
 		publicIPsRaw := v.(*schema.Set).List()
+		if networkConfiguration.PublicIPAddressConfiguration == nil {
+			networkConfiguration.PublicIPAddressConfiguration = &batch.PublicIPAddressConfiguration{}
+		}
+
 		networkConfiguration.PublicIPAddressConfiguration.IPAddressIds = utils.ExpandStringSlice(publicIPsRaw)
 	}
 

--- a/azurerm/internal/services/batch/batch_pool.go
+++ b/azurerm/internal/services/batch/batch_pool.go
@@ -582,11 +582,11 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*batch.NetworkConf
 	}
 
 	if v, ok := networkConfigValue["public_ips"]; ok {
-		publicIPsRaw := v.(*schema.Set).List()
 		if networkConfiguration.PublicIPAddressConfiguration == nil {
 			networkConfiguration.PublicIPAddressConfiguration = &batch.PublicIPAddressConfiguration{}
 		}
 
+		publicIPsRaw := v.(*schema.Set).List()
 		networkConfiguration.PublicIPAddressConfiguration.IPAddressIds = utils.ExpandStringSlice(publicIPsRaw)
 	}
 
@@ -599,6 +599,10 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*batch.NetworkConf
 	}
 
 	if v, ok := networkConfigValue["public_address_provisioning_type"]; ok {
+		if networkConfiguration.PublicIPAddressConfiguration == nil {
+			networkConfiguration.PublicIPAddressConfiguration = &batch.PublicIPAddressConfiguration{}
+		}
+
 		if value := v.(string); value != "" {
 			networkConfiguration.PublicIPAddressConfiguration.Provision = batch.IPAddressProvisioningType(value)
 		}

--- a/azurerm/internal/services/batch/batch_pool_data_source.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source.go
@@ -418,7 +418,7 @@ func dataSourceBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("start_task", flattenBatchPoolStartTask(props.StartTask))
 		d.Set("metadata", FlattenBatchMetaData(props.Metadata))
 
-		if err := d.Set("network_configuration", FlattenBatchPoolNetworkConfiguration(props.NetworkConfiguration)); err != nil {
+		if err := d.Set("network_configuration", flattenBatchPoolNetworkConfiguration(props.NetworkConfiguration)); err != nil {
 			return fmt.Errorf("error setting `network_configuration`: %v", err)
 		}
 	}

--- a/azurerm/internal/services/batch/batch_pool_resource.go
+++ b/azurerm/internal/services/batch/batch_pool_resource.go
@@ -791,10 +791,8 @@ func resourceBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("start_task", flattenBatchPoolStartTask(props.StartTask))
 		d.Set("metadata", FlattenBatchMetaData(props.Metadata))
 
-		if props.NetworkConfiguration != nil {
-			if err := d.Set("network_configuration", FlattenBatchPoolNetworkConfiguration(props.NetworkConfiguration)); err != nil {
-				return fmt.Errorf("error setting `network_configuration`: %v", err)
-			}
+		if err := d.Set("network_configuration", flattenBatchPoolNetworkConfiguration(props.NetworkConfiguration)); err != nil {
+			return fmt.Errorf("error setting `network_configuration`: %v", err)
 		}
 	}
 

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -1278,8 +1278,9 @@ resource "azurerm_batch_pool" "test" {
   }
 
   network_configuration {
-    subnet_id  = azurerm_subnet.test.id
-    public_ips = [azurerm_public_ip.test.id]
+    public_address_provisioning_type = "UserManaged"
+    public_ips                       = [azurerm_public_ip.test.id]
+    subnet_id                        = azurerm_subnet.test.id
 
     endpoint_configuration {
       name                = "SSH"


### PR DESCRIPTION
This also ensures that all fields are set during the `flattenBatchPoolNetworkConfiguration` function