### PR TITLE
azurerm_lb_backend_address_pool: support for `backend_address`

### DIFF
--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -22,6 +22,7 @@ func SchemaResourceGroupNameDeprecated() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
+		Computed:     true,
 		ValidateFunc: validateResourceGroupName,
 		Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",
 	}

--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -22,6 +22,15 @@ func SchemaResourceGroupNameDeprecated() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
+		ValidateFunc: validateResourceGroupName,
+		Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",
+	}
+}
+
+func SchemaResourceGroupNameDeprecatedComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
 		Computed:     true,
 		ValidateFunc: validateResourceGroupName,
 		Deprecated:   "This field is no longer used and will be removed in the next major version of the Azure Provider",

--- a/azurerm/internal/services/loadbalancer/backend_address_pool_resource.go
+++ b/azurerm/internal/services/loadbalancer/backend_address_pool_resource.go
@@ -52,7 +52,7 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 			},
 
 			// TODO 3.0: remove this as it can be inferred from "loadbalancer_id"
-			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(),
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecatedComputed(),
 
 			"loadbalancer_id": {
 				Type:         schema.TypeString,

--- a/azurerm/internal/services/loadbalancer/client/client.go
+++ b/azurerm/internal/services/loadbalancer/client/client.go
@@ -6,19 +6,24 @@ import (
 )
 
 type Client struct {
-	LoadBalancersClient      *network.LoadBalancersClient
-	LoadBalancingRulesClient *network.LoadBalancerLoadBalancingRulesClient
+	LoadBalancersClient                   *network.LoadBalancersClient
+	LoadBalancerBackendAddressPoolsClient *network.LoadBalancerBackendAddressPoolsClient
+	LoadBalancingRulesClient              *network.LoadBalancerLoadBalancingRulesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
 	loadBalancersClient := network.NewLoadBalancersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&loadBalancersClient.Client, o.ResourceManagerAuthorizer)
 
+	loadBalancerBackendAddressPoolsClient := network.NewLoadBalancerBackendAddressPoolsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&loadBalancerBackendAddressPoolsClient.Client, o.ResourceManagerAuthorizer)
+
 	loadBalancingRulesClient := network.NewLoadBalancerLoadBalancingRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&loadBalancingRulesClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		LoadBalancersClient:      &loadBalancersClient,
-		LoadBalancingRulesClient: &loadBalancingRulesClient,
+		LoadBalancersClient:                   &loadBalancersClient,
+		LoadBalancerBackendAddressPoolsClient: &loadBalancerBackendAddressPoolsClient,
+		LoadBalancingRulesClient:              &loadBalancingRulesClient,
 	}
 }

--- a/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_data_source_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_backend_address_pool_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccAzureRMDataSourceLoadBalancerBackEndAddressPool_basic(t *testing.T) 
 }
 
 func (r LoadBalancerBackendAddressPool) dataSourceBasic(data acceptance.TestData) string {
-	resource := r.basic(data)
+	resource := r.basicSkuBasic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/d/lb_backend_address_pool.html.markdown
+++ b/website/docs/d/lb_backend_address_pool.html.markdown
@@ -65,8 +65,6 @@ A `backend_address` block exports the following:
 
 * `ip_address` - The IP address pre-allocated for this Backend Address with in the Virtual Network of `virtual_network_id`.
 
-* `network_interface_ip_configuration` - The Network Interface's ip configuration reference of this Backend Address.
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/d/lb_backend_address_pool.html.markdown
+++ b/website/docs/d/lb_backend_address_pool.html.markdown
@@ -46,8 +46,26 @@ The following attributes are exported:
 * `id` - The ID of the Backend Address Pool.
 
 * `name` - The name of the Backend Address Pool.
+
+* `backend_address` - An array of `backend_address` block as defined below.
  
 * `backend_ip_configurations` - An array of references to IP addresses defined in network interfaces.
+
+* `load_balancing_rules` - An array of the Load Balancing Rules associated with this Backend Address Pool.
+
+* `outbound_rules` - An array of the Load Balancing Outbound Rules associated with this Backend Address Pool.
+
+---
+
+A `backend_address` block exports the following:
+
+* `name` - The name of the Backend Address.
+
+* `virtual_network_id` - The ID of the Virtual Network that is pre-allocated for this Backend Address.
+
+* `ip_address` - The IP address pre-allocated for this Backend Address with in the Virtual Network of `virtual_network_id`.
+
+* `network_interface_ip_configuration` - The Network Interface's ip configuration reference of this Backend Address.
 
 ## Timeouts
 

--- a/website/docs/r/lb_backend_address_pool.html.markdown
+++ b/website/docs/r/lb_backend_address_pool.html.markdown
@@ -50,13 +50,11 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Backend Address Pool.
   
-* `resource_group_name` - (Optional / **Deprecated**) The name of the resource group in which to create the resource.
-  
 * `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Backend Address Pool.
 
 * `backend_address` - (Optional) An array of `backend_address` block as defined below.
 
--> **NOTE**: The `backend_address` is only allowed when the Load Balancer in which this Backend Address Pool resides is of `Standard` sku. See [the Azure document](https://docs.microsoft.com/en-us/azure/load-balancer/backend-pool-management#limitations) for more details.
+-> **NOTE**: The `backend_address` can only be configured when the Backend Address Pool Load Balancer's SKU is `Standard`. See [the Azure document](https://docs.microsoft.com/en-us/azure/load-balancer/backend-pool-management#limitations) for more details.
 
 ---
 
@@ -81,12 +79,6 @@ The following attributes are exported:
 * `load_balancing_rules` - The Load Balancing Rules associated with this Backend Address Pool.
 
 * `outbound_rules` - An array of the Load Balancing Outbound Rules associated with this Backend Address Pool.
-
----
-
-A `backend_address` block exports the following:
-
-* `network_interface_ip_configuration` - The Network Interface's ip configuration reference of this Backend Address.
 
 ## Timeouts
 

--- a/website/docs/r/lb_backend_address_pool.html.markdown
+++ b/website/docs/r/lb_backend_address_pool.html.markdown
@@ -39,9 +39,8 @@ resource "azurerm_lb" "example" {
 }
 
 resource "azurerm_lb_backend_address_pool" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  loadbalancer_id     = azurerm_lb.example.id
-  name                = "BackEndAddressPool"
+  loadbalancer_id = azurerm_lb.example.id
+  name            = "BackEndAddressPool"
 }
 ```
 
@@ -50,18 +49,44 @@ resource "azurerm_lb_backend_address_pool" "example" {
 The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Backend Address Pool.
-* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
+  
+* `resource_group_name` - (Optional / **Deprecated**) The name of the resource group in which to create the resource.
+  
 * `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Backend Address Pool.
+
+* `backend_address` - (Optional) An array of `backend_address` block as defined below.
+
+-> **NOTE**: The `backend_address` is only allowed when the Load Balancer in which this Backend Address Pool resides is of `Standard` sku. See [the Azure document](https://docs.microsoft.com/en-us/azure/load-balancer/backend-pool-management#limitations) for more details.
+
+---
+
+A `backend_address` supports the following:
+
+* `name` - (Required) The name of the Backend Address.
+
+* `virtual_network_id` - (Required) The ID of the Virtual Network that is pre-allocated for this Backend Address.
+
+* `ip_address` - (Required) The IP address pre-allocated for this Backend Address with in the Virtual Network of `virtual_network_id`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The ID of the Backend Address Pool.
+  
+* `backend_address` - An array of `backend_address` block as defined below.
 
 * `backend_ip_configurations` - The Backend IP Configurations associated with this Backend Address Pool.
 
 * `load_balancing_rules` - The Load Balancing Rules associated with this Backend Address Pool.
+
+* `outbound_rules` - An array of the Load Balancing Outbound Rules associated with this Backend Address Pool.
+
+---
+
+A `backend_address` block exports the following:
+
+* `network_interface_ip_configuration` - The Network Interface's ip configuration reference of this Backend Address.
 
 ## Timeouts
 


### PR DESCRIPTION
- Support `outbound_rules` for both ds and resource
- Support `backend_address` for both ds and resource
- Use the backend address pool dedicated endpoint in data source and resource Read callback to make the code easier to maintain

Note that the backend address pool API is kind of confusing, for which I've submit Azure/azure-rest-api-specs#11234. However, after offline ping with service team, it turns out they implement *Standard* sku LB and *Basic* sku LB in quite different way. They are not probably gonna change current API behavior in turns of backend address pool. See my [comment](https://github.com/Azure/azure-rest-api-specs/issues/11234#issuecomment-765871828) for more details.

Because of this fact, the implementation in this PR (mostly for CreateUpdate/Delete) will first check the LB sku, then call towards different endpoints accordingly.

Supersedes #8920

## Test Result

```shell
💢 make testacc TEST=./azurerm/internal/services/loadbalancer TESTARGS='-run TestAccAzureRMLoadBalancerBackEndAddressPool_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/loadbalancer -v -run TestAccAzureRMLoadBalancerBackEndAddressPool_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_basicSkuBasic
=== PAUSE TestAccAzureRMLoadBalancerBackEndAddressPool_basicSkuBasic
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuNIC
=== PAUSE TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuNIC
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPBasic
=== PAUSE TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPBasic
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPUpdate
=== PAUSE TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPUpdate
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_requiresImport
=== PAUSE TestAccAzureRMLoadBalancerBackEndAddressPool_requiresImport
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_BasicSkuRemoval
=== PAUSE TestAccAzureRMLoadBalancerBackEndAddressPool_BasicSkuRemoval
=== CONT  TestAccAzureRMLoadBalancerBackEndAddressPool_basicSkuBasic
=== CONT  TestAccAzureRMLoadBalancerBackEndAddressPool_requiresImport
=== CONT  TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPBasic
=== CONT  TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPUpdate
=== CONT  TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuNIC
=== CONT  TestAccAzureRMLoadBalancerBackEndAddressPool_BasicSkuRemoval
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuNIC (204.34s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPBasic (216.80s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_basicSkuBasic (266.50s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_requiresImport (283.75s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_BasicSkuRemoval (332.49s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_standardSkuIPUpdate (428.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loadbalancer        428.057s
```