### PR TITLE
load-balancers: removing the direct dependency on `acceptance.AzureProvider`

### DIFF
--- a/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
@@ -53,19 +54,10 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_removal(t *testing.T) {
 	r := LoadBalancerBackendAddressPool{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.removal(data),
-			Check: resource.ComposeTestCheckFunc(
-				r.IsMissing("azurerm_lb.test", fmt.Sprintf("Address-pool-%d", data.RandomInteger)),
-			),
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -99,44 +91,43 @@ func (r LoadBalancerBackendAddressPool) Exists(ctx context.Context, client *clie
 	return utils.Bool(true), nil
 }
 
-func (r LoadBalancerBackendAddressPool) IsMissing(loadBalancerName string, backendPoolName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).LoadBalancers.LoadBalancersClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[loadBalancerName]
-		if !ok {
-			return fmt.Errorf("not found: %q", loadBalancerName)
-		}
-
-		id, err := parse.LoadBalancerID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		lb, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(lb.Response) {
-				return fmt.Errorf("Load Balancer %q (resource group %q) not found while checking for Backend Address Pool removal", id.Name, id.ResourceGroup)
-			}
-			return fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Backend Address Pool removal", id.Name, id.ResourceGroup)
-		}
-		props := lb.LoadBalancerPropertiesFormat
-		if props == nil || props.BackendAddressPools == nil {
-			return fmt.Errorf("Backend Pool %q not found in Load Balancer %q (resource group %q)", backendPoolName, id.Name, id.ResourceGroup)
-		}
-
-		found := false
-		for _, v := range *props.BackendAddressPools {
-			if v.Name != nil && *v.Name == backendPoolName {
-				found = true
-			}
-		}
-		if found {
-			return fmt.Errorf("Backend Pool %q not removed from Load Balancer %q (resource group %q)", backendPoolName, id.Name, id.ResourceGroup)
-		}
-		return nil
+func (r LoadBalancerBackendAddressPool) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.LoadBalancerBackendAddressPoolID(state.ID)
+	if err != nil {
+		return nil, err
 	}
+
+	lb, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Load Balancer %q (Resource Group %q)", id.LoadBalancerName, id.ResourceGroup)
+	}
+	if lb.LoadBalancerPropertiesFormat == nil {
+		return nil, fmt.Errorf("`properties` was nil")
+	}
+	if lb.LoadBalancerPropertiesFormat.BackendAddressPools == nil {
+		return nil, fmt.Errorf("`properties.BackendAddressPools` was nil")
+	}
+
+	backendAddressPools := make([]network.BackendAddressPool, 0)
+	for _, backendAddressPool := range *lb.LoadBalancerPropertiesFormat.BackendAddressPools {
+		if backendAddressPool.Name == nil || *backendAddressPool.Name == id.BackendAddressPoolName {
+			continue
+		}
+
+		backendAddressPools = append(backendAddressPools, backendAddressPool)
+	}
+	lb.LoadBalancerPropertiesFormat.BackendAddressPools = &backendAddressPools
+
+	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
+	if err != nil {
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r LoadBalancerBackendAddressPool) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource_test.go
@@ -120,11 +120,11 @@ func (r LoadBalancerBackendAddressPool) Destroy(ctx context.Context, client *cli
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 	if err != nil {
-		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(true), nil

--- a/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_resource_test.go
@@ -179,34 +179,3 @@ resource "azurerm_lb_backend_address_pool" "import" {
 }
 `, template)
 }
-
-func (r LoadBalancerBackendAddressPool) removal(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_public_ip" "test" {
-  name                = "test-ip-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Static"
-}
-
-resource "azurerm_lb" "test" {
-  name                = "arm-test-loadbalancer-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  frontend_ip_configuration {
-    name                 = "one-%d"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}

--- a/azurerm/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -48,24 +49,15 @@ func TestAccAzureRMLoadBalancerNatPool_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadBalancerNatPool_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerNatPool_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_nat_pool", "test")
 	r := LoadBalancerNatPool{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.removal(data),
-			Check: resource.ComposeTestCheckFunc(
-				r.IsMissing("azurerm_lb.test", fmt.Sprintf("NatPool-%d", data.RandomInteger)),
-			),
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -97,46 +89,6 @@ func TestAccAzureRMLoadBalancerNatPool_update(t *testing.T) {
 	})
 }
 
-func (r LoadBalancerNatPool) IsMissing(loadBalancerName string, natPoolName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).LoadBalancers.LoadBalancersClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[loadBalancerName]
-		if !ok {
-			return fmt.Errorf("not found: %q", loadBalancerName)
-		}
-
-		id, err := parse.LoadBalancerID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		lb, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(lb.Response) {
-				return fmt.Errorf("Load Balancer %q (resource group %q) not found while checking for Nat Pool removal", id.Name, id.ResourceGroup)
-			}
-			return fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Nat Pool removal", id.Name, id.ResourceGroup)
-		}
-		props := lb.LoadBalancerPropertiesFormat
-		if props == nil || props.InboundNatPools == nil {
-			return fmt.Errorf("Nat Pool %q not found in Load Balancer %q (resource group %q)", natPoolName, id.Name, id.ResourceGroup)
-		}
-
-		found := false
-		for _, v := range *props.InboundNatPools {
-			if v.Name != nil && *v.Name == natPoolName {
-				found = true
-			}
-		}
-		if found {
-			return fmt.Errorf("Nat Pool %q not removed from Load Balancer %q (resource group %q)", natPoolName, id.Name, id.ResourceGroup)
-		}
-		return nil
-	}
-}
-
 func (r LoadBalancerNatPool) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.LoadBalancerInboundNatPoolID(state.ID)
 	if err != nil {
@@ -166,6 +118,45 @@ func (r LoadBalancerNatPool) Exists(ctx context.Context, client *clients.Client,
 	}
 
 	return utils.Bool(found), nil
+}
+
+func (r LoadBalancerNatPool) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.LoadBalancerInboundNatPoolID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	lb, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Load Balancer %q (Resource Group %q)", id.LoadBalancerName, id.ResourceGroup)
+	}
+	if lb.LoadBalancerPropertiesFormat == nil {
+		return nil, fmt.Errorf("`properties` was nil")
+	}
+	if lb.LoadBalancerPropertiesFormat.InboundNatPools == nil {
+		return nil, fmt.Errorf("`properties.InboundNatPools` was nil")
+	}
+
+	inboundNatPools := make([]network.InboundNatPool, 0)
+	for _, inboundNatPool := range *lb.LoadBalancerPropertiesFormat.InboundNatPools {
+		if inboundNatPool.Name == nil || *inboundNatPool.Name == id.InboundNatPoolName {
+			continue
+		}
+
+		inboundNatPools = append(inboundNatPools, inboundNatPool)
+	}
+	lb.LoadBalancerPropertiesFormat.InboundNatPools = &inboundNatPools
+
+	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
+	if err != nil {
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r LoadBalancerNatPool) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
@@ -149,11 +149,11 @@ func (r LoadBalancerNatPool) Destroy(ctx context.Context, client *clients.Client
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 	if err != nil {
-		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(true), nil

--- a/azurerm/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
@@ -219,37 +219,6 @@ resource "azurerm_lb_nat_pool" "import" {
 `, template)
 }
 
-func (r LoadBalancerNatPool) removal(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_public_ip" "test" {
-  name                = "test-ip-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Static"
-}
-
-resource "azurerm_lb" "test" {
-  name                = "arm-test-loadbalancer-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  frontend_ip_configuration {
-    name                 = "one-%d"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
 func (r LoadBalancerNatPool) multiplePools(data, data2 acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_nat_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_nat_rule_resource_test.go
@@ -195,11 +195,11 @@ func (r LoadBalancerNatRule) Destroy(ctx context.Context, client *clients.Client
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 	if err != nil {
-		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(true), nil

--- a/azurerm/internal/services/loadbalancer/loadbalancer_nat_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_nat_rule_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
@@ -91,24 +92,17 @@ func TestAccAzureRMLoadBalancerNatRule_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadBalancerNatRule_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerNatRule_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_nat_rule", "test")
 	r := LoadBalancerNatRule{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data, "Basic"),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.template(data, "Basic"),
-			Check: resource.ComposeTestCheckFunc(
-				r.IsMissing("azurerm_lb.test", fmt.Sprintf("NatRule-%d", data.RandomInteger)),
-			),
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config: func(data acceptance.TestData) string {
+				return r.basic(data, "Basic")
+			},
+			TestResource: r,
+		}),
 	})
 }
 
@@ -172,44 +166,43 @@ func (r LoadBalancerNatRule) Exists(ctx context.Context, client *clients.Client,
 	return utils.Bool(found), nil
 }
 
-func (r LoadBalancerNatRule) IsMissing(loadBalancerName string, natRuleName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).LoadBalancers.LoadBalancersClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[loadBalancerName]
-		if !ok {
-			return fmt.Errorf("not found: %q", loadBalancerName)
-		}
-
-		id, err := parse.LoadBalancerID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		lb, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(lb.Response) {
-				return fmt.Errorf("Load Balancer %q (resource group %q) not found while checking for Nat Rule removal", id.Name, id.ResourceGroup)
-			}
-			return fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Nat Rule removal", id.Name, id.ResourceGroup)
-		}
-		props := lb.LoadBalancerPropertiesFormat
-		if props == nil || props.InboundNatRules == nil {
-			return fmt.Errorf("Nat Rule %q not found in Load Balancer %q (resource group %q)", natRuleName, id.Name, id.ResourceGroup)
-		}
-
-		found := false
-		for _, v := range *props.InboundNatRules {
-			if v.Name != nil && *v.Name == natRuleName {
-				found = true
-			}
-		}
-		if found {
-			return fmt.Errorf("Nat Rule %q not removed from Load Balancer %q (resource group %q)", natRuleName, id.Name, id.ResourceGroup)
-		}
-		return nil
+func (r LoadBalancerNatRule) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.LoadBalancerInboundNatRuleID(state.ID)
+	if err != nil {
+		return nil, err
 	}
+
+	lb, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Load Balancer %q (Resource Group %q)", id.LoadBalancerName, id.ResourceGroup)
+	}
+	if lb.LoadBalancerPropertiesFormat == nil {
+		return nil, fmt.Errorf("`properties` was nil")
+	}
+	if lb.LoadBalancerPropertiesFormat.InboundNatRules == nil {
+		return nil, fmt.Errorf("`properties.InboundNatRules` was nil")
+	}
+
+	inboundNatRules := make([]network.InboundNatRule, 0)
+	for _, inboundNatRule := range *lb.LoadBalancerPropertiesFormat.InboundNatRules {
+		if inboundNatRule.Name == nil || *inboundNatRule.Name == id.InboundNatRuleName {
+			continue
+		}
+
+		inboundNatRules = append(inboundNatRules, inboundNatRule)
+	}
+	lb.LoadBalancerPropertiesFormat.InboundNatRules = &inboundNatRules
+
+	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
+	if err != nil {
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r LoadBalancerNatRule) template(data acceptance.TestData, sku string) string {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
@@ -241,45 +241,6 @@ resource "azurerm_lb_outbound_rule" "import" {
 `, template)
 }
 
-func (r LoadBalancerOutboundRule) removal(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_public_ip" "test" {
-  name                = "test-ip-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
-resource "azurerm_lb_backend_address_pool" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  loadbalancer_id     = azurerm_lb.test.id
-  name                = "be-%d"
-}
-
-resource "azurerm_lb" "test" {
-  name                = "arm-test-loadbalancer-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-
-  frontend_ip_configuration {
-    name                 = "one-%d"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
 func (r LoadBalancerOutboundRule) multipleRules(data, data2 acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
@@ -161,11 +161,11 @@ func (r LoadBalancerOutboundRule) Destroy(ctx context.Context, client *clients.C
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 	if err != nil {
-		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(true), nil

--- a/azurerm/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_outbound_rule_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
@@ -47,24 +48,15 @@ func TestAccAzureRMLoadBalancerOutboundRule_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadBalancerOutboundRule_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerOutboundRule_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_outbound_rule", "test")
 	r := LoadBalancerOutboundRule{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.removal(data),
-			Check: resource.ComposeTestCheckFunc(
-				r.IsMissing("azurerm_lb.test", fmt.Sprintf("OutboundRule-%d", data.RandomInteger)),
-			),
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -140,44 +132,43 @@ func (r LoadBalancerOutboundRule) Exists(ctx context.Context, client *clients.Cl
 	return utils.Bool(found), nil
 }
 
-func (r LoadBalancerOutboundRule) IsMissing(loadBalancerName string, outboundRuleName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).LoadBalancers.LoadBalancersClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[loadBalancerName]
-		if !ok {
-			return fmt.Errorf("not found: %q", loadBalancerName)
-		}
-
-		id, err := parse.LoadBalancerID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		lb, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(lb.Response) {
-				return fmt.Errorf("Load Balancer %q (resource group %q) not found while checking for Outbound Rule removal", id.Name, id.ResourceGroup)
-			}
-			return fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Outbound Rule removal", id.Name, id.ResourceGroup)
-		}
-		props := lb.LoadBalancerPropertiesFormat
-		if props == nil || props.OutboundRules == nil {
-			return fmt.Errorf("Outbound Rule %q not found in Load Balancer %q (resource group %q)", outboundRuleName, id.Name, id.ResourceGroup)
-		}
-
-		found := false
-		for _, v := range *props.OutboundRules {
-			if v.Name != nil && *v.Name == outboundRuleName {
-				found = true
-			}
-		}
-		if found {
-			return fmt.Errorf("Outbound Rule %q not removed from Load Balancer %q (resource group %q)", outboundRuleName, id.Name, id.ResourceGroup)
-		}
-		return nil
+func (r LoadBalancerOutboundRule) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.LoadBalancerOutboundRuleID(state.ID)
+	if err != nil {
+		return nil, err
 	}
+
+	lb, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Load Balancer %q (Resource Group %q)", id.LoadBalancerName, id.ResourceGroup)
+	}
+	if lb.LoadBalancerPropertiesFormat == nil {
+		return nil, fmt.Errorf("`properties` was nil")
+	}
+	if lb.LoadBalancerPropertiesFormat.OutboundRules == nil {
+		return nil, fmt.Errorf("`properties.OutboundRules` was nil")
+	}
+
+	outboundRules := make([]network.OutboundRule, 0)
+	for _, outboundRule := range *lb.LoadBalancerPropertiesFormat.OutboundRules {
+		if outboundRule.Name == nil || *outboundRule.Name == id.OutboundRuleName {
+			continue
+		}
+
+		outboundRules = append(outboundRules, outboundRule)
+	}
+	lb.LoadBalancerPropertiesFormat.OutboundRules = &outboundRules
+
+	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
+	if err != nil {
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r LoadBalancerOutboundRule) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
@@ -232,37 +232,6 @@ resource "azurerm_lb_probe" "import" {
 `, template)
 }
 
-func (r LoadBalancerProbe) removal(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_public_ip" "test" {
-  name                = "test-ip-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Static"
-}
-
-resource "azurerm_lb" "test" {
-  name                = "arm-test-loadbalancer-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  frontend_ip_configuration {
-    name                 = "one-%d"
-    public_ip_address_id = azurerm_public_ip.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
 func (r LoadBalancerProbe) multipleProbes(data, data2 acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
@@ -166,6 +166,7 @@ func (r LoadBalancerProbe) Destroy(ctx context.Context, client *clients.Client, 
 
 		probes = append(probes, probe)
 	}
+	lb.LoadBalancerPropertiesFormat.Probes = &probes
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 	if err != nil {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
@@ -170,11 +170,11 @@ func (r LoadBalancerProbe) Destroy(ctx context.Context, client *clients.Client, 
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 	if err != nil {
-		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(true), nil

--- a/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -48,24 +49,15 @@ func TestAccAzureRMLoadBalancerProbe_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadBalancerProbe_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerProbe_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_probe", "test")
 	r := LoadBalancerProbe{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.removal(data),
-			Check: resource.ComposeTestCheckFunc(
-				r.IsMissing("azurerm_lb.test", fmt.Sprintf("probe-%d", data.RandomInteger)),
-			),
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -149,44 +141,42 @@ func (r LoadBalancerProbe) Exists(ctx context.Context, client *clients.Client, s
 	return utils.Bool(found), nil
 }
 
-func (r LoadBalancerProbe) IsMissing(loadBalancerName string, probeName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).LoadBalancers.LoadBalancersClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[loadBalancerName]
-		if !ok {
-			return fmt.Errorf("not found: %q", loadBalancerName)
-		}
-
-		id, err := parse.LoadBalancerID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		lb, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(lb.Response) {
-				return fmt.Errorf("Load Balancer %q (resource group %q) not found while checking for Probe removal", id.Name, id.ResourceGroup)
-			}
-			return fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Probe removal", id.Name, id.ResourceGroup)
-		}
-		props := lb.LoadBalancerPropertiesFormat
-		if props == nil || props.Probes == nil {
-			return fmt.Errorf("Probe %q not found in Load Balancer %q (resource group %q)", probeName, id.Name, id.ResourceGroup)
-		}
-
-		found := false
-		for _, v := range *props.Probes {
-			if v.Name != nil && *v.Name == probeName {
-				found = true
-			}
-		}
-		if found {
-			return fmt.Errorf("Probe %q not removed from Load Balancer %q (resource group %q)", probeName, id.Name, id.ResourceGroup)
-		}
-		return nil
+func (r LoadBalancerProbe) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.LoadBalancerProbeID(state.ID)
+	if err != nil {
+		return nil, err
 	}
+
+	lb, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Load Balancer %q (Resource Group %q)", id.LoadBalancerName, id.ResourceGroup)
+	}
+	if lb.LoadBalancerPropertiesFormat == nil {
+		return nil, fmt.Errorf("`properties` was nil")
+	}
+	if lb.LoadBalancerPropertiesFormat.Probes == nil {
+		return nil, fmt.Errorf("`properties.Probes` was nil")
+	}
+
+	probes := make([]network.Probe, 0)
+	for _, probe := range *lb.LoadBalancerPropertiesFormat.Probes {
+		if probe.Name == nil || *probe.Name == id.ProbeName {
+			continue
+		}
+
+		probes = append(probes, probe)
+	}
+
+	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
+	if err != nil {
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r LoadBalancerProbe) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/loadbalancer/loadbalancer_rule_data_source_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_rule_data_source_test.go
@@ -53,7 +53,7 @@ func TestAccAzureRMDataSourceLoadBalancerRule_complete(t *testing.T) {
 }
 
 func (r LoadBalancerRule) basicDataSource(data acceptance.TestData) string {
-	template := r.basic(data, "Basic")
+	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/loadbalancer/loadbalancer_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_rule_resource_test.go
@@ -201,11 +201,11 @@ func (r LoadBalancerRule) Destroy(ctx context.Context, client *clients.Client, s
 
 	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
 	if err != nil {
-		return nil, fmt.Errorf("updating LoadBalancer %s (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("updating Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
-		return nil, fmt.Errorf("waiting for update of LoadBalancer %s (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("waiting for update of Load Balancer %q (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
 	}
 
 	return utils.Bool(true), nil

--- a/azurerm/internal/services/loadbalancer/loadbalancer_rule_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_rule_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
@@ -23,7 +24,7 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -53,7 +54,7 @@ func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -67,7 +68,7 @@ func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -82,7 +83,7 @@ func TestAccAzureRMLoadBalancerRule_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -91,24 +92,15 @@ func TestAccAzureRMLoadBalancerRule_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMLoadBalancerRule_removal(t *testing.T) {
+func TestAccAzureRMLoadBalancerRule_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_lb_rule", "test")
 	r := LoadBalancerRule{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data, "Basic"),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.template(data, "Basic"),
-			Check: resource.ComposeTestCheckFunc(
-				r.IsMissing("azurerm_lb.test", fmt.Sprintf("LbRule-%s", data.RandomStringOfLength(8))),
-			),
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -169,68 +161,54 @@ func (r LoadBalancerRule) Exists(ctx context.Context, client *clients.Client, st
 		return nil, err
 	}
 
-	lb, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	rule, err := client.LoadBalancers.LoadBalancingRulesClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, id.Name)
 	if err != nil {
-		if utils.ResponseWasNotFound(lb.Response) {
-			return nil, fmt.Errorf("Load Balancer %q (resource group %q) not found for Load Balancing Rule %q", id.LoadBalancerName, id.ResourceGroup, id.Name)
+		if utils.ResponseWasNotFound(rule.Response) {
+			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Load Balancing Rule %q", id.LoadBalancerName, id.ResourceGroup, id.Name)
-	}
-	props := lb.LoadBalancerPropertiesFormat
-	if props == nil || props.LoadBalancingRules == nil || len(*props.LoadBalancingRules) == 0 {
-		return nil, fmt.Errorf("Load Balancing Rule %q not found in Load Balancer %q (resource group %q)", id.Name, id.LoadBalancerName, id.ResourceGroup)
+
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	found := false
-	for _, v := range *props.LoadBalancingRules {
-		if v.Name != nil && *v.Name == id.Name {
-			found = true
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("Load Balancing Rule %q not found in Load Balancer %q (resource group %q)", id.Name, id.LoadBalancerName, id.ResourceGroup)
-	}
-	return utils.Bool(found), nil
+	return utils.Bool(rule.ID != nil), nil
 }
 
-func (r LoadBalancerRule) IsMissing(loadBalancerName string, loadBalancingRuleName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).LoadBalancers.LoadBalancersClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[loadBalancerName]
-		if !ok {
-			return fmt.Errorf("not found: %q", loadBalancerName)
-		}
-
-		id, err := parse.LoadBalancerID(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		lb, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(lb.Response) {
-				return fmt.Errorf("Load Balancer %q (resource group %q) not found while checking for Load Balancing Rule removal", id.Name, id.ResourceGroup)
-			}
-			return fmt.Errorf("failed reading Load Balancer %q (resource group %q) for Load Balancing Rule removal", id.Name, id.ResourceGroup)
-		}
-		props := lb.LoadBalancerPropertiesFormat
-		if props == nil || props.LoadBalancingRules == nil {
-			return fmt.Errorf("Load Balancing Rule %q not found in Load Balancer %q (resource group %q)", loadBalancingRuleName, id.Name, id.ResourceGroup)
-		}
-
-		found := false
-		for _, v := range *props.LoadBalancingRules {
-			if v.Name != nil && *v.Name == loadBalancingRuleName {
-				found = true
-			}
-		}
-		if found {
-			return fmt.Errorf("Outbound Rule %q not removed from Load Balancer %q (resource group %q)", loadBalancingRuleName, id.Name, id.ResourceGroup)
-		}
-		return nil
+func (r LoadBalancerRule) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.LoadBalancingRuleID(state.ID)
+	if err != nil {
+		return nil, err
 	}
+
+	loadBalancer, err := client.LoadBalancers.LoadBalancersClient.Get(ctx, id.ResourceGroup, id.LoadBalancerName, "")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	if loadBalancer.LoadBalancerPropertiesFormat == nil {
+		return nil, fmt.Errorf(`properties was nil`)
+	}
+	if loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules == nil {
+		return nil, fmt.Errorf(`properties.LoadBalancingRules was nil`)
+	}
+	rules := make([]network.LoadBalancingRule, 0)
+	for _, v := range *loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules {
+		if v.Name == nil || *v.Name == id.Name {
+			continue
+		}
+
+		rules = append(rules, v)
+	}
+	loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules = &rules
+
+	future, err := client.LoadBalancers.LoadBalancersClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
+	if err != nil {
+		return nil, fmt.Errorf("updating LoadBalancer %s (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.LoadBalancers.LoadBalancersClient.Client); err != nil {
+		return nil, fmt.Errorf("waiting for update of LoadBalancer %s (Resource Group %q): %+v", id.LoadBalancerName, id.ResourceGroup, err)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r LoadBalancerRule) template(data acceptance.TestData, sku string) string {
@@ -266,20 +244,19 @@ resource "azurerm_lb" "test" {
 `, data.RandomInteger, data.Locations.Primary, sku)
 }
 
-// nolint: unparam
-func (r LoadBalancerRule) basic(data acceptance.TestData, sku string) string {
-	template := r.template(data, sku)
+func (r LoadBalancerRule) basic(data acceptance.TestData) string {
+	template := r.template(data, "Basic")
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_lb_rule" "test" {
-  resource_group_name            = "${azurerm_resource_group.test.name}"
-  loadbalancer_id                = "${azurerm_lb.test.id}"
   name                           = "LbRule-%s"
+  resource_group_name            = azurerm_resource_group.test.name
+  loadbalancer_id                = azurerm_lb.test.id
+  frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
   protocol                       = "Tcp"
   frontend_port                  = 3389
   backend_port                   = 3389
-  frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
 `, template, data.RandomStringOfLength(8))
 }
@@ -309,7 +286,7 @@ resource "azurerm_lb_rule" "test" {
 }
 
 func (r LoadBalancerRule) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data, "Basic")
+	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
This PR continues removing the direct dependency on `acceptance.AzureProvider` - by switching to use a DisappearsStep for the Load Balancer tests.