### PR TITLE
Resolves issue 10346 - acctests failing on Recoveryservices

### DIFF
--- a/azurerm/internal/services/recoveryservices/backup_policy_vm_resource_test.go
+++ b/azurerm/internal/services/recoveryservices/backup_policy_vm_resource_test.go
@@ -347,7 +347,7 @@ resource "azurerm_backup_policy_vm" "import" {
     count = 10
   }
 }
-`, r.template(data))
+`, r.basicDaily(data))
 }
 
 func (r BackupProtectionPolicyVMResource) basicWeekly(data acceptance.TestData) string {


### PR DESCRIPTION
See issue [10346](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10346).
See [errors gist](https://gist.github.com/MitchDrage/c4dfcc2bb095ae287719d464c8c3ff97)
This resolves two issues in running acctests against RecoveryServices. Some other test failures are mentioned in the linked issue, however are caused by dangling resources from the below tests.

1. --- FAIL: TestAccBackupProtectionPolicyVM_requiresImport
- This test is failing due to a missing 'azurerm_backup_policy_vm' 'test' resource.
- The test config in 'requiresImport' and the inherited config 'template' doesn't include a resource 'azurerm_backup_policy_vm' 'test', however basicDaily does.
- Changing 'requiresImport' to reference 'basicDaily' instead of 'template' resolves the issue (basicDaily inherits from template anyway, and appears not to have any other purpose).
- Result: --- PASS: TestAccRecoveryServicesVault_requiresImport (143.37s)


2. --- FAIL: TestAccBackupProtectedVm_updateBackupPolicyId
- Failure in test step 0 is due to a duplicate VM resource between the 'withVM' and 'base'. Removing 'withVM' and getting the VM config from 'withSecondPolicy' resolves the issue.
- Failure in test step 1 also used the 'withVM' config. Moving this one to 'withSecondPolicy' also resolves this issue.
- Step 2 is a step to revert the policy in step 1, so moving the config from 'withVM' to 'withSecondPolicy' removes the dependency on 'withVM' and resolves the 3rd issue.
- The resource '"azurerm_backup_policy_vm" "test"' within 'withFirstPolicy' is also created in 'base' so throws a duplicate resource error. Removing 'withFirstPolicy' resolves the issue - it is redundant as best I can tell since all of it's resources are in 'base'.
- By linking 'withSecondPolicy' directly to 'base', the following configs are now redundant and can be removed: withVM, withFirstPolicy, withVault. As touched on above, these three configs are all duplicating resources that are in 'base' and therefore throwing conflict errors.
- 'withSecondPolicy' renamed to 'withBasePolicy' for cleanliness.

3. Replaced 'address_prefix' with 'address_prefixes' as the former is deprecated.