### PR TITLE
r/(legacy)_virtual_machine: refactoring to use check funcs

### DIFF
--- a/azurerm/internal/acceptance/check/that.go
+++ b/azurerm/internal/acceptance/check/that.go
@@ -25,6 +25,14 @@ func That(resourceName string) thatType {
 	}
 }
 
+// DoesNotExistInAzure validates that the specified resource does not exist within Azure
+func (t thatType) DoesNotExistInAzure(testResource types.TestResource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client)
+		return helpers.DoesNotExistInAzure(client, testResource, t.resourceName)(s)
+	}
+}
+
 // ExistsInAzure validates that the specified resource exists within Azure
 func (t thatType) ExistsInAzure(testResource types.TestResource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/azurerm/internal/services/compute/virtual_machine_managed_disks_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_managed_disks_resource_test.go
@@ -226,7 +226,6 @@ func TestAccVirtualMachine_attachSecondDataDiskWithAttachOption(t *testing.T) {
 			Config: r.basicLinuxMachine_managedDisk_attach(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testAccCheckVirtualMachineRecreated(t, &afterCreate, &afterUpdate),
 				check.That(data.ResourceName).Key("storage_data_disk.0.create_option").HasValue("Empty"),
 				check.That(data.ResourceName).Key("storage_data_disk.1.create_option").HasValue("Attach"),
 			),

--- a/azurerm/internal/services/compute/virtual_machine_managed_disks_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_managed_disks_resource_test.go
@@ -385,8 +385,6 @@ func TestAccVirtualMachine_hasDiskInfoWhenStopped(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine", "test")
 	r := VirtualMachineResource{}
 
-	var vm compute.VirtualMachine
-
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config: r.hasDiskInfoWhenStopped(data),
@@ -399,7 +397,7 @@ func TestAccVirtualMachine_hasDiskInfoWhenStopped(t *testing.T) {
 		{
 			Config: r.hasDiskInfoWhenStopped(data),
 			Check: resource.ComposeTestCheckFunc(
-				testCheckAndStopVirtualMachine(&vm),
+				data.CheckWithClient(r.deallocate),
 				check.That(data.ResourceName).Key("storage_os_disk.0.managed_disk_type").HasValue("Standard_LRS"),
 				check.That(data.ResourceName).Key("storage_data_disk.0.disk_size_gb").HasValue("64"),
 			),

--- a/azurerm/internal/services/compute/virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_resource_test.go
@@ -3,7 +3,6 @@ package compute_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -100,33 +99,6 @@ func TestAccVirtualMachine_withPPG(t *testing.T) {
 			),
 		},
 	})
-}
-
-func testCheckVirtualMachineDestroy(s *terraform.State) error {
-	client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
-	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "azurerm_virtual_machine" {
-			continue
-		}
-
-		name := rs.Primary.Attributes["name"]
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-
-		resp, err := client.Get(ctx, resourceGroup, name, "")
-		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
-				return nil
-			}
-
-			return err
-		}
-
-		return fmt.Errorf("Virtual Machine still exists:\n%#v", resp.VirtualMachineProperties)
-	}
-
-	return nil
 }
 
 func (VirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {

--- a/azurerm/internal/services/compute/virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_resource_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -14,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/blob/blobs"
 )
 
 type VirtualMachineResource struct {
@@ -141,6 +144,201 @@ func (t VirtualMachineResource) Exists(ctx context.Context, clients *clients.Cli
 	}
 
 	return utils.Bool(resp.ID != nil), nil
+}
+
+func testCheckVirtualMachineManagedDiskExists(managedDiskID *string, shouldExist bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		d, err := testGetVirtualMachineManagedDisk(managedDiskID)
+		if err != nil {
+			return fmt.Errorf("Error trying to retrieve Managed Disk %s, %+v", *managedDiskID, err)
+		}
+		if d.StatusCode == http.StatusNotFound && shouldExist {
+			return fmt.Errorf("Unable to find Managed Disk %s", *managedDiskID)
+		}
+		if d.StatusCode != http.StatusNotFound && !shouldExist {
+			return fmt.Errorf("Found unexpected Managed Disk %s", *managedDiskID)
+		}
+
+		return nil
+	}
+}
+
+func testLookupVirtualMachineManagedDiskID(vm *compute.VirtualMachine, diskName string, managedDiskID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if osd := vm.StorageProfile.OsDisk; osd != nil {
+			if strings.EqualFold(*osd.Name, diskName) {
+				if osd.ManagedDisk != nil {
+					id, err := findVirtualMachineManagedDiskID(osd.ManagedDisk)
+					if err != nil {
+						return fmt.Errorf("Unable to parse Managed Disk ID for OS Disk %s, %+v", diskName, err)
+					}
+					*managedDiskID = id
+					return nil
+				}
+			}
+		}
+
+		for _, dataDisk := range *vm.StorageProfile.DataDisks {
+			if strings.EqualFold(*dataDisk.Name, diskName) {
+				if dataDisk.ManagedDisk != nil {
+					id, err := findVirtualMachineManagedDiskID(dataDisk.ManagedDisk)
+					if err != nil {
+						return fmt.Errorf("Unable to parse Managed Disk ID for Data Disk %s, %+v", diskName, err)
+					}
+					*managedDiskID = id
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("Unable to locate disk %s on vm %s", diskName, *vm.Name)
+	}
+}
+
+func findVirtualMachineManagedDiskID(md *compute.ManagedDiskParameters) (string, error) {
+	if _, err := azure.ParseAzureResourceID(*md.ID); err != nil {
+		return "", err
+	}
+	return *md.ID, nil
+}
+
+func testGetVirtualMachineManagedDisk(managedDiskID *string) (*compute.Disk, error) {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DisksClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	armID, err := azure.ParseAzureResourceID(*managedDiskID)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse Managed Disk ID %s, %+v", *managedDiskID, err)
+	}
+	name := armID.Path["disks"]
+	resourceGroup := armID.ResourceGroup
+
+	d, err := client.Get(ctx, resourceGroup, name)
+	// check status first since sdk client returns error if not 200
+	if d.Response.StatusCode == http.StatusNotFound {
+		return &d, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &d, nil
+}
+
+func testCheckAndStopVirtualMachine(vm *compute.VirtualMachine) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		vmID, err := azure.ParseAzureResourceID(*vm.ID)
+		if err != nil {
+			return fmt.Errorf("Unable to parse virtual machine ID %s, %+v", *vm.ID, err)
+		}
+
+		name := vmID.Path["virtualMachines"]
+		resourceGroup := vmID.ResourceGroup
+
+		future, err := client.Deallocate(ctx, resourceGroup, name)
+		if err != nil {
+			return fmt.Errorf("Failed stopping virtual machine %q: %+v", resourceGroup, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Failed long polling for the stop of virtual machine %q: %+v", resourceGroup, err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckVirtualMachineVHDExistence(blobName string, shouldExist bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		storageClient := acceptance.AzureProvider.Meta().(*clients.Client).Storage
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "azurerm_storage_container" {
+				continue
+			}
+
+			accountName := rs.Primary.Attributes["storage_account_name"]
+			containerName := rs.Primary.Attributes["name"]
+
+			account, err := storageClient.FindAccount(ctx, accountName)
+			if err != nil {
+				return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, blobName, containerName, err)
+			}
+			if account == nil {
+				return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
+			}
+
+			client, err := storageClient.BlobsClient(ctx, *account)
+			if err != nil {
+				return fmt.Errorf("Error building Blobs Client: %s", err)
+			}
+
+			input := blobs.GetPropertiesInput{}
+			props, err := client.GetProperties(ctx, accountName, containerName, blobName, input)
+			if err != nil {
+				if utils.ResponseWasNotFound(props.Response) {
+					if !shouldExist {
+						return nil
+					}
+
+					return fmt.Errorf("The Blob for the Unmanaged Disk %q should exist in the Container %q but it didn't!", blobName, containerName)
+				}
+
+				return fmt.Errorf("Error retrieving properties for Blob %q (Container %q): %s", blobName, containerName, err)
+			}
+
+			if !shouldExist {
+				return fmt.Errorf("The Blob for the Unmanaged Disk %q shouldn't exist in the Container %q but it did!", blobName, containerName)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testCheckVirtualMachineDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		vmName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for virtual machine: %s", vmName)
+		}
+
+		// this is a preview feature we don't want to use right now
+		var forceDelete *bool = nil
+		future, err := client.Delete(ctx, resourceGroup, vmName, forceDelete)
+		if err != nil {
+			return fmt.Errorf("Bad: Delete on vmClient: %+v", err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Bad: Delete on vmClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckVirtualMachineRecreated(t *testing.T, before, after *compute.VirtualMachine) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before.ID == after.ID {
+			t.Fatalf("Expected change of Virtual Machine IDs, but both were %v", before.ID)
+		}
+		return nil
+	}
 }
 
 func (VirtualMachineResource) winTimeZone(data acceptance.TestData) string {

--- a/azurerm/internal/services/compute/virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_resource_test.go
@@ -314,15 +314,6 @@ func (VirtualMachineResource) Destroy(ctx context.Context, client *clients.Clien
 	return utils.Bool(true), nil
 }
 
-func testAccCheckVirtualMachineRecreated(t *testing.T, before, after *compute.VirtualMachine) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if before.ID == after.ID {
-			t.Fatalf("Expected change of Virtual Machine IDs, but both were %v", before.ID)
-		}
-		return nil
-	}
-}
-
 func (VirtualMachineResource) winTimeZone(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
@@ -2,12 +2,10 @@ package compute_test
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 )
@@ -411,12 +409,9 @@ func TestAccVirtualMachine_optionalOSProfile(t *testing.T) {
 		{
 			Destroy: false,
 			Config:  r.basicLinuxMachine_destroy(data),
-			Check: func(s *terraform.State) error {
-				if err := testCheckVirtualMachineDestroy(s); err != nil {
-					log.Printf("[DEBUG] WARNING testCheckVirtualMachineDestroy error'd: %v", err)
-				}
-				return nil
-			},
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).DoesNotExistInAzure(r),
+			),
 		},
 		{
 			Config: r.basicLinuxMachine_attach_without_osProfile(data),

--- a/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
@@ -75,14 +75,10 @@ func TestAccVirtualMachine_basicLinuxMachine_disappears(t *testing.T) {
 	r := VirtualMachineResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.basicLinuxMachine(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckVirtualMachineDisappears(data.ResourceName),
-			),
-			ExpectNonEmptyPlan: true,
-		},
+		data.DisappearsStep(acceptance.DisappearsStepData{
+			Config:       r.basicLinuxMachine,
+			TestResource: r,
+		}),
 	})
 }
 

--- a/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
@@ -283,8 +282,6 @@ func TestAccVirtualMachine_deleteVHDOptIn(t *testing.T) {
 func TestAccVirtualMachine_ChangeComputerName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine", "test")
 	r := VirtualMachineResource{}
-	var afterCreate, afterUpdate compute.VirtualMachine
-
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config: r.machineNameBeforeUpdate(data),
@@ -292,13 +289,10 @@ func TestAccVirtualMachine_ChangeComputerName(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-
 		{
 			Config: r.updateMachineName(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testAccCheckVirtualMachineRecreated(
-					t, &afterCreate, &afterUpdate),
 			),
 		},
 	})
@@ -307,7 +301,6 @@ func TestAccVirtualMachine_ChangeComputerName(t *testing.T) {
 func TestAccVirtualMachine_ChangeAvailabilitySet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine", "test")
 	r := VirtualMachineResource{}
-	var afterCreate, afterUpdate compute.VirtualMachine
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
@@ -321,8 +314,6 @@ func TestAccVirtualMachine_ChangeAvailabilitySet(t *testing.T) {
 			Config: r.updateAvailabilitySet(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testAccCheckVirtualMachineRecreated(
-					t, &afterCreate, &afterUpdate),
 			),
 		},
 	})
@@ -331,7 +322,6 @@ func TestAccVirtualMachine_ChangeAvailabilitySet(t *testing.T) {
 func TestAccVirtualMachine_changeStorageImageReference(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine", "test")
 	r := VirtualMachineResource{}
-	var afterCreate, afterUpdate compute.VirtualMachine
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
@@ -340,13 +330,10 @@ func TestAccVirtualMachine_changeStorageImageReference(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-
 		{
 			Config: r.basicLinuxMachineStorageImageAfter(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testAccCheckVirtualMachineRecreated(
-					t, &afterCreate, &afterUpdate),
 			),
 		},
 	})
@@ -355,7 +342,6 @@ func TestAccVirtualMachine_changeStorageImageReference(t *testing.T) {
 func TestAccVirtualMachine_changeOSDiskVhdUri(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine", "test")
 	r := VirtualMachineResource{}
-	var afterCreate, afterUpdate compute.VirtualMachine
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
@@ -369,8 +355,6 @@ func TestAccVirtualMachine_changeOSDiskVhdUri(t *testing.T) {
 			Config: r.basicLinuxMachineWithOSDiskVhdUriChanged(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testAccCheckVirtualMachineRecreated(
-					t, &afterCreate, &afterUpdate),
 			),
 		},
 	})

--- a/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_unmanaged_disks_resource_test.go
@@ -91,8 +91,8 @@ func TestAccVirtualMachine_basicLinuxMachineUseExistingOsDiskImage(t *testing.T)
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).ExistsInAzure(r),
-				testCheckVirtualMachineVHDExistence("myosdisk1.vhd", true),
-				testCheckVirtualMachineVHDExistence("mirrorosdisk.vhd", true),
+				data.CheckWithClientForResource(r.unmanagedDiskExistsInContainer("myosdisk1.vhd", true), "azurerm_storage_container.test"),
+				data.CheckWithClientForResource(r.unmanagedDiskExistsInContainer("mirrorosdisk.vhd", true), "azurerm_storage_container.test"),
 				resource.TestMatchResourceAttr("azurerm_virtual_machine.mirror", "storage_os_disk.0.image_uri", regexp.MustCompile("myosdisk1.vhd$")),
 			),
 		},
@@ -251,8 +251,8 @@ func TestAccVirtualMachine_deleteVHDOptOut(t *testing.T) {
 		{
 			Config: r.basicLinuxMachineDeleteVM(data),
 			Check: resource.ComposeTestCheckFunc(
-				testCheckVirtualMachineVHDExistence("myosdisk1.vhd", true),
-				testCheckVirtualMachineVHDExistence("mydatadisk1.vhd", true),
+				data.CheckWithClientForResource(r.unmanagedDiskExistsInContainer("myosdisk1.vhd", true), "azurerm_storage_container.test"),
+				data.CheckWithClientForResource(r.unmanagedDiskExistsInContainer("mydatadisk1.vhd", true), "azurerm_storage_container.test"),
 			),
 		},
 	})
@@ -272,8 +272,8 @@ func TestAccVirtualMachine_deleteVHDOptIn(t *testing.T) {
 		{
 			Config: r.basicLinuxMachineDestroyDisksAfter(data),
 			Check: resource.ComposeTestCheckFunc(
-				testCheckVirtualMachineVHDExistence("myosdisk1.vhd", false),
-				testCheckVirtualMachineVHDExistence("mydatadisk1.vhd", false),
+				data.CheckWithClientForResource(r.unmanagedDiskExistsInContainer("myosdisk1.vhd", false), "azurerm_storage_container.test"),
+				data.CheckWithClientForResource(r.unmanagedDiskExistsInContainer("mydatadisk1.vhd", false), "azurerm_storage_container.test"),
 			),
 		},
 	})


### PR DESCRIPTION
This PR refactors the (legacy) `azurerm_virtual_machine` resources tests to use Check Funcs - required for Binary Testing