### PR TITLE
New resource: azurerm_api_management_identity_provider_aadb2c

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
@@ -84,7 +84,7 @@ func TestAccApiManagementApiDiagnostic_complete(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiDiagnosticResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiDiagnosticResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.ApiDiagnosticID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_api_operation_policy_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_operation_policy_resource_test.go
@@ -94,7 +94,7 @@ func TestAccApiManagementAPIOperationPolicy_rawXml(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiOperationPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiOperationPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_api_operation_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_operation_resource_test.go
@@ -123,7 +123,7 @@ func TestAccApiManagementApiOperation_representations(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiOperationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiOperationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_api_policy_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_policy_resource_test.go
@@ -99,7 +99,7 @@ func TestAccApiManagementAPIPolicy_customPolicy(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_resource_test.go
@@ -262,7 +262,7 @@ func TestAccApiManagementApi_complete(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_api_schema_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_schema_resource_test.go
@@ -47,7 +47,7 @@ func TestAccApiManagementApiSchema_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiSchemaResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiSchemaResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_api_version_set_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_version_set_resource_test.go
@@ -102,7 +102,7 @@ func TestAccApiManagementApiVersionSet_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementApiVersionSetResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementApiVersionSetResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.ApiVersionSetID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_authorization_server_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_authorization_server_resource_test.go
@@ -62,7 +62,7 @@ func TestAccApiManagementAuthorizationServer_complete(t *testing.T) {
 	})
 }
 
-func (t ApiManagementAuthorizationServerResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementAuthorizationServerResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_backend_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_backend_resource_test.go
@@ -174,7 +174,7 @@ func TestAccApiManagementBackend_requiresImport(t *testing.T) {
 	})
 }
 
-func (r ApiManagementAuthorizationBackendResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementAuthorizationBackendResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_certificate_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_certificate_resource_test.go
@@ -60,7 +60,7 @@ func TestAccApiManagementCertificate_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementCertificateResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementCertificateResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go
@@ -83,7 +83,7 @@ func TestAccApiManagementCustomDomain_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementCustomDomainResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementCustomDomainResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.CustomDomainID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource_test.go
@@ -84,7 +84,7 @@ func TestAccApiManagementDiagnostic_complete(t *testing.T) {
 	})
 }
 
-func (t ApiManagementDiagnosticResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementDiagnosticResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	diagnosticId, err := parse.DiagnosticID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_group_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_group_resource_test.go
@@ -104,7 +104,7 @@ func TestAccApiManagementGroup_descriptionDisplayNameUpdate(t *testing.T) {
 	})
 }
 
-func (t ApiManagementGroupResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementGroupResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_group_user_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_group_user_resource_test.go
@@ -48,7 +48,7 @@ func TestAccAzureRMApiManagementGroupUser_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementGroupUserResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementGroupUserResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource_test.go
@@ -78,7 +78,7 @@ func TestAccApiManagementIdentityProviderAAD_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementIdentityProviderAADResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementIdentityProviderAADResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -79,15 +80,12 @@ func TestAccApiManagementIdentityProviderAAD_requiresImport(t *testing.T) {
 }
 
 func (ApiManagementIdentityProviderAADResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.IdentityProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		return nil, fmt.Errorf("reading ApiManagement Identity Provider AAD (%s): %+v", id, err)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -1,0 +1,233 @@
+package apimanagement
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementIdentityProviderAADB2C() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementIdentityProviderAADB2CCreateUpdate,
+		Read:   resourceArmApiManagementIdentityProviderAADB2CRead,
+		Update: resourceArmApiManagementIdentityProviderAADB2CCreateUpdate,
+		Delete: resourceArmApiManagementIdentityProviderAADB2CDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"client_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"client_secret": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			// For AADB2C identity providers, `allowed_tenants` must specify exactly one tenant
+			"allowed_tenant": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"signin_tenant": {
+				Type:     schema.TypeString,
+				Required: true,
+				// B2C tenant domains can be customized, and GUIDs might work here too
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"authority": {
+				Type:     schema.TypeString,
+				Required: true,
+				// B2C login domains can be customized and don't necessarily end in b2clogin.com
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"signup_policy": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"signin_policy": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"profile_editing_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"password_reset_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+
+	clientID := d.Get("client_id").(string)
+	clientSecret := d.Get("client_secret").(string)
+
+	allowedTenant := d.Get("allowed_tenant").(string)
+	signinTenant := d.Get("signin_tenant").(string)
+	authority := d.Get("authority").(string)
+	signupPolicy := d.Get("signup_policy").(string)
+
+	signinPolicy := d.Get("signin_policy").(string)
+	profileEditingPolicy := d.Get("profile_editing_policy").(string)
+	passwordResetPolicy := d.Get("password_reset_policy").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Identity Provider %q (API Management Service %q / Resource Group %q): %s", apimanagement.AadB2C, serviceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_identity_provider_aadb2c", *existing.ID)
+		}
+	}
+
+	parameters := apimanagement.IdentityProviderCreateContract{
+		IdentityProviderCreateContractProperties: &apimanagement.IdentityProviderCreateContractProperties{
+			ClientID:                 utils.String(clientID),
+			ClientSecret:             utils.String(clientSecret),
+			Type:                     apimanagement.AadB2C,
+			AllowedTenants:           utils.ExpandStringSlice([]interface{}{allowedTenant}),
+			SigninTenant:             utils.String(signinTenant),
+			Authority:                utils.String(authority),
+			SignupPolicyName:         utils.String(signupPolicy),
+			SigninPolicyName:         utils.String(signinPolicy),
+			ProfileEditingPolicyName: utils.String(profileEditingPolicy),
+			PasswordResetPolicyName:  utils.String(passwordResetPolicy),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, apimanagement.AadB2C, parameters, ""); err != nil {
+		return fmt.Errorf("creating or updating Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.AadB2C, resourceGroup, serviceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
+	if err != nil {
+		return fmt.Errorf("retrieving Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.AadB2C, resourceGroup, serviceName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read ID for Identity Provider %q (Resource Group %q / API Management Service %q)", apimanagement.AadB2C, resourceGroup, serviceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmApiManagementIdentityProviderAADB2CRead(d, meta)
+}
+
+func resourceArmApiManagementIdentityProviderAADB2CRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Identity Provider %q (Resource Group %q / API Management Service %q) was not found - removing from state!", identityProviderName, resourceGroup, serviceName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+	}
+
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("api_management_name", serviceName)
+
+	if props := resp.IdentityProviderContractProperties; props != nil {
+		d.Set("client_id", props.ClientID)
+		d.Set("signin_tenant", props.SigninTenant)
+		d.Set("authority", props.Authority)
+		d.Set("signup_policy", props.SignupPolicyName)
+		d.Set("signin_policy", props.SigninPolicyName)
+		d.Set("profile_editing_policy", props.ProfileEditingPolicyName)
+		d.Set("password_reset_policy", props.PasswordResetPolicyName)
+
+		allowedTenant := ""
+		if allowedTenants := props.AllowedTenants; allowedTenants != nil && len(*allowedTenants) > 0 {
+			t := *allowedTenants
+			allowedTenant = t[0]
+		}
+		d.Set("allowed_tenant", allowedTenant)
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementIdentityProviderAADB2CDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	if resp, err := client.Delete(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName), ""); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("deleting Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -120,16 +120,16 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 	profileEditingPolicy := d.Get("profile_editing_policy").(string)
 	passwordResetPolicy := d.Get("password_reset_policy").(string)
 
+	id := parse.NewIdentityProviderID(client.SubscriptionID, resourceGroup, serviceName, string(apimanagement.AadB2C))
+
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Identity Provider %q (API Management Service %q / Resource Group %q): %s", apimanagement.AadB2C, serviceName, resourceGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %s", id.String(), err)
 			}
-		}
-
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_api_management_identity_provider_aadb2c", *existing.ID)
+		} else {
+			return tf.ImportAsExistsError("azurerm_api_management_identity_provider_aadb2c", id.ID())
 		}
 	}
 
@@ -152,15 +152,7 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 		return fmt.Errorf("creating or updating Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.AadB2C, resourceGroup, serviceName, err)
 	}
 
-	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
-	if err != nil {
-		return fmt.Errorf("retrieving Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.AadB2C, resourceGroup, serviceName, err)
-	}
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read ID for Identity Provider %q (Resource Group %q / API Management Service %q)", apimanagement.AadB2C, resourceGroup, serviceName)
-	}
-	d.SetId(*resp.ID)
-
+	d.SetId(id.ID())
 	return resourceArmApiManagementIdentityProviderAADB2CRead(d, meta)
 }
 

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -168,27 +169,24 @@ func resourceArmApiManagementIdentityProviderAADB2CRead(d *schema.ResourceData, 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.IdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Identity Provider %q (Resource Group %q / API Management Service %q) was not found - removing from state!", identityProviderName, resourceGroup, serviceName)
+			log.Printf("[DEBUG] Identity Provider %q (Resource Group %q / API Management Service %q) was not found - removing from state!", id.Name, id.ResourceGroup, id.ServiceName)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", id.Name, id.ResourceGroup, id.ServiceName, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("api_management_name", serviceName)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("api_management_name", id.ServiceName)
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
@@ -215,17 +213,14 @@ func resourceArmApiManagementIdentityProviderAADB2CDelete(d *schema.ResourceData
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.IdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	if resp, err := client.Delete(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName), ""); err != nil {
+	if resp, err := client.Delete(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name), ""); err != nil {
 		if !utils.ResponseWasNotFound(resp) {
-			return fmt.Errorf("deleting Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+			return fmt.Errorf("deleting Identity Provider %q (Resource Group %q / API Management Service %q): %+v", id.Name, id.ResourceGroup, id.ServiceName, err)
 		}
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/schemaz"
+
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -37,7 +39,7 @@ func resourceArmApiManagementIdentityProviderAADB2C() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
-			"api_management_name": azure.SchemaApiManagementName(),
+			"api_management_name": schemaz.SchemaApiManagementName(),
 
 			"client_id": {
 				Type:         schema.TypeString,

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -100,15 +100,12 @@ func testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t *testing.T
 }
 
 func (ApiManagementIdentityProviderAADB2CResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.IdentityProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		return nil, fmt.Errorf("reading ApiManagement Identity Provider AADB2C (%s): %+v", id, err)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource_test.go
@@ -1,0 +1,194 @@
+package apimanagement_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+/*
+Note that this resource requires a preexisting B2C tenant with matching policies already created.
+Accordingly, these tests rely on additional environment variables to be set (and be valid):
+* ARM_TEST_B2C_TENANT_ID      - the UUID of the B2C tenant
+* ARM_TEST_B2C_TENANT_SLUG    - the first part of the *.onmicrosoft.com domain of the B2C tenant
+* ARM_TEST_B2C_CLIENT_ID      - client ID of an application in the B2C domain with privileges to read directory data
+* ARM_TEST_B2C_CLIENT_SECRET  - client secret for that application
+*/
+
+type ApiManagementIdentityProviderAADB2CResource struct {
+}
+
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+	r := ApiManagementIdentityProviderAADB2CResource{}
+	b2cConfig := testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t)
+	env, err := acceptance.Environment()
+	if err != nil {
+		t.Fatalf("could not load Azure Environment: %+v", err)
+	}
+	apiDomain := env.APIManagementHostNameSuffix
+	if apiDomain == "" {
+		t.Fatalf("APIManagementHostNameSuffix was empty")
+	}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data, b2cConfig, apiDomain),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("client_secret"),
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+	r := ApiManagementIdentityProviderAADB2CResource{}
+	b2cConfig := testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t)
+	apiDomain := acceptance.AzureProvider.Meta().(*clients.Client).Account.Environment.APIManagementHostNameSuffix
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data, b2cConfig, apiDomain),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:      r.requiresImport(data, b2cConfig, apiDomain),
+			ExpectError: acceptance.RequiresImportError(data.ResourceType),
+		},
+	})
+}
+
+func testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t *testing.T) map[string]string {
+	config := map[string]string{
+		"tenant_id":     "",
+		"tenant_slug":   "",
+		"client_id":     "",
+		"client_secret": "",
+	}
+
+	for k := range config {
+		e := fmt.Sprintf("ARM_TEST_B2C_%s", strings.ToUpper(k))
+		if v := os.Getenv(e); v != "" {
+			config[k] = v
+			continue
+		}
+		vars := make([]string, 0, len(config))
+		for k := range config {
+			v := fmt.Sprintf("ARM_TEST_B2C_%s", strings.ToUpper(k))
+			vars = append(vars, v)
+		}
+		t.Skip(fmt.Sprintf("Acceptance tests for resource `azurerm_api_management_identity_provider_aadb2c` skipped unless environment variables set: %s", strings.Join(vars, ", ")))
+	}
+
+	return config
+}
+
+func (ApiManagementIdentityProviderAADB2CResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := azure.ParseAzureResourceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	if err != nil {
+		return nil, fmt.Errorf("reading ApiManagement Identity Provider AADB2C (%s): %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (ApiManagementIdentityProviderAADB2CResource) basic(data acceptance.TestData, b2cConfig map[string]string, apiDomain string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {
+  tenant_id     = "%[1]s"
+  client_id     = "%[2]s"
+  client_secret = "%[3]s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[5]d"
+  location = "%[6]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[5]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azuread_application" "test" {
+  name                       = "acctestAM-%[5]d"
+  oauth2_allow_implicit_flow = true
+  reply_urls                 = ["https://${azurerm_api_management.test.name}.developer.%[8]s/signin"]
+}
+
+resource "azuread_application_password" "test" {
+  application_object_id = azuread_application.test.object_id
+  end_date_relative     = "36h"
+  value                 = "P@55w0rD!%[7]s"
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "test" {
+  resource_group_name    = azurerm_resource_group.test.name
+  api_management_name    = azurerm_api_management.test.name
+  client_id              = azuread_application.test.application_id
+  client_secret          = "P@55w0rD!%[7]s"
+  allowed_tenant         = "%[4]s.onmicrosoft.com"
+  signin_tenant          = "%[4]s.onmicrosoft.com"
+  authority              = "%[4]s.b2clogin.com"
+  signin_policy          = "B2C_1_Login"
+  signup_policy          = "B2C_1_Signup"
+  profile_editing_policy = "B2C_1_EditProfile"
+  password_reset_policy  = "B2C_1_ResetPassword"
+
+  depends_on = [azuread_application_password.test]
+}
+`, b2cConfig["tenant_id"], b2cConfig["client_id"], b2cConfig["client_secret"], b2cConfig["tenant_slug"], data.RandomInteger, data.Locations.Primary, data.RandomString, apiDomain)
+}
+
+func (r ApiManagementIdentityProviderAADB2CResource) requiresImport(data acceptance.TestData, b2cConfig map[string]string, apiDomain string) string {
+	template := r.basic(data, b2cConfig, apiDomain)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_identity_provider_aadb2c" "import" {
+  resource_group_name    = azurerm_api_management_identity_provider_aadb2c.test.resource_group_name
+  api_management_name    = azurerm_api_management_identity_provider_aadb2c.test.api_management_name
+  client_id              = azurerm_api_management_identity_provider_aadb2c.test.client_id
+  client_secret          = azurerm_api_management_identity_provider_aadb2c.test.client_secret
+  allowed_tenant         = azurerm_api_management_identity_provider_aadb2c.test.allowed_tenant
+  signin_tenant          = azurerm_api_management_identity_provider_aadb2c.test.signin_tenant
+  authority              = azurerm_api_management_identity_provider_aadb2c.test.authority
+  signup_policy          = azurerm_api_management_identity_provider_aadb2c.test.signup_policy
+  signin_policy          = azurerm_api_management_identity_provider_aadb2c.test.signin_policy
+  profile_editing_policy = azurerm_api_management_identity_provider_aadb2c.test.profile_editing_policy
+  password_reset_policy  = azurerm_api_management_identity_provider_aadb2c.test.password_reset_policy
+}
+`, template)
+}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -73,15 +74,12 @@ func TestAccApiManagementIdentityProviderFacebook_requiresImport(t *testing.T) {
 }
 
 func (ApiManagementIdentityProviderFacebookResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.IdentityProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		return nil, fmt.Errorf("reading ApiManagement Identity Provider Facebook (%s): %+v", id, err)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource_test.go
@@ -72,7 +72,7 @@ func TestAccApiManagementIdentityProviderFacebook_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementIdentityProviderFacebookResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementIdentityProviderFacebookResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -73,15 +74,12 @@ func TestAccApiManagementIdentityProviderGoogle_requiresImport(t *testing.T) {
 }
 
 func (ApiManagementIdentityProviderGoogleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.IdentityProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		return nil, fmt.Errorf("reading ApiManagement Identity Provider Google (%s): %+v", id, err)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource_test.go
@@ -72,7 +72,7 @@ func TestAccApiManagementIdentityProviderGoogle_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementIdentityProviderGoogleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementIdentityProviderGoogleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_microsoft_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_microsoft_resource_test.go
@@ -72,7 +72,7 @@ func TestAccApiManagementIdentityProviderMicrosoft_requiresImport(t *testing.T) 
 	})
 }
 
-func (t ApiManagementIdentityProviderMicrosoftResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementIdentityProviderMicrosoftResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_microsoft_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_microsoft_resource_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -73,15 +74,12 @@ func TestAccApiManagementIdentityProviderMicrosoft_requiresImport(t *testing.T) 
 }
 
 func (ApiManagementIdentityProviderMicrosoftResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.IdentityProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		return nil, fmt.Errorf("reading ApiManagement Identity Provider Microsoft (%s): %+v", id, err)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource_test.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
-
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -74,15 +74,12 @@ func TestAccApiManagementIdentityProviderTwitter_requiresImport(t *testing.T) {
 }
 
 func (ApiManagementIdentityProviderTwitterResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.IdentityProviderID(state.ID)
 	if err != nil {
 		return nil, err
 	}
-	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
 
-	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	resp, err := clients.ApiManagement.IdentityProviderClient.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.IdentityProviderType(id.Name))
 	if err != nil {
 		return nil, fmt.Errorf("reading ApiManagement Identity Provider Twitter (%s): %+v", id, err)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource_test.go
@@ -73,7 +73,7 @@ func TestAccApiManagementIdentityProviderTwitter_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementIdentityProviderTwitterResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementIdentityProviderTwitterResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -183,7 +183,7 @@ func TestAccApiManagementLogger_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementLoggerResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementLoggerResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_named_value_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_named_value_resource_test.go
@@ -54,7 +54,7 @@ func TestAccApiManagementNamedValue_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementNamedValueResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementNamedValueResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_openid_connect_provider_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_openid_connect_provider_resource_test.go
@@ -69,7 +69,7 @@ func TestAccApiManagementOpenIDConnectProvider_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementOpenIDConnectProviderResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementOpenIDConnectProviderResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_policy_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_policy_resource_test.go
@@ -69,7 +69,7 @@ func TestAccApiManagementPolicy_customPolicy(t *testing.T) {
 	})
 }
 
-func (t ApiManagementPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.PolicyID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_product_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_product_api_resource_test.go
@@ -47,7 +47,7 @@ func TestAccApiManagementProductApi_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementProductAPIResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementProductAPIResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_product_group_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_product_group_resource_test.go
@@ -47,7 +47,7 @@ func TestAccApiManagementProductGroup_requiresImport(t *testing.T) {
 	})
 }
 
-func (t ApiManagementProductGroupResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementProductGroupResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_product_policy_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_product_policy_resource_test.go
@@ -79,7 +79,7 @@ func TestAccApiManagementProductPolicy_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementProductPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementProductPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_product_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_product_resource_test.go
@@ -156,7 +156,7 @@ func TestAccApiManagementProduct_approvalRequiredError(t *testing.T) {
 	})
 }
 
-func (t ApiManagementProductResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementProductResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_property_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_property_resource_test.go
@@ -67,7 +67,7 @@ func TestAccApiManagementProperty_update(t *testing.T) {
 	})
 }
 
-func (t ApiManagementPropertyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementPropertyResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource_test.go
@@ -264,7 +264,7 @@ func TestAccApiManagement_consumption(t *testing.T) {
 	})
 }
 
-func (t ApiManagementResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.ApiManagementID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -122,7 +122,7 @@ func TestAccApiManagementSubscription_complete(t *testing.T) {
 	})
 }
 
-func (t ApiManagementSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.SubscriptionID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/api_management_user_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_user_resource_test.go
@@ -178,7 +178,7 @@ func TestAccApiManagementUser_complete(t *testing.T) {
 	})
 }
 
-func (t ApiManagementUserResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (ApiManagementUserResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/registration.go
+++ b/azurerm/internal/services/apimanagement/registration.go
@@ -49,6 +49,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_api_management_group":                       resourceApiManagementGroup(),
 		"azurerm_api_management_group_user":                  resourceApiManagementGroupUser(),
 		"azurerm_api_management_identity_provider_aad":       resourceApiManagementIdentityProviderAAD(),
+		"azurerm_api_management_identity_provider_aadb2c":    resourceArmApiManagementIdentityProviderAADB2C(),
 		"azurerm_api_management_identity_provider_facebook":  resourceApiManagementIdentityProviderFacebook(),
 		"azurerm_api_management_identity_provider_google":    resourceApiManagementIdentityProviderGoogle(),
 		"azurerm_api_management_identity_provider_microsoft": resourceApiManagementIdentityProviderMicrosoft(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -806,6 +806,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/api_management_identity_provider_aadb2c.html">azurerm_api_management_identity_provider_aadb2c</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_identity_provider_facebook.html">azurerm_api_management_identity_provider_facebook</a>
                 </li>
 

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -1,0 +1,105 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aadb2c"
+description: |-
+Manages an API Management AADB2C Identity Provider.
+---
+
+# azurerm_api_management_identity_provider_aadb2c
+
+Manages an API Management AADB2C Identity Provider.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "example" {
+  name                = "example-apim"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+  sku_name            = "Developer_1"
+}
+
+resource "azuread_application" "example" {
+  name                       = "acctestAM-%[5]d"
+  oauth2_allow_implicit_flow = true
+  reply_urls                 = ["https://${azurerm_api_management.test.name}.developer.azure-api.net/signin"]
+}
+
+resource "azuread_application_password" "example" {
+  application_object_id = azuread_application.test.object_id
+  end_date_relative     = "36h"
+  value                 = "P@55w0rD!%[7]s"
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "example" {
+  api_management_id = azurerm_api_management.example.id
+  client_id         = azuread_application.example.application_id
+  client_secret     = "P@55w0rD!%[7]s"
+  allowed_tenant    = "myb2ctenant.onmicrosoft.com"
+  signin_tenant     = "myb2ctenant.onmicrosoft.com"
+  authority         = "myb2ctenant.b2clogin.com"
+  signin_policy     = "B2C_1_Login"
+  signup_policy     = "B2C_1_Signup"
+
+  depends_on = [azuread_application_password.example]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) The Name of the API Management Service where this AAD Identity Provider should be created. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+
+* `client_id` - (Required) Client ID of the Application in your B2C tenant.
+
+* `client_secret` - (Required) Client secret of the Application in your B2C tenant.
+
+* `allowed_tenant` - (Required) The allowed AAD tenant, usually your B2C tenant domain.
+
+* `signin_tenant` - (Required) The tenant to use instead of Common when logging into Active Directory, usually your B2C tenant domain.
+
+* `authority` - (Required) OpenID Connect discovery endpoint hostname, usually your b2clogin.com domain.
+
+* `signin_policy` - (Required) Signup Policy Name.
+
+* `signup_policy` - (Required) Signin Policy Name.
+
+---
+
+* `password_reset_policy` - (Optional) Password reset Policy Name.
+
+* `profile_editing_policy` - (Optional) Profile editing Policy Name.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the API Management Identity Provider Resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Management Resources.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Resources.
+* `update` - (Defaults to 30 minutes) Used when updating the API Management Resources.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Resources.
+
+## Import
+
+API Management Resourcess can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/AadB2C
+```

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -3,12 +3,12 @@ subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aadb2c"
 description: |-
-  Manages an API Management AADB2C Identity Provider.
+  Manages an API Management Azure AD B2C Identity Provider.
 ---
 
 # azurerm_api_management_identity_provider_aadb2c
 
-Manages an API Management AADB2C Identity Provider.
+Manages an API Management Azure AD B2C Identity Provider.
 
 ## Example Usage
 
@@ -71,9 +71,9 @@ The following arguments are supported:
 
 * `authority` - (Required) OpenID Connect discovery endpoint hostname, usually your b2clogin.com domain.
 
-* `signin_policy` - (Required) Signup Policy Name.
+* `signin_policy` - (Required) Signin Policy Name.
 
-* `signup_policy` - (Required) Signin Policy Name.
+* `signup_policy` - (Required) Signup Policy Name.
 
 ---
 
@@ -85,20 +85,20 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the API Management Identity Provider Resource.
+* `id` - The ID of the API Management Azure AD B2C Identity Provider Resource.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the API Management Resources.
-* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Resources.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Resources.
-* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Resources.
+* `create` - (Defaults to 30 minutes) Used when creating the API Management Azure AD B2C Identity Provider.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Azure AD B2C Identity Provider.
+* `update` - (Defaults to 30 minutes) Used when updating the API Management Azure AD B2C Identity Provider.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Azure AD B2C Identity Provider.
 
 ## Import
 
-API Management Resourcess can be imported using the `resource id`, e.g.
+API Management Azure AD B2C Identity Providers can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/AadB2C

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -3,7 +3,7 @@ subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aadb2c"
 description: |-
-Manages an API Management AADB2C Identity Provider.
+  Manages an API Management AADB2C Identity Provider.
 ---
 
 # azurerm_api_management_identity_provider_aadb2c


### PR DESCRIPTION
Add new resource `azurerm_api_management_identity_provider_aadb2c`.

This is tricky to test because creation requires a preexisting B2C tenant with matching policies already configured, plus an application registration in that tenant with sufficient privileges to create another application configured for the APIM instance.

I've set one up by hand (it's the only way at present) and confirmed it works locally. Any B2C tenant can be used, using the basic configuration described at https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-aad-b2c

Accordingly, the acctests rely on additional environment variables to be set (and be valid). The tests are skipped if these are not set.

Very much open to suggestions if there's a better way to inject/detect/consume these!

| Variable  | Description |
| ------ | ------ |
| `ARM_TEST_B2C_TENANT_ID`      | the UUID of the B2C tenant |
| `ARM_TEST_B2C_TENANT_SLUG`   | the first part of the *.onmicrosoft.com domain of the B2C tenant |
| `ARM_TEST_B2C_CLIENT_ID`      | client ID of an application in the B2C domain with privileges to create applications |
| `ARM_TEST_B2C_CLIENT_SECRET`  | client secret for that application |

### Test results

```
GOROOT=/Users/tom/.goenv/versions/1.14.5 #gosetup
GOPATH=/Users/tom/go #gosetup
/Users/tom/.goenv/versions/1.14.5/bin/go test -c -o /private/var/folders/56/y8d3vjgj1qg6mqv6c_m0cy_w0000gp/T/___TestAccAzureRMApiManagementIdentityProviderAADB2C_basic_in_github_com_terraform_providers_terraform_provider_azurerm_azurerm_internal_services_apimanagement github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement #gosetup
/Users/tom/.goenv/versions/1.14.5/bin/go tool test2json -t /private/var/folders/56/y8d3vjgj1qg6mqv6c_m0cy_w0000gp/T/___TestAccAzureRMApiManagementIdentityProviderAADB2C_basic_in_github_com_terraform_providers_terraform_provider_azurerm_azurerm_internal_services_apimanagement -test.v -test.run ^\QTestAccAzureRMApiManagementIdentityProviderAADB2C_basic\E$
=== RUN   TestAccAzureRMApiManagementIdentityProviderAADB2C_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderAADB2C_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderAADB2C_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderAADB2C_basic (2189.53s)
PASS

Process finished with exit code 0
```

Replaces: #7785