### PR TITLE
Support for sql auditing to Azure Monitor

### DIFF
--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -19,14 +19,14 @@ func ExtendedAuditingSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"storage_account_access_key": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
 				"storage_endpoint": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
 					ValidateFunc: validation.IsURLWithHTTPS,
 				},
 
@@ -40,6 +40,12 @@ func ExtendedAuditingSchema() *schema.Schema {
 					Optional:     true,
 					ValidateFunc: validation.IntBetween(0, 3285),
 				},
+
+				"monitor_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
 			},
 		},
 	}
@@ -49,18 +55,15 @@ func ExpandSqlServerBlobAuditingPolicies(input []interface{}) *sql.ExtendedServe
 	if len(input) == 0 || input[0] == nil {
 		return &sql.ExtendedServerBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
-
-			// NOTE: this works around a regression in the Azure API detailed here:
-			// https://github.com/Azure/azure-rest-api-specs/issues/11271
-			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	serverBlobAuditingPolicies := input[0].(map[string]interface{})
 
 	ExtendedServerBlobAuditingPolicyProperties := sql.ExtendedServerBlobAuditingPolicyProperties{
-		State:                   sql.BlobAuditingPolicyStateEnabled,
-		StorageAccountAccessKey: utils.String(serverBlobAuditingPolicies["storage_account_access_key"].(string)),
-		StorageEndpoint:         utils.String(serverBlobAuditingPolicies["storage_endpoint"].(string)),
+		State:                       sql.BlobAuditingPolicyStateEnabled,
+		StorageAccountAccessKey:     utils.String(serverBlobAuditingPolicies["storage_account_access_key"].(string)),
+		StorageEndpoint:             utils.String(serverBlobAuditingPolicies["storage_endpoint"].(string)),
+		IsAzureMonitorTargetEnabled: utils.Bool(serverBlobAuditingPolicies["monitor_enabled"].(bool)),
 	}
 	if v, ok := serverBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
 		ExtendedServerBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
@@ -93,6 +96,10 @@ func FlattenSqlServerBlobAuditingPolicies(extendedServerBlobAuditingPolicy *sql.
 	if extendedServerBlobAuditingPolicy.RetentionDays != nil {
 		retentionDays = *extendedServerBlobAuditingPolicy.RetentionDays
 	}
+	var monitor bool
+	if extendedServerBlobAuditingPolicy.IsAzureMonitorTargetEnabled != nil {
+		monitor = *extendedServerBlobAuditingPolicy.IsAzureMonitorTargetEnabled
+	}
 
 	return []interface{}{
 		map[string]interface{}{
@@ -100,6 +107,7 @@ func FlattenSqlServerBlobAuditingPolicies(extendedServerBlobAuditingPolicy *sql.
 			"storage_endpoint":                        storageEndpoint,
 			"storage_account_access_key_is_secondary": secondKeyInUse,
 			"retention_in_days":                       retentionDays,
+			"monitor_enabled":                         monitor,
 		},
 	}
 }
@@ -108,18 +116,15 @@ func ExpandMsSqlDBBlobAuditingPolicies(input []interface{}) *sql.ExtendedDatabas
 	if len(input) == 0 || input[0] == nil {
 		return &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
-
-			// NOTE: this works around a regression in the Azure API detailed here:
-			// https://github.com/Azure/azure-rest-api-specs/issues/11271
-			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	dbBlobAuditingPolicies := input[0].(map[string]interface{})
 
 	ExtendedDatabaseBlobAuditingPolicyProperties := sql.ExtendedDatabaseBlobAuditingPolicyProperties{
-		State:                   sql.BlobAuditingPolicyStateEnabled,
-		StorageAccountAccessKey: utils.String(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
-		StorageEndpoint:         utils.String(dbBlobAuditingPolicies["storage_endpoint"].(string)),
+		State:                       sql.BlobAuditingPolicyStateEnabled,
+		StorageAccountAccessKey:     utils.String(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
+		StorageEndpoint:             utils.String(dbBlobAuditingPolicies["storage_endpoint"].(string)),
+		IsAzureMonitorTargetEnabled: utils.Bool(dbBlobAuditingPolicies["monitor_enabled"].(bool)),
 	}
 	if v, ok := dbBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
 		ExtendedDatabaseBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
@@ -152,6 +157,10 @@ func FlattenMsSqlDBBlobAuditingPolicies(extendedDatabaseBlobAuditingPolicy *sql.
 	if extendedDatabaseBlobAuditingPolicy.RetentionDays != nil {
 		retentionDays = *extendedDatabaseBlobAuditingPolicy.RetentionDays
 	}
+	var monitor bool
+	if extendedDatabaseBlobAuditingPolicy.IsAzureMonitorTargetEnabled != nil {
+		monitor = *extendedDatabaseBlobAuditingPolicy.IsAzureMonitorTargetEnabled
+	}
 
 	return []interface{}{
 		map[string]interface{}{
@@ -159,6 +168,7 @@ func FlattenMsSqlDBBlobAuditingPolicies(extendedDatabaseBlobAuditingPolicy *sql.
 			"storage_endpoint":                        storageEndpoint,
 			"storage_account_access_key_is_secondary": secondKeyInUse,
 			"retention_in_days":                       retentionDays,
+			"monitor_enabled":                         monitor,
 		},
 	}
 }

--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -41,7 +41,7 @@ func ExtendedAuditingSchema() *schema.Schema {
 					ValidateFunc: validation.IntBetween(0, 3285),
 				},
 
-				"monitor_enabled": {
+				"log_monitoring_enabled": {
 					Type:     schema.TypeBool,
 					Optional: true,
 					Default:  true,
@@ -63,7 +63,7 @@ func ExpandSqlServerBlobAuditingPolicies(input []interface{}) *sql.ExtendedServe
 		State:                       sql.BlobAuditingPolicyStateEnabled,
 		StorageAccountAccessKey:     utils.String(serverBlobAuditingPolicies["storage_account_access_key"].(string)),
 		StorageEndpoint:             utils.String(serverBlobAuditingPolicies["storage_endpoint"].(string)),
-		IsAzureMonitorTargetEnabled: utils.Bool(serverBlobAuditingPolicies["monitor_enabled"].(bool)),
+		IsAzureMonitorTargetEnabled: utils.Bool(serverBlobAuditingPolicies["log_monitoring_enabled"].(bool)),
 	}
 	if v, ok := serverBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
 		ExtendedServerBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
@@ -107,7 +107,7 @@ func FlattenSqlServerBlobAuditingPolicies(extendedServerBlobAuditingPolicy *sql.
 			"storage_endpoint":                        storageEndpoint,
 			"storage_account_access_key_is_secondary": secondKeyInUse,
 			"retention_in_days":                       retentionDays,
-			"monitor_enabled":                         monitor,
+			"log_monitoring_enabled":                  monitor,
 		},
 	}
 }
@@ -124,7 +124,7 @@ func ExpandMsSqlDBBlobAuditingPolicies(input []interface{}) *sql.ExtendedDatabas
 		State:                       sql.BlobAuditingPolicyStateEnabled,
 		StorageAccountAccessKey:     utils.String(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
 		StorageEndpoint:             utils.String(dbBlobAuditingPolicies["storage_endpoint"].(string)),
-		IsAzureMonitorTargetEnabled: utils.Bool(dbBlobAuditingPolicies["monitor_enabled"].(bool)),
+		IsAzureMonitorTargetEnabled: utils.Bool(dbBlobAuditingPolicies["log_monitoring_enabled"].(bool)),
 	}
 	if v, ok := dbBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
 		ExtendedDatabaseBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
@@ -168,7 +168,7 @@ func FlattenMsSqlDBBlobAuditingPolicies(extendedDatabaseBlobAuditingPolicy *sql.
 			"storage_endpoint":                        storageEndpoint,
 			"storage_account_access_key_is_secondary": secondKeyInUse,
 			"retention_in_days":                       retentionDays,
-			"monitor_enabled":                         monitor,
+			"log_monitoring_enabled":                  monitor,
 		},
 	}
 }

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -71,7 +71,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicy() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 3285),
 			},
 
-			"monitor_enabled": {
+			"log_monitoring_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -112,7 +112,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *schema.ResourceD
 			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("monitor_enabled").(bool)),
+			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
@@ -169,7 +169,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyRead(d *schema.ResourceData, met
 		d.Set("storage_endpoint", props.StorageEndpoint)
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
-		d.Set("monitor_enabled", props.IsAzureMonitorTargetEnabled)
+		d.Set("log_monitoring_enabled", props.IsAzureMonitorTargetEnabled)
 	}
 
 	return nil

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -423,6 +423,7 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     }
   }
 
+  // log, metric will return all disabled categories
   lifecycle {
     ignore_changes = [log, metric]
   }
@@ -461,6 +462,7 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     }
   }
 
+  // log, metric will return all disabled categories
   lifecycle {
     ignore_changes = [log, metric]
   }
@@ -503,6 +505,7 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     }
   }
 
+  // log, metric will return all disabled categories
   lifecycle {
     ignore_changes = [log, metric]
   }
@@ -544,6 +547,7 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
     }
   }
 
+  // log, metric will return all disabled categories
   lifecycle {
     ignore_changes = [log, metric]
   }

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -108,6 +108,64 @@ func TestAccMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall(t *test
 	})
 }
 
+func TestAccMsSqlDatabaseExtendedAuditingPolicy_logAnalytics(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database_extended_auditing_policy", "test")
+	r := MsSqlDatabaseExtendedAuditingPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+		{
+			Config: r.logAnalytics(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+		{
+			Config: r.logAnalyticsAndStorageAccount(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+	})
+}
+
+func TestAccMsSqlDatabaseExtendedAuditingPolicy_eventhub(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database_extended_auditing_policy", "test")
+	r := MsSqlDatabaseExtendedAuditingPolicyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+		{
+			Config: r.eventhub(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+		{
+			Config: r.eventhubAndStorageAccount(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_access_key"),
+	})
+}
+
 func (MsSqlDatabaseExtendedAuditingPolicyResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.DatabaseExtendedAuditingPolicyID(state.ID)
 	if err != nil {
@@ -293,4 +351,210 @@ resource "azurerm_mssql_database_extended_auditing_policy" "test" {
   ]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r MsSqlDatabaseExtendedAuditingPolicyResource) monitorTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctest-LAW-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctest-EHN-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctest-EH-%[2]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "test" {
+  name                = "acctestEHRule"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  listen              = true
+  send                = true
+  manage              = true
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "test" {
+  server_id       = azurerm_mssql_server.test.id
+  monitor_enabled = true
+}
+
+`, r.template(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseExtendedAuditingPolicyResource) logAnalytics(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "acctest-DS-%[2]d"
+  target_resource_id         = azurerm_mssql_database.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id     = azurerm_mssql_database.test.id
+  monitor_enabled = true
+}
+`, r.monitorTemplate(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseExtendedAuditingPolicyResource) logAnalyticsAndStorageAccount(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "acctest-DS-%[2]d"
+  target_resource_id         = azurerm_mssql_database.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id                = azurerm_mssql_database.test.id
+  storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  monitor_enabled            = true
+}
+`, r.monitorTemplate(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseExtendedAuditingPolicyResource) eventhub(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                           = "acctest-DS-%[2]d"
+  target_resource_id             = azurerm_mssql_database.test.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
+  eventhub_name                  = azurerm_eventhub.test.name
+
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id     = azurerm_mssql_database.test.id
+  monitor_enabled = true
+}
+`, r.monitorTemplate(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseExtendedAuditingPolicyResource) eventhubAndStorageAccount(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                           = "acctest-DS-%[2]d"
+  target_resource_id             = azurerm_mssql_database.test.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
+  eventhub_name                  = azurerm_eventhub.test.name
+
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id                = azurerm_mssql_database.test.id
+  storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  monitor_enabled            = true
+}
+`, r.monitorTemplate(data), data.RandomInteger)
 }

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource_test.go
@@ -390,8 +390,8 @@ resource "azurerm_eventhub_namespace_authorization_rule" "test" {
 }
 
 resource "azurerm_mssql_server_extended_auditing_policy" "test" {
-  server_id       = azurerm_mssql_server.test.id
-  monitor_enabled = true
+  server_id              = azurerm_mssql_server.test.id
+  log_monitoring_enabled = true
 }
 
 `, r.template(data), data.RandomInteger)
@@ -430,8 +430,8 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
 }
 
 resource "azurerm_mssql_database_extended_auditing_policy" "test" {
-  database_id     = azurerm_mssql_database.test.id
-  monitor_enabled = true
+  database_id            = azurerm_mssql_database.test.id
+  log_monitoring_enabled = true
 }
 `, r.monitorTemplate(data), data.RandomInteger)
 }
@@ -472,7 +472,7 @@ resource "azurerm_mssql_database_extended_auditing_policy" "test" {
   database_id                = azurerm_mssql_database.test.id
   storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
-  monitor_enabled            = true
+  log_monitoring_enabled     = true
 }
 `, r.monitorTemplate(data), data.RandomInteger)
 }
@@ -513,8 +513,8 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
 }
 
 resource "azurerm_mssql_database_extended_auditing_policy" "test" {
-  database_id     = azurerm_mssql_database.test.id
-  monitor_enabled = true
+  database_id            = azurerm_mssql_database.test.id
+  log_monitoring_enabled = true
 }
 `, r.monitorTemplate(data), data.RandomInteger)
 }
@@ -558,7 +558,7 @@ resource "azurerm_mssql_database_extended_auditing_policy" "test" {
   database_id                = azurerm_mssql_database.test.id
   storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
-  monitor_enabled            = true
+  log_monitoring_enabled     = true
 }
 `, r.monitorTemplate(data), data.RandomInteger)
 }

--- a/azurerm/internal/services/mssql/mssql_database_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource_test.go
@@ -367,26 +367,69 @@ func TestAccMsSqlDatabase_withBlobAuditingPolices(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.withoutBlobAuditingPolices(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.withBlobAuditingPolices(data),
+			Config: r.withBlobAuditingPolicesForStorageAccount(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("extended_auditing_policy.0.storage_account_access_key"),
 		{
-			Config: r.withBlobAuditingPolicesUpdated(data),
+			Config: r.withBlobAuditingPolicesForStorageAccountUpdated(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("extended_auditing_policy.0.storage_account_access_key"),
+		{
+			Config: r.withBlobAuditingPolicesDisabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMsSqlDatabase_withBlobAuditingPolicesForMonitor(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
+	r := MsSqlDatabaseResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.withoutBlobAuditingPolices(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withBlobAuditingPolicesForStorageAccount(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("extended_auditing_policy.0.storage_account_access_key"),
+		{
+			Config: r.withBlobAuditingPolicesForLogAnalytics(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("extended_auditing_policy.0.storage_account_access_key"),
+		{
+			Config: r.withBlobAuditingPolicesForEventhub(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.withBlobAuditingPolicesDisabled(data),
 			Check: resource.ComposeTestCheckFunc(
@@ -952,7 +995,7 @@ resource "azurerm_mssql_database" "test" {
 `, r.template(data), data.RandomInteger, state)
 }
 
-func (r MsSqlDatabaseResource) withBlobAuditingPolices(data acceptance.TestData) string {
+func (r MsSqlDatabaseResource) withBlobAuditingPolicesTemplate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -972,8 +1015,57 @@ resource "azurerm_storage_account" "test2" {
   account_replication_type = "LRS"
 }
 
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctest-EHN-%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctest-EH-%[3]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "test" {
+  name                = "acctestEHRule"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  listen              = true
+  send                = true
+  manage              = true
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctest-LAW-%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+`, r.template(data), data.RandomIntOfLength(15), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseResource) withoutBlobAuditingPolices(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
 resource "azurerm_mssql_database" "test" {
-  name      = "acctest-db-%[3]d"
+  name      = "acctest-db-%[2]d"
+  server_id = azurerm_sql_server.test.id
+}
+`, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseResource) withBlobAuditingPolicesForStorageAccount(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[2]d"
   server_id = azurerm_sql_server.test.id
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.test.primary_blob_endpoint
@@ -982,31 +1074,15 @@ resource "azurerm_mssql_database" "test" {
     retention_in_days                       = 6
   }
 }
-`, r.template(data), data.RandomIntOfLength(15), data.RandomInteger)
+`, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)
 }
 
-func (r MsSqlDatabaseResource) withBlobAuditingPolicesUpdated(data acceptance.TestData) string {
+func (r MsSqlDatabaseResource) withBlobAuditingPolicesForStorageAccountUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "azurerm_storage_account" "test" {
-  name                     = "acctest%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_storage_account" "test2" {
-  name                     = "acctest2%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_mssql_database" "test" {
-  name      = "acctest-db-%[3]d"
+  name      = "acctest-db-%[2]d"
   server_id = azurerm_sql_server.test.id
   extended_auditing_policy {
     storage_endpoint                        = azurerm_storage_account.test2.primary_blob_endpoint
@@ -1015,35 +1091,104 @@ resource "azurerm_mssql_database" "test" {
     retention_in_days                       = 3
   }
 }
-`, r.template(data), data.RandomIntOfLength(15), data.RandomInteger)
+`, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)
 }
 
 func (r MsSqlDatabaseResource) withBlobAuditingPolicesDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "azurerm_storage_account" "test" {
-  name                     = "acctest%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_storage_account" "test2" {
-  name                     = "acctest2%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
 resource "azurerm_mssql_database" "test" {
   name                     = "acctest-db-%[3]d"
   server_id                = azurerm_sql_server.test.id
   extended_auditing_policy = []
 }
-`, r.template(data), data.RandomIntOfLength(15), data.RandomInteger)
+`, r.withBlobAuditingPolicesTemplate(data), data.RandomIntOfLength(15), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseResource) withBlobAuditingPolicesForLogAnalytics(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "acctest-DS-%[2]d"
+  target_resource_id         = azurerm_mssql_database.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+}
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[2]d"
+  server_id = azurerm_sql_server.test.id
+  extended_auditing_policy {
+    monitor_enabled = true
+  }
+}
+`, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseResource) withBlobAuditingPolicesForEventhub(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                           = "acctest-DS-%[2]d"
+  target_resource_id             = azurerm_mssql_database.test.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
+  eventhub_name                  = azurerm_eventhub.test.name
+
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+
+}
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[2]d"
+  server_id = azurerm_sql_server.test.id
+  extended_auditing_policy {
+    monitor_enabled = true
+  }
+}
+`, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)
 }
 
 func (r MsSqlDatabaseResource) updateSku(data acceptance.TestData) string {

--- a/azurerm/internal/services/mssql/mssql_database_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource_test.go
@@ -1141,7 +1141,7 @@ resource "azurerm_mssql_database" "test" {
   name      = "acctest-db-%[2]d"
   server_id = azurerm_sql_server.test.id
   extended_auditing_policy {
-    monitor_enabled = true
+    log_monitoring_enabled = true
   }
 }
 `, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)
@@ -1185,7 +1185,7 @@ resource "azurerm_mssql_database" "test" {
   name      = "acctest-db-%[2]d"
   server_id = azurerm_sql_server.test.id
   extended_auditing_policy {
-    monitor_enabled = true
+    log_monitoring_enabled = true
   }
 }
 `, r.withBlobAuditingPolicesTemplate(data), data.RandomInteger)

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -47,7 +47,7 @@ func resourceMsSqlServerExtendedAuditingPolicy() *schema.Resource {
 
 			"storage_endpoint": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ValidateFunc: validation.IsURLWithHTTPS,
 			},
 
@@ -69,6 +69,12 @@ func resourceMsSqlServerExtendedAuditingPolicy() *schema.Resource {
 				Optional:     true,
 				Default:      0,
 				ValidateFunc: validation.IntBetween(0, 3285),
+			},
+
+			"monitor_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
 			},
 		},
 	}
@@ -102,14 +108,11 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *schema.ResourceDat
 
 	params := sql.ExtendedServerBlobAuditingPolicy{
 		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
-			State:                      sql.BlobAuditingPolicyStateEnabled,
-			StorageEndpoint:            utils.String(d.Get("storage_endpoint").(string)),
-			IsStorageSecondaryKeyInUse: utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
-			RetentionDays:              utils.Int32(int32(d.Get("retention_in_days").(int))),
-
-			// NOTE: this works around a regression in the Azure API detailed here:
-			// https://github.com/Azure/azure-rest-api-specs/issues/11271
-			IsAzureMonitorTargetEnabled: utils.Bool(true),
+			State:                       sql.BlobAuditingPolicyStateEnabled,
+			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
+			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("monitor_enabled").(bool)),
 		},
 	}
 
@@ -171,6 +174,7 @@ func resourceMsSqlServerExtendedAuditingPolicyRead(d *schema.ResourceData, meta 
 		d.Set("storage_endpoint", props.StorageEndpoint)
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
+		d.Set("monitor_enabled", props.IsAzureMonitorTargetEnabled)
 	}
 
 	return nil
@@ -189,10 +193,6 @@ func resourceMsSqlServerExtendedAuditingPolicyDelete(d *schema.ResourceData, met
 	params := sql.ExtendedServerBlobAuditingPolicy{
 		ExtendedServerBlobAuditingPolicyProperties: &sql.ExtendedServerBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
-
-			// NOTE: this works around a regression in the Azure API detailed here:
-			// https://github.com/Azure/azure-rest-api-specs/issues/11271
-			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		},
 	}
 

--- a/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -71,7 +71,7 @@ func resourceMsSqlServerExtendedAuditingPolicy() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 3285),
 			},
 
-			"monitor_enabled": {
+			"log_monitoring_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -112,7 +112,7 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *schema.ResourceDat
 			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
 			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
 			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("monitor_enabled").(bool)),
+			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
@@ -174,7 +174,7 @@ func resourceMsSqlServerExtendedAuditingPolicyRead(d *schema.ResourceData, meta 
 		d.Set("storage_endpoint", props.StorageEndpoint)
 		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
 		d.Set("retention_in_days", props.RetentionDays)
-		d.Set("monitor_enabled", props.IsAzureMonitorTargetEnabled)
+		d.Set("log_monitoring_enabled", props.IsAzureMonitorTargetEnabled)
 	}
 
 	return nil

--- a/azurerm/internal/services/sql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/sql/helper/sql_extended_auditing.go
@@ -19,14 +19,14 @@ func ExtendedAuditingSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"storage_account_access_key": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
 				"storage_endpoint": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
 					ValidateFunc: validation.IsURLWithHTTPS,
 				},
 
@@ -40,6 +40,12 @@ func ExtendedAuditingSchema() *schema.Schema {
 					Optional:     true,
 					ValidateFunc: validation.IntBetween(0, 3285),
 				},
+
+				"monitor_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  true,
+				},
 			},
 		},
 	}
@@ -49,18 +55,15 @@ func ExpandAzureRmSqlServerBlobAuditingPolicies(input []interface{}) *sql.Extend
 	if len(input) == 0 {
 		return &sql.ExtendedServerBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
-
-			// NOTE: this works around a regression in the Azure API detailed here:
-			// https://github.com/Azure/azure-rest-api-specs/issues/11271
-			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	serverBlobAuditingPolicies := input[0].(map[string]interface{})
 
 	ExtendedServerBlobAuditingPolicyProperties := sql.ExtendedServerBlobAuditingPolicyProperties{
-		State:                   sql.BlobAuditingPolicyStateEnabled,
-		StorageAccountAccessKey: utils.String(serverBlobAuditingPolicies["storage_account_access_key"].(string)),
-		StorageEndpoint:         utils.String(serverBlobAuditingPolicies["storage_endpoint"].(string)),
+		State:                       sql.BlobAuditingPolicyStateEnabled,
+		StorageAccountAccessKey:     utils.String(serverBlobAuditingPolicies["storage_account_access_key"].(string)),
+		StorageEndpoint:             utils.String(serverBlobAuditingPolicies["storage_endpoint"].(string)),
+		IsAzureMonitorTargetEnabled: utils.Bool(serverBlobAuditingPolicies["monitor_enabled"].(bool)),
 	}
 	if v, ok := serverBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
 		ExtendedServerBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
@@ -93,6 +96,10 @@ func FlattenAzureRmSqlServerBlobAuditingPolicies(extendedServerBlobAuditingPolic
 	if extendedServerBlobAuditingPolicy.RetentionDays != nil {
 		retentionDays = *extendedServerBlobAuditingPolicy.RetentionDays
 	}
+	var monitor bool
+	if extendedServerBlobAuditingPolicy.IsAzureMonitorTargetEnabled != nil {
+		monitor = *extendedServerBlobAuditingPolicy.IsAzureMonitorTargetEnabled
+	}
 
 	return []interface{}{
 		map[string]interface{}{
@@ -100,6 +107,7 @@ func FlattenAzureRmSqlServerBlobAuditingPolicies(extendedServerBlobAuditingPolic
 			"storage_endpoint":                        storageEndpoint,
 			"storage_account_access_key_is_secondary": secondKeyInUse,
 			"retention_in_days":                       retentionDays,
+			"monitor_enabled":                         monitor,
 		},
 	}
 }
@@ -108,18 +116,15 @@ func ExpandAzureRmSqlDBBlobAuditingPolicies(input []interface{}) *sql.ExtendedDa
 	if len(input) == 0 {
 		return &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
 			State: sql.BlobAuditingPolicyStateDisabled,
-
-			// NOTE: this works around a regression in the Azure API detailed here:
-			// https://github.com/Azure/azure-rest-api-specs/issues/11271
-			IsAzureMonitorTargetEnabled: utils.Bool(true),
 		}
 	}
 	dbBlobAuditingPolicies := input[0].(map[string]interface{})
 
 	ExtendedDatabaseBlobAuditingPolicyProperties := sql.ExtendedDatabaseBlobAuditingPolicyProperties{
-		State:                   sql.BlobAuditingPolicyStateEnabled,
-		StorageAccountAccessKey: utils.String(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
-		StorageEndpoint:         utils.String(dbBlobAuditingPolicies["storage_endpoint"].(string)),
+		State:                       sql.BlobAuditingPolicyStateEnabled,
+		StorageAccountAccessKey:     utils.String(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
+		StorageEndpoint:             utils.String(dbBlobAuditingPolicies["storage_endpoint"].(string)),
+		IsAzureMonitorTargetEnabled: utils.Bool(dbBlobAuditingPolicies["monitor_enabled"].(bool)),
 	}
 	if v, ok := dbBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
 		ExtendedDatabaseBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
@@ -152,6 +157,10 @@ func FlattenAzureRmSqlDBBlobAuditingPolicies(extendedDatabaseBlobAuditingPolicy 
 	if extendedDatabaseBlobAuditingPolicy.RetentionDays != nil {
 		retentionDays = *extendedDatabaseBlobAuditingPolicy.RetentionDays
 	}
+	var monitor bool
+	if extendedDatabaseBlobAuditingPolicy.IsAzureMonitorTargetEnabled != nil {
+		monitor = *extendedDatabaseBlobAuditingPolicy.IsAzureMonitorTargetEnabled
+	}
 
 	return []interface{}{
 		map[string]interface{}{
@@ -159,6 +168,7 @@ func FlattenAzureRmSqlDBBlobAuditingPolicies(extendedDatabaseBlobAuditingPolicy 
 			"storage_endpoint":                        storageEndpoint,
 			"storage_account_access_key_is_secondary": secondKeyInUse,
 			"retention_in_days":                       retentionDays,
+			"monitor_enabled":                         monitor,
 		},
 	}
 }

--- a/examples/sql-azure/sql_auditing_eventhub/main.tf
+++ b/examples/sql-azure/sql_auditing_eventhub/main.tf
@@ -71,7 +71,6 @@ resource "azurerm_monitor_diagnostic_setting" "example" {
   lifecycle {
     ignore_changes = [log, metric]
   }
-
 }
 
 resource "azurerm_mssql_database_extended_auditing_policy" "example" {

--- a/examples/sql-azure/sql_auditing_eventhub/main.tf
+++ b/examples/sql-azure/sql_auditing_eventhub/main.tf
@@ -1,0 +1,85 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_mssql_server" "example" {
+  name                         = "${var.prefix}-server-primary"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = var.location
+  version                      = "12.0"
+  administrator_login          = "mradministrator"
+  administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_mssql_database" "example" {
+  name      = "${var.prefix}-db-primary"
+  server_id = azurerm_mssql_server.example.id
+}
+
+resource "azurerm_eventhub_namespace" "example" {
+  name                = "${var.prefix}-EHN"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_eventhub" "example" {
+  name                = "${var.prefix}-EH"
+  namespace_name      = azurerm_eventhub_namespace.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "example" {
+  name                = "${var.prefix}EHRule"
+  namespace_name      = azurerm_eventhub_namespace.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  listen              = true
+  send                = true
+  manage              = true
+}
+
+resource "azurerm_monitor_diagnostic_setting" "example" {
+  name                           = "${var.prefix}-DS"
+  target_resource_id             = azurerm_mssql_database.example.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.example.id
+  eventhub_name                  = azurerm_eventhub.example.name
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "example" {
+  database_id     = azurerm_mssql_database.example.id
+  monitor_enabled = true
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "example" {
+  server_id       = azurerm_mssql_server.example.id
+  monitor_enabled = true
+}

--- a/examples/sql-azure/sql_auditing_eventhub/variables.tf
+++ b/examples/sql-azure/sql_auditing_eventhub/variables.tf
@@ -1,0 +1,7 @@
+variable "location" {
+  description = "The Azure location where the primary resources in this example should be created."
+}
+
+variable "prefix" {
+  description = "The prefix used for all resources created as a part of this example"
+}

--- a/examples/sql-azure/sql_auditing_log_analytics/main.tf
+++ b/examples/sql-azure/sql_auditing_log_analytics/main.tf
@@ -1,0 +1,67 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_mssql_server" "example" {
+  name                         = "${var.prefix}-server-primary"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = var.location
+  version                      = "12.0"
+  administrator_login          = "mradministrator"
+  administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_mssql_database" "example" {
+  name      = "${var.prefix}-db-primary"
+  server_id = azurerm_mssql_server.example.id
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "${var.prefix}-LAW"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_monitor_diagnostic_setting" "example" {
+  name                       = "${var.prefix}-DS"
+  target_resource_id         = azurerm_mssql_database.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  log {
+    category = "SQLSecurityAuditEvents"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [log, metric]
+  }
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "example" {
+  database_id     = azurerm_mssql_database.example.id
+  monitor_enabled = true
+}
+
+resource "azurerm_mssql_server_extended_auditing_policy" "example" {
+  server_id       = azurerm_mssql_server.example.id
+  monitor_enabled = true
+}

--- a/examples/sql-azure/sql_auditing_log_analytics/variables.tf
+++ b/examples/sql-azure/sql_auditing_log_analytics/variables.tf
@@ -1,0 +1,7 @@
+variable "location" {
+  description = "The Azure location where the primary resources in this example should be created."
+}
+
+variable "prefix" {
+  description = "The prefix used for all resources created as a part of this example"
+}

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -138,10 +138,11 @@ a `threat_detection_policy` block supports the following:
 
 A `extended_auditing_policy` block supports the following:
 
-* `storage_account_access_key` - (Required)  Specifies the access key to use for the auditing storage account.
-* `storage_endpoint` - (Required) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
+* `storage_account_access_key` - (Optional)  Specifies the access key to use for the auditing storage account.
+* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
 * `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
+* `monitor_enabled` - (Optional) Enable audit events to Azure Monitor? To enable audit events to Log Analytics, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_log_analytics` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/sql-azure/sql_auditing_log_analytics). To enable audit events to Eventhub, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_eventhub` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/sql-azure/sql_auditing_eventhub). 
 
 ---
 

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -61,15 +61,16 @@ The following arguments are supported:
 
 * `database_id` - (Required) The ID of the sql database to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `storage_endpoint` - (Required) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
-
----
+* `storage_endpoint` - (Optional) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
 
 * `retention_in_days` - (Optional) The number of days to retain logs for in the storage account.
 
 * `storage_account_access_key` - (Optional) The access key to use for the auditing storage account.
 
 * `storage_account_access_key_is_secondary` - (Optional) Is `storage_account_access_key` value the storage's secondary key?
+
+* `monitor_enabled` - (Optional) Enable audit events to Azure Monitor? To enable audit events to Log Analytics, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_log_analytics` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/sql-azure/sql_auditing_log_analytics). To enable audit events to Eventhub, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_eventhub` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/sql-azure/sql_auditing_eventhub). 
+
 
 ## Attributes Reference
 

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -130,13 +130,15 @@ An `azuread_administrator` block supports the following:
 
 An `extended_auditing_policy` block supports the following:
 
-* `storage_account_access_key` - (Required)  Specifies the access key to use for the auditing storage account.
+* `storage_account_access_key` - (Optional)  Specifies the access key to use for the auditing storage account.
 
-* `storage_endpoint` - (Required) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
+* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
 
 * `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
 
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
+
+* `monitor_enabled` - (Optional) Enable audit events to Azure Monitor? To enable server audit events to Azure Monitor, please enable its master database audit events to Azure Monitor.
 
 ### Timeouts
 

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -56,15 +56,15 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the sql server to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `storage_endpoint` - (Required) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
-
----
+* `storage_endpoint` - (Optional) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
 
 * `retention_in_days` - (Optional) The number of days to retain logs for in the storage account.
 
 * `storage_account_access_key` - (Optional) The access key to use for the auditing storage account.
 
 * `storage_account_access_key_is_secondary` - (Optional) Is `storage_account_access_key` value the storage's secondary key?
+
+* `monitor_enabled` - (Optional) Enable audit events to Azure Monitor? To enable server audit events to Azure Monitor, please enable its master database audit events to Azure Monitor.
 
 ## Attributes Reference
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -132,10 +132,11 @@ The following arguments are supported:
 
 A `extended_auditing_policy` block supports the following:
 
-* `storage_account_access_key` - (Required)  Specifies the access key to use for the auditing storage account.
-* `storage_endpoint` - (Required) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
+* `storage_account_access_key` - (Optional)  Specifies the access key to use for the auditing storage account.
+* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
 * `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
+* `monitor_enabled` - (Optional) Enable audit events to Azure Monitor? To enable audit events to Log Analytics, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_log_analytics` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/sql-azure/sql_auditing_log_analytics). To enable audit events to Eventhub, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_eventhub` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/sql-azure/sql_auditing_eventhub). 
 
 ## Attributes Reference
 

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -103,13 +103,15 @@ The following attributes are exported:
 
 A `extended_auditing_policy` block supports the following:
 
-* `storage_account_access_key` - (Required)  Specifies the access key to use for the auditing storage account.
+* `storage_account_access_key` - (Optional)  Specifies the access key to use for the auditing storage account.
 
-* `storage_endpoint` - (Required) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
+* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net).
 
 * `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
 
 * `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
+
+* `monitor_enabled` - (Optional) Enable audit events to Azure Monitor? To enable server audit events to Azure Monitor, please enable its master database audit events to Azure Monitor.
 
 ### Timeouts
 


### PR DESCRIPTION
Fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7695
https://github.com/terraform-providers/terraform-provider-azurerm/issues/10100
https://github.com/terraform-providers/terraform-provider-azurerm/issues/6849


=== RUN   TestAccMsSqlDatabaseExtendedAuditingPolicy_basic
=== PAUSE TestAccMsSqlDatabaseExtendedAuditingPolicy_basic
=== CONT  TestAccMsSqlDatabaseExtendedAuditingPolicy_basic
--- PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_basic (358.57s)
=== RUN   TestAccMsSqlDatabaseExtendedAuditingPolicy_requiresImport
=== PAUSE TestAccMsSqlDatabaseExtendedAuditingPolicy_requiresImport
=== CONT  TestAccMsSqlDatabaseExtendedAuditingPolicy_requiresImport
--- PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_requiresImport (391.47s)
=== RUN   TestAccMsSqlDatabaseExtendedAuditingPolicy_complete
=== PAUSE TestAccMsSqlDatabaseExtendedAuditingPolicy_complete
=== CONT  TestAccMsSqlDatabaseExtendedAuditingPolicy_complete
--- PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_complete (422.68s)
=== RUN   TestAccMsSqlDatabaseExtendedAuditingPolicy_update
=== PAUSE TestAccMsSqlDatabaseExtendedAuditingPolicy_update
=== CONT  TestAccMsSqlDatabaseExtendedAuditingPolicy_update
--- PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_update (547.36s)
=== RUN   TestAccMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall
=== PAUSE TestAccMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall
=== CONT  TestAccMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall
--- PASS: TestAccMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall (354.62s)

=== RUN   TestAccMsSqlDatabase_withBlobAuditingPolices
=== PAUSE TestAccMsSqlDatabase_withBlobAuditingPolices
=== CONT  TestAccMsSqlDatabase_withBlobAuditingPolices
--- PASS: TestAccMsSqlDatabase_withBlobAuditingPolices (564.62s)
=== RUN   TestAccMsSqlDatabase_withBlobAuditingPolicesForMonitor
=== PAUSE TestAccMsSqlDatabase_withBlobAuditingPolicesForMonitor
=== CONT  TestAccMsSqlDatabase_withBlobAuditingPolicesForMonitor
--- PASS: TestAccMsSqlDatabase_withBlobAuditingPolicesForMonitor (803.68s)

All regression tests have passed.

