### PR TITLE
identity: adding a helper package for Managed Identities

### DIFF
--- a/azurerm/internal/identity/README.md
+++ b/azurerm/internal/identity/README.md
@@ -1,0 +1,63 @@
+# Identity
+
+This package contains helpers for working with Managed Identities.
+
+Azure supports up to 4 different combinations of Managed Identities:
+
+* `None` - where no Managed Identity is available/configured for this Azure Resource.
+* `SystemAssigned` - where Azure will generate a Managed Identity (Service Principal) for this Azure Resource.
+* `SystemAssigned, UserAssigned` - where Azure will generate a Managed Identity (Service Principal) for this Azure Resource, but they can also be assigned.
+* `UserAssigned` - where specific Managed Identities can be assigned to this Azure Resource.
+
+Since Managed Identities are an optional feature - within Terarform we're exposing this in 3 manners, exposed in this package as 3 types:
+
+* `SystemAssigned`
+* `SystemAssignedUserAssigned` (coming soon)
+* `UserAssigned` (coming soon)
+
+Where the block is Optional within Terraform - for consistency across the Provider we've opted to treat the absence of the `identity` block to represent "None" - and the presence of the block to indicate one of the Managed Identity types above.
+
+## Usage
+
+Within the resource itself, assign a type reference via:
+
+```go
+type resourceNameIdentity = identity.SystemAssigned
+```
+
+which can then be instantiated and used to call the Expand, Flatten and Schema functions:
+
+```go
+resourceNameIdentity{}.Schema()
+resourceNameIdentity{}.Expand(d.Get("identity").([]interface{}))
+resourceNameIdentity{}.Flatten(input)
+```
+
+Due to the Azure SDK using a different Type for each Service Package, at this time an Expand and Flatten function are needed to cast from the intermediate type `*identity.ExpandedConfig` to the type used within the Azure SDK for the specified Service Package, for example:
+
+```go
+func expandResourceNameIdentity(input []interface{}) (*somepackage.PackageTypeForManagedIdentity, error) {
+	config, err := resourceNameIdentity{}.Expand(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &somepackage.ManagedIdentityProperties{
+		Type:        somepackage.ManagedIdentityType(config.Type),
+		TenantID:    config.TenantId,
+		PrincipalID: config.PrincipalId,
+	}, nil
+}
+
+func flattenResourceNameIdentity(input *somepackage.ManagedIdentityProperties) []interface{} {
+	var config *identity.ExpandedConfig
+	if input != nil {
+		config = &identity.ExpandedConfig{
+			Type:        string(input.Type),
+			PrincipalId: input.PrincipalID,
+			TenantId:    input.TenantID,
+		}
+	}
+	return resourceNameIdentity{}.Flatten(config)
+}
+```

--- a/azurerm/internal/identity/schema.go
+++ b/azurerm/internal/identity/schema.go
@@ -6,8 +6,10 @@ import (
 
 const none = "None"
 const systemAssigned = "SystemAssigned"
-const systemAssignedUserAssigned = "SystemAssigned, UserAssigned"
-const userAssigned = "UserAssigned"
+
+// TODO: support UserAssigned & SystemAssigned, UserAssigned
+// const systemAssignedUserAssigned = "SystemAssigned, UserAssigned"
+// const userAssigned = "UserAssigned"
 
 type ExpandedConfig struct {
 	// Type is the type of User Assigned Identity, either `None`, `SystemAssigned`, `UserAssigned`

--- a/azurerm/internal/identity/schema.go
+++ b/azurerm/internal/identity/schema.go
@@ -1,0 +1,25 @@
+package identity
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const none = "None"
+const systemAssigned = "SystemAssigned"
+const systemAssignedUserAssigned = "SystemAssigned, UserAssigned"
+const userAssigned = "UserAssigned"
+
+type ExpandedConfig struct {
+	// Type is the type of User Assigned Identity, either `None`, `SystemAssigned`, `UserAssigned`
+	// or `SystemAssigned, UserAssigned`
+	Type                    string
+	PrincipalId             *string
+	TenantId                *string
+	UserAssignedIdentityIds *[]string
+}
+
+type Identity interface {
+	Expand(input []interface{}) (*ExpandedConfig, error)
+	Flatten(input *ExpandedConfig) []interface{}
+	Schema() *schema.Schema
+}

--- a/azurerm/internal/identity/system_assigned.go
+++ b/azurerm/internal/identity/system_assigned.go
@@ -1,0 +1,71 @@
+package identity
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var _ Identity = SystemAssigned{}
+
+type SystemAssigned struct{}
+
+func (s SystemAssigned) Expand(input []interface{}) (*ExpandedConfig, error) {
+	if len(input) == 0 || input[0] == nil {
+		return &ExpandedConfig{
+			Type: none,
+		}, nil
+	}
+
+	return &ExpandedConfig{
+		Type: systemAssigned,
+	}, nil
+}
+
+func (s SystemAssigned) Flatten(input *ExpandedConfig) []interface{} {
+	if input == nil || input.Type == none {
+		return []interface{}{}
+	}
+
+	var coalesce = func(input *string) string {
+		if input == nil {
+			return ""
+		}
+
+		return *input
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":         input.Type,
+			"principal_id": coalesce(input.PrincipalId),
+			"tenant_id":    coalesce(input.TenantId),
+		},
+	}
+}
+
+func (s SystemAssigned) Schema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						systemAssigned,
+					}, false),
+				},
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/azurerm/internal/services/springcloud/spring_cloud_app_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_app_resource.go
@@ -11,12 +11,15 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/identity"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/springcloud/validate"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
+
+type springCloudAppIdentity = identity.SystemAssigned
 
 func resourceSpringCloudApp() *schema.Resource {
 	return &schema.Resource{
@@ -54,33 +57,7 @@ func resourceSpringCloudApp() *schema.Resource {
 				ValidateFunc: validate.SpringCloudServiceName,
 			},
 
-			"identity": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							// other two enum: 'UserAssigned', 'SystemAssignedUserAssigned' are not supported for now
-							ValidateFunc: validation.StringInSlice([]string{
-								string(appplatform.SystemAssigned),
-							}, false),
-						},
-
-						"principal_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
-						"tenant_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"identity": springCloudAppIdentity{}.Schema(),
 
 			"is_public": {
 				Type:     schema.TypeBool,
@@ -154,9 +131,14 @@ func resourceSpringCloudAppCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
+	identity, err := expandSpringCloudAppIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return err
+	}
+
 	app := appplatform.AppResource{
 		Location: serviceResp.Location,
-		Identity: expandSpringCloudAppIdentity(d.Get("identity").([]interface{})),
+		Identity: identity,
 		Properties: &appplatform.AppResourceProperties{
 			Public: utils.Bool(d.Get("is_public").(bool)),
 		},
@@ -189,24 +171,30 @@ func resourceSpringCloudAppUpdate(d *schema.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("service_name").(string)
+	id, err := parse.SpringCloudAppID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	identity, err := expandSpringCloudAppIdentity(d.Get("identity").([]interface{}))
+	if err != nil {
+		return err
+	}
 
 	app := appplatform.AppResource{
-		Identity: expandSpringCloudAppIdentity(d.Get("identity").([]interface{})),
+		Identity: identity,
 		Properties: &appplatform.AppResourceProperties{
 			Public:         utils.Bool(d.Get("is_public").(bool)),
 			HTTPSOnly:      utils.Bool(d.Get("https_only").(bool)),
 			PersistentDisk: expandSpringCloudAppPersistentDisk(d.Get("persistent_disk").([]interface{})),
 		},
 	}
-	future, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, name, app)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.AppName, app)
 	if err != nil {
-		return fmt.Errorf("update Spring Cloud App %q (Spring Cloud Service %q / Resource Group %q): %+v", name, serviceName, resourceGroup, err)
+		return fmt.Errorf("update %s: %+v", id, err)
 	}
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of Spring Cloud App %q (Spring Cloud Service %q / Resource Group %q): %+v", name, serviceName, resourceGroup, err)
+		return fmt.Errorf("waiting for update of %s: %+v", id, err)
 	}
 
 	return resourceSpringCloudAppRead(d, meta)
@@ -264,22 +252,23 @@ func resourceSpringCloudAppDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if _, err := client.Delete(ctx, id.ResourceGroup, id.SpringName, id.AppName); err != nil {
-		return fmt.Errorf("deleting Spring Cloud App %q (Spring Cloud Service %q / Resource Group %q): %+v", id.AppName, id.SpringName, id.ResourceGroup, err)
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil
 }
 
-func expandSpringCloudAppIdentity(input []interface{}) *appplatform.ManagedIdentityProperties {
-	if len(input) == 0 || input[0] == nil {
-		return &appplatform.ManagedIdentityProperties{
-			Type: appplatform.None,
-		}
+func expandSpringCloudAppIdentity(input []interface{}) (*appplatform.ManagedIdentityProperties, error) {
+	config, err := springCloudAppIdentity{}.Expand(input)
+	if err != nil {
+		return nil, err
 	}
-	identity := input[0].(map[string]interface{})
+
 	return &appplatform.ManagedIdentityProperties{
-		Type: appplatform.ManagedIdentityType(identity["type"].(string)),
-	}
+		Type:        appplatform.ManagedIdentityType(config.Type),
+		TenantID:    config.TenantId,
+		PrincipalID: config.PrincipalId,
+	}, nil
 }
 
 func expandSpringCloudAppPersistentDisk(input []interface{}) *appplatform.PersistentDisk {
@@ -293,28 +282,16 @@ func expandSpringCloudAppPersistentDisk(input []interface{}) *appplatform.Persis
 	}
 }
 
-func flattenSpringCloudAppIdentity(identity *appplatform.ManagedIdentityProperties) []interface{} {
-	if identity == nil {
-		return make([]interface{}, 0)
+func flattenSpringCloudAppIdentity(input *appplatform.ManagedIdentityProperties) []interface{} {
+	var config *identity.ExpandedConfig
+	if input != nil {
+		config = &identity.ExpandedConfig{
+			Type:        string(input.Type),
+			PrincipalId: input.PrincipalID,
+			TenantId:    input.TenantID,
+		}
 	}
-
-	principalId := ""
-	if identity.PrincipalID != nil {
-		principalId = *identity.PrincipalID
-	}
-
-	tenantId := ""
-	if identity.TenantID != nil {
-		tenantId = *identity.TenantID
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"principal_id": principalId,
-			"tenant_id":    tenantId,
-			"type":         string(identity.Type),
-		},
-	}
+	return springCloudAppIdentity{}.Flatten(config)
 }
 
 func flattenSpringCloudAppPersistentDisk(input *appplatform.PersistentDisk) []interface{} {


### PR DESCRIPTION
The intention here is to make this code and convention more reusable, since the `identity` block should be treated in a common manner across different resources.

That is, the presence of an `identity` block should indicate that an identity is attached - and the absence should indicate that no identity should be assigned.

This commit introduces the foundation for this - and an implementation for System Assigned Identities - which maps to the following schema:

```
resource "azurerm_example" "example" {
  identity {
    type = "SystemAssigned"
  }
}
```

With documentation showing how to use this to map to and from the Azure SDK types - since unfortunately the Azure SDK isn't using common base types here.

This PR also switches the `azurerm_spring_cloud_app` resource over to using this new helper function.