### PR TITLE
azurerm_storage_data_lake_gen2_[filesystem|path] - change the `ace` property to a TypeSet to ensure consistent ordering

### DIFF
--- a/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -78,7 +78,7 @@ func resourceStorageDataLakeGen2FileSystem() *schema.Resource {
 			"properties": MetaDataSchema(),
 
 			"ace": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -123,7 +123,7 @@ func resourceStorageDataLakeGen2FileSystemCreate(d *schema.ResourceData, meta in
 		return err
 	}
 
-	aceRaw := d.Get("ace").([]interface{})
+	aceRaw := d.Get("ace").(*schema.Set).List()
 	acl, err := ExpandDataLakeGen2AceList(aceRaw)
 	if err != nil {
 		return fmt.Errorf("Error parsing ace list: %s", err)
@@ -200,7 +200,7 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *schema.ResourceData, meta in
 		return err
 	}
 
-	aceRaw := d.Get("ace").([]interface{})
+	aceRaw := d.Get("ace").(*schema.Set).List()
 	acl, err := ExpandDataLakeGen2AceList(aceRaw)
 	if err != nil {
 		return fmt.Errorf("Error parsing ace list: %s", err)

--- a/azurerm/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -107,7 +107,7 @@ func resourceStorageDataLakeGen2Path() *schema.Resource {
 			},
 
 			"ace": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -183,7 +183,7 @@ func resourceStorageDataLakeGen2PathCreate(d *schema.ResourceData, meta interfac
 	default:
 		return fmt.Errorf("Unhandled resource type %q", resourceString)
 	}
-	aceRaw := d.Get("ace").([]interface{})
+	aceRaw := d.Get("ace").(*schema.Set).List()
 	acl, err := ExpandDataLakeGen2AceList(aceRaw)
 	if err != nil {
 		return fmt.Errorf("Error parsing ace list: %s", err)
@@ -247,7 +247,7 @@ func resourceStorageDataLakeGen2PathUpdate(d *schema.ResourceData, meta interfac
 
 	path := d.Get("path").(string)
 
-	aceRaw := d.Get("ace").([]interface{})
+	aceRaw := d.Get("ace").(*schema.Set).List()
 	acl, err := ExpandDataLakeGen2AceList(aceRaw)
 	if err != nil {
 		return fmt.Errorf("Error parsing ace list: %s", err)


### PR DESCRIPTION
Convert TypeList to TypeSet since SDK/API's order is non-deterministic