### PR TITLE
azurerm_eventhub_namespace: Expose trusted_service_access_enabled in …

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -151,6 +151,11 @@ func resourceEventHubNamespace() *schema.Resource {
 							}, false),
 						},
 
+						"trusted_service_access_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
 						// 128 limit per https://docs.microsoft.com/azure/event-hubs/event-hubs-quotas
 						"virtual_network_rule": {
 							Type:       schema.TypeList,
@@ -473,6 +478,10 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *eventhub.Networ
 		DefaultAction: eventhub.DefaultAction(block["default_action"].(string)),
 	}
 
+	if v, ok := block["trusted_service_access_enabled"]; ok {
+		ruleset.TrustedServiceAccessEnabled = utils.Bool(v.(bool))
+	}
+
 	if v, ok := block["virtual_network_rule"].([]interface{}); ok {
 		if len(v) > 0 {
 			var rules []eventhub.NWRuleSetVirtualNetworkRules
@@ -547,9 +556,10 @@ func flattenEventHubNamespaceNetworkRuleset(ruleset eventhub.NetworkRuleSet) []i
 	}
 
 	return []interface{}{map[string]interface{}{
-		"default_action":       string(ruleset.DefaultAction),
-		"virtual_network_rule": vnetBlocks,
-		"ip_rule":              ipBlocks,
+		"default_action":                 string(ruleset.DefaultAction),
+		"virtual_network_rule":           vnetBlocks,
+		"ip_rule":                        ipBlocks,
+		"trusted_service_access_enabled": ruleset.TrustedServiceAccessEnabled,
 	}}
 }
 

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -140,6 +140,21 @@ func TestAccEventHubNamespace_standardUpdateIdentity(t *testing.T) {
 	})
 }
 
+func TestAccEventHubNamespace_networkrule_iprule_trusted_services(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
+	r := EventHubNamespaceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.networkrule_iprule_trusted_services(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccEventHubNamespace_networkrule_iprule(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
 	r := EventHubNamespaceResource{}
@@ -593,6 +608,35 @@ resource "azurerm_eventhub_namespace" "test" {
 
   network_rulesets {
     default_action = "Deny"
+    ip_rule {
+      ip_mask = "10.0.0.0/16"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (EventHubNamespaceResource) networkrule_iprule_trusted_services(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eh-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  capacity            = "2"
+
+  network_rulesets {
+    default_action                 = "Deny"
+    trusted_service_access_enabled = true
     ip_rule {
       ip_mask = "10.0.0.0/16"
     }

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -73,6 +73,8 @@ A `network_rulesets` block supports the following:
 
 * `default_action` - (Required) The default action to take when a rule is not matched. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
 
+* `trusted_service_access_enabled` - (Optional) Whether Trusted Microsoft Services are allowed to bypass firewall.
+
 * `virtual_network_rule` - (Optional) One or more `virtual_network_rule` blocks as defined below.
 
 * `ip_rule` - (Optional) One or more `ip_rule` blocks as defined below.


### PR DESCRIPTION
…network_rulesets

Fixes #10118

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/eventhub -timeout=1000m -run TestAccEventHubNamespace_networkrule_iprule_trusted_services
=== RUN   TestAccEventHubNamespace_networkrule_iprule_trusted_services
=== PAUSE TestAccEventHubNamespace_networkrule_iprule_trusted_services
=== CONT  TestAccEventHubNamespace_networkrule_iprule_trusted_services
--- PASS: TestAccEventHubNamespace_networkrule_iprule_trusted_services (259.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub	260.594s
```