### PR TITLE
`azurerm_iot_time_series_insights_reference_data_set` - Add `ForceNew` to `key_property` and `data_string_comparison_behavior`

### DIFF
--- a/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_reference_data_set_resource.go
+++ b/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_reference_data_set_resource.go
@@ -59,6 +59,7 @@ func resourceIoTTimeSeriesInsightsReferenceDataSet() *schema.Resource {
 			"data_string_comparison_behavior": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  string(timeseriesinsights.Ordinal),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(timeseriesinsights.Ordinal),
@@ -69,16 +70,19 @@ func resourceIoTTimeSeriesInsightsReferenceDataSet() *schema.Resource {
 			"key_property": {
 				Type:     schema.TypeSet,
 				Required: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(timeseriesinsights.ReferenceDataKeyPropertyTypeBool),
 								string(timeseriesinsights.ReferenceDataKeyPropertyTypeDateTime),

--- a/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_reference_data_set_resource_test.go
+++ b/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_reference_data_set_resource_test.go
@@ -131,11 +131,6 @@ resource "azurerm_iot_time_series_insights_reference_data_set" "test" {
     type = "String"
   }
 
-  key_property {
-    name = "keyProperty2"
-    type = "Bool"
-  }
-
   tags = {
     Environment = "Production"
   }

--- a/website/docs/r/iot_time_series_insights_reference_data_set.html.markdown
+++ b/website/docs/r/iot_time_series_insights_reference_data_set.html.markdown
@@ -46,9 +46,9 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `data_string_comparison_behavior` - (Optional) The comparison behavior that will be used to compare keys. Valid values include `Ordinal` and `OrdinalIgnoreCase`. Defaults to `Ordinal`.
+* `data_string_comparison_behavior` - (Optional) The comparison behavior that will be used to compare keys. Valid values include `Ordinal` and `OrdinalIgnoreCase`. Defaults to `Ordinal`. Changing this forces a new resource to be created.
 
-* `key_property` - (Optional) A `key_property` block as defined below.
+* `key_property` - (Optional) A `key_property` block as defined below. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -56,9 +56,9 @@ The following arguments are supported:
 
 A `key_property` block supports the following:
 
-* `name`- (Required) The name of the key property.
+* `name`- (Required) The name of the key property. Changing this forces a new resource to be created.
 
-* `type` - (Required) The data type of the key property. Valid values include `Bool`, `DateTime`, `Double`, `String`.
+* `type` - (Required) The data type of the key property. Valid values include `Bool`, `DateTime`, `Double`, `String`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes `TestAccIoTTimeSeriesInsightsReferenceDataSet_update`

```
--- PASS: TestAccIoTTimeSeriesInsightsReferenceDataSet_update (285.17s)
```