### PR TITLE
r/analysisservices_server: fixing the broken Suspend test

### DIFF
--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -204,7 +204,7 @@ func TestAccAzureRMAnalysisServicesServer_suspended(t *testing.T) {
 			Config: r.scale(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("S1"),
+				check.That(data.ResourceName).Key("sku").HasValue("B2"),
 				data.CheckWithClient(r.checkState(analysisservices.StatePaused)),
 			),
 		},
@@ -219,7 +219,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -239,7 +239,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -263,7 +263,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -288,7 +288,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -309,7 +309,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -330,7 +330,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -357,7 +357,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -390,7 +390,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-analysis-%d"
   location = "%s"
 }
 
@@ -494,7 +494,7 @@ resource "azurerm_analysis_services_server" "test" {
   name                = "acctestass%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "S1"
+  sku                 = "B2"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
This uses a different resource group name to the Basic test meaning that when we scale this, this ultimately ends up destroying and recreating the Server (and the RG) rather than pausing and suspending it.