### PR TITLE
Adding note about databricks public/private subnets

### DIFF
--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `virtual_network_id` - (Optional) The ID of a Virtual Network where this Databricks Cluster should be created.
 
-~> **NOTE** Databricks requires that a network security group is associated with public and private subnets when `virtual_network_id` is set.
+~> **NOTE** Databricks requires that a network security group is associated with public and private subnets when `virtual_network_id` is set. Also, both public and private subnets must be delegated to `Microsoft.Databricks/workspaces`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
When integrating databricks into an existing VNET, both required subnets (public and private) must be delegated to `Microsoft.Databricks/workspaces`