### PR TITLE
azurerm_api_management_diagnostic add additional options, fix log_client_ip

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -185,7 +185,7 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, meta
 		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
-	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists {
+	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists { //nolint:SA1019
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -185,8 +185,7 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, meta
 		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
-	logClientIP, _ := d.GetOk("log_client_ip")
-	if logClientIP != nil {
+	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists {
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -182,14 +182,7 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, meta
 	}
 
 	if verbosity, ok := d.GetOk("verbosity"); ok {
-		switch verbosity.(string) {
-		case string(apimanagement.Verbose):
-			parameters.Verbosity = apimanagement.Verbose
-		case string(apimanagement.Information):
-			parameters.Verbosity = apimanagement.Information
-		case string(apimanagement.Error):
-			parameters.Verbosity = apimanagement.Error
-		}
+		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
 	logClientIP, _ := d.GetOk("log_client_ip")
@@ -198,14 +191,7 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, meta
 	}
 
 	if httpCorrelationProtocol, ok := d.GetOk("http_correlation_protocol"); ok {
-		switch httpCorrelationProtocol.(string) {
-		case string(apimanagement.HTTPCorrelationProtocolNone):
-			parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocolNone
-		case string(apimanagement.HTTPCorrelationProtocolLegacy):
-			parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocolLegacy
-		case string(apimanagement.HTTPCorrelationProtocolW3C):
-			parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocolW3C
-		}
+		parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocol(httpCorrelationProtocol.(string))
 	}
 
 	frontendRequest, frontendRequestSet := d.GetOk("frontend_request")

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -192,7 +192,8 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, meta
 		}
 	}
 
-	if logClientIP, ok := d.GetOk("log_client_ip"); ok {
+	logClientIP, _ := d.GetOk("log_client_ip")
+	if logClientIP != nil {
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -161,7 +161,7 @@ func resourceApiManagementDiagnosticCreateUpdate(d *schema.ResourceData, meta in
 		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
-	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists {
+	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists { //nolint:SA1019
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -158,14 +158,7 @@ func resourceApiManagementDiagnosticCreateUpdate(d *schema.ResourceData, meta in
 	}
 
 	if verbosity, ok := d.GetOk("verbosity"); ok {
-		switch verbosity.(string) {
-		case string(apimanagement.Verbose):
-			parameters.Verbosity = apimanagement.Verbose
-		case string(apimanagement.Information):
-			parameters.Verbosity = apimanagement.Information
-		case string(apimanagement.Error):
-			parameters.Verbosity = apimanagement.Error
-		}
+		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
 	logClientIP, _ := d.GetOk("log_client_ip")
@@ -174,14 +167,7 @@ func resourceApiManagementDiagnosticCreateUpdate(d *schema.ResourceData, meta in
 	}
 
 	if httpCorrelationProtocol, ok := d.GetOk("http_correlation_protocol"); ok {
-		switch httpCorrelationProtocol.(string) {
-		case string(apimanagement.HTTPCorrelationProtocolNone):
-			parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocolNone
-		case string(apimanagement.HTTPCorrelationProtocolLegacy):
-			parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocolLegacy
-		case string(apimanagement.HTTPCorrelationProtocolW3C):
-			parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocolW3C
-		}
+		parameters.HTTPCorrelationProtocol = apimanagement.HTTPCorrelationProtocol(httpCorrelationProtocol.(string))
 	}
 
 	frontendRequest, frontendRequestSet := d.GetOk("frontend_request")

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -168,7 +168,8 @@ func resourceApiManagementDiagnosticCreateUpdate(d *schema.ResourceData, meta in
 		}
 	}
 
-	if logClientIP, ok := d.GetOk("log_client_ip"); ok {
+	logClientIP, _ := d.GetOk("log_client_ip")
+	if logClientIP != nil {
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -161,8 +161,7 @@ func resourceApiManagementDiagnosticCreateUpdate(d *schema.ResourceData, meta in
 		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
-	logClientIP, _ := d.GetOk("log_client_ip")
-	if logClientIP != nil {
+	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists {
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource_test.go
@@ -71,7 +71,7 @@ func TestAccApiManagementDiagnostic_requiresImport(t *testing.T) {
 
 func TestAccApiManagementDiagnostic_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_diagnostic", "test")
-	r := ApiManagementApiDiagnosticResource{}
+	r := ApiManagementDiagnosticResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{

--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -52,6 +52,48 @@ resource "azurerm_api_management_diagnostic" "example" {
   resource_group_name      = azurerm_resource_group.example.name
   api_management_name      = azurerm_api_management.example.name
   api_management_logger_id = azurerm_api_management_logger.example.id
+
+  sampling_percentage       = 5.0
+  always_log_errors         = true
+  log_client_ip             = true
+  verbosity                 = "Verbose"
+  http_correlation_protocol = "W3C"
+
+  frontend_request {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "accept",
+      "origin",
+    ]
+  }
+
+  frontend_response {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "content-length",
+      "origin",
+    ]
+  }
+
+  backend_request {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "accept",
+      "origin",
+    ]
+  }
+
+  backend_response {
+    body_bytes = 32
+    headers_to_log = [
+      "content-type",
+      "content-length",
+      "origin",
+    ]
+  }
 }
 ```
 
@@ -68,6 +110,33 @@ The following arguments are supported:
 * `api_management_logger_id` - (Required) The id of the target API Management Logger where the API Management Diagnostic should be saved.
 
 ---
+
+
+* `always_log_errors` - (Optional) Always log errors. Send telemetry if there is an erroneous condition, regardless of sampling settings.
+
+* `backend_request` - (Optional) A `backend_request` block as defined below.
+
+* `backend_response` - (Optional) A `backend_response` block as defined below.
+
+* `frontend_request` - (Optional) A `frontend_request` block as defined below.
+
+* `frontend_response` - (Optional) A `frontend_response` block as defined below.
+
+* `http_correlation_protocol` - (Optional) The HTTP Correlation Protocol to use. Possible values are `None`, `Legacy` or `W3C`.
+
+* `log_client_ip` - (Optional) Log client IP address.
+
+* `sampling_percentage` - (Optional) Sampling (%). For high traffic APIs, please read this [documentation](https://docs.microsoft.com/azure/api-management/api-management-howto-app-insights#performance-implications-and-log-sampling) to understand performance implications and log sampling. Valid values are between `0.0` and `100.0`.
+
+* `verbosity` - (Optional) Logging verbosity. Possible values are `verbose`, `information` or `error`.
+
+---
+
+A `backend_request`, `backend_response`, `frontend_request` or `frontend_response` block supports the following:
+
+* `body_bytes` - (Optional) Number of payload bytes to log (up to 8192).
+
+* `headers_to_log` - (Optional) Specifies a list of headers to log.
 
 ## Attributes Reference
 


### PR DESCRIPTION
_This looks larger then it is._

Fixes the remaining request in #9196 by adding additional options to `azurerm_api_management_diagnostic`. The heavy lifting was done by recent PRs for `azure_api_management_api_diagnostic` as the Go SDK uses the same struct for both diagnostics [apimangement.DiagnosticContract](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement?utm_source=gopls#DiagnosticContract). This allowed the code to be completely reused.

Fixes #10322 which was found while testing this PR. Update to only checking if the input variable is nil as the `ok` value from `GetOk` does a Zero check which fails to work correctly with a Boolean variable. There could be some other ramifications of this I'm not aware of but I couldn't find a test case for this resource that was an issue.

**question (non-blocking):** the new options to `azurerm_api_management_diagnostic` reuse the functions `expandApiManagementApiDiagnosticHTTPMessageDiagnostic` and `flattenApiManagementApiDiagnosticHTTPMessageDiagnostic` should I rename these? I didn't because I wasn't sure it mattered.