### PR TITLE
Fix a crash in azurerm_storage_account_datasource

### DIFF
--- a/azurerm/internal/services/storage/storage_account_data_source.go
+++ b/azurerm/internal/services/storage/storage_account_data_source.go
@@ -26,8 +26,9 @@ func dataSourceStorageAccount() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: ValidateStorageAccountName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),


### PR DESCRIPTION
It crashes if the name passed to it is an empty string.

Fixes #10369