### PR TITLE
datafactory & keyvault: removing direct usages on `acceptance.AzureProvider`

### DIFF
--- a/azurerm/internal/acceptance/check/that.go
+++ b/azurerm/internal/acceptance/check/that.go
@@ -1,6 +1,8 @@
 package check
 
 import (
+	"encoding/json"
+	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -45,6 +47,45 @@ type thatWithKeyType struct {
 
 	// key being the specific field we're querying e.g. bar or a nested object ala foo.0.bar
 	key string
+}
+
+// JsonAssertionFunc is a function which takes a deserialized JSON object and asserts on it
+type JsonAssertionFunc func(input []interface{}) (*bool, error)
+
+// ContainsKeyValue returns a TestCheckFunc which asserts upon a given JSON string set into
+// the State by deserializing it and then asserting on it via the JsonAssertionFunc
+func (t thatWithKeyType) ContainsJsonValue(assertion JsonAssertionFunc) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, exists := s.RootModule().Resources[t.resourceName]
+		if !exists {
+			return fmt.Errorf("%q was not found in the state", t.resourceName)
+		}
+
+		value, exists := rs.Primary.Attributes[t.key]
+		if !exists {
+			return fmt.Errorf("the value %q does not exist within %q", t.key, t.resourceName)
+		}
+
+		if value == "" {
+			return fmt.Errorf("the value for %q was empty", t.key)
+		}
+
+		var out []interface{}
+		if err := json.Unmarshal([]byte(value), &out); err != nil {
+			return fmt.Errorf("deserializing the value for %q (%q) to json: %+v", t.key, value, err)
+		}
+
+		ok, err := assertion(out)
+		if err != nil {
+			return fmt.Errorf("asserting value for %q: %+v", t.key, err)
+		}
+
+		if ok == nil || !*ok {
+			return fmt.Errorf("assertion failed for %q: %+v", t.key, err)
+		}
+
+		return nil
+	}
 }
 
 // DoesNotExist returns a TestCheckFunc which validates that the specific key

--- a/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource_test.go
@@ -137,7 +137,7 @@ func (r KeyVaultCertificateIssuerResource) Destroy(ctx context.Context, client *
 		return utils.Bool(false), fmt.Errorf("failed to look up base URI from id %q: %+v", keyVaultId, err)
 	}
 
-	ok, err := azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+	ok, err := azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if key vault %q for Certificate Issuer %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
 	}

--- a/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
@@ -3,7 +3,6 @@ package keyvault_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -198,7 +197,7 @@ func TestAccKeyVaultKey_updatedExternally(t *testing.T) {
 			Config: r.basicEC(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				updateExpiryDateForKeyVaultKey(data.ResourceName, "2029-02-02T12:59:00Z"),
+				data.CheckWithClient(r.updateExpiryDate("2029-02-02T12:59:00Z")),
 			),
 			ExpectNonEmptyPlan: true,
 		},
@@ -221,14 +220,10 @@ func TestAccKeyVaultKey_disappears(t *testing.T) {
 	r := KeyVaultKeyResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basicEC(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckKeyVaultKeyDisappears(data.ResourceName),
-			),
-			ExpectNonEmptyPlan: true,
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basicEC,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -309,31 +304,13 @@ func (KeyVaultKeyResource) destroyParentKeyVault(ctx context.Context, client *cl
 	return nil
 }
 
-func updateExpiryDateForKeyVaultKey(resourceName string, expiryDate string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
-		vaultClient := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		name := rs.Primary.Attributes["name"]
-		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+func (KeyVaultKeyResource) updateExpiryDate(expiryDate string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+		name := state.Attributes["name"]
+		keyVaultId := state.Attributes["key_vault_id"]
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, clients.KeyVault.VaultsClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
-		}
-
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
-		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
-		}
-		if !ok {
-			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
-			return nil
+			return fmt.Errorf("looking up base uri for Key %q from %q: %+v", name, keyVaultId, err)
 		}
 
 		expirationDate, err := time.Parse(time.RFC3339, expiryDate)
@@ -346,62 +323,27 @@ func updateExpiryDateForKeyVaultKey(resourceName string, expiryDate string) reso
 				Expires: &expirationUnixTime,
 			},
 		}
-		if _, err = client.UpdateKey(ctx, vaultBaseUrl, name, "", update); err != nil {
+		if _, err = clients.KeyVault.ManagementClient.UpdateKey(ctx, vaultBaseUrl, name, "", update); err != nil {
 			return fmt.Errorf("updating secret: %+v", err)
-		}
-
-		resp, err := client.GetKey(ctx, vaultBaseUrl, name, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Key Vault Key %q (resource group: %q) does not exist", name, vaultBaseUrl)
-			}
-
-			return fmt.Errorf("Bad: Get on keyVaultManagementClient: %+v", err)
 		}
 
 		return nil
 	}
 }
 
-func testCheckKeyVaultKeyDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
-		vaultClient := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		name := rs.Primary.Attributes["name"]
-		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
-		if err != nil {
-			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
-		}
-
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
-		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
-		}
-		if !ok {
-			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
-			return nil
-		}
-
-		resp, err := client.DeleteKey(ctx, vaultBaseUrl, name)
-		if err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
-				return nil
-			}
-
-			return fmt.Errorf("Bad: Delete on keyVaultManagementClient: %+v", err)
-		}
-
-		return nil
+func (KeyVaultKeyResource) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	name := state.Attributes["name"]
+	keyVaultId := state.Attributes["key_vault_id"]
+	vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, client.KeyVault.VaultsClient, keyVaultId)
+	if err != nil {
+		return nil, fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 	}
+
+	if _, err := client.KeyVault.ManagementClient.DeleteKey(ctx, vaultBaseUrl, name); err != nil {
+		return nil, fmt.Errorf("deleting keyVaultManagementClient: %+v", err)
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r KeyVaultKeyResource) basicEC(data acceptance.TestData) string {

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -3,7 +3,6 @@ package keyvault_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
@@ -59,14 +58,10 @@ func TestAccKeyVaultSecret_disappears(t *testing.T) {
 	r := KeyVaultSecretResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckKeyVaultSecretDisappears(data.ResourceName),
-			),
-			ExpectNonEmptyPlan: true,
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basic,
+			TestResource: r,
+		}),
 	})
 }
 
@@ -136,7 +131,7 @@ func TestAccKeyVaultSecret_updatingValueChangedExternally(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
-				updateKeyVaultSecretValue(data.ResourceName, "mad-scientist"),
+				data.CheckWithClient(r.updateSecretValue("mad-scientist")),
 			),
 			ExpectNonEmptyPlan: true,
 		},
@@ -203,7 +198,7 @@ func TestAccKeyVaultSecret_withExternalAccessPolicy(t *testing.T) {
 	})
 }
 
-func (t KeyVaultSecretResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (KeyVaultSecretResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	client := clients.KeyVault.ManagementClient
 	keyVaultClient := clients.KeyVault.VaultsClient
 
@@ -231,77 +226,40 @@ func (t KeyVaultSecretResource) Exists(ctx context.Context, clients *clients.Cli
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func testCheckKeyVaultSecretDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
-		vaultClient := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+func (KeyVaultSecretResource) Destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	dataPlaneClient := client.KeyVault.ManagementClient
+	vaultClient := client.KeyVault.VaultsClient
 
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		name := rs.Primary.Attributes["name"]
-		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
-		if err != nil {
-			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
-		}
-
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
-		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
-		}
-		if !ok {
-			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
-			return nil
-		}
-
-		resp, err := client.DeleteSecret(ctx, vaultBaseUrl, name)
-		if err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
-				return nil
-			}
-
-			return fmt.Errorf("Bad: Delete on keyVaultManagementClient: %+v", err)
-		}
-
-		return nil
+	name := state.Attributes["name"]
+	keyVaultId := state.Attributes["key_vault_id"]
+	vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+	if err != nil {
+		return nil, fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 	}
+
+	if _, err := dataPlaneClient.DeleteSecret(ctx, vaultBaseUrl, name); err != nil {
+		return nil, fmt.Errorf("Bad: Delete on keyVaultManagementClient: %+v", err)
+	}
+
+	return utils.Bool(true), nil
 }
 
-func updateKeyVaultSecretValue(resourceName, value string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.ManagementClient
-		vaultClient := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+func (r KeyVaultSecretResource) updateSecretValue(value string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+		dataPlaneClient := clients.KeyVault.ManagementClient
+		vaultClient := clients.KeyVault.VaultsClient
 
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-		name := rs.Primary.Attributes["name"]
-		keyVaultId := rs.Primary.Attributes["key_vault_id"]
+		name := state.Attributes["name"]
+		keyVaultId := state.Attributes["key_vault_id"]
 		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
-		}
-
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
-		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
-		}
-		if !ok {
-			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
-			return nil
+			return fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
 		updated := keyvault.SecretSetParameters{
 			Value: utils.String(value),
 		}
-		if _, err = client.SetSecret(ctx, vaultBaseUrl, name, updated); err != nil {
+		if _, err = dataPlaneClient.SetSecret(ctx, vaultBaseUrl, name, updated); err != nil {
 			return fmt.Errorf("updating secret: %+v", err)
 		}
 		return nil


### PR DESCRIPTION
This PR removes direct assertions on `acceptance.AzureProvider` by switching to use Check funcs.

This also introduces a new assertion function to validate upon a json value stored in the state, rather than checking the value in the API (since this is being read back)