### PR TITLE
r/advanced_threat_protection: adding a state migration to ensure the ID has a `/` prefix

### DIFF
--- a/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -22,9 +23,10 @@ func resourceAdvancedThreatProtection() *schema.Resource {
 		Update: resourceAdvancedThreatProtectionCreateUpdate,
 		Delete: resourceAdvancedThreatProtectionDelete,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.AdvancedThreatProtectionID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/parse"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -27,6 +28,11 @@ func resourceAdvancedThreatProtection() *schema.Resource {
 			_, err := parse.AdvancedThreatProtectionID(id)
 			return err
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			migration.AdvancedThreatProtectionV0ToV1(),
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/securitycenter/migration/advanced_threat_protection_v0_to_v1.go
+++ b/azurerm/internal/services/securitycenter/migration/advanced_threat_protection_v0_to_v1.go
@@ -1,0 +1,54 @@
+package migration
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/parse"
+)
+
+func AdvancedThreatProtectionV0ToV1() schema.StateUpgrader {
+	return schema.StateUpgrader{
+		Version: 0,
+		Type:    advancedThreatProtectionV0Schema().CoreConfigSchema().ImpliedType(),
+		Upgrade: advancedThreadProtectionV0toV1Upgrade,
+	}
+}
+
+func advancedThreatProtectionV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"target_resource_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func advancedThreadProtectionV0toV1Upgrade(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+
+	// remove the existing `/` if it's present (2.42+) which'll do nothing if it wasn't (2.38)
+	newId := strings.TrimPrefix(oldId, "/")
+	newId = fmt.Sprintf("/%s", oldId)
+
+	parsedId, err := parse.AdvancedThreatProtectionID(newId)
+	if err != nil {
+		return nil, err
+	}
+
+	newId = parsedId.ID()
+
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+	rawState["id"] = newId
+	return rawState, nil
+}

--- a/azurerm/internal/services/securitycenter/migration/advanced_threat_protection_v0_to_v1.go
+++ b/azurerm/internal/services/securitycenter/migration/advanced_threat_protection_v0_to_v1.go
@@ -38,8 +38,7 @@ func advancedThreadProtectionV0toV1Upgrade(rawState map[string]interface{}, meta
 	oldId := rawState["id"].(string)
 
 	// remove the existing `/` if it's present (2.42+) which'll do nothing if it wasn't (2.38)
-	newId := strings.TrimPrefix(oldId, "/")
-	newId = fmt.Sprintf("/%s", oldId)
+	newId := fmt.Sprintf("/%s", strings.TrimPrefix(oldId, "/"))
 
 	parsedId, err := parse.AdvancedThreatProtectionID(newId)
 	if err != nil {


### PR DESCRIPTION
Also adds import time validation for the `azurerm_advanced_threat_protection` to check the ID is an Advanced Threat Protection ID

Fixes #10179