### PR TITLE
key vault related test fix-ups - part 1

### DIFF
--- a/azurerm/internal/services/compute/tests/disk_encryption_set_resource_test.go
+++ b/azurerm/internal/services/compute/tests/disk_encryption_set_resource_test.go
@@ -215,6 +215,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/disk_encryption_set_resource_test.go
+++ b/azurerm/internal/services/compute/tests/disk_encryption_set_resource_test.go
@@ -200,7 +200,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
@@ -504,6 +504,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
@@ -488,7 +488,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -512,7 +512,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -527,6 +527,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -317,7 +317,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -332,6 +332,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_other_resource_test.go
@@ -1516,6 +1516,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
       "update",
     ]
 

--- a/azurerm/internal/services/compute/tests/managed_disk_resource_test.go
+++ b/azurerm/internal/services/compute/tests/managed_disk_resource_test.go
@@ -766,6 +766,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
     ]
 
     secret_permissions = [
@@ -950,6 +951,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/managed_disk_resource_test.go
+++ b/azurerm/internal/services/compute/tests/managed_disk_resource_test.go
@@ -756,7 +756,7 @@ resource "azurerm_key_vault" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
-  sku_name            = "premium"
+  sku_name            = "standard"
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
@@ -936,7 +936,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   enabled_for_disk_encryption = true
   soft_delete_enabled         = true
   purge_protection_enabled    = true

--- a/azurerm/internal/services/compute/tests/snapshot_data_source_test.go
+++ b/azurerm/internal/services/compute/tests/snapshot_data_source_test.go
@@ -108,7 +108,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name = "premium"
+  sku_name = "standard"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id

--- a/azurerm/internal/services/compute/tests/snapshot_data_source_test.go
+++ b/azurerm/internal/services/compute/tests/snapshot_data_source_test.go
@@ -118,11 +118,13 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
     ]
 
     secret_permissions = [
       "delete",
       "get",
+      "purge",
       "set",
     ]
   }

--- a/azurerm/internal/services/compute/tests/snapshot_resource_test.go
+++ b/azurerm/internal/services/compute/tests/snapshot_resource_test.go
@@ -362,7 +362,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
 
-  sku_name = "premium"
+  sku_name = "standard"
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"

--- a/azurerm/internal/services/compute/tests/virtual_machine_managed_disks_resource_test.go
+++ b/azurerm/internal/services/compute/tests/virtual_machine_managed_disks_resource_test.go
@@ -863,6 +863,7 @@ resource "azurerm_key_vault" "test" {
       "listissuers",
       "managecontacts",
       "manageissuers",
+      "purge",
       "setissuers",
       "update",
     ]

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
@@ -524,6 +524,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
@@ -509,7 +509,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
@@ -1947,6 +1947,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
       "update",
     ]
 
@@ -2439,6 +2440,7 @@ resource "azurerm_key_vault" "test" {
       "listissuers",
       "managecontacts",
       "manageissuers",
+      "purge",
       "setissuers",
       "update",
     ]

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_data_resource_test.go
@@ -569,6 +569,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_data_resource_test.go
@@ -554,7 +554,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_os_resource_test.go
@@ -327,6 +327,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "create",
     "delete",
     "get",
+    "purge",
     "update",
   ]
 

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_os_resource_test.go
@@ -312,7 +312,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   soft_delete_enabled         = true
   purge_protection_enabled    = true
   enabled_for_disk_encryption = true

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_other_resource_test.go
@@ -1692,6 +1692,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
       "update",
     ]
 
@@ -2079,6 +2080,7 @@ resource "azurerm_key_vault" "test" {
       "listissuers",
       "managecontacts",
       "manageissuers",
+      "purge",
       "setissuers",
       "update",
     ]

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_other_resource_test.go
@@ -1065,7 +1065,7 @@ resource "azurerm_key_vault" "test" {
   location                    = azurerm_resource_group.test.location
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "premium"
+  sku_name                    = "standard"
   enabled_for_disk_encryption = true
   soft_delete_enabled         = true
   purge_protection_enabled    = true

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_other_resource_test.go
@@ -1079,7 +1079,8 @@ resource "azurerm_key_vault_access_policy" "acctest" {
   key_permissions = [
     "get",
     "create",
-    "delete"
+    "delete",
+    "purge",
   ]
 }
 

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -1201,7 +1201,7 @@ resource "azurerm_key_vault" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-  sku_name            = "premium"
+  sku_name            = "standard"
 
   purge_protection_enabled = true
   soft_delete_enabled      = true

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -1215,6 +1215,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
       "update",
     ]
 

--- a/azurerm/internal/services/keyvault/key_vault_access_policy_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_access_policy_resource_test.go
@@ -299,7 +299,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name = "premium"
+  sku_name = "standard"
 
   tags = {
     environment = "Production"

--- a/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
@@ -667,7 +667,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -732,7 +732,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -793,7 +793,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -29,7 +29,7 @@ func TestAccKeyVault_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku_name").HasValue("premium"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("standard"),
 			),
 		},
 		data.ImportStep(),
@@ -182,6 +182,29 @@ func TestAccKeyVault_update(t *testing.T) {
 				check.That(data.ResourceName).Key("access_policy.#").HasValue("0"),
 			),
 		},
+	})
+}
+
+func TestAccKeyVault_upgradeSKU(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("standard"),
+			),
+		},
+		data.ImportStep(), {
+			Config: r.basicPremiumSKU(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("premium"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -739,7 +762,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -1199,6 +1222,49 @@ resource "azurerm_key_vault" "test" {
     email = "example@example.com"
     name  = "example"
     phone = "01234567890"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (KeyVaultResource) basicPremiumSKU(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    certificate_permissions = [
+      "managecontacts",
+    ]
+
+    key_permissions = [
+      "create",
+    ]
+
+    secret_permissions = [
+      "set",
+    ]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -522,7 +522,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -624,7 +624,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -659,7 +659,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -695,7 +695,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -787,7 +787,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -822,7 +822,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -859,7 +859,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -907,7 +907,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -950,7 +950,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -1020,7 +1020,7 @@ resource "azurerm_key_vault" "test" {
   location                 = azurerm_resource_group.test.location
   resource_group_name      = azurerm_resource_group.test.name
   tenant_id                = data.azurerm_client_config.current.tenant_id
-  sku_name                 = "premium"
+  sku_name                 = "standard"
   soft_delete_enabled      = "%t"
   purge_protection_enabled = "%t"
 }
@@ -1046,7 +1046,7 @@ resource "azurerm_key_vault" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-  sku_name            = "premium"
+  sku_name            = "standard"
   soft_delete_enabled = %t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
@@ -1094,7 +1094,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 }
@@ -1119,7 +1119,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
@@ -1146,7 +1146,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -1174,7 +1174,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -435,7 +435,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -489,7 +489,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -538,7 +538,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "premium"
+  sku_name                   = "standard"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 

--- a/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
@@ -236,7 +236,14 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions = ["get", "list", "create", "delete", "recover"]
+  key_permissions = [
+    "create",
+    "delete",
+    "get",
+    "list",
+    "purge",
+    "recover",
+  ]
 }
 
 resource "azurerm_key_vault_key" "first" {

--- a/azurerm/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource_test.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource_test.go
@@ -76,7 +76,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name = "premium"
+  sku_name = "standard"
 
   soft_delete_enabled        = true
   soft_delete_retention_days = 7

--- a/azurerm/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource_test.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource_test.go
@@ -91,8 +91,9 @@ resource "azurerm_key_vault_access_policy" "terraform" {
     "create",
     "delete",
     "get",
-    "update",
     "list",
+    "purge",
+    "update",
   ]
 
   secret_permissions = [

--- a/azurerm/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -319,7 +319,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name = "premium"
+  sku_name = "standard"
 }
 
 resource "azurerm_storage_account" "test" {

--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -381,7 +381,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name = "premium"
+  sku_name = "standard"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -462,7 +462,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name = "premium"
+  sku_name = "standard"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id

--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -391,6 +391,7 @@ resource "azurerm_key_vault" "test" {
       "create",
       "delete",
       "get",
+      "purge",
       "update",
     ]
 

--- a/azurerm/internal/services/resource/template_deployment_resource_test.go
+++ b/azurerm/internal/services/resource/template_deployment_resource_test.go
@@ -507,8 +507,8 @@ resource "azurerm_key_vault" "test" {
   location            = "%s"
   name                = "vault%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku_name = "standard"
+  soft_delete_enabled = true
+  sku_name            = "standard"
 
   tenant_id                       = data.azurerm_client_config.current.tenant_id
   enabled_for_template_deployment = true

--- a/azurerm/internal/services/springcloud/spring_cloud_certificate_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_certificate_resource_test.go
@@ -112,19 +112,38 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
+  soft_delete_enabled = true
 
   access_policy {
-    tenant_id               = data.azurerm_client_config.current.tenant_id
-    object_id               = data.azurerm_client_config.current.object_id
-    secret_permissions      = ["set"]
-    certificate_permissions = ["create", "delete", "get", "update"]
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = [
+      "set",
+    ]
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "get",
+      "purge",
+      "update",
+    ]
   }
 
   access_policy {
-    tenant_id               = data.azurerm_client_config.current.tenant_id
-    object_id               = data.azuread_service_principal.test.object_id
-    secret_permissions      = ["get", "list"]
-    certificate_permissions = ["get", "list"]
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azuread_service_principal.test.object_id
+
+    secret_permissions = [
+      "get",
+      "list",
+    ]
+
+    certificate_permissions = [
+      "get",
+      "list",
+    ]
   }
 }
 

--- a/azurerm/internal/services/storage/storage_encryption_scope_resource_test.go
+++ b/azurerm/internal/services/storage/storage_encryption_scope_resource_test.go
@@ -158,7 +158,11 @@ func (t StorageEncryptionScopeResource) keyVaultKey(data acceptance.TestData) st
 	template := t.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 %s
@@ -176,7 +180,11 @@ func (t StorageEncryptionScopeResource) keyVaultKeyUpdated(data acceptance.TestD
 	template := t.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 %s
@@ -207,7 +215,11 @@ func (t StorageEncryptionScopeResource) microsoftManagedKey(data acceptance.Test
 	template := t.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 %s

--- a/azurerm/internal/services/web/app_service_certificate_resource_test.go
+++ b/azurerm/internal/services/web/app_service_certificate_resource_test.go
@@ -140,23 +140,43 @@ resource "azurerm_key_vault" "test" {
   name                = "acct%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  soft_delete_enabled = true
 
   tenant_id = data.azurerm_client_config.test.tenant_id
 
   sku_name = "standard"
 
   access_policy {
-    tenant_id               = data.azurerm_client_config.test.tenant_id
-    object_id               = data.azurerm_client_config.test.object_id
-    secret_permissions      = ["delete", "get", "set"]
-    certificate_permissions = ["create", "delete", "get", "import"]
+    tenant_id = data.azurerm_client_config.test.tenant_id
+    object_id = data.azurerm_client_config.test.object_id
+
+    secret_permissions = [
+      "delete",
+      "get",
+      "purge",
+      "set",
+    ]
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "get",
+      "purge",
+      "import",
+    ]
   }
 
   access_policy {
-    tenant_id               = data.azurerm_client_config.test.tenant_id
-    object_id               = data.azuread_service_principal.test.object_id
-    secret_permissions      = ["get"]
-    certificate_permissions = ["get"]
+    tenant_id = data.azurerm_client_config.test.tenant_id
+    object_id = data.azuread_service_principal.test.object_id
+
+    secret_permissions = [
+      "get",
+    ]
+
+    certificate_permissions = [
+      "get",
+    ]
   }
 }
 


### PR DESCRIPTION
This PR attempts to resolve _most_ of the test issues introduced by the soft delete change on the service at the end of 2020.  Several test scenarios are not currently possible to fix at present, but these should be resolvable when binary testing is available.
