### PR TITLE
r/kubernetes_cluster: updating the versions of kubernetes in use

### DIFF
--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_resource_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	olderKubernetesVersion   = "1.16.15"
-	currentKubernetesVersion = "1.17.11"
+	olderKubernetesVersion   = "1.18.14"
+	currentKubernetesVersion = "1.19.6"
 )
 
 func TestAccAzureRMKubernetes_all(t *testing.T) {


### PR DESCRIPTION
This PR updates the "current" and "old" versions of AKS to match the latest outputs:

<img width="1082" alt="Screenshot 2021-01-18 at 16 08 55" src="https://user-images.githubusercontent.com/666005/104931996-77d83280-59a7-11eb-94be-14101404c2a1.png">
