### PR TITLE
user_assigned_identity: add state migration for ID casing

### DIFF
--- a/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
+++ b/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
@@ -8,7 +8,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
 )
 
@@ -55,17 +54,9 @@ func userAssignedIdentityUpgradeV0ToV1(rawState map[string]interface{}, meta int
 	if err != nil {
 		return rawState, err
 	}
-	
+
 	newId := id.ID()
 	log.Printf("Updating `id` from %q to %q", oldId, newId)
 	rawState["id"] = newId
-	return rawState, nil
-
-	log.Printf("[DEBUG] Migrating IDs to correct casing for User Assigned Idenitity")
-	name := rawState["name"].(string)
-	resourceGroup := rawState["resource_group_name"].(string)
-	id := parse.NewUserAssignedIdentityID(subscriptionId, resourceGroup, name)
-
-	rawState["id"] = id.ID()
 	return rawState, nil
 }

--- a/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
+++ b/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
@@ -1,0 +1,62 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
+)
+
+func UserAssignedIdentityV0ToV1() schema.StateUpgrader {
+	return schema.StateUpgrader{
+		Version: 0,
+		Type:    userAssignedIdentityV0Schema().CoreConfigSchema().ImpliedType(),
+		Upgrade: userAssignedIdentityUpgradeV0ToV1,
+	}
+}
+
+func userAssignedIdentityV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringLenBetween(3, 128),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": azure.SchemaLocation(),
+
+			"tags": tags.Schema(),
+
+			"principal_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func userAssignedIdentityUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
+	log.Printf("[DEBUG] Migrating IDs to correct casing for User Assigned Idenitity")
+	name := rawState["name"].(string)
+	resourceGroup := rawState["resource_group_name"].(string)
+	id := parse.NewUserAssignedIdentityID(subscriptionId, resourceGroup, name)
+
+	rawState["id"] = id.ID()
+	return rawState, nil
+}

--- a/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
+++ b/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
@@ -50,7 +50,16 @@ func userAssignedIdentityV0Schema() *schema.Resource {
 }
 
 func userAssignedIdentityUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	oldId := rawState["id"].(string)
+	id, err := parse.UserAssignedIdentityID(oldId)
+	if err != nil {
+		return rawState, err
+	}
+	
+	newId := id.ID()
+	log.Printf("Updating `id` from %q to %q", oldId, newId)
+	rawState["id"] = newId
+	return rawState, nil
 
 	log.Printf("[DEBUG] Migrating IDs to correct casing for User Assigned Idenitity")
 	name := rawState["name"].(string)

--- a/azurerm/internal/services/msi/user_assigned_identity_resource.go
+++ b/azurerm/internal/services/msi/user_assigned_identity_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -29,6 +30,11 @@ func resourceArmUserAssignedIdentity() *schema.Resource {
 			_, err := parse.UserAssignedIdentityID(id)
 			return err
 		}),
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			migration.UserAssignedIdentityV0ToV1(),
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),


### PR DESCRIPTION
Old `user_assigned_identity` are saved in the state with `resourcegroups` all in lowercase, forcing all resource that use it's `.id` property reference do a lowercasing dance every plan/apply.
This should fix the problem.