### PR TITLE
Docs explaining `mssql_server/database` auditing configuration with LAW or Event Hub

### DIFF
--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -141,6 +141,24 @@ A `extended_auditing_policy` block supports the following:
 * `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
 
+~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing, an `azurerm_monitor_diagnostic_setting` should be configured like so. 
+```hcl
+resource "azurerm_monitor_diagnostic_setting" "azure_mssql_auditing" {
+  name                       = "azure-mssql-auditing"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  target_resource_id         = azurerm_mssql_database.example.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}
+```
+
 ---
 
 A `long_term_retention_policy` block supports the following:

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -12,6 +12,24 @@ Manages a Ms Sql Database Extended Auditing Policy.
 
 ~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
+~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing, an `azurerm_monitor_diagnostic_setting` should be configured like so. 
+```hcl
+resource "azurerm_monitor_diagnostic_setting" "azure_mssql_auditing" {
+  name                       = "azure-mssql-auditing"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  target_resource_id         = azurerm_mssql_database.example.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}
+```
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -138,6 +138,29 @@ An `extended_auditing_policy` block supports the following:
 
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
 
+~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing for `azurerm_mssql_server`, an `azurerm_monitor_diagnostic_setting` resource should be configured on every database including `master` like so. 
+```hcl
+data "azurerm_mssql_database" "master" {
+  name                = "master"
+  resource_group_name = "example-mssql-server-id"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "azure_mssql_auditing" {
+  name                       = "azure-mssql-auditing"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  target_resource_id         = data.azurerm_mssql_database.master.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}
+```
+
 ### Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -138,7 +138,7 @@ An `extended_auditing_policy` block supports the following:
 
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
 
-~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing for `azurerm_mssql_server`, an `azurerm_monitor_diagnostic_setting` resource should be configured on every database including `master` like so. 
+~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing for `azurerm_mssql_server`, an `azurerm_monitor_diagnostic_setting` resource should be configured on database `master` like so. 
 ```hcl
 data "azurerm_mssql_database" "master" {
   name                = "master"

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -12,6 +12,29 @@ Manages a Ms Sql Server Extended Auditing Policy.
 
 ~> **NOTE:** The Server Extended Auditing Policy Can be set inline here as well as with the [mssql_server_extended_auditing_policy resource](mssql_server_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
+~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing for `azurerm_mssql_server`, an `azurerm_monitor_diagnostic_setting` should be configured on every database including `master` like so. 
+```hcl
+data "azurerm_mssql_database" "master" {
+  name                = "master"
+  resource_group_name = "example-mssql-server-id"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "azure_mssql_auditing" {
+  name                       = "azure-mssql-auditing"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  target_resource_id         = data.azurerm_mssql_database.master.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}
+```
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -12,7 +12,7 @@ Manages a Ms Sql Server Extended Auditing Policy.
 
 ~> **NOTE:** The Server Extended Auditing Policy Can be set inline here as well as with the [mssql_server_extended_auditing_policy resource](mssql_server_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
-~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing for `azurerm_mssql_server`, an `azurerm_monitor_diagnostic_setting` should be configured on every database including `master` like so. 
+~> **NOTE** (Preview) To configure Log Analytics or Event Hub as target of Azure SQL Auditing for `azurerm_mssql_server`, an `azurerm_monitor_diagnostic_setting` should be configured on `master` like so. 
 ```hcl
 data "azurerm_mssql_database" "master" {
   name                = "master"


### PR DESCRIPTION
Fixes #6849, or: how to configure sending Azure MSSQL auditing to an Azure Log Analytics Workspace or Azure Event Hub.

Although closed, it needs some documentation to prevent more simuleer issues and provide this information more easily to the `azurerm` users.

I'm not sure whether this is the right way to document it, suggestions more than welcome. If implementation of the toggle `isAzureMonitorTargetEnabled` ([link to issue comment](https://github.com/terraform-providers/terraform-provider-azurerm/issues/6849#issuecomment-764521747), [link to API docs](https://docs.microsoft.com/en-us/rest/api/sql/database%20auditing%20settings/createorupdate)) is considered a nice addition, let me know.