### PR TITLE
azurerm_redis_cache - support multiple zone availability 

### DIFF
--- a/azurerm/internal/services/redis/redis_cache_resource.go
+++ b/azurerm/internal/services/redis/redis_cache_resource.go
@@ -64,7 +64,7 @@ func resourceRedisCache() *schema.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
-			"zones": azure.SchemaSingleZone(),
+			"zones": azure.SchemaMultipleZones(),
 
 			"capacity": {
 				Type:     schema.TypeInt,

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `zones` - (Optional) A list of a one or more Availability Zones, where the Redis Cache should be allocated.
 
--> **Please Note**: Availability Zones are [i Preview and only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) - as such you must be opted into the Preview to use this functionality. You can [opt into the Availability Zones Preview in the Azure Portal](http://aka.ms/azenroll).
+-> **Please Note**: Availability Zones are [in Preview and only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) - as such you must be opted into the Preview to use this functionality. You can [opt into the Availability Zones Preview in the Azure Portal](http://aka.ms/azenroll).
 
 ---
 

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -73,9 +73,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `zones` - (Optional) A list of a single item of the Availability Zone which the Redis Cache should be allocated in.
+* `zones` - (Optional) A list of a one or more Availability Zones, where the Redis Cache should be allocated.
 
--> **Please Note**: Availability Zones are [in Preview and only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) - as such you must be opted into the Preview to use this functionality. You can [opt into the Availability Zones Preview in the Azure Portal](http://aka.ms/azenroll).
+-> **Please Note**: Availability Zones are [i Preview and only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) - as such you must be opted into the Preview to use this functionality. You can [opt into the Availability Zones Preview in the Azure Portal](http://aka.ms/azenroll).
 
 ---
 


### PR DESCRIPTION
Azure Cache for Redis supports deploying to multiple availability zones. The Terraform provider should support this as well.