### PR TITLE
r/azurerm_servicebus_namespace - Allowed setting messaging units capacity to 16 for Premium SKU

### DIFF
--- a/azurerm/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/azurerm/internal/services/servicebus/servicebus_namespace_resource.go
@@ -78,7 +78,7 @@ func resourceServiceBusNamespace() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      0,
-				ValidateFunc: validation.IntInSlice([]int{0, 1, 2, 4, 8}),
+				ValidateFunc: validation.IntInSlice([]int{0, 1, 2, 4, 8, 16}),
 			},
 
 			"default_primary_connection_string": {
@@ -159,7 +159,7 @@ func resourceServiceBusNamespaceCreateUpdate(d *schema.ResourceData, meta interf
 			return fmt.Errorf("Service Bus SKU %q only supports `capacity` of 0", sku)
 		}
 		if strings.EqualFold(sku, string(servicebus.Premium)) && capacity.(int) == 0 {
-			return fmt.Errorf("Service Bus SKU %q only supports `capacity` of 1, 2, 4 or 8", sku)
+			return fmt.Errorf("Service Bus SKU %q only supports `capacity` of 1, 2, 4, 8 or 16", sku)
 		}
 		parameters.Sku.Capacity = utils.Int32(int32(capacity.(int)))
 	}

--- a/azurerm/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/azurerm/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -120,7 +120,7 @@ func TestAccAzureRMServiceBusNamespace_premiumCapacity(t *testing.T) {
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config:      r.premiumCapacity(data),
-			ExpectError: regexp.MustCompile("Service Bus SKU \"Premium\" only supports `capacity` of 1, 2, 4 or 8"),
+			ExpectError: regexp.MustCompile("Service Bus SKU \"Premium\" only supports `capacity` of 1, 2, 4, 8 or 16"),
 		},
 	})
 }

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `sku` - (Required) Defines which tier to use. Options are basic, standard or premium. Changing this forces a new resource to be created.
 
-* `capacity` - (Optional) Specifies the capacity. When `sku` is `Premium`, capacity can be `1`, `2`, `4` or `8`. When `sku` is `Basic` or `Standard`, capacity can be `0` only.
+* `capacity` - (Optional) Specifies the capacity. When `sku` is `Premium`, capacity can be `1`, `2`, `4`, `8` or `16`. When `sku` is `Basic` or `Standard`, capacity can be `0` only.
 
 * `zone_redundant` - (Optional) Whether or not this resource is zone redundant. `sku` needs to be `Premium`. Defaults to `false`.
 


### PR DESCRIPTION
Allowed the `azurerm_servicebus_namespace` resource to support the capacity of 16 for the number of messaging units to be set when using the Premium SKU.

![Screenshot 2021-01-27 at 17 41 03](https://user-images.githubusercontent.com/264361/106031587-5d006f00-60c7-11eb-822a-ef8afe47cc60.png)

Microsoft documentation (https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging) only shows support for a capacity of up to 8, but we have been able to request 16 due to high levels of throttling at 8. Microsoft has confirmed going up to 16 is not possible in the portal, but customers can request it via a support ticket. This change is essential for us as Terraform wants to keep reverting our capacity back to 8:

```
------------------------------------------------------------------------
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
Terraform will perform the following actions:
  # azurerm_servicebus_namespace.servicebusNameSpace[0] will be updated in-place
  ~ resource "azurerm_servicebus_namespace" "servicebusNameSpace" {
      ~ capacity                            = 16 -> 8
        default_primary_connection_string   = (sensitive value)
        default_primary_key                 = (sensitive value)
        default_secondary_connection_string = (sensitive value)
        default_secondary_key               = (sensitive value)
        id                                  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/prdsbrg/providers/Microsoft.ServiceBus/namespaces/prdsb"
        location                            = "canadaeast"
        name                                = "prdsb"
        resource_group_name                 = "prdsbrg"
        sku                                 = "premium"
        tags                                = {}
        zone_redundant                      = false
    }
Plan: 0 to add, 1 to change, 0 to destroy.
```

But when we cannot enforce 16 in config due to validation rules within the provider, which this PR now addresses:

```
Error: expected capacity to be one of [0 1 2 4 8], got 16
  on ../../modules/resources/paas/serviceBus/nameSpace.tf line 1, in resource "azurerm_servicebus_namespace" "servicebusNameSpace":
   1: resource "azurerm_servicebus_namespace" "servicebusNameSpace" {
```
