### PR TITLE
`azurerm_cosmosdb_gremlin_graph`: Expose `default_ttl`

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -404,6 +404,10 @@ func resourceCosmosDbGremlinGraphRead(d *schema.ResourceData, meta interface{}) 
 					return fmt.Errorf("Error setting `unique_key`: %+v", err)
 				}
 			}
+
+			if defaultTTL := props.DefaultTTL; defaultTTL != nil {
+				d.Set("default_ttl", defaultTTL)
+			}
 		}
 	}
 

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -72,6 +72,12 @@ func resourceCosmosDbGremlinGraph() *schema.Resource {
 				ValidateFunc: validate.CosmosEntityName,
 			},
 
+			"default_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+
 			"throughput": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -233,6 +239,12 @@ func resourceCosmosDbGremlinGraphCreate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
+	if defaultTTL, hasDefaultTTL := d.GetOk("default_ttl"); hasDefaultTTL {
+		if defaultTTL != 0 {
+			db.GremlinGraphCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
+		}
+	}
+
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
 		if throughput != 0 {
 			db.GremlinGraphCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
@@ -304,6 +316,10 @@ func resourceCosmosDbGremlinGraphUpdate(d *schema.ResourceData, meta interface{}
 		db.GremlinGraphCreateUpdateProperties.Resource.UniqueKeyPolicy = &documentdb.UniqueKeyPolicy{
 			UniqueKeys: keys,
 		}
+	}
+
+	if defaultTTL, hasDefaultTTL := d.GetOk("default_ttl"); hasDefaultTTL {
+		db.GremlinGraphCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
 	}
 
 	future, err := client.CreateUpdateGremlinGraph(ctx, id.ResourceGroup, id.DatabaseAccountName, id.GremlinDatabaseName, id.GraphName, db)

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
@@ -86,18 +86,20 @@ func TestAccCosmosDbGremlinGraph_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.update(data, 700),
+			Config: r.update(data, 700, 900),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("throughput").HasValue("700"),
+				check.That(data.ResourceName).Key("default_ttl").HasValue("900"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.update(data, 1700),
+			Config: r.update(data, 1700, 1900),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("throughput").HasValue("1700"),
+				check.That(data.ResourceName).Key("default_ttl").HasValue("1900"),
 			),
 		},
 		data.ImportStep(),
@@ -251,7 +253,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
 `, CosmosGremlinDatabaseResource{}.basic(data), data.RandomInteger)
 }
 
-func (CosmosGremlinGraphResource) update(data acceptance.TestData, throughput int) string {
+func (CosmosGremlinGraphResource) update(data acceptance.TestData, throughput int, defaultTTL int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -262,6 +264,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
   database_name       = azurerm_cosmosdb_gremlin_database.test.name
   partition_key_path  = "/test"
   throughput          = %[3]d
+  default_ttl         = %[4]d
 
   index_policy {
     automatic      = true
@@ -279,7 +282,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
     paths = ["/definition/id1", "/definition/id2"]
   }
 }
-`, CosmosGremlinDatabaseResource{}.basic(data), data.RandomInteger, throughput)
+`, CosmosGremlinDatabaseResource{}.basic(data), data.RandomInteger, throughput, defaultTTL)
 }
 
 func (CosmosGremlinGraphResource) autoscale(data acceptance.TestData, maxThroughput int) string {

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of the Gremlin graph (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `default_ttl` - (Optional) The default time to live (TTL) of the Gremlin graph. If the value is missing or set to "-1", items don’t expire.
+
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
 ~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 


### PR DESCRIPTION
Support for default_ttl on azurerm_cosmosdb_gremlin_graph

Fixes #10123 