### PR TITLE
[FIX]  azure_linux_virtual_machine - Allocation failure

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -490,7 +490,7 @@ func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	var vm compute.VirtualMachine
-	json.Unmarshal(vmResp, &vm)
+	_ = json.Unmarshal(vmResp, &vm)
 
 	if vm.ID == nil {
 		return fmt.Errorf("retrieving Linux Virtual Machine %q (Resource Group %q): `id` was nil", name, resourceGroup)


### PR DESCRIPTION
Hi all,

there was just a small fix for the issue #7516.

When you create a VM in a region where you couldn't get the requested resource you ran in that issue mentioned in #7516.

To create a Linux Resource we are using the async [Azure api](https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate) to create or update the VM.
The Azure api normally returns an **20x** status code that will give you the garantie that the VM will be created. (also wenn it's later running into a **failed** state).
So it was not enough to handle an error (Http status 4XX/5XX ) because the VM will be created on Azure ... also when it runs into a failed state later.
To fix that issue,  we have to add the ID of the VM into the state.

With the updated state / error handling of deploying an VW it's now possible to handle all errors that could be happen after creating an VM.

A `terraform destroy` was also working for that issue.



**Current state:**
```
No virtual machine informations saved

"resources": [
    {
       ...
    }
}
```
Azure view:
![Screen Shot 2021-01-12 at 10 25 08](https://user-images.githubusercontent.com/4014687/104307056-098b0000-54cf-11eb-947a-236160b46dd5.png)



**State after the FIX:**
```
"resources": [
    {
        "mode": "managed",
        "type": "azurerm_linux_virtual_machine",
        "name": "example",
        "provider": "provider[\"registry.terraform.io/hashicorp/azurerm\"]",
        "instances": [
          {
            ...,
            "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXXXXX-XXXXXXXXX/resourceGroups/test/providers/Microsoft.Compute/virtualMachines/example-machine",
            ...
          }
        ]
    }
}
```
Azure view:
![Screen Shot 2021-01-12 at 10 25 08](https://user-images.githubusercontent.com/4014687/104307056-098b0000-54cf-11eb-947a-236160b46dd5.png)

Bg Tobi
