### PR TITLE
refactor: removing more usages on `acceptance.AzureProvider`

### DIFF
--- a/azurerm/internal/services/web/function_app_data_source_test.go
+++ b/azurerm/internal/services/web/function_app_data_source_test.go
@@ -18,7 +18,6 @@ func TestAccFunctionAppDataSource_basic(t *testing.T) {
 		{
 			Config: FunctionAppDataSource{}.basic(data),
 			Check: resource.ComposeTestCheckFunc(
-				testCheckFunctionAppHasNoContentShare(data.ResourceName),
 				check.That(data.ResourceName).Key("outbound_ip_addresses").Exists(),
 				check.That(data.ResourceName).Key("possible_outbound_ip_addresses").Exists(),
 				check.That(data.ResourceName).Key("custom_domain_verification_id").Exists(),

--- a/azurerm/internal/services/web/function_app_host_keys_data_source_test.go
+++ b/azurerm/internal/services/web/function_app_host_keys_data_source_test.go
@@ -18,7 +18,6 @@ func TestAccFunctionAppHostKeysDataSource_basic(t *testing.T) {
 		{
 			Config: FunctionAppHostKeysDataSource{}.basic(data),
 			Check: resource.ComposeTestCheckFunc(
-				testCheckFunctionAppHasNoContentShare(data.ResourceName),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("default_function_key").Exists(),
 			),

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -29,7 +29,7 @@ func TestAccFunctionApp_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckFunctionAppHasNoContentShare(data.ResourceName),
+				data.CheckWithClient(r.hasContentShareAppSetting(false)),
 				check.That(data.ResourceName).Key("version").HasValue("~1"),
 				check.That(data.ResourceName).Key("outbound_ip_addresses").Exists(),
 				check.That(data.ResourceName).Key("possible_outbound_ip_addresses").Exists(),
@@ -95,7 +95,7 @@ func TestAccFunctionApp_requiresImport(t *testing.T) {
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckFunctionAppHasNoContentShare(data.ResourceName),
+				data.CheckWithClient(r.hasContentShareAppSetting(false)),
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
@@ -398,7 +398,7 @@ func TestAccFunctionApp_consumptionPlan(t *testing.T) {
 			Config: r.consumptionPlan(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckFunctionAppHasContentShare(data.ResourceName),
+				data.CheckWithClient(r.hasContentShareAppSetting(true)),
 				check.That(data.ResourceName).Key("site_config.0.use_32_bit_worker_process").HasValue("true"),
 			),
 		},
@@ -414,7 +414,7 @@ func TestAccFunctionApp_consumptionPlanUppercaseName(t *testing.T) {
 			Config: r.consumptionPlanUppercaseName(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckFunctionAppHasContentShare(data.ResourceName),
+				data.CheckWithClient(r.hasContentShareAppSetting(true)),
 				check.That(data.ResourceName).Key("site_config.0.use_32_bit_worker_process").HasValue("true"),
 			),
 		},
@@ -504,7 +504,7 @@ func TestAccFunctionApp_loggingDisabled(t *testing.T) {
 			Config: r.loggingDisabled(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckFunctionAppHasNoContentShare(data.ResourceName),
+				data.CheckWithClient(r.hasContentShareAppSetting(false)),
 				check.That(data.ResourceName).Key("enable_builtin_logging").HasValue("false"),
 			),
 		},
@@ -908,64 +908,27 @@ func (r FunctionAppResource) Exists(ctx context.Context, clients *clients.Client
 	return utils.Bool(true), nil
 }
 
-func testCheckFunctionAppHasContentShare(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		functionAppName := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Function App: %s", functionAppName)
-		}
-
-		appSettingsResp, err := client.ListApplicationSettings(ctx, resourceGroup, functionAppName)
+func (r FunctionAppResource) hasContentShareAppSetting(shouldExist bool) func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+	return func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+		id, err := parse.FunctionAppID(state.ID)
 		if err != nil {
-			return fmt.Errorf("Error making Read request on AzureRM Function App AppSettings %q: %+v", functionAppName, err)
+			return err
 		}
 
+		appSettingsResp, err := clients.Web.AppServicesClient.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+		if err != nil {
+			return fmt.Errorf("listing AppSettings: %+v", err)
+		}
+
+		exists := false
 		for k := range appSettingsResp.Properties {
 			if strings.EqualFold("WEBSITE_CONTENTSHARE", k) {
-				return nil
+				exists = true
+				break
 			}
 		}
-
-		return fmt.Errorf("Function App %q does not contain the Website Content Share!", functionAppName)
-	}
-}
-
-func testCheckFunctionAppHasNoContentShare(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		functionAppName := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Function App: %s", functionAppName)
-		}
-
-		appSettingsResp, err := client.ListApplicationSettings(ctx, resourceGroup, functionAppName)
-		if err != nil {
-			return fmt.Errorf("Error making Read request on AzureRM Function App AppSettings %q: %+v", functionAppName, err)
-		}
-
-		for k, v := range appSettingsResp.Properties {
-			if strings.EqualFold("WEBSITE_CONTENTSHARE", k) && v != nil && *v != "" {
-				return fmt.Errorf("Function App %q contains the Website Content Share!", functionAppName)
-			}
+		if exists != shouldExist {
+			return fmt.Errorf("expected %t but got %t", shouldExist, exists)
 		}
 
 		return nil


### PR DESCRIPTION
This PR continues removing direct usages on `acceptance.AzureProvider`, switching these out for the new test framework:

* `azurerm_function_app`
* `azurerm_monitor_log_profile`
* `azurerm_storage_account_customer_managed_key`
* `azurerm_storage_blob`
* `azurerm_storage_sync_cloud_endpoint`