### PR TITLE
r/key_vault: defaulting `soft_delete_enabled` on to match the updated API behaviour

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_data_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/set"
@@ -23,137 +24,142 @@ func dataSourceKeyVault() *schema.Resource {
 			Read: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.KeyVaultName,
-			},
+		Schema: func() map[string]*schema.Schema {
+			dsSchema := map[string]*schema.Schema{
+				"name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validate.KeyVaultName,
+				},
 
-			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+				"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
 
-			"location": azure.SchemaLocationForDataSource(),
+				"location": azure.SchemaLocationForDataSource(),
 
-			"sku_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"sku_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 
-			"vault_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"vault_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 
-			"access_policy": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"tenant_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"object_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"application_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"certificate_permissions": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+				"access_policy": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"tenant_id": {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
-						},
-						"key_permissions": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"object_id": {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
-						},
-						"secret_permissions": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"application_id": {
+								Type:     schema.TypeString,
+								Computed: true,
 							},
-						},
-						"storage_permissions": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+							"certificate_permissions": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"key_permissions": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"secret_permissions": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"storage_permissions": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
 							},
 						},
 					},
 				},
-			},
 
-			"enabled_for_deployment": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
+				"enabled_for_deployment": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 
-			"enabled_for_disk_encryption": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
+				"enabled_for_disk_encryption": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 
-			"enabled_for_template_deployment": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
+				"enabled_for_template_deployment": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 
-			"network_acls": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"default_action": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"bypass": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ip_rules": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-						"virtual_network_subnet_ids": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      set.HashStringIgnoreCase,
+				"network_acls": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"default_action": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"bypass": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"ip_rules": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      schema.HashString,
+							},
+							"virtual_network_subnet_ids": {
+								Type:     schema.TypeSet,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      set.HashStringIgnoreCase,
+							},
 						},
 					},
 				},
-			},
 
-			"purge_protection_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
+				"purge_protection_enabled": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
 
-			"soft_delete_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-
-			"tags": tags.SchemaDataSource(),
-		},
+				"tags": tags.SchemaDataSource(),
+			}
+			if !features.ThreePointOh() {
+				dsSchema["soft_delete_enabled"] = &schema.Schema{
+					Type:       schema.TypeBool,
+					Computed:   true,
+					Deprecated: `Azure has removed support for disabling Soft Delete as of 2020-12-15, as such this field will always return 'true' and will be removed in version 3.0 of the Azure Provider.`,
+				}
+			}
+			return dsSchema
+		}(),
 	}
 }
 
@@ -186,9 +192,13 @@ func dataSourceKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("enabled_for_deployment", props.EnabledForDeployment)
 		d.Set("enabled_for_disk_encryption", props.EnabledForDiskEncryption)
 		d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
-		d.Set("soft_delete_enabled", props.EnableSoftDelete)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
 		d.Set("vault_uri", props.VaultURI)
+
+		// TODO: remove in 3.0
+		if !features.ThreePointOh() {
+			d.Set("soft_delete_enabled", true)
+		}
 
 		if sku := props.Sku; sku != nil {
 			if err := d.Set("sku_name", string(sku.Name)); err != nil {

--- a/azurerm/internal/services/keyvault/key_vault_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_data_source_test.go
@@ -133,5 +133,5 @@ data "azurerm_key_vault" "test" {
   name                = azurerm_key_vault.test.name
   resource_group_name = azurerm_key_vault.test.resource_group_name
 }
-`, KeyVaultResource{}.softDelete(data, true))
+`, KeyVaultResource{}.softDelete(data))
 }

--- a/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
@@ -269,7 +269,7 @@ func TestAccKeyVaultKey_withExternalAccessPolicy(t *testing.T) {
 	})
 }
 
-func (t KeyVaultKeyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (r KeyVaultKeyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.KeyVault.ManagementClient
 	keyVaultClient := clients.KeyVault.VaultsClient
 
@@ -410,7 +410,7 @@ resource "azurerm_key_vault_key" "test" {
     "verify",
   ]
 }
-`, r.template(data), data.RandomString)
+`, r.templateStandard(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) basicECUpdatedExternally(data acceptance.TestData) string {
@@ -437,7 +437,7 @@ resource "azurerm_key_vault_key" "test" {
     Rick = "Morty"
   }
 }
-`, r.template(data), data.RandomString)
+`, r.templateStandard(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) requiresImport(data acceptance.TestData) string {
@@ -481,7 +481,7 @@ resource "azurerm_key_vault_key" "test" {
     "wrapKey",
   ]
 }
-`, r.template(data), data.RandomString)
+`, r.templateStandard(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) basicRSAHSM(data acceptance.TestData) string {
@@ -507,7 +507,7 @@ resource "azurerm_key_vault_key" "test" {
     "wrapKey",
   ]
 }
-`, r.template(data), data.RandomString)
+`, r.templatePremium(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) complete(data acceptance.TestData) string {
@@ -539,7 +539,7 @@ resource "azurerm_key_vault_key" "test" {
     "hello" = "world"
   }
 }
-`, r.template(data), data.RandomString)
+`, r.templateStandard(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) basicUpdated(data acceptance.TestData) string {
@@ -564,7 +564,7 @@ resource "azurerm_key_vault_key" "test" {
     "wrapKey",
   ]
 }
-`, r.template(data), data.RandomString)
+`, r.templateStandard(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) curveEC(data acceptance.TestData) string {
@@ -586,7 +586,7 @@ resource "azurerm_key_vault_key" "test" {
     "verify",
   ]
 }
-`, r.template(data), data.RandomString)
+`, r.templateStandard(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) basicECHSM(data acceptance.TestData) string {
@@ -608,7 +608,7 @@ resource "azurerm_key_vault_key" "test" {
     "verify",
   ]
 }
-`, r.template(data), data.RandomString)
+`, r.templatePremium(data), data.RandomString)
 }
 
 func (r KeyVaultKeyResource) softDeleteRecovery(data acceptance.TestData, purge bool) string {
@@ -645,7 +645,7 @@ resource "azurerm_key_vault_key" "test" {
     "hello" = "world"
   }
 }
-`, purge, r.template(data), data.RandomString)
+`, purge, r.templateStandard(data), data.RandomString)
 }
 
 func (KeyVaultKeyResource) withExternalAccessPolicy(data acceptance.TestData) string {
@@ -779,7 +779,15 @@ resource "azurerm_key_vault_key" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
-func (KeyVaultKeyResource) template(data acceptance.TestData) string {
+func (r KeyVaultKeyResource) templateStandard(data acceptance.TestData) string {
+	return r.template(data, "standard")
+}
+
+func (r KeyVaultKeyResource) templatePremium(data acceptance.TestData) string {
+	return r.template(data, "premium")
+}
+
+func (KeyVaultKeyResource) template(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 data "azurerm_client_config" "current" {}
 
@@ -793,7 +801,7 @@ resource "azurerm_key_vault" "test" {
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "standard"
+  sku_name                   = "%s"
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
@@ -821,5 +829,5 @@ resource "azurerm_key_vault" "test" {
     environment = "Production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, sku)
 }

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -323,7 +323,7 @@ func resourceKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 		parameters.Properties.EnablePurgeProtection = utils.Bool(purgeProtectionEnabled)
 	}
 
-	if v := d.Get("soft_delete_retention_days"); v != 0 {
+	if v := d.Get("soft_delete_retention_days"); v != 90 {
 		parameters.Properties.SoftDeleteRetentionInDays = utils.Int32(int32(v.(int)))
 	}
 
@@ -548,7 +548,7 @@ func resourceKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 		// hence the double-checking here
 		if oldValue != 0 {
 			// Code="BadRequest" Message="The property \"softDeleteRetentionInDays\" has been set already and it can't be modified."
-			return fmt.Errorf("updating Key Vault %q (Resource Group %q): once Soft Delete has been Enabled it's not possible to change `soft_delete_retention_days`", name, resourceGroup)
+			return fmt.Errorf("updating Key Vault %q (Resource Group %q): once `soft_delete_retention_days` has been configured it cannot be modified", name, resourceGroup)
 		}
 
 		update.Properties.SoftDeleteRetentionInDays = utils.Int32(int32(d.Get("soft_delete_retention_days").(int)))

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -46,8 +47,11 @@ func resourceKeyVault() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		MigrateState:  resourceKeyVaultMigrateState,
-		SchemaVersion: 1,
+		MigrateState: resourceKeyVaultMigrateState,
+		StateUpgraders: []schema.StateUpgrader{
+			migration.KeyVaultV1ToV2Upgrader(),
+		},
+		SchemaVersion: 2,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
@@ -55,168 +56,177 @@ func resourceKeyVault() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.KeyVaultName,
-			},
-
-			"location": azure.SchemaLocation(),
-
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"sku_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(keyvault.Standard),
-					string(keyvault.Premium),
-				}, false),
-			},
-
-			"tenant_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.IsUUID,
-			},
-
-			"access_policy": {
-				Type:       schema.TypeList,
-				ConfigMode: schema.SchemaConfigModeAttr,
-				Optional:   true,
-				Computed:   true,
-				MaxItems:   1024,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"tenant_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-						"object_id": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.IsUUID,
-						},
-						"application_id": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validate.IsUUIDOrEmpty,
-						},
-						"certificate_permissions": azure.SchemaKeyVaultCertificatePermissions(),
-						"key_permissions":         azure.SchemaKeyVaultKeyPermissions(),
-						"secret_permissions":      azure.SchemaKeyVaultSecretPermissions(),
-						"storage_permissions":     azure.SchemaKeyVaultStoragePermissions(),
-					},
+		Schema: func() map[string]*schema.Schema {
+			rSchema := map[string]*schema.Schema{
+				"name": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validate.KeyVaultName,
 				},
-			},
 
-			"enabled_for_deployment": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"location": azure.SchemaLocation(),
 
-			"enabled_for_disk_encryption": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"resource_group_name": azure.SchemaResourceGroupName(),
 
-			"enabled_for_template_deployment": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"sku_name": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(keyvault.Standard),
+						string(keyvault.Premium),
+					}, false),
+				},
 
-			"enable_rbac_authorization": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"tenant_id": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsUUID,
+				},
 
-			"network_acls": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"default_action": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(keyvault.Allow),
-								string(keyvault.Deny),
-							}, false),
-						},
-						"bypass": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(keyvault.None),
-								string(keyvault.AzureServices),
-							}, false),
-						},
-						"ip_rules": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-						"virtual_network_subnet_ids": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      set.HashStringIgnoreCase,
+				"access_policy": {
+					Type:       schema.TypeList,
+					ConfigMode: schema.SchemaConfigModeAttr,
+					Optional:   true,
+					Computed:   true,
+					MaxItems:   1024,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"tenant_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.IsUUID,
+							},
+							"object_id": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.IsUUID,
+							},
+							"application_id": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validate.IsUUIDOrEmpty,
+							},
+							"certificate_permissions": azure.SchemaKeyVaultCertificatePermissions(),
+							"key_permissions":         azure.SchemaKeyVaultKeyPermissions(),
+							"secret_permissions":      azure.SchemaKeyVaultSecretPermissions(),
+							"storage_permissions":     azure.SchemaKeyVaultStoragePermissions(),
 						},
 					},
 				},
-			},
 
-			"purge_protection_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"enabled_for_deployment": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
 
-			"soft_delete_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+				"enabled_for_disk_encryption": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
 
-			"soft_delete_retention_days": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(7, 90),
-			},
+				"enabled_for_template_deployment": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
 
-			"contact": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"email": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"phone": {
-							Type:     schema.TypeString,
-							Optional: true,
+				"enable_rbac_authorization": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
+
+				"network_acls": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"default_action": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(keyvault.Allow),
+									string(keyvault.Deny),
+								}, false),
+							},
+							"bypass": {
+								Type:     schema.TypeString,
+								Required: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(keyvault.None),
+									string(keyvault.AzureServices),
+								}, false),
+							},
+							"ip_rules": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      schema.HashString,
+							},
+							"virtual_network_subnet_ids": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+								Set:      set.HashStringIgnoreCase,
+							},
 						},
 					},
 				},
-			},
 
-			"tags": tags.Schema(),
+				"purge_protection_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+				},
 
-			// Computed
-			"vault_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
+				"soft_delete_retention_days": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Default:      90,
+					ValidateFunc: validation.IntBetween(7, 90),
+				},
+
+				"contact": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"email": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"phone": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+
+				"tags": tags.Schema(),
+
+				// Computed
+				"vault_uri": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			}
+
+			if !features.ThreePointOh() {
+				rSchema["soft_delete_enabled"] = &schema.Schema{
+					Type:       schema.TypeBool,
+					Optional:   true,
+					Computed:   true,
+					Deprecated: `Azure has removed support for disabling Soft Delete as of 2020-12-15, as such this field is no longer configurable and can be safely removed. This field will be removed in version 3.0 of the Azure Provider.`,
+				}
+			}
+
+			return rSchema
+		}(),
 	}
 }
 
@@ -300,23 +310,21 @@ func resourceKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 			EnabledForTemplateDeployment: &enabledForTemplateDeployment,
 			EnableRbacAuthorization:      &enableRbacAuthorization,
 			NetworkAcls:                  networkAcls,
+
+			// @tombuildsstuff: as of 2020-12-15 this is now defaulted on, and appears to be so in all regions
+			// This has been confirmed in Azure Public and Azure China - but I couldn't find any more
+			// documentation with further details
+			EnableSoftDelete: utils.Bool(true),
 		},
 		Tags: tags.Expand(t),
 	}
 
-	// This settings can only be set if it is true, if set when value is false API returns errors
-	softDeleteEnabled := d.Get("soft_delete_enabled").(bool)
-	if softDeleteEnabled {
-		parameters.Properties.EnableSoftDelete = utils.Bool(true)
-
-		if softDeleteRetentionInDays := d.Get("soft_delete_retention_days").(int); softDeleteRetentionInDays != 0 {
-			parameters.Properties.SoftDeleteRetentionInDays = utils.Int32(int32(softDeleteRetentionInDays))
-		}
-	} else {
-		parameters.Properties.EnableSoftDelete = utils.Bool(false)
-	}
 	if purgeProtectionEnabled := d.Get("purge_protection_enabled").(bool); purgeProtectionEnabled {
 		parameters.Properties.EnablePurgeProtection = utils.Bool(purgeProtectionEnabled)
+	}
+
+	if v := d.Get("soft_delete_retention_days"); v != 0 {
+		parameters.Properties.SoftDeleteRetentionInDays = utils.Int32(int32(v.(int)))
 	}
 
 	if recoverSoftDeletedKeyVault {
@@ -525,28 +533,6 @@ func resourceKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChange("soft_delete_enabled") {
-		if update.Properties == nil {
-			update.Properties = &keyvault.VaultPatchProperties{}
-		}
-
-		newValue := d.Get("soft_delete_enabled").(bool)
-
-		// existing.Properties guaranteed non-nil above
-		oldValue := false
-		if existing.Properties.EnableSoftDelete != nil {
-			oldValue = *existing.Properties.EnableSoftDelete
-		}
-
-		// whilst this should have got caught in the customizeDiff this won't work if that fields interpolated
-		// hence the double-checking here
-		if oldValue && !newValue {
-			return fmt.Errorf("Error updating Key Vault %q (Resource Group %q): once Soft Delete has been Enabled it's not possible to disable it", name, resourceGroup)
-		}
-
-		update.Properties.EnableSoftDelete = utils.Bool(newValue)
-	}
-
 	if d.HasChange("soft_delete_retention_days") {
 		if update.Properties == nil {
 			update.Properties = &keyvault.VaultPatchProperties{}
@@ -561,6 +547,7 @@ func resourceKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 		// whilst this should have got caught in the customizeDiff this won't work if that fields interpolated
 		// hence the double-checking here
 		if oldValue != 0 {
+			// Code="BadRequest" Message="The property \"softDeleteRetentionInDays\" has been set already and it can't be modified."
 			return fmt.Errorf("updating Key Vault %q (Resource Group %q): once Soft Delete has been Enabled it's not possible to change `soft_delete_retention_days`", name, resourceGroup)
 		}
 
@@ -643,10 +630,23 @@ func resourceKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("enabled_for_disk_encryption", props.EnabledForDiskEncryption)
 		d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 		d.Set("enable_rbac_authorization", props.EnableRbacAuthorization)
-		d.Set("soft_delete_enabled", props.EnableSoftDelete)
-		d.Set("soft_delete_retention_days", props.SoftDeleteRetentionInDays)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
 		d.Set("vault_uri", props.VaultURI)
+
+		// @tombuildsstuff: the API doesn't return this field if it's not configured
+		// however https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview
+		// defaults this to 90 days, as such we're going to have to assume that for the moment
+		// in lieu of anything being returned
+		softDeleteRetentionDays := 90
+		if props.SoftDeleteRetentionInDays != nil && *props.SoftDeleteRetentionInDays != 0 {
+			softDeleteRetentionDays = int(*props.SoftDeleteRetentionInDays)
+		}
+		d.Set("soft_delete_retention_days", softDeleteRetentionDays)
+
+		// TODO: remove in 3.0
+		if !features.ThreePointOh() {
+			d.Set("soft_delete_enabled", true)
+		}
 
 		skuName := ""
 		if sku := props.Sku; sku != nil {
@@ -660,25 +660,23 @@ func resourceKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("sku_name", skuName)
 
 		if err := d.Set("network_acls", flattenKeyVaultNetworkAcls(props.NetworkAcls)); err != nil {
-			return fmt.Errorf("Error setting `network_acls` for KeyVault %q: %+v", *resp.Name, err)
+			return fmt.Errorf("setting `network_acls` for KeyVault %q: %+v", *resp.Name, err)
 		}
 
 		flattenedPolicies := azure.FlattenKeyVaultAccessPolicies(props.AccessPolicies)
 		if err := d.Set("access_policy", flattenedPolicies); err != nil {
-			return fmt.Errorf("Error setting `access_policy` for KeyVault %q: %+v", *resp.Name, err)
+			return fmt.Errorf("setting `access_policy` for KeyVault %q: %+v", *resp.Name, err)
 		}
 
-		log.Printf("[STEBUG] - timing before")
-		if resp, err := managementClient.GetCertificateContacts(ctx, *props.VaultURI); err != nil {
-			if !utils.ResponseWasForbidden(resp.Response) && !utils.ResponseWasNotFound(resp.Response) {
+		contactsResp, err := managementClient.GetCertificateContacts(ctx, *props.VaultURI)
+		if err != nil {
+			if !utils.ResponseWasForbidden(contactsResp.Response) && !utils.ResponseWasNotFound(contactsResp.Response) {
 				return fmt.Errorf("retrieving `contact` for KeyVault: %+v", err)
 			}
-		} else {
-			if err := d.Set("contact", flattenKeyVaultCertificateContactList(resp.ContactList)); err != nil {
-				return fmt.Errorf("setting `contact` for KeyVault: %+v", err)
-			}
 		}
-		log.Printf("[STEBUG] - timing after")
+		if err := d.Set("contact", flattenKeyVaultCertificateContactList(contactsResp)); err != nil {
+			return fmt.Errorf("setting `contact` for KeyVault: %+v", err)
+		}
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -919,13 +917,13 @@ func flattenKeyVaultNetworkAcls(input *keyvault.NetworkRuleSet) []interface{} {
 	return []interface{}{output}
 }
 
-func flattenKeyVaultCertificateContactList(input *[]KeyVaultMgmt.Contact) []interface{} {
+func flattenKeyVaultCertificateContactList(input KeyVaultMgmt.Contacts) []interface{} {
 	results := make([]interface{}, 0)
-	if input == nil {
+	if input.ContactList == nil {
 		return results
 	}
 
-	for _, contact := range *input {
+	for _, contact := range *input.ContactList {
 		emailAddress := ""
 		if contact.EmailAddress != nil {
 			emailAddress = *contact.EmailAddress

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -1002,7 +1002,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
-  }
+}
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -253,67 +253,19 @@ func TestAccKeyVault_justCert(t *testing.T) {
 	})
 }
 
-func TestAccKeyVault_softDeleteEnabled(t *testing.T) {
+func TestAccKeyVault_softDelete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
 	r := KeyVaultResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.softDelete(data, true),
+			Config: r.softDelete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccKeyVault_softDeleteViaUpdate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
-	r := KeyVaultResource{}
-
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.softDelete(data, false),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.softDelete(data, true),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccKeyVault_softDeleteAttemptToDisable(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
-	r := KeyVaultResource{}
-
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.softDelete(data, true),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config:      r.softDelete(data, false),
-			ExpectError: regexp.MustCompile("once Soft Delete has been Enabled it's not possible to disable it"),
-		},
 	})
 }
 
@@ -324,10 +276,9 @@ func TestAccKeyVault_softDeleteRecovery(t *testing.T) {
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			// create it regularly
-			Config: r.softDelete(data, true),
+			Config: r.softDelete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
 			),
 		},
@@ -338,10 +289,9 @@ func TestAccKeyVault_softDeleteRecovery(t *testing.T) {
 		},
 		{
 			// attempting to re-create it requires recovery, which is enabled by default
-			Config: r.softDelete(data, true),
+			Config: r.softDelete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
 			),
 		},
@@ -359,7 +309,6 @@ func TestAccKeyVault_softDeleteRecoveryDisabled(t *testing.T) {
 			Config: r.softDeleteRecoveryDisabled(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
 			),
 		},
@@ -386,7 +335,6 @@ func TestAccKeyVault_purgeProtectionEnabled(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -403,7 +351,6 @@ func TestAccKeyVault_purgeProtectionAndSoftDeleteEnabled(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -420,7 +367,6 @@ func TestAccKeyVault_purgeProtectionViaUpdate(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -429,7 +375,6 @@ func TestAccKeyVault_purgeProtectionViaUpdate(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -446,7 +391,6 @@ func TestAccKeyVault_purgeProtectionAttemptToDisable(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("purge_protection_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("soft_delete_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -546,7 +490,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -579,7 +522,6 @@ resource "azurerm_key_vault" "import" {
   resource_group_name        = azurerm_key_vault.test.resource_group_name
   tenant_id                  = azurerm_key_vault.test.tenant_id
   sku_name                   = "premium"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -648,7 +590,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -683,7 +624,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -719,7 +659,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -763,7 +702,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -811,7 +749,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   enabled_for_deployment          = true
@@ -846,7 +783,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy = []
@@ -883,7 +819,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -931,7 +866,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -974,7 +908,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   %s
@@ -1044,13 +977,12 @@ resource "azurerm_key_vault" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   tenant_id                = data.azurerm_client_config.current.tenant_id
   sku_name                 = "standard"
-  soft_delete_enabled      = "%t"
   purge_protection_enabled = "%t"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled, enabled)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
 }
 
-func (KeyVaultResource) softDelete(data acceptance.TestData, enabled bool) string {
+func (KeyVaultResource) softDelete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1070,9 +1002,8 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
   sku_name            = "standard"
-  soft_delete_enabled = %t
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enabled)
+  }
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (KeyVaultResource) softDeleteAbsent(data acceptance.TestData) string {
@@ -1118,7 +1049,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -1143,7 +1073,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
 }
@@ -1170,7 +1099,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy = []
@@ -1198,7 +1126,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {
@@ -1247,7 +1174,6 @@ resource "azurerm_key_vault" "test" {
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "premium"
-  soft_delete_enabled        = true
   soft_delete_retention_days = 7
 
   access_policy {

--- a/azurerm/internal/services/keyvault/migration/key_vault_v1_to_v2.go
+++ b/azurerm/internal/services/keyvault/migration/key_vault_v1_to_v2.go
@@ -27,7 +27,7 @@ func keyVaultV1ToV2Upgrade(rawState map[string]interface{}, _ interface{}) (map[
 			oldVal = int(val)
 		}
 		if val, ok := v.(int); ok {
-			oldVal = int(val)
+			oldVal = val
 		}
 	}
 

--- a/azurerm/internal/services/keyvault/migration/key_vault_v1_to_v2.go
+++ b/azurerm/internal/services/keyvault/migration/key_vault_v1_to_v2.go
@@ -1,0 +1,235 @@
+package migration
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/set"
+)
+
+func KeyVaultV1ToV2Upgrader() schema.StateUpgrader {
+	return schema.StateUpgrader{
+		Type:    keyVaultV1Schema().CoreConfigSchema().ImpliedType(),
+		Upgrade: keyVaultV1ToV2Upgrade,
+		Version: 1,
+	}
+}
+
+func keyVaultV1ToV2Upgrade(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	// @tombuildsstuff: this is an int in the schema but was previously set into the
+	// state as `*int32` - so using `.(int)` causes:
+	// panic: interface conversion: interface {} is float64, not int
+	// so I guess we try both?
+	oldVal := 0
+	if v, ok := rawState["soft_delete_retention_days"]; ok {
+		if val, ok := v.(float64); ok {
+			oldVal = int(val)
+		}
+		if val, ok := v.(int); ok {
+			oldVal = int(val)
+		}
+	}
+
+	if oldVal == 0 {
+		// The Azure API force-upgraded all Key Vaults so that Soft Delete was enabled on 2020-12-15
+		// As a part of this, all Key Vaults got a default "retention days" of 90 days, however
+		// for both newly created and upgraded key vaults, this value isn't returned unless it's
+		// explicitly set by a user.
+		//
+		// As such we have to default this to a value of 90 days, which whilst assuming this default is
+		// less than ideal, unfortunately there's little choice otherwise as this isn't returned.
+		// Whilst the API Documentation doesn't show this default, it's listed here:
+		//
+		// > Once a secret, key, certificate, or key vault is deleted, it will remain recoverable
+		// > for a configurable period of 7 to 90 calendar days. If no configuration is specified
+		// > the default recovery period will be set to 90 days
+		// https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview
+		//
+		// Notably this value cannot be updated once it's initially been configured, meaning that we
+		// must not send this during creation if it's the default value, to allow users to change
+		// this value later. This also means we can't use Terraform's "ForceNew" here without breaking
+		// the one-time change.
+		//
+		// Hopefully in time this behaviour is fixed, but for now I'm not sure what else we can do.
+		//
+		// - @tombuildsstuff
+		rawState["soft_delete_retention_days"] = 90
+	}
+	return rawState, nil
+}
+
+func keyVaultV1Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.KeyVaultName,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"sku_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"tenant_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"access_policy": {
+				Type:       schema.TypeList,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Optional:   true,
+				Computed:   true,
+				MaxItems:   1024,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"object_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"application_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"certificate_permissions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"key_permissions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"secret_permissions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"storage_permissions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"enabled_for_deployment": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"enabled_for_disk_encryption": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"enabled_for_template_deployment": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"enable_rbac_authorization": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"network_acls": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_action": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"bypass": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"ip_rules": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"virtual_network_subnet_ids": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      set.HashStringIgnoreCase,
+						},
+					},
+				},
+			},
+
+			"purge_protection_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"soft_delete_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"soft_delete_retention_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"contact": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"phone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"tags": tags.Schema(),
+
+			// Computed
+			"vault_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -53,8 +53,6 @@ The following attributes are exported:
 
 * `enabled_for_template_deployment` - Can Azure Resource Manager retrieve secrets from the Key Vault?
 
-* `soft_delete_enabled` -  Is soft delete enabled on this Key Vault? 
-
 * `purge_protection_enabled` - Is purge protection enabled on this Key Vault?
 
 * `tags` - A mapping of tags assigned to the Key Vault.

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -16,6 +16,8 @@ Manages a Key Vault.
 
 ~> **Note:** Terraform will automatically recover a soft-deleted Key Vault during Creation if one is found - you can opt out of this using the `features` block within the Provider block.
 
+!> **Note:** As of 2020-12-15 Azure now requires that Soft Delete is enabled on Key Vaults and this can no longer be disabled. Version v2.42 of the Azure Provider and later ignore the value of the `soft_delete_enabled` field and force this value to be `true` - as such this field can be safely removed from your Terraform Configuration. This field will be removed in version 3.0 of the Azure Provider. 
+
 ## Example Usage
 
 ```hcl
@@ -30,17 +32,16 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "resourceGroup1"
-  location = "West US"
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_key_vault" "example" {
-  name                        = "testvault"
+  name                        = "examplekeyvault"
   location                    = azurerm_resource_group.example.location
   resource_group_name         = azurerm_resource_group.example.name
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  soft_delete_enabled         = true
   soft_delete_retention_days  = 7
   purge_protection_enabled    = false
 
@@ -49,11 +50,6 @@ resource "azurerm_key_vault" "example" {
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
-
-    certificate_permissions = [
-      "get",
-      "managecontacts",
-    ]
 
     key_permissions = [
       "get",
@@ -66,21 +62,6 @@ resource "azurerm_key_vault" "example" {
     storage_permissions = [
       "get",
     ]
-  }
-
-  network_acls {
-    default_action = "Deny"
-    bypass         = "AzureServices"
-  }
-
-  contact {
-    email = "example@example.com"
-    name  = "example"
-    phone = "0123456789"
-  }
-
-  tags = {
-    environment = "Testing"
   }
 }
 ```
@@ -119,15 +100,9 @@ The following arguments are supported:
 
 !> **Note:** Once Purge Protection has been Enabled it's not possible to Disable it. Support for [disabling purge protection is being tracked in this Azure API issue](https://github.com/Azure/azure-rest-api-specs/issues/8075). Deleting the Key Vault with Purge Protection Enabled will schedule the Key Vault to be deleted (which will happen by Azure in the configured number of days, currently 90 days - which will be configurable in Terraform in the future).
 
-* `soft_delete_enabled` - (Optional) Should Soft Delete be enabled for this Key Vault? Defaults to `false`.
+* `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted. This value can be between `7` and `90` (the default) days.
 
-!> **Note:** Once Soft Delete has been Enabled it's not possible to Disable it.
-
-~> **Note:** Terraform will check when creating a Key Vault for a previous soft-deleted Key Vault and recover it if one exists. You can configure this behaviour using the `features` block within the `provider` block.  
-
-* `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted.
-
-~> **Note:** This field can only be set once Soft Delete is Enabled and cannot be updated.
+~> **Note:** This field can only be configured one time and cannot be updated.
 
 * `contact` - (Optional) One or more `contact` block as defined below.
 


### PR DESCRIPTION
This PR updates the `azurerm_key_vault` resource to match the updated API behaviour rolled out over late last month / the new year. Whilst #10007 provides one solution to this, after extensive testing there was ultimately more necessary to make this work, as such this PR includes:

* Data Source: `azurerm_key_vault` - deprecating the field `soft_delete_enabled` (and conditionally removing this should 3.0 mode be enabled)
* Resource: `azurerm_key_vault` - deprecating the field `soft_delete_enabled` and defaulting this to true (conditionally removing this should 3.0 mode be enabled). Notably this PR removes the error when attempting to disable/enable this - but since this is hard-coded to `true` in the Read function, operators can update their configurations (or remove the field) to clear this diff.
* * Resource: `azurerm_key_vault` - defaulting the field `soft_delete_retention_days` to `90` days, to match the API behaviour. Notably it's only possible to set this value a single time (either during create, or one-time during update) at which point it's immutable - so a state migration was necessary to default this if not explicitly set - as it's defaulted in the API but not returned unless explicitly configured.

As such this PR supersedes #10007 but fixes #9988 (albeit in a slightly different manner).