### PR TITLE
"azurerm_key_vault" - supports ipv4 and cidr format for property "network_acls.ip_rules"

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -17,6 +17,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	commonValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
@@ -165,8 +166,14 @@ func resourceKeyVault() *schema.Resource {
 							"ip_rules": {
 								Type:     schema.TypeSet,
 								Optional: true,
-								Elem:     &schema.Schema{Type: schema.TypeString},
-								Set:      schema.HashString,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+									ValidateFunc: validation.Any(
+										commonValidate.IPv4Address,
+										commonValidate.CIDR,
+									),
+								},
+								Set: set.HashIPv4AddressOrCIDR,
 							},
 							"virtual_network_subnet_ids": {
 								Type:     schema.TypeSet,

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -642,7 +642,7 @@ resource "azurerm_key_vault" "test" {
   network_acls {
     default_action             = "Allow"
     bypass                     = "AzureServices"
-    ip_rules                   = ["123.0.0.102/32"]
+    ip_rules                   = ["123.0.0.102/32", "123.0.0.101"]
     virtual_network_subnet_ids = [azurerm_subnet.test_a.id]
   }
 }

--- a/azurerm/internal/tf/set/set.go
+++ b/azurerm/internal/tf/set/set.go
@@ -1,11 +1,13 @@
 package set
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 )
 
 func HashInt(v interface{}) int {
@@ -39,4 +41,17 @@ func normalizeIPv6Address(ipv6 interface{}) string {
 		return ""
 	}
 	return r.String()
+}
+
+func HashIPv4AddressOrCIDR(ipv4 interface{}) int {
+	warnings, errors := validate.IPv4Address(ipv4, "")
+
+	// maybe cidr, just hash it
+	if len(warnings) > 0 || len(errors) > 0 {
+		return schema.HashString(ipv4)
+	}
+
+	// convert to cidr hash
+	cidr := fmt.Sprintf("%s/32", ipv4.(string))
+	return schema.HashString(cidr)
 }


### PR DESCRIPTION
fix #8701

generally two ways to fix this issue:
1. only cidr format is allowed
2. accept cidr and ipv4, when calculate hash, convert ipv4 to cidr

this PR choose the second way