### PR TITLE
tc: updating the default version of tf to 0.14.4

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -5,7 +5,7 @@ var defaultStartHour = 0
 var defaultParallelism = 20
 
 // specifies the default version of Terraform Core which should be used for testing
-var defaultTerraformCoreVersion = "0.12.28"
+var defaultTerraformCoreVersion = "0.14.5"
 
 var locations = mapOf(
         "public" to LocationConfiguration("westeurope", "eastus2", "francecentral", false),


### PR DESCRIPTION
This won't take effect until binary testing is enabled but there's no harm in staying up to date here