### PR TITLE
Removed usage of /terraform-plugin-sdk/helper/hashcode

### DIFF
--- a/azurerm/internal/location/schema.go
+++ b/azurerm/internal/location/schema.go
@@ -1,7 +1,6 @@
 package location
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -54,7 +53,7 @@ func DiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
 
 func HashCode(location interface{}) int {
 	loc := location.(string)
-	return hashcode.String(Normalize(loc))
+	return schema.HashString(Normalize(loc))
 }
 
 func StateFunc(location interface{}) string {

--- a/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/azurerm/internal/services/analysisservices/analysis_services_server_resource.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -465,5 +464,5 @@ func hashAnalysisServicesServerIpv4FirewallRule(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["range_start"].(string)))
 	buf.WriteString(m["range_end"].(string))
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/automation/helper/automation_job_schedule.go
+++ b/azurerm/internal/services/automation/helper/automation_job_schedule.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/automation/mgmt/2018-06-30-preview/automation"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/automation/validate"
@@ -140,5 +139,5 @@ func resourceAutomationJobScheduleHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-%s-%s-%s", scheduleName, utils.FlattenMapStringPtrString(m.Parameters), runOn, *m.JobScheduleID))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/compute/ssh_keys.go
+++ b/azurerm/internal/services/compute/ssh_keys.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -193,5 +192,5 @@ func SSHKeySchemaHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s", m["username"]))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/compute/virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/virtual_machine_resource.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -1901,7 +1900,7 @@ func resourceVirtualMachineStorageOsProfileHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["computer_name"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineStorageOsProfileWindowsConfigHash(v interface{}) int {
@@ -1919,7 +1918,7 @@ func resourceVirtualMachineStorageOsProfileWindowsConfigHash(v interface{}) int 
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineStorageOsProfileLinuxConfigHash(v interface{}) int {
@@ -1929,7 +1928,7 @@ func resourceVirtualMachineStorageOsProfileLinuxConfigHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%t-", m["disable_password_authentication"].(bool)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineStorageImageReferenceHash(v interface{}) int {
@@ -1950,7 +1949,7 @@ func resourceVirtualMachineStorageImageReferenceHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineGetManagedDiskInfo(d *schema.ResourceData, disk *compute.ManagedDiskParameters, meta interface{}) (*compute.Disk, error) {

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -1570,7 +1569,7 @@ func resourceVirtualMachineScaleSetStorageProfileImageReferenceHash(v interface{
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineScaleSetStorageProfileOsDiskHash(v interface{}) int {
@@ -1584,7 +1583,7 @@ func resourceVirtualMachineScaleSetStorageProfileOsDiskHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineScaleSetNetworkConfigurationHash(v interface{}) int {
@@ -1650,7 +1649,7 @@ func resourceVirtualMachineScaleSetNetworkConfigurationHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineScaleSetOsProfileLinuxConfigHash(v interface{}) int {
@@ -1672,7 +1671,7 @@ func resourceVirtualMachineScaleSetOsProfileLinuxConfigHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineScaleSetOsProfileWindowsConfigHash(v interface{}) int {
@@ -1687,7 +1686,7 @@ func resourceVirtualMachineScaleSetOsProfileWindowsConfigHash(v interface{}) int
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceVirtualMachineScaleSetExtensionHash(v interface{}) int {
@@ -1720,7 +1719,7 @@ func resourceVirtualMachineScaleSetExtensionHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func expandVirtualMachineScaleSetSku(d *schema.ResourceData) *compute.Sku {

--- a/azurerm/internal/services/containers/container_group_resource.go
+++ b/azurerm/internal/services/containers/container_group_resource.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -1558,7 +1557,7 @@ func resourceArmContainerGroupPortsHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["protocol"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func flattenContainerGroupDnsConfig(input *containerinstance.DNSConfiguration) []interface{} {

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -1055,7 +1054,7 @@ func resourceAzureRMCosmosDBAccountGeoLocationHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-%d", location, priority))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceAzureRMCosmosDBAccountCapabilitiesHash(v interface{}) int {
@@ -1065,7 +1064,7 @@ func resourceAzureRMCosmosDBAccountCapabilitiesHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash(v interface{}) int {
@@ -1075,7 +1074,7 @@ func resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash(v interface{}) int {
 		buf.WriteString(strings.ToLower(m["id"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func diffSuppressIgnoreKeyVaultKeyVersion(k, old, new string, d *schema.ResourceData) bool {

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -271,5 +270,5 @@ func resourceDataFactoryIntegrationRuntimeSelfHostedRbacAuthorizationHash(v inte
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/dns/dns_caa_record_resource.go
+++ b/azurerm/internal/services/dns/dns_caa_record_resource.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -250,5 +249,5 @@ func resourceDnsCaaRecordHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["value"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/dns/dns_mx_record_resource.go
+++ b/azurerm/internal/services/dns/dns_mx_record_resource.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
@@ -242,5 +241,5 @@ func resourceDnsMxRecordHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["exchange"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/dns/dns_srv_record_resource.go
+++ b/azurerm/internal/services/dns/dns_srv_record_resource.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
@@ -248,5 +247,5 @@ func resourceDnsSrvRecordHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
 	"github.com/hashicorp/go-azure-helpers/response"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -490,5 +489,5 @@ func resourceMonitorActivityLogAlertActionHash(input interface{}) int {
 	if v, ok := input.(map[string]interface{}); ok {
 		buf.WriteString(fmt.Sprintf("%s-", v["action_group_id"].(string)))
 	}
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-helpers/response"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -929,7 +928,7 @@ func resourceMonitorMetricAlertActionHash(input interface{}) int {
 	if v, ok := input.(map[string]interface{}); ok {
 		buf.WriteString(fmt.Sprintf("%s-", v["action_group_id"].(string)))
 	}
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func monitorMetricAlertStateRefreshFunc(ctx context.Context, client *insights.MetricAlertsClient, resourceGroupName string, name string) resource.StateRefreshFunc {

--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -838,7 +837,7 @@ func hashVirtualNetworkGatewayRootCert(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["public_cert_data"].(string)))
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func hashVirtualNetworkGatewayRevokedCert(v interface{}) int {
@@ -848,7 +847,7 @@ func hashVirtualNetworkGatewayRevokedCert(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["thumbprint"].(string)))
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func resourceGroupAndVirtualNetworkGatewayFromId(virtualNetworkGatewayId string) (string, string, error) {

--- a/azurerm/internal/services/network/virtual_network_resource.go
+++ b/azurerm/internal/services/network/virtual_network_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -481,7 +480,7 @@ func resourceAzureSubnetHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func getExistingSubnet(ctx context.Context, resGroup string, vnetName string, subnetName string, meta interface{}) (*network.Subnet, error) {

--- a/azurerm/internal/services/policy/policy_set_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_set_definition_resource.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-09-01/policy"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
@@ -779,5 +778,5 @@ func resourceARMPolicySetDefinitionPolicyDefinitionGroupHash(v interface{}) int 
 		buf.WriteString(m["name"].(string))
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }

--- a/azurerm/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/azurerm/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-01-10/siterecovery"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -514,7 +513,7 @@ func resourceSiteRecoveryReplicatedVMDiskHash(v interface{}) int {
 		}
 	}
 
-	return hashcode.String(buf.String())
+	return schema.HashString(buf.String())
 }
 
 func waitForReplicationToBeHealthy(d *schema.ResourceData, meta interface{}) (*siterecovery.ReplicationProtectedItem, error) {

--- a/azurerm/internal/tf/set/set.go
+++ b/azurerm/internal/tf/set/set.go
@@ -5,16 +5,15 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func HashInt(v interface{}) int {
-	return hashcode.String(strconv.Itoa(v.(int)))
+	return schema.HashString(strconv.Itoa(v.(int)))
 }
 
 func HashStringIgnoreCase(v interface{}) int {
-	return hashcode.String(strings.ToLower(v.(string)))
+	return schema.HashString(strings.ToLower(v.(string)))
 }
 
 func FromStringSlice(slice []string) *schema.Set {
@@ -27,7 +26,7 @@ func FromStringSlice(slice []string) *schema.Set {
 
 // HashIPv6Address normalizes an IPv6 address and returns a hash for it
 func HashIPv6Address(ipv6 interface{}) int {
-	return hashcode.String(normalizeIPv6Address(ipv6))
+	return schema.HashString(normalizeIPv6Address(ipv6))
 }
 
 // NormalizeIPv6Address returns the normalized notation of an IPv6


### PR DESCRIPTION
In terraform-plugin-sdk v2 the `/terraform-plugin-sdk/helper/hashcode` function has been made internal. This PR changes all references to this function to use schema.HashString instead (which in turn uses that internal). This will make the upgrade to the v2 plugin SDK easier (#10022)

Fixes #10238