### PR TITLE
testing: data sources should fail using import steps

### DIFF
--- a/azurerm/internal/acceptance/steps.go
+++ b/azurerm/internal/acceptance/steps.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -76,6 +77,15 @@ func (td TestData) ImportStep(ignore ...string) resource.TestStep {
 // optionally ignoring any fields which may not be imported (for example, as they're
 // not returned from the API)
 func (td TestData) ImportStepFor(resourceName string, ignore ...string) resource.TestStep {
+	if strings.HasPrefix(resourceName, "data.") {
+		return resource.TestStep{
+			ResourceName: resourceName,
+			SkipFunc: func() (bool, error) {
+				return false, fmt.Errorf("Data Sources (%q) do not support import - remove the ImportStep / ImportStepFor`", resourceName)
+			},
+		}
+	}
+
 	step := resource.TestStep{
 		ResourceName:      resourceName,
 		ImportState:       true,


### PR DESCRIPTION
This commit forces a test failure when using an ImportStep within a Data Source, since the output is misleading:

```
testing.go:684: Step 1 error: 7 problems:
This is a bug in the provider, which should be reported in the provider's own issue tracker.
- Provider produced invalid object: Provider "azurerm" planned an invalid value for data.azurerm_something.test during refresh: .timeouts: unsupported attribute "update".
This is a bug in the provider, which should be reported in the provider's own issue tracker.
- Provider produced invalid object: Provider "azurerm" planned an invalid value for data.azurerm_something.test during refresh: .timeouts: unsupported attribute "create".
This is a bug in the provider, which should be reported in the provider's own issue tracker.
- Provider produced invalid object: Provider "azurerm" planned an invalid value for data.azurerm_something.test during refresh: .timeouts: unsupported attribute "delete".
```