### PR TITLE
`azurerm_linux|windows_virtual_machine_scale_set` - Support `extensions_time_budget`

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -652,6 +652,102 @@ func TestAccLinuxVirtualMachineScaleSet_otherVmExtensionsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsWithExtensionsTimeBudget(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
+func TestAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsWithExtensionsTimeBudgetUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT1H"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
+func TestAccAzureRMLinuxVirtualMachineScaleSet_otherExtensionsTimeBudgetWithoutExtensions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
+func TestAccAzureRMLinuxVirtualMachineScaleSet_otherExtensionsTimeBudgetWithoutExtensionsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT1H"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
 func TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHost(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
 	r := LinuxVirtualMachineScaleSetResource{}
@@ -2440,6 +2536,118 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) otherVmExtensionsWithExtensionsTimeBudget(data acceptance.TestData, duration string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
+  }
+
+  extensions_time_budget = "%s"
+}
+`, template, data.RandomInteger, duration)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) otherExtensionsTimeBudgetWithoutExtensions(data acceptance.TestData, duration string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extensions_time_budget = "%s"
+}
+`, template, data.RandomInteger, duration)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) otherEncryptionAtHost(data acceptance.TestData, enabled bool) string {

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
@@ -143,6 +144,13 @@ func resourceLinuxVirtualMachineScaleSet() *schema.Resource {
 			},
 
 			"extension": VirtualMachineScaleSetExtensionsSchema(),
+
+			"extensions_time_budget": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "PT1H30M",
+				ValidateFunc: azValidate.ISO8601DurationBetween("PT15M", "PT2H"),
+			},
 
 			"health_probe_id": {
 				Type:         schema.TypeString,
@@ -420,6 +428,13 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *schema.ResourceData, meta inte
 				return err
 			}
 		}
+	}
+
+	if v, ok := d.GetOk("extensions_time_budget"); ok {
+		if virtualMachineProfile.ExtensionProfile == nil {
+			virtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+		}
+		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(v.(string))
 	}
 
 	if adminPassword, ok := d.GetOk("admin_password"); ok {
@@ -801,6 +816,13 @@ func resourceLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta inte
 		}
 	}
 
+	if d.HasChange("extensions_time_budget") {
+		if updateProps.VirtualMachineProfile.ExtensionProfile == nil {
+			updateProps.VirtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+		}
+		updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(d.Get("extensions_time_budget").(string))
+	}
+
 	if d.HasChange("tags") {
 		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
@@ -991,6 +1013,12 @@ func resourceLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta interf
 			}
 			d.Set("extension", extensionProfile)
 		}
+
+		extensionsTimeBudget := "PT1H30M"
+		if profile.ExtensionProfile != nil && profile.ExtensionProfile.ExtensionsTimeBudget != nil {
+			extensionsTimeBudget = *profile.ExtensionProfile.ExtensionsTimeBudget
+		}
+		d.Set("extensions_time_budget", extensionsTimeBudget)
 
 		encryptionAtHostEnabled := false
 		if profile.SecurityProfile != nil && profile.SecurityProfile.EncryptionAtHost != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource_test.go
@@ -14,7 +14,7 @@ import (
 type LinuxVirtualMachineScaleSetResource struct {
 }
 
-func (t LinuxVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (r LinuxVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.VirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -787,6 +787,102 @@ func TestAccWindowsVirtualMachineScaleSet_otherVmExtensionUpdate(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachineScaleSet_otherVmExtensionsWithExtensionsTimeBudget(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_otherVmExtensionsWithExtensionsTimeBudgetUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT1H"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherVmExtensionsWithExtensionsTimeBudget(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_otherExtensionsTimeBudgetWithoutExtensions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
+func TestAccWindowsVirtualMachineScaleSet_otherExtensionsTimeBudgetWithoutExtensionsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT1H"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+		{
+			Config: r.otherExtensionsTimeBudgetWithoutExtensions(data, "PT30M"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+		data.ImportStep("admin_password", "extension"),
+	})
+}
+
 func TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 	r := WindowsVirtualMachineScaleSetResource{}
@@ -2730,6 +2826,114 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   }
 }
 `, r.template(data), enabled)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) otherVmExtensionsWithExtensionsTimeBudget(data acceptance.TestData, duration string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Compute"
+    type                       = "CustomScriptExtension"
+    type_handler_version       = "1.10"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({
+      "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\""
+    })
+
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
+  }
+
+  extensions_time_budget = "%s"
+}
+`, template, duration)
+}
+
+func (r WindowsVirtualMachineScaleSetResource) otherExtensionsTimeBudgetWithoutExtensions(data acceptance.TestData, duration string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extensions_time_budget = "%s"
+}
+`, template, duration)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) otherEncryptionAtHostEnabled(data acceptance.TestData, enabled bool) string {

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -146,6 +146,13 @@ func resourceWindowsVirtualMachineScaleSet() *schema.Resource {
 
 			"extension": VirtualMachineScaleSetExtensionsSchema(),
 
+			"extensions_time_budget": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "PT1H30M",
+				ValidateFunc: validate.ISO8601DurationBetween("PT15M", "PT2H"),
+			},
+
 			"health_probe_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -437,6 +444,13 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta in
 				return err
 			}
 		}
+	}
+
+	if v, ok := d.GetOk("extensions_time_budget"); ok {
+		if virtualMachineProfile.ExtensionProfile == nil {
+			virtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+		}
+		virtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(v.(string))
 	}
 
 	enableAutomaticUpdates := d.Get("enable_automatic_updates").(bool)
@@ -831,6 +845,13 @@ func resourceWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta in
 		}
 	}
 
+	if d.HasChange("extensions_time_budget") {
+		if updateProps.VirtualMachineProfile.ExtensionProfile == nil {
+			updateProps.VirtualMachineProfile.ExtensionProfile = &compute.VirtualMachineScaleSetExtensionProfile{}
+		}
+		updateProps.VirtualMachineProfile.ExtensionProfile.ExtensionsTimeBudget = utils.String(d.Get("extensions_time_budget").(string))
+	}
+
 	if d.HasChange("tags") {
 		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
@@ -1050,6 +1071,12 @@ func resourceWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta inte
 			}
 			d.Set("extension", extensionProfile)
 		}
+
+		extensionsTimeBudget := "PT1H30M"
+		if profile.ExtensionProfile != nil && profile.ExtensionProfile.ExtensionsTimeBudget != nil {
+			extensionsTimeBudget = *profile.ExtensionProfile.ExtensionsTimeBudget
+		}
+		d.Set("extensions_time_budget", extensionsTimeBudget)
 
 		encryptionAtHostEnabled := false
 		if profile.SecurityProfile != nil && profile.SecurityProfile.EncryptionAtHost != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource_test.go
@@ -15,7 +15,7 @@ import (
 type WindowsVirtualMachineScaleSetResource struct {
 }
 
-func (t WindowsVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (r WindowsVirtualMachineScaleSetResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.VirtualMachineScaleSetID(state.ID)
 	if err != nil {
 		return nil, err

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -150,6 +150,8 @@ The following arguments are supported:
 
 !> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
 
+* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. Defaults to 90 minutes (`PT1H30M`).
+
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 
 !> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
 
-* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. Defaults to 90 minutes (`PT1H30M`).
+* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between `15` minutes and `120` minutes (inclusive) and should be specified in ISO 8601 format. Defaults to `90` minutes (`PT1H30M`).
 
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -136,6 +136,8 @@ The following arguments are supported:
 
 !> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
 
+* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. Defaults to 90 minutes (`PT1H30M`).
+
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -136,7 +136,7 @@ The following arguments are supported:
 
 !> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
 
-* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. Defaults to 90 minutes (`PT1H30M`).
+* `extensions_time_budget` - (Optional) Specifies the duration allocated for all extensions to start. The time duration should be between `15` minutes and `120` minutes (inclusive) and should be specified in ISO 8601 format. Defaults to `90` minutes (`PT1H30M`).
 
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This is a reopen of PR https://github.com/terraform-providers/terraform-provider-azurerm/pull/9280
Previously there is a service bug, now the bug has been fixed.