### PR TITLE
network: removing the direct dependency on `acceptance.AzureProvider`

### DIFF
--- a/azurerm/internal/azuresdkhacks/network_interface.go
+++ b/azurerm/internal/azuresdkhacks/network_interface.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
+// TODO: move this into the network package
+
 // UpdateNetworkInterfaceAllowingRemovalOfNSG patches our way around a design flaw in the Azure
 // Resource Manager API <-> Azure SDK for Go where it's not possible to remove a Network Security Group
 func UpdateNetworkInterfaceAllowingRemovalOfNSG(ctx context.Context, client *network.InterfacesClient, resourceGroupName string, networkInterfaceName string, parameters network.Interface) (result network.InterfacesCreateOrUpdateFuture, err error) {

--- a/azurerm/internal/services/containers/container_registry_resource_test.go
+++ b/azurerm/internal/services/containers/container_registry_resource_test.go
@@ -83,7 +83,7 @@ func TestAccContainerRegistry_basic_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.basic_basic(data),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -146,7 +146,7 @@ func TestAccContainerRegistry_basic_basic2Premium2basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.basic_basic(data),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue("Basic"),
@@ -160,7 +160,7 @@ func TestAccContainerRegistry_basic_basic2Premium2basic(t *testing.T) {
 			),
 		},
 		{
-			Config: r.basic_basic(data),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue("Basic"),
@@ -400,7 +400,7 @@ func (t ContainerRegistryResource) Exists(ctx context.Context, clients *clients.
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func (ContainerRegistryResource) basic_basic(data acceptance.TestData) string {
+func (ContainerRegistryResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/containers/container_registry_resource_test.go
+++ b/azurerm/internal/services/containers/container_registry_resource_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -211,54 +211,59 @@ func TestAccContainerRegistry_geoReplication(t *testing.T) {
 	skuPremium := "Premium"
 	skuBasic := "Basic"
 
+	primaryLocation := location.Normalize(data.Locations.Primary)
+	secondaryLocation := location.Normalize(data.Locations.Secondary)
+	ternaryLocation := location.Normalize(data.Locations.Ternary)
+
 	data.ResourceTest(t, r, []resource.TestStep{
 		// first config creates an ACR with locations
 		{
-			// TODO: fix this to use dynamic locations
-			Config: r.geoReplication(data, skuPremium, `eastus", "westus`),
+			Config: r.geoReplication(data, skuPremium, []string{primaryLocation, secondaryLocation}),
 			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
 				check.That(data.ResourceName).Key("georeplication_locations.#").HasValue("2"),
-				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckContainerRegistryGeoreplications(data.ResourceName, skuPremium, []string{`"eastus"`, `"westus"`}),
+				check.That(data.ResourceName).Key("georeplication_locations.0").HasValue(primaryLocation),
+				check.That(data.ResourceName).Key("georeplication_locations.1").HasValue(secondaryLocation),
 			),
 		},
-		// second config udpates the ACR with updated locations
+		// second config updates the ACR with updated locations
 		{
-			Config: r.geoReplication(data, skuPremium, `centralus", "eastus`),
+			Config: r.geoReplication(data, skuPremium, []string{ternaryLocation, primaryLocation}),
 			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
 				check.That(data.ResourceName).Key("georeplication_locations.#").HasValue("2"),
-				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckContainerRegistryGeoreplications(data.ResourceName, skuPremium, []string{`"eastus"`, `"centralus"`}),
+				check.That(data.ResourceName).Key("georeplication_locations.0").HasValue(ternaryLocation),
+				check.That(data.ResourceName).Key("georeplication_locations.1").HasValue(primaryLocation),
 			),
 		},
-		// third config udpates the ACR with no location
+		// third config updates the ACR with no location
 		{
 			Config: r.geoReplicationUpdateWithNoLocation(data, skuPremium),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckContainerRegistryGeoreplications(data.ResourceName, skuPremium, nil),
+				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
+				check.That(data.ResourceName).Key("georeplication_locations.#").HasValue("0"),
 			),
 		},
 		// fourth config updates an ACR with replicas
 		{
-			Config: r.geoReplication(data, skuPremium, `eastus", "westus`),
+			Config: r.geoReplication(data, skuPremium, []string{primaryLocation, secondaryLocation}),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
-				check.That(data.ResourceName).Key("georeplication_locations.#").HasValue("2"),
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckContainerRegistryGeoreplications(data.ResourceName, skuPremium, []string{`"eastus"`, `"westus"`}),
+				check.That(data.ResourceName).Key("georeplication_locations.#").HasValue("2"),
+				check.That(data.ResourceName).Key("georeplication_locations.0").HasValue(primaryLocation),
+				check.That(data.ResourceName).Key("georeplication_locations.1").HasValue(secondaryLocation),
 			),
 		},
 		// fifth config updates the SKU to basic and no replicas (should remove the existing replicas if any)
 		{
 			Config: r.geoReplicationUpdateWithNoLocation_basic(data),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("sku").HasValue(skuBasic),
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckContainerRegistryGeoreplications(data.ResourceName, skuBasic, nil),
+				check.That(data.ResourceName).Key("sku").HasValue(skuBasic),
+				check.That(data.ResourceName).Key("georeplication_locations.#").HasValue("0"),
 			),
 		},
 	})
@@ -395,46 +400,6 @@ func (t ContainerRegistryResource) Exists(ctx context.Context, clients *clients.
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func testCheckContainerRegistryGeoreplications(resourceName string, sku string, expectedLocations []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acceptance.AzureProvider.Meta().(*clients.Client).Containers.ReplicationsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		name := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
-		}
-
-		resp, err := conn.List(ctx, resourceGroup, name)
-		if err != nil {
-			return fmt.Errorf("Bad: Get on containerRegistryClient: %+v", err)
-		}
-
-		georeplicationValues := resp.Values()
-		expectedLocationsCount := len(expectedLocations) + 1 // the main location is returned by the API as a geolocation for replication.
-
-		// if Sku is not premium, listing the geo-replications locations returns an empty list
-		if !strings.EqualFold(sku, string(containerregistry.Premium)) {
-			expectedLocationsCount = 0
-		}
-
-		actualLocationsCount := len(georeplicationValues)
-
-		if expectedLocationsCount != actualLocationsCount {
-			return fmt.Errorf("Bad: Container Registry %q (resource group: %q) expected locations count is %d, actual location count is %d", name, resourceGroup, expectedLocationsCount, actualLocationsCount)
-		}
-
-		return nil
-	}
-}
-
 func (ContainerRegistryResource) basic_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -542,7 +507,12 @@ resource "azurerm_container_registry" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (ContainerRegistryResource) geoReplication(data acceptance.TestData, sku string, georeplicationLocations string) string {
+func (ContainerRegistryResource) geoReplication(data acceptance.TestData, sku string, replicationRegions []string) string {
+	regions := make([]string, 0)
+	for _, region := range replicationRegions {
+		// ensure they're quoted
+		regions = append(regions, fmt.Sprint("%q", region))
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -558,9 +528,9 @@ resource "azurerm_container_registry" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   sku                      = "%s"
-  georeplication_locations = ["%s"]
+  georeplication_locations = [%s]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, sku, georeplicationLocations)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, sku, strings.Join(regions, ","))
 }
 
 func (ContainerRegistryResource) geoReplicationUpdateWithNoLocation(data acceptance.TestData, sku string) string {

--- a/azurerm/internal/services/containers/container_registry_resource_test.go
+++ b/azurerm/internal/services/containers/container_registry_resource_test.go
@@ -511,7 +511,7 @@ func (ContainerRegistryResource) geoReplication(data acceptance.TestData, sku st
 	regions := make([]string, 0)
 	for _, region := range replicationRegions {
 		// ensure they're quoted
-		regions = append(regions, fmt.Sprint("%q", region))
+		regions = append(regions, fmt.Sprintf("%q", region))
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/azurerm/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
+++ b/azurerm/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
@@ -57,12 +57,12 @@ func TestAccNetworkInterfaceBackendAddressPoolAssociation_deleted(t *testing.T) 
 	r := NetworkInterfaceBackendAddressPoolResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		// intentional as this is a Virtual Resource
+		// intentionally not using a DisppearsStep as this is a Virtual Resource
 		{
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckNetworkInterfaceBackendAddressPoolAssociationDisappears(data.ResourceName),
+				data.CheckWithClient(r.destroy),
 			),
 			ExpectNonEmptyPlan: true,
 		},
@@ -136,59 +136,48 @@ func (t NetworkInterfaceBackendAddressPoolResource) Exists(ctx context.Context, 
 	return utils.Bool(found), nil
 }
 
-func testCheckNetworkInterfaceBackendAddressPoolAssociationDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.InterfacesClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+func (NetworkInterfaceBackendAddressPoolResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
+	nicID, err := azure.ParseAzureResourceID(state.Attributes["network_interface_id"])
+	if err != nil {
+		return err
+	}
 
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
+	nicName := nicID.Path["networkInterfaces"]
+	resourceGroup := nicID.ResourceGroup
+	backendAddressPoolId := state.Attributes["backend_address_pool_id"]
+	ipConfigurationName := state.Attributes["ip_configuration_name"]
 
-		nicID, err := azure.ParseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
-		if err != nil {
-			return err
-		}
+	read, err := client.Network.InterfacesClient.Get(ctx, resourceGroup, nicName, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	}
 
-		nicName := nicID.Path["networkInterfaces"]
-		resourceGroup := nicID.ResourceGroup
-		backendAddressPoolId := rs.Primary.Attributes["backend_address_pool_id"]
-		ipConfigurationName := rs.Primary.Attributes["ip_configuration_name"]
+	c := azure.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
+	if c == nil {
+		return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
+	}
+	config := *c
 
-		read, err := client.Get(ctx, resourceGroup, nicName, "")
-		if err != nil {
-			return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-		}
-
-		c := azure.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
-		if c == nil {
-			return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
-		}
-		config := *c
-
-		updatedPools := make([]network.BackendAddressPool, 0)
-		if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools != nil {
-			for _, pool := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools {
-				if *pool.ID != backendAddressPoolId {
-					updatedPools = append(updatedPools, pool)
-				}
+	updatedPools := make([]network.BackendAddressPool, 0)
+	if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools != nil {
+		for _, pool := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools {
+			if *pool.ID != backendAddressPoolId {
+				updatedPools = append(updatedPools, pool)
 			}
 		}
-		config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &updatedPools
-
-		future, err := client.CreateOrUpdate(ctx, resourceGroup, nicName, read)
-		if err != nil {
-			return fmt.Errorf("Error removing Backend Address Pool Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-		}
-
-		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error waiting for removal of Backend Address Pool Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-		}
-
-		return nil
 	}
+	config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerBackendAddressPools = &updatedPools
+
+	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, resourceGroup, nicName, read)
+	if err != nil {
+		return fmt.Errorf("Error removing Backend Address Pool Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
+		return fmt.Errorf("Error waiting for removal of Backend Address Pool Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	}
+
+	return nil
 }
 
 func (r NetworkInterfaceBackendAddressPoolResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
+++ b/azurerm/internal/services/network/network_interface_backend_address_pool_association_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -137,12 +138,12 @@ func (t NetworkInterfaceBackendAddressPoolResource) Exists(ctx context.Context, 
 }
 
 func (NetworkInterfaceBackendAddressPoolResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
-	nicID, err := azure.ParseAzureResourceID(state.Attributes["network_interface_id"])
+	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
 	if err != nil {
 		return err
 	}
 
-	nicName := nicID.Path["networkInterfaces"]
+	nicName := nicID.Name
 	resourceGroup := nicID.ResourceGroup
 	backendAddressPoolId := state.Attributes["backend_address_pool_id"]
 	ipConfigurationName := state.Attributes["ip_configuration_name"]

--- a/azurerm/internal/services/network/network_interface_nat_rule_association_resource_test.go
+++ b/azurerm/internal/services/network/network_interface_nat_rule_association_resource_test.go
@@ -57,12 +57,12 @@ func TestAccNetworkInterfaceNATRuleAssociation_deleted(t *testing.T) {
 	r := NetworkInterfaceNATRuleAssociationResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		// intentional as this is a Virtual Resource
+		// intentionally not using a DisappearsStep as this is a Virtual Resource
 		{
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckNetworkInterfaceNATRuleAssociationDisappears(data.ResourceName),
+				data.CheckWithClient(r.destroy),
 			),
 			ExpectNonEmptyPlan: true,
 		},
@@ -131,59 +131,48 @@ func (t NetworkInterfaceNATRuleAssociationResource) Exists(ctx context.Context, 
 	return utils.Bool(found), nil
 }
 
-func testCheckNetworkInterfaceNATRuleAssociationDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.InterfacesClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+func (NetworkInterfaceNATRuleAssociationResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
+	nicID, err := azure.ParseAzureResourceID(state.Attributes["network_interface_id"])
+	if err != nil {
+		return err
+	}
 
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
+	nicName := nicID.Path["networkInterfaces"]
+	resourceGroup := nicID.ResourceGroup
+	ipConfigurationName := state.Attributes["ip_configuration_name"]
+	natRuleId := state.Attributes["nat_rule_id"]
 
-		nicID, err := azure.ParseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
-		if err != nil {
-			return err
-		}
+	read, err := client.Network.InterfacesClient.Get(ctx, resourceGroup, nicName, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	}
 
-		nicName := nicID.Path["networkInterfaces"]
-		resourceGroup := nicID.ResourceGroup
-		ipConfigurationName := rs.Primary.Attributes["ip_configuration_name"]
-		natRuleId := rs.Primary.Attributes["nat_rule_id"]
+	c := azure.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
+	if c == nil {
+		return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
+	}
+	config := *c
 
-		read, err := client.Get(ctx, resourceGroup, nicName, "")
-		if err != nil {
-			return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-		}
-
-		c := azure.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
-		if c == nil {
-			return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
-		}
-		config := *c
-
-		updatedRules := make([]network.InboundNatRule, 0)
-		if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules != nil {
-			for _, rule := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules {
-				if *rule.ID != natRuleId {
-					updatedRules = append(updatedRules, rule)
-				}
+	updatedRules := make([]network.InboundNatRule, 0)
+	if config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules != nil {
+		for _, rule := range *config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules {
+			if *rule.ID != natRuleId {
+				updatedRules = append(updatedRules, rule)
 			}
 		}
-		config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules = &updatedRules
-
-		future, err := client.CreateOrUpdate(ctx, resourceGroup, nicName, read)
-		if err != nil {
-			return fmt.Errorf("Error removing NAT Rule Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-		}
-
-		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error waiting for removal of NAT Rule Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
-		}
-
-		return nil
 	}
+	config.InterfaceIPConfigurationPropertiesFormat.LoadBalancerInboundNatRules = &updatedRules
+
+	future, err := client.Network.InterfacesClient.CreateOrUpdate(ctx, resourceGroup, nicName, read)
+	if err != nil {
+		return fmt.Errorf("Error removing NAT Rule Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Network.InterfacesClient.Client); err != nil {
+		return fmt.Errorf("Error waiting for removal of NAT Rule Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+	}
+
+	return nil
 }
 
 func (r NetworkInterfaceNATRuleAssociationResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/network/network_interface_nat_rule_association_resource_test.go
+++ b/azurerm/internal/services/network/network_interface_nat_rule_association_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -132,12 +133,12 @@ func (t NetworkInterfaceNATRuleAssociationResource) Exists(ctx context.Context, 
 }
 
 func (NetworkInterfaceNATRuleAssociationResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
-	nicID, err := azure.ParseAzureResourceID(state.Attributes["network_interface_id"])
+	nicID, err := parse.NetworkInterfaceID(state.Attributes["network_interface_id"])
 	if err != nil {
 		return err
 	}
 
-	nicName := nicID.Path["networkInterfaces"]
+	nicName := nicID.Name
 	resourceGroup := nicID.ResourceGroup
 	ipConfigurationName := state.Attributes["ip_configuration_name"]
 	natRuleId := state.Attributes["nat_rule_id"]

--- a/azurerm/internal/services/network/subnet_nat_gateway_association_resource_test.go
+++ b/azurerm/internal/services/network/subnet_nat_gateway_association_resource_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -94,13 +94,13 @@ func TestAccAzureRMSubnetNatGatewayAssociation_updateSubnet(t *testing.T) {
 }
 
 func (t SubnetNatGatewayAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.SubnetID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 	resourceGroup := id.ResourceGroup
-	virtualNetworkName := id.Path["virtualNetworks"]
-	subnetName := id.Path["subnets"]
+	virtualNetworkName := id.VirtualNetworkName
+	subnetName := id.Name
 
 	resp, err := clients.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
@@ -116,15 +116,14 @@ func (t SubnetNatGatewayAssociationResource) Exists(ctx context.Context, clients
 }
 
 func (SubnetNatGatewayAssociationResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
-	subnetId := state.Attributes["subnet_id"]
-	parsedSubnetId, err := azure.ParseAzureResourceID(subnetId)
+	parsedSubnetId, err := parse.SubnetID(state.Attributes["subnet_id"])
 	if err != nil {
 		return err
 	}
 
 	resourceGroup := parsedSubnetId.ResourceGroup
-	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
-	subnetName := parsedSubnetId.Path["subnets"]
+	virtualNetworkName := parsedSubnetId.VirtualNetworkName
+	subnetName := parsedSubnetId.Name
 
 	subnet, err := client.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {

--- a/azurerm/internal/services/network/subnet_resource_test.go
+++ b/azurerm/internal/services/network/subnet_resource_test.go
@@ -297,30 +297,28 @@ func (SubnetResource) Destroy(ctx context.Context, client *clients.Client, state
 	return utils.Bool(true), nil
 }
 
-func (SubnetResource) hasNoRouteTable(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
+func (SubnetResource) hasNoNatGateway(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
 	id, err := parse.SubnetID(state.ID)
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, "")
+	subnet, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, "")
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if utils.ResponseWasNotFound(subnet.Response) {
 			return fmt.Errorf("Bad: Subnet %q (Virtual Network %q / Resource Group: %q) does not exist", id.Name, id.VirtualNetworkName, id.ResourceGroup)
 		}
-
 		return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
 	}
 
-	props := resp.SubnetPropertiesFormat
+	props := subnet.SubnetPropertiesFormat
 	if props == nil {
 		return fmt.Errorf("Properties was nil for Subnet %q (Virtual Network %q / Resource Group: %q)", id.Name, id.VirtualNetworkName, id.ResourceGroup)
 	}
 
-	if props.RouteTable != nil && ((props.RouteTable.ID == nil) || (props.RouteTable.ID != nil && *props.RouteTable.ID == "")) {
+	if props.NatGateway != nil && ((props.NatGateway.ID == nil) || (props.NatGateway.ID != nil && *props.NatGateway.ID == "")) {
 		return fmt.Errorf("No Route Table should exist for Subnet %q (Virtual Network %q / Resource Group: %q) but got %q", id.Name, id.VirtualNetworkName, id.ResourceGroup, *props.RouteTable.ID)
 	}
-
 	return nil
 }
 
@@ -346,6 +344,33 @@ func (SubnetResource) hasNoNetworkSecurityGroup(ctx context.Context, client *cli
 
 	if props.NetworkSecurityGroup != nil && ((props.NetworkSecurityGroup.ID == nil) || (props.NetworkSecurityGroup.ID != nil && *props.NetworkSecurityGroup.ID == "")) {
 		return fmt.Errorf("No Network Security Group should exist for Subnet %q (Virtual Network %q / Resource Group: %q) but got %q", id.Name, id.VirtualNetworkName, id.ResourceGroup, *props.NetworkSecurityGroup.ID)
+	}
+
+	return nil
+}
+
+func (SubnetResource) hasNoRouteTable(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
+	id, err := parse.SubnetID(state.ID)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Network.SubnetsClient.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Bad: Subnet %q (Virtual Network %q / Resource Group: %q) does not exist", id.Name, id.VirtualNetworkName, id.ResourceGroup)
+		}
+
+		return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
+	}
+
+	props := resp.SubnetPropertiesFormat
+	if props == nil {
+		return fmt.Errorf("Properties was nil for Subnet %q (Virtual Network %q / Resource Group: %q)", id.Name, id.VirtualNetworkName, id.ResourceGroup)
+	}
+
+	if props.RouteTable != nil && ((props.RouteTable.ID == nil) || (props.RouteTable.ID != nil && *props.RouteTable.ID == "")) {
+		return fmt.Errorf("No Route Table should exist for Subnet %q (Virtual Network %q / Resource Group: %q) but got %q", id.Name, id.VirtualNetworkName, id.ResourceGroup, *props.RouteTable.ID)
 	}
 
 	return nil

--- a/azurerm/internal/services/network/subnet_route_table_association_resource.go
+++ b/azurerm/internal/services/network/subnet_route_table_association_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -59,7 +60,7 @@ func resourceSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta inte
 	subnetId := d.Get("subnet_id").(string)
 	routeTableId := d.Get("route_table_id").(string)
 
-	parsedSubnetId, err := azure.ParseAzureResourceID(subnetId)
+	parsedSubnetId, err := parse.SubnetID(subnetId)
 	if err != nil {
 		return err
 	}
@@ -72,8 +73,8 @@ func resourceSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta inte
 	locks.ByName(parsedRouteTableId.Name, routeTableResourceName)
 	defer locks.UnlockByName(parsedRouteTableId.Name, routeTableResourceName)
 
-	subnetName := parsedSubnetId.Path["subnets"]
-	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
+	subnetName := parsedSubnetId.Name
+	virtualNetworkName := parsedSubnetId.VirtualNetworkName
 	resourceGroup := parsedSubnetId.ResourceGroup
 
 	locks.ByName(virtualNetworkName, VirtualNetworkResourceName)
@@ -125,13 +126,13 @@ func resourceSubnetRouteTableAssociationRead(d *schema.ResourceData, meta interf
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.SubnetID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	virtualNetworkName := id.Path["virtualNetworks"]
-	subnetName := id.Path["subnets"]
+	virtualNetworkName := id.VirtualNetworkName
+	subnetName := id.Name
 
 	resp, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
@@ -166,13 +167,13 @@ func resourceSubnetRouteTableAssociationDelete(d *schema.ResourceData, meta inte
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.SubnetID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	virtualNetworkName := id.Path["virtualNetworks"]
-	subnetName := id.Path["subnets"]
+	virtualNetworkName := id.VirtualNetworkName
+	subnetName := id.Name
 
 	// retrieve the subnet
 	read, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")

--- a/azurerm/internal/services/network/subnet_route_table_association_resource_test.go
+++ b/azurerm/internal/services/network/subnet_route_table_association_resource_test.go
@@ -80,20 +80,20 @@ func TestAccSubnetRouteTableAssociation_deleted(t *testing.T) {
 	r := SubnetRouteTableAssociationResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		// intentional since this is a Virtual Resource
 		{
+			// NOTE: intentionally not using a DisappearsStep as this is a Virtual Resource
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckSubnetRouteTableAssociationDisappears(data.ResourceName),
-				testCheckSubnetHasNoRouteTable(data.ResourceName),
+				data.CheckWithClient(r.destroy),
+				data.CheckWithClientForResource(SubnetResource{}.hasNoRouteTable, "azurerm_subnet.test"),
 			),
 			ExpectNonEmptyPlan: true,
 		},
 	})
 }
 
-func (t SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
 		return nil, err
@@ -115,89 +115,35 @@ func (t SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients
 	return utils.Bool(props.RouteTable.ID != nil), nil
 }
 
-func testCheckSubnetRouteTableAssociationDisappears(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.SubnetsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		subnetId := rs.Primary.Attributes["subnet_id"]
-		parsedId, err := azure.ParseAzureResourceID(subnetId)
-		if err != nil {
-			return err
-		}
-
-		resourceGroup := parsedId.ResourceGroup
-		virtualNetworkName := parsedId.Path["virtualNetworks"]
-		subnetName := parsedId.Path["subnets"]
-
-		read, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
-		if err != nil {
-			if !utils.ResponseWasNotFound(read.Response) {
-				return fmt.Errorf("Error retrieving Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
-			}
-		}
-
-		read.SubnetPropertiesFormat.RouteTable = nil
-
-		future, err := client.CreateOrUpdate(ctx, resourceGroup, virtualNetworkName, subnetName, read)
-		if err != nil {
-			return fmt.Errorf("Error updating Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
-		}
-		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error waiting for completion of Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
-		}
-
-		return nil
+func (SubnetRouteTableAssociationResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
+	subnetId := state.Attributes["subnet_id"]
+	parsedId, err := azure.ParseAzureResourceID(subnetId)
+	if err != nil {
+		return err
 	}
-}
 
-func testCheckSubnetHasNoRouteTable(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.SubnetsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+	resourceGroup := parsedId.ResourceGroup
+	virtualNetworkName := parsedId.Path["virtualNetworks"]
+	subnetName := parsedId.Path["subnets"]
 
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
+	read, err := client.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
+	if err != nil {
+		if !utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Error retrieving Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
 		}
-
-		subnetId := rs.Primary.Attributes["subnet_id"]
-		parsedId, err := azure.ParseAzureResourceID(subnetId)
-		if err != nil {
-			return err
-		}
-
-		resourceGroupName := parsedId.ResourceGroup
-		virtualNetworkName := parsedId.Path["virtualNetworks"]
-		subnetName := parsedId.Path["subnets"]
-
-		resp, err := client.Get(ctx, resourceGroupName, virtualNetworkName, subnetName, "")
-		if err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Subnet %q (Virtual Network %q / Resource Group: %q) does not exist", subnetName, virtualNetworkName, resourceGroupName)
-			}
-
-			return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
-		}
-
-		props := resp.SubnetPropertiesFormat
-		if props == nil {
-			return fmt.Errorf("Properties was nil for Subnet %q (Virtual Network %q / Resource Group: %q)", subnetName, virtualNetworkName, resourceGroupName)
-		}
-
-		if props.RouteTable != nil && ((props.RouteTable.ID == nil) || (props.RouteTable.ID != nil && *props.RouteTable.ID == "")) {
-			return fmt.Errorf("No Route Table should exist for Subnet %q (Virtual Network %q / Resource Group: %q) but got %q", subnetName, virtualNetworkName, resourceGroupName, *props.RouteTable.ID)
-		}
-
-		return nil
 	}
+
+	read.SubnetPropertiesFormat.RouteTable = nil
+
+	future, err := client.Network.SubnetsClient.CreateOrUpdate(ctx, resourceGroup, virtualNetworkName, subnetName, read)
+	if err != nil {
+		return fmt.Errorf("Error updating Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Network.SubnetsClient.Client); err != nil {
+		return fmt.Errorf("Error waiting for completion of Subnet %q (Network %q / Resource Group %q): %+v", subnetName, virtualNetworkName, resourceGroup, err)
+	}
+
+	return nil
 }
 
 func (r SubnetRouteTableAssociationResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/network/subnet_route_table_association_resource_test.go
+++ b/azurerm/internal/services/network/subnet_route_table_association_resource_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -94,13 +94,13 @@ func TestAccSubnetRouteTableAssociation_deleted(t *testing.T) {
 }
 
 func (SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := parse.SubnetID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 	resourceGroup := id.ResourceGroup
-	virtualNetworkName := id.Path["virtualNetworks"]
-	subnetName := id.Path["subnets"]
+	virtualNetworkName := id.VirtualNetworkName
+	subnetName := id.Name
 
 	resp, err := clients.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
@@ -116,15 +116,14 @@ func (SubnetRouteTableAssociationResource) Exists(ctx context.Context, clients *
 }
 
 func (SubnetRouteTableAssociationResource) destroy(ctx context.Context, client *clients.Client, state *terraform.InstanceState) error {
-	subnetId := state.Attributes["subnet_id"]
-	parsedId, err := azure.ParseAzureResourceID(subnetId)
+	parsedId, err := parse.SubnetID(state.Attributes["subnet_id"])
 	if err != nil {
 		return err
 	}
 
 	resourceGroup := parsedId.ResourceGroup
-	virtualNetworkName := parsedId.Path["virtualNetworks"]
-	subnetName := parsedId.Path["subnets"]
+	virtualNetworkName := parsedId.VirtualNetworkName
+	subnetName := parsedId.Name
 
 	read, err := client.Network.SubnetsClient.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {


### PR DESCRIPTION
Continuing the ongoing split to enable binary testing