### PR TITLE
[Docs]`function_app` Regional VNet Integration

### DIFF
--- a/azurerm/internal/services/web/app_service_virtual_network_swift_connection_resource_test.go
+++ b/azurerm/internal/services/web/app_service_virtual_network_swift_connection_resource_test.go
@@ -120,6 +120,22 @@ func (t AppServiceVirtualNetworkSwiftConnectionResource) disappears(ctx context.
 	return nil
 }
 
+func TestAccAppServiceVirtualNetworkSwiftConnection_functionAppBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_virtual_network_swift_connection", "test")
+	r := AppServiceVirtualNetworkSwiftConnectionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.functionAppBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("subnet_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (AppServiceVirtualNetworkSwiftConnectionResource) base(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -227,4 +243,76 @@ resource "azurerm_app_service_virtual_network_swift_connection" "import" {
   subnet_id      = azurerm_app_service_virtual_network_swift_connection.test.subnet_id
 }
 `, template)
+}
+
+func (AppServiceVirtualNetworkSwiftConnectionResource) functionAppBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appservice-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-VNET-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  lifecycle {
+    ignore_changes = [ddos_protection_plan]
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.1.0/24"
+
+  delegation {
+    name = "acctestdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest-ASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                       = "acctest-FA-%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+}
+
+resource "azurerm_app_service_virtual_network_swift_connection" "test" {
+  app_service_id = azurerm_function_app.test.id
+  subnet_id      = azurerm_subnet.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
+++ b/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
@@ -13,6 +13,9 @@ Manages an App Service Virtual Network Association (this is for the [Regional VN
 
 ~> **Note:** This resource can be used for both `azurerm_app_service` and `azurerm_function_app`.
 
+~> **Note:** There is a hard limit of [one VNet integration per App Service Plan](https://docs.microsoft.com/en-us/azure/app-service/web-sites-integrate-with-vnet#regional-vnet-integration). 
+Multiple apps in the same App Service plan can use the same VNet.
+
 ## Example Usage (with App Service)
 
 ```hcl

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -11,6 +11,9 @@ description: |-
 
 Manages a Function App.
 
+~> **Note:** To connect an Azure Function App and a subnet within the same region `azurerm_app_service_virtual_network_swift_connection` can be used.
+For an example, check the `azurerm_app_service_virtual_network_swift_connection` documentation.
+
 ## Example Usage (with App Service Plan)
 
 ```hcl


### PR DESCRIPTION
Fixes #1460.

- Regional VNet integration example on `azurerm_app_service_virtual_network_swift_connection`
- Docs mentioning the ability to use `azurerm_app_service_virtual_network_swift_connection` with `azure_function_app`
  - on `azurerm_function_app` 
  - on `azurerm_app_service_virtual_network_swift_connection` resource itself
- AccTest using `azurerm_function_app` and `azurerm_app_service_virtual_network_swift_connection`
- Removal of preview
- > One Regional VNet Integration per App Service Plan