### PR TITLE
r/app_configuration: updating the requiresImport test to use a standard tier

### DIFF
--- a/azurerm/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -54,7 +54,7 @@ func TestAccAppConfiguration_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.free(data),
+			Config: r.standard(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),


### PR DESCRIPTION
There can only be a single "free" instance in a subscription at any one time, as there's a free test checking that sku can be provisioned - updating the requiresImport test to use a standard sku makes this pass consistently.