### PR TITLE
test fix: securitycenter contact

### DIFF
--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/terraform-providers/terraform-provider-azuread/azuread"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/testclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
@@ -22,8 +21,18 @@ func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {
 		PreCheck: func() { PreCheck(t) },
 		Steps:    steps,
 	}
-
 	td.runAcceptanceTest(t, testCase)
+}
+
+func (td TestData) DataSourceTestInSequence(t *testing.T, steps []resource.TestStep) {
+	// DataSources don't need a check destroy - however since this is a wrapper function
+	// and not matching the ignore pattern `XXX_data_source_test.go`, this needs to be explicitly opted out
+	testCase := resource.TestCase{
+		PreCheck: func() { PreCheck(t) },
+		Steps:    steps,
+	}
+
+	td.runAcceptanceSequentialTest(t, testCase)
 }
 
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []resource.TestStep) {
@@ -38,7 +47,6 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 		},
 		Steps: steps,
 	}
-
 	td.runAcceptanceTest(t, testCase)
 }
 

--- a/azurerm/internal/services/securitycenter/security_center_contact_resource_test.go
+++ b/azurerm/internal/services/securitycenter/security_center_contact_resource_test.go
@@ -32,7 +32,7 @@ func testAccSecurityCenterContact_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_contact", "test")
 	r := SecurityCenterContactResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceSequentialTest(t, r, []resource.TestStep{
 		{
 			Config: r.template("basic@example.com", "+1-555-555-5555", true, true),
 			Check: resource.ComposeTestCheckFunc(
@@ -50,7 +50,7 @@ func testAccSecurityCenterContact_basic(t *testing.T) {
 func testAccSecurityCenterContact_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_contact", "test")
 	r := SecurityCenterContactResource{}
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceSequentialTest(t, r, []resource.TestStep{
 		{
 			Config: r.template("require@example.com", "+1-555-555-5555", true, true),
 			Check: resource.ComposeTestCheckFunc(
@@ -71,7 +71,7 @@ func testAccSecurityCenterContact_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_contact", "test")
 	r := SecurityCenterContactResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceSequentialTest(t, r, []resource.TestStep{
 		{
 			Config: r.template("update@example.com", "+1-555-555-5555", true, true),
 			Check: resource.ComposeTestCheckFunc(
@@ -100,7 +100,7 @@ func testAccSecurityCenterContact_phoneOptional(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_contact", "test")
 	r := SecurityCenterContactResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceSequentialTest(t, r, []resource.TestStep{
 		{
 			Config: r.templateWithoutPhone("basic@example.com", true, true),
 			Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
in the func `RunTestsInSequence`, it just iterate the map and run the testcase. But for each test case, it will invoke `data.ResourceTest`, then invoke `td.runAcceptanceTest(t, testCase)`, then invoke `resource.ParallelTest(t, testCase)`, it will set the `Parallel` flag to `true`.

in go testing framework, it will use goroutine to run test case

So the func `RunTestsInSequence` could not work properly.

A simple test case to confirm:
```
func TestParallel(t *testing.T) {
	tests := map[string]map[string]func(t *testing.T){
		"test": {
			"test1": func(t *testing.T) {
				t.Parallel()
				log.Println("test1 start")
				time.Sleep(10 * time.Second)
				log.Println("test1 end")
			},
			"test2": func(t *testing.T) {
				t.Parallel()
				log.Println("test2 start")
				time.Sleep(10 * time.Second)
				log.Println("test2 end")
			},
		},
	}
	for group, m := range tests {
		m := m
		t.Run(group, func(t *testing.T) {
			for name, tc := range m {
				tc := tc
				t.Run(name, func(t *testing.T) {
					tc(t)
				})
			}
		})
	}
}
```

-----------------------------------------------------------------

have already been fixed in PR #10924 
update the PR to fix the remaining test case that needs to be run in sequence