### PR TITLE
`azurerm_role_assignment` - fix race condition in read after create

### DIFF
--- a/azurerm/internal/services/authorization/parse/role_assignment.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment.go
@@ -1,0 +1,53 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+// /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
+// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
+// /providers/Microsoft.Management/managementGroups/74253c84-2d7f-4522-a73f-8897fd715d21/providers/Microsoft.Authorization/roleAssignments/4d6124f3-1888-5851-0ffa-3b86bd56a2e4
+
+type RoleAssignmentID struct {
+	SubscriptionID  string
+	ResourceGroup   string
+	ManagementGroup string
+	Name            string
+}
+
+func RoleAssignmentId(input string) (*RoleAssignmentID, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("Role Assignment ID is empty string")
+	}
+
+	roleAssignmentId := RoleAssignmentID{}
+
+	if strings.HasPrefix(input, "/subscriptions/") {
+		id, err := azure.ParseAzureResourceID(input)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse %q as Azure resource ID", input)
+		}
+		roleAssignmentId.SubscriptionID = id.SubscriptionID
+		roleAssignmentId.ResourceGroup = id.ResourceGroup
+		if roleAssignmentId.Name, err = id.PopSegment("roleAssignments"); err != nil {
+			return nil, err
+		}
+	} else if strings.HasPrefix(input, "/providers/Microsoft.Management/") {
+		idParts := strings.Split(input, "/providers/Microsoft.Authorization/roleAssignments/")
+		if len(idParts) != 2 {
+			return nil, fmt.Errorf("could not parse Role Assignment ID %q for Management Group", input)
+		}
+		roleAssignmentId.Name = idParts[1]
+
+		roleAssignmentId.ManagementGroup = strings.Trim(idParts[0], "/providers/Microsoft.Management/managementGroups/")
+
+	} else {
+		return nil, fmt.Errorf("could not parse Role Assignment ID %q", input)
+	}
+
+	return &roleAssignmentId, nil
+
+}

--- a/azurerm/internal/services/authorization/parse/role_assignment.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment.go
@@ -7,10 +7,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-// /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
-// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
-// /providers/Microsoft.Management/managementGroups/74253c84-2d7f-4522-a73f-8897fd715d21/providers/Microsoft.Authorization/roleAssignments/4d6124f3-1888-5851-0ffa-3b86bd56a2e4
-
 type RoleAssignmentID struct {
 	SubscriptionID  string
 	ResourceGroup   string

--- a/azurerm/internal/services/authorization/parse/role_assignment.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment.go
@@ -45,5 +45,4 @@ func RoleAssignmentId(input string) (*RoleAssignmentID, error) {
 	}
 
 	return &roleAssignmentId, nil
-
 }

--- a/azurerm/internal/services/authorization/parse/role_assignment.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment.go
@@ -21,7 +21,8 @@ func RoleAssignmentId(input string) (*RoleAssignmentID, error) {
 
 	roleAssignmentId := RoleAssignmentID{}
 
-	if strings.HasPrefix(input, "/subscriptions/") {
+	switch {
+	case strings.HasPrefix(input, "/subscriptions/"):
 		id, err := azure.ParseAzureResourceID(input)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse %q as Azure resource ID", input)
@@ -31,16 +32,14 @@ func RoleAssignmentId(input string) (*RoleAssignmentID, error) {
 		if roleAssignmentId.Name, err = id.PopSegment("roleAssignments"); err != nil {
 			return nil, err
 		}
-	} else if strings.HasPrefix(input, "/providers/Microsoft.Management/") {
+	case strings.HasPrefix(input, "/providers/Microsoft.Management/"):
 		idParts := strings.Split(input, "/providers/Microsoft.Authorization/roleAssignments/")
 		if len(idParts) != 2 {
 			return nil, fmt.Errorf("could not parse Role Assignment ID %q for Management Group", input)
 		}
 		roleAssignmentId.Name = idParts[1]
-
 		roleAssignmentId.ManagementGroup = strings.Trim(idParts[0], "/providers/Microsoft.Management/managementGroups/")
-
-	} else {
+	default:
 		return nil, fmt.Errorf("could not parse Role Assignment ID %q", input)
 	}
 

--- a/azurerm/internal/services/authorization/parse/role_assignment_test.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment_test.go
@@ -1,0 +1,188 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = RoleAssignmentId{}
+
+func TestRoleAssignmentIDFormatter(t *testing.T) {
+	testData := []struct {
+		SubscriptionId  string
+		ResourceGroup   string
+		ManagementGroup string
+		Name            string
+		Expected        string
+	}{
+		{
+			SubscriptionId:  "",
+			ResourceGroup:   "",
+			ManagementGroup: "",
+			Name:            "23456781-2349-8764-5631-234567890121",
+		},
+		{
+			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+			ResourceGroup:   "group1",
+			ManagementGroup: "managementGroup1",
+			Name:            "23456781-2349-8764-5631-234567890121",
+		},
+		{
+			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+			ResourceGroup:   "",
+			ManagementGroup: "managementGroup1",
+			Name:            "23456781-2349-8764-5631-234567890121",
+		},
+		{
+			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+			ResourceGroup:   "",
+			ManagementGroup: "",
+			Name:            "23456781-2349-8764-5631-234567890121",
+			Expected:        "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+		},
+		{
+			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+			ResourceGroup:   "group1",
+			ManagementGroup: "",
+			Name:            "23456781-2349-8764-5631-234567890121",
+			Expected:        "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+		},
+		{
+			SubscriptionId:  "",
+			ResourceGroup:   "",
+			ManagementGroup: "12345678-1234-9876-4563-123456789012",
+			Name:            "23456781-2349-8764-5631-234567890121",
+			Expected:        "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("testing %+v", v)
+		actual, err := NewRoleAssignmentID(v.SubscriptionId, v.ResourceGroup, v.ManagementGroup, v.Name)
+		if err != nil {
+			if v.Expected == "" {
+				continue
+			}
+		}
+		actualId := actual.ID()
+		if actualId != v.Expected {
+			t.Fatalf("expected %q, got %q", v.Expected, actualId)
+		}
+	}
+}
+
+func TestRoleAssignmentID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *RoleAssignmentId
+	}{
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// just subscription
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup value
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Management Group value
+			Input: "/providers/Microsoft.Management/managementGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Role Assignment value at Subscription Scope
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Authorization/roleAssignments/",
+			Error: true,
+		},
+
+		{
+			// missing Role Assignment value at Management Group scope
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroup1/providers/Microsoft.Authorization/roleAssignments/",
+			Error: true,
+		},
+
+		{
+			// valid at subscription scope
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:  "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:   "",
+				ManagementGroup: "",
+				Name:            "23456781-2349-8764-5631-234567890121",
+			},
+		},
+
+		{
+			// valid at resource group scope
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:  "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:   "group1",
+				ManagementGroup: "",
+				Name:            "23456781-2349-8764-5631-234567890121",
+			},
+		},
+
+		{
+			// valid at management group scope
+			Input: "/providers/Microsoft.Management/managementGroups/managementGroup1/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:  "",
+				ResourceGroup:   "",
+				ManagementGroup: "managementGroup1",
+				Name:            "23456781-2349-8764-5631-234567890121",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := RoleAssignmentID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("expected a value but got an error: %+v", err)
+		}
+
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.SubscriptionID != v.Expected.SubscriptionID {
+			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.SubscriptionID, actual.SubscriptionID)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.ManagementGroup != v.Expected.ManagementGroup {
+			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.ManagementGroup, actual.ManagementGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/authorization/role_assignment_resource.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource.go
@@ -150,7 +150,6 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 		properties.RoleAssignmentProperties.PrincipalType = authorization.ServicePrincipal
 	}
 
-	// TODO: we should switch this to use the timeout
 	if err := resource.Retry(d.Timeout(schema.TimeoutCreate), retryRoleAssignmentsClient(d, scope, name, properties, meta)); err != nil {
 		return err
 	}

--- a/azurerm/internal/services/authorization/role_assignment_resource.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource.go
@@ -151,32 +151,16 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// TODO: we should switch this to use the timeout
-	if err := resource.Retry(300*time.Second, retryRoleAssignmentsClient(d, scope, name, properties, meta)); err != nil {
+	if err := resource.Retry(d.Timeout(schema.TimeoutCreate), retryRoleAssignmentsClient(d, scope, name, properties, meta)); err != nil {
 		return err
 	}
+
 	read, err := roleAssignmentsClient.Get(ctx, scope, name)
 	if err != nil {
 		return err
 	}
 	if read.ID == nil {
 		return fmt.Errorf("Cannot read Role Assignment ID for %q (Scope %q)", name, scope)
-	}
-
-	stateConf := &resource.StateChangeConf{
-		Pending: []string{
-			"pending",
-		},
-		Target: []string{
-			"ready",
-		},
-		Refresh:                   roleAssignmentCreateStateRefreshFunc(ctx, roleAssignmentsClient, *read.ID),
-		MinTimeout:                5 * time.Second,
-		ContinuousTargetOccurence: 5,
-		Timeout:                   d.Timeout(schema.TimeoutCreate),
-	}
-
-	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("failed waiting for Role Assignment %q to finish replicating: %+v", name, err)
 	}
 
 	d.SetId(*read.ID)
@@ -260,6 +244,27 @@ func retryRoleAssignmentsClient(d *schema.ResourceData, scope string, name strin
 			}
 
 			return resource.NonRetryableError(err)
+		}
+
+		if resp.ID == nil {
+			return resource.NonRetryableError(fmt.Errorf("creation of Role Assignment %q did not return an id value", name))
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{
+				"pending",
+			},
+			Target: []string{
+				"ready",
+			},
+			Refresh:                   roleAssignmentCreateStateRefreshFunc(ctx, roleAssignmentsClient, *resp.ID),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 5,
+			Timeout:                   d.Timeout(schema.TimeoutCreate),
+		}
+
+		if _, err := stateConf.WaitForState(); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("failed waiting for Role Assignment %q to finish replicating: %+v", name, err))
 		}
 
 		return nil

--- a/azurerm/internal/services/authorization/role_assignment_resource_test.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource_test.go
@@ -22,11 +22,19 @@ func TestAccRoleAssignment(t *testing.T) {
 	// Azure only being happy about provisioning a couple at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
-			//"emptyName":      testAccRoleAssignment_emptyName,
-			"roleName":       testAccRoleAssignment_roleName,
-			"dataActions":    testAccRoleAssignment_dataActions,
-			"builtin":        testAccRoleAssignment_builtin,
-			"custom":         testAccRoleAssignment_custom,
+			"roleName": testAccRoleAssignment_roleName,
+			"custom":   testAccRoleAssignment_custom,
+		},
+		"basic_empty_name": {
+			"emptyName": testAccRoleAssignment_emptyName,
+		},
+		"built_in": {
+			"builtin": testAccRoleAssignment_builtin,
+		},
+		"data_actions": {
+			"dataActions": testAccRoleAssignment_dataActions,
+		},
+		"requires_import": {
 			"requiresImport": testAccRoleAssignment_requiresImport,
 		},
 		"assignment": {
@@ -40,8 +48,8 @@ func TestAccRoleAssignment(t *testing.T) {
 	})
 }
 
-func TestAccRoleAssignment_emptyName(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
+func testAccRoleAssignment_emptyName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	r := RoleAssignmentResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
@@ -49,7 +57,7 @@ func TestAccRoleAssignment_emptyName(t *testing.T) {
 			Config: r.emptyNameConfig(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				resource.TestCheckResourceAttrSet(data.ResourceName, "name"),
+				check.That(data.ResourceName).Key("name").Exists(),
 			),
 		},
 		data.ImportStep("skip_service_principal_aad_check"),
@@ -67,8 +75,8 @@ func testAccRoleAssignment_roleName(t *testing.T) {
 			Config: r.roleNameConfig(id),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				resource.TestCheckResourceAttrSet(data.ResourceName, "role_definition_id"),
-				resource.TestCheckResourceAttr(data.ResourceName, "role_definition_name", "Log Analytics Reader"),
+				check.That(data.ResourceName).Key("role_definition_id").Exists(),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Log Analytics Reader"),
 			),
 		},
 		data.ImportStep("skip_service_principal_aad_check"),
@@ -86,8 +94,8 @@ func testAccRoleAssignment_requiresImport(t *testing.T) {
 			Config: r.roleNameConfig(id),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				resource.TestCheckResourceAttrSet(data.ResourceName, "role_definition_id"),
-				resource.TestCheckResourceAttr(data.ResourceName, "role_definition_name", "Log Analytics Reader"),
+				check.That(data.ResourceName).Key("role_definition_id").Exists(),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Log Analytics Reader"),
 			),
 		},
 		{
@@ -226,7 +234,7 @@ func (r RoleAssignmentResource) Exists(ctx context.Context, client *clients.Clie
 		return nil, err
 	}
 
-	resp, err := client.Authorization.RoleAssignmentsClient.GetByID(ctx, id.Name)
+	resp, err := client.Authorization.RoleAssignmentsClient.GetByID(ctx, state.ID)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return utils.Bool(false), nil
@@ -281,7 +289,7 @@ func (RoleAssignmentResource) requiresImportConfig(id string) string {
 
 resource "azurerm_role_assignment" "import" {
   name                 = azurerm_role_assignment.test.name
-  scope                = azurerm_role_assignment.test.id
+  scope                = azurerm_role_assignment.test.scope
   role_definition_name = azurerm_role_assignment.test.role_definition_name
   principal_id         = azurerm_role_assignment.test.principal_id
 }

--- a/azurerm/internal/services/authorization/role_assignment_resource_test.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource_test.go
@@ -229,7 +229,7 @@ func testAccRoleAssignment_managementGroup(t *testing.T) {
 }
 
 func (r RoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.RoleAssignmentId(state.ID)
+	id, err := parse.RoleAssignmentID(state.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/services/authorization/role_assignment_resource_test.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource_test.go
@@ -22,7 +22,7 @@ func TestAccRoleAssignment(t *testing.T) {
 	// Azure only being happy about provisioning a couple at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
-			"emptyName":      testAccRoleAssignment_emptyName,
+			//"emptyName":      testAccRoleAssignment_emptyName,
 			"roleName":       testAccRoleAssignment_roleName,
 			"dataActions":    testAccRoleAssignment_dataActions,
 			"builtin":        testAccRoleAssignment_builtin,
@@ -40,7 +40,7 @@ func TestAccRoleAssignment(t *testing.T) {
 	})
 }
 
-func testAccRoleAssignment_emptyName(t *testing.T) {
+func TestAccRoleAssignment_emptyName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_definition", "test")
 	r := RoleAssignmentResource{}
 
@@ -221,17 +221,17 @@ func testAccRoleAssignment_managementGroup(t *testing.T) {
 }
 
 func (r RoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.RoleDefinitionId(state.ID)
+	id, err := parse.RoleAssignmentId(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := client.Authorization.RoleAssignmentsClient.Get(ctx, id.Scope, id.RoleID)
+	resp, err := client.Authorization.RoleAssignmentsClient.GetByID(ctx, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("retrieving Role Assignment for role %q (Scope %q): %+v", id.RoleID, id.Scope, err)
+		return nil, fmt.Errorf("retrieving Role Assignment for role %q: %+v", id.Name, err)
 	}
 	return utils.Bool(true), nil
 }


### PR DESCRIPTION
supersedes #9698

fixes #9379

This PR resolves some long standing issues in role_assignment by moving the consistency check into the create retry logic. It also separates tests that have a uniqueness constraint on them for definition/scope combinations. 
