### PR TITLE
`azurerm_virtual_network_gateway`: bgp setting support `APIPA`

### DIFF
--- a/azurerm/internal/services/network/parse/virtual_network_gateway.go
+++ b/azurerm/internal/services/network/parse/virtual_network_gateway.go
@@ -1,0 +1,69 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type VirtualNetworkGatewayId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewVirtualNetworkGatewayID(subscriptionId, resourceGroup, name string) VirtualNetworkGatewayId {
+	return VirtualNetworkGatewayId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id VirtualNetworkGatewayId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Gateway", segmentsStr)
+}
+
+func (id VirtualNetworkGatewayId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworkGateways/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// VirtualNetworkGatewayID parses a VirtualNetworkGateway ID into an VirtualNetworkGatewayId struct
+func VirtualNetworkGatewayID(input string) (*VirtualNetworkGatewayId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := VirtualNetworkGatewayId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("virtualNetworkGateways"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/network/parse/virtual_network_gateway_ip_configuration.go
+++ b/azurerm/internal/services/network/parse/virtual_network_gateway_ip_configuration.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type VirtualNetworkGatewayIpConfigurationId struct {
+	SubscriptionId            string
+	ResourceGroup             string
+	VirtualNetworkGatewayName string
+	IpConfigurationName       string
+}
+
+func NewVirtualNetworkGatewayIpConfigurationID(subscriptionId, resourceGroup, virtualNetworkGatewayName, ipConfigurationName string) VirtualNetworkGatewayIpConfigurationId {
+	return VirtualNetworkGatewayIpConfigurationId{
+		SubscriptionId:            subscriptionId,
+		ResourceGroup:             resourceGroup,
+		VirtualNetworkGatewayName: virtualNetworkGatewayName,
+		IpConfigurationName:       ipConfigurationName,
+	}
+}
+
+func (id VirtualNetworkGatewayIpConfigurationId) String() string {
+	segments := []string{
+		fmt.Sprintf("Ip Configuration Name %q", id.IpConfigurationName),
+		fmt.Sprintf("Virtual Network Gateway Name %q", id.VirtualNetworkGatewayName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Virtual Network Gateway Ip Configuration", segmentsStr)
+}
+
+func (id VirtualNetworkGatewayIpConfigurationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworkGateways/%s/ipConfigurations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.VirtualNetworkGatewayName, id.IpConfigurationName)
+}
+
+// VirtualNetworkGatewayIpConfigurationID parses a VirtualNetworkGatewayIpConfiguration ID into an VirtualNetworkGatewayIpConfigurationId struct
+func VirtualNetworkGatewayIpConfigurationID(input string) (*VirtualNetworkGatewayIpConfigurationId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := VirtualNetworkGatewayIpConfigurationId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.VirtualNetworkGatewayName, err = id.PopSegment("virtualNetworkGateways"); err != nil {
+		return nil, err
+	}
+	if resourceId.IpConfigurationName, err = id.PopSegment("ipConfigurations"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/network/parse/virtual_network_gateway_ip_configuration_test.go
+++ b/azurerm/internal/services/network/parse/virtual_network_gateway_ip_configuration_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualNetworkGatewayIpConfigurationId{}
+
+func TestVirtualNetworkGatewayIpConfigurationIDFormatter(t *testing.T) {
+	actual := NewVirtualNetworkGatewayIpConfigurationID("12345678-1234-9876-4563-123456789012", "resGroup1", "gw1", "cfg1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/cfg1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualNetworkGatewayIpConfigurationID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *VirtualNetworkGatewayIpConfigurationId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/",
+			Error: true,
+		},
+
+		{
+			// missing IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/",
+			Error: true,
+		},
+
+		{
+			// missing value for IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/cfg1",
+			Expected: &VirtualNetworkGatewayIpConfigurationId{
+				SubscriptionId:            "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:             "resGroup1",
+				VirtualNetworkGatewayName: "gw1",
+				IpConfigurationName:       "cfg1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/GW1/IPCONFIGURATIONS/CFG1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := VirtualNetworkGatewayIpConfigurationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.VirtualNetworkGatewayName != v.Expected.VirtualNetworkGatewayName {
+			t.Fatalf("Expected %q but got %q for VirtualNetworkGatewayName", v.Expected.VirtualNetworkGatewayName, actual.VirtualNetworkGatewayName)
+		}
+		if actual.IpConfigurationName != v.Expected.IpConfigurationName {
+			t.Fatalf("Expected %q but got %q for IpConfigurationName", v.Expected.IpConfigurationName, actual.IpConfigurationName)
+		}
+	}
+}

--- a/azurerm/internal/services/network/parse/virtual_network_gateway_test.go
+++ b/azurerm/internal/services/network/parse/virtual_network_gateway_test.go
@@ -1,0 +1,112 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = VirtualNetworkGatewayId{}
+
+func TestVirtualNetworkGatewayIDFormatter(t *testing.T) {
+	actual := NewVirtualNetworkGatewayID("12345678-1234-9876-4563-123456789012", "resGroup1", "gw1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestVirtualNetworkGatewayID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *VirtualNetworkGatewayId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1",
+			Expected: &VirtualNetworkGatewayId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "gw1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/GW1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := VirtualNetworkGatewayID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/network/resourceids.go
+++ b/azurerm/internal/services/network/resourceids.go
@@ -40,3 +40,7 @@ package network
 
 // Subnet Service Endpoint Policy
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=SubnetServiceEndpointStoragePolicy -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/serviceEndpointPolicies/policy1
+
+// Virtual Network Gateway
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkGateway -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=VirtualNetworkGatewayIpConfiguration -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/cfg1

--- a/azurerm/internal/services/network/validate/virtual_network_gateway.go
+++ b/azurerm/internal/services/network/validate/virtual_network_gateway.go
@@ -1,0 +1,31 @@
+package validate
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+)
+
+func IPAddressInAzureReservedAPIPARange(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	ip := net.ParseIP(v)
+	if four := ip.To4(); four == nil {
+		errors = append(errors, fmt.Errorf("expected %s to contain a valid IPv4 address, got: %s", k, v))
+	}
+
+	// See: https://docs.microsoft.com/en-us/azure/vpn-gateway/bgp-howto#2-create-the-vpn-gateway-for-testvnet1-with-bgp-parameters
+	azureAPIPAStart := net.ParseIP("169.254.21.0")
+	azureAPIPAEnd := net.ParseIP("169.254.22.255")
+
+	if !(bytes.Compare(ip, azureAPIPAStart) >= 0 && bytes.Compare(ip, azureAPIPAEnd) <= 0) {
+		errors = append(errors, fmt.Errorf("%s is not within Azure reserved APIPA range: [%s, %s]", ip, azureAPIPAStart, azureAPIPAEnd))
+		return warnings, errors
+	}
+
+	return nil, nil
+}

--- a/azurerm/internal/services/network/validate/virtual_network_gateway_id.go
+++ b/azurerm/internal/services/network/validate/virtual_network_gateway_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
+)
+
+func VirtualNetworkGatewayID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.VirtualNetworkGatewayID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/network/validate/virtual_network_gateway_id_test.go
+++ b/azurerm/internal/services/network/validate/virtual_network_gateway_id_test.go
@@ -1,0 +1,76 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestVirtualNetworkGatewayID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/GW1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := VirtualNetworkGatewayID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/network/validate/virtual_network_gateway_ip_configuration_id.go
+++ b/azurerm/internal/services/network/validate/virtual_network_gateway_ip_configuration_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
+)
+
+func VirtualNetworkGatewayIpConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.VirtualNetworkGatewayIpConfigurationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/network/validate/virtual_network_gateway_ip_configuration_id_test.go
+++ b/azurerm/internal/services/network/validate/virtual_network_gateway_ip_configuration_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestVirtualNetworkGatewayIpConfigurationID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VirtualNetworkGatewayName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/",
+			Valid: false,
+		},
+
+		{
+			// missing IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for IpConfigurationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/virtualNetworkGateways/gw1/ipConfigurations/cfg1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/GW1/IPCONFIGURATIONS/CFG1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := VirtualNetworkGatewayIpConfigurationID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -480,14 +482,14 @@ func getVirtualNetworkGatewayConnectionProperties(d *schema.ResourceData) (*netw
 	if v, ok := d.GetOk("virtual_network_gateway_id"); ok {
 		virtualNetworkGatewayId := v.(string)
 
-		_, name, err := resourceGroupAndVirtualNetworkGatewayFromId(virtualNetworkGatewayId)
+		gwid, err := parse.VirtualNetworkGatewayID(virtualNetworkGatewayId)
 		if err != nil {
-			return nil, fmt.Errorf("Error Getting VirtualNetworkGateway Name and Group:: %+v", err)
+			return nil, err
 		}
 
 		props.VirtualNetworkGateway1 = &network.VirtualNetworkGateway{
 			ID:   &virtualNetworkGatewayId,
-			Name: &name,
+			Name: &gwid.Name,
 			VirtualNetworkGatewayPropertiesFormat: &network.VirtualNetworkGatewayPropertiesFormat{
 				IPConfigurations: &[]network.VirtualNetworkGatewayIPConfiguration{},
 			},
@@ -511,15 +513,13 @@ func getVirtualNetworkGatewayConnectionProperties(d *schema.ResourceData) (*netw
 	}
 
 	if v, ok := d.GetOk("peer_virtual_network_gateway_id"); ok {
-		peerVirtualNetworkGatewayId := v.(string)
-		_, name, err := resourceGroupAndVirtualNetworkGatewayFromId(peerVirtualNetworkGatewayId)
+		gwid, err := parse.VirtualNetworkGatewayID(v.(string))
 		if err != nil {
-			return nil, fmt.Errorf("Error Getting VirtualNetworkGateway Name and Group:: %+v", err)
+			return nil, err
 		}
-
 		props.VirtualNetworkGateway2 = &network.VirtualNetworkGateway{
-			ID:   &peerVirtualNetworkGatewayId,
-			Name: &name,
+			ID:   utils.String(gwid.ID()),
+			Name: &gwid.Name,
 			VirtualNetworkGatewayPropertiesFormat: &network.VirtualNetworkGatewayPropertiesFormat{
 				IPConfigurations: &[]network.VirtualNetworkGatewayIPConfiguration{},
 			},

--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -832,7 +832,6 @@ func flattenVirtualNetworkGatewayBgpPeeringAddresses(input *[]network.IPConfigur
 	}
 
 	return output, nil
-
 }
 
 func flattenVirtualNetworkGatewayIPConfigurations(ipConfigs *[]network.VirtualNetworkGatewayIPConfiguration) []interface{} {
@@ -952,17 +951,6 @@ func hashVirtualNetworkGatewayRevokedCert(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["thumbprint"].(string)))
 
 	return schema.HashString(buf.String())
-}
-
-func resourceGroupAndVirtualNetworkGatewayFromId(virtualNetworkGatewayId string) (string, string, error) {
-	id, err := azure.ParseAzureResourceID(virtualNetworkGatewayId)
-	if err != nil {
-		return "", "", err
-	}
-	name := id.Path["virtualNetworkGateways"]
-	resGroup := id.ResourceGroup
-
-	return resGroup, name, nil
 }
 
 func validateVirtualNetworkGatewaySubnetId(i interface{}, k string) (warnings []string, errors []error) {

--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -319,7 +319,6 @@ func resourceVirtualNetworkGateway() *schema.Resource {
 							Type:       schema.TypeString,
 							Optional:   true,
 							Computed:   true,
-							ForceNew:   true,
 							Deprecated: "Deprecated in favor of `peering_addresses`",
 						},
 

--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -330,7 +330,6 @@ func resourceVirtualNetworkGateway() *schema.Resource {
 						"peering_addresses": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Computed: true,
 							MinItems: 1,
 							MaxItems: 2,
 							Elem: &schema.Resource{

--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -319,7 +319,7 @@ func resourceVirtualNetworkGateway() *schema.Resource {
 							Type:       schema.TypeString,
 							Optional:   true,
 							Computed:   true,
-							Deprecated: "Deprecated in favor of `peering_addresses`",
+							Deprecated: "Deprecated in favor of `bgp_settings.0.peering_addresses.0.default_addresses.0`",
 						},
 
 						"peer_weight": {

--- a/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
@@ -892,8 +892,7 @@ resource "azurerm_virtual_network_gateway" "test" {
   bgp_settings {
     asn = "65010"
     peering_addresses {
-      ip_configuration_name = "gw-ip"
-      apipa_addresses       = ["169.254.21.1"]
+      apipa_addresses = ["169.254.21.1"]
     }
   }
 }

--- a/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
@@ -847,7 +847,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-ngw-%d"
   location = "%s"
 }
 
@@ -1118,7 +1118,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-ngw-%d"
   location = "%s"
 }
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -162,6 +162,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+---
+
 The `ip_configuration` block supports:
 
 * `name` - (Optional) A user-defined name of the IP configuration. Defaults to
@@ -178,6 +180,8 @@ The `ip_configuration` block supports:
 
 * `public_ip_address_id` - (Required) The ID of the public ip address to associate
     with the Virtual Network Gateway.
+
+---
 
 The `vpn_client_configuration` block supports:
 
@@ -221,22 +225,38 @@ The `vpn_client_configuration` block supports:
     The supported values are `SSTP`, `IkeV2` and `OpenVPN`.
     Values `SSTP` and `IkeV2` are incompatible with the use of 
     `aad_tenant`, `aad_audience` and `aad_issuer`.
+  
+---
 
 The `bgp_settings` block supports:
 
 * `asn` - (Optional) The Autonomous System Number (ASN) to use as part of the BGP.
 
-* `peering_address` - (Optional) The BGP peer IP address of the virtual network
+* `peering_address` - (Optional / **Deprecated**) The BGP peer IP address of the virtual network
     gateway. This address is needed to configure the created gateway as a BGP Peer
     on the on-premises VPN devices. The IP address must be part of the subnet of
     the Virtual Network Gateway. Changing this forces a new resource to be created.
 
+* `peering_addresses` - (Optional) A list of `peering_addresses` as defined below. You can specify either one `peering_addresses` (normal use case) or two (when `active_active` is `true`).
+
 * `peer_weight` - (Optional) The weight added to routes which have been learned
     through BGP peering. Valid values can be between `0` and `100`.
+  
+---
 
 A `custom_route` block supports the following:
 
 * `address_prefixes` - (Optional) A list of address blocks reserved for this virtual network in CIDR notation. Changing this forces a new resource to be created.
+
+---
+
+A `peering_addresses` supports the following:
+
+* `ip_configuration_name` - (Required) The name of the IP configuration of this Virtual Network Gateway (as you defined in the`ip_configuration`).
+
+* `apipa_addresses` - (Optional) A list of Azure custom APIPA addresses assigned to the BGP peer of the Virtual Network Gateway. The valid range for the Azure reserved APIPA address is from "169.254.21.0" to "169.254.22.255".
+
+---
 
 The `root_certificate` block supports:
 
@@ -246,6 +266,8 @@ The `root_certificate` block supports:
     authority. The certificate must be provided in Base-64 encoded X.509 format
     (PEM). In particular, this argument *must not* include the
     `-----BEGIN CERTIFICATE-----` or `-----END CERTIFICATE-----` markers.
+ 
+---
 
 The `root_revoked_certificate` block supports:
 
@@ -253,12 +275,29 @@ The `root_revoked_certificate` block supports:
 
 * `public_cert_data` - (Required) The SHA1 thumbprint of the certificate to be
     revoked.
-
+  
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The ID of the Virtual Network Gateway.
+
+* `bgp_settings` - A block of `bgp_settings`.
+
+---
+
+The `bgp_settings` block supports:
+
+* `peering_addresses` - A list of `peering_addresses` as defined below.
+
+---
+
+The `peering_addresses` supports:
+
+* `default_addresses` - A list of peering address assigned to the BGP peer of the Virtual Network Gateway.
+
+* `tunnel_ip_addresses` - A list of tunnel IP addresses assigned to the BGP peer of the Virtual Network Gateway.
+
 
 ## Timeouts
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -232,11 +232,6 @@ The `bgp_settings` block supports:
 
 * `asn` - (Optional) The Autonomous System Number (ASN) to use as part of the BGP.
 
-* `peering_address` - (Optional / **Deprecated**) The BGP peer IP address of the virtual network
-    gateway. This address is needed to configure the created gateway as a BGP Peer
-    on the on-premises VPN devices. The IP address must be part of the subnet of
-    the Virtual Network Gateway. Changing this forces a new resource to be created.
-
 * `peering_addresses` - (Optional) A list of `peering_addresses` as defined below. You can specify either one `peering_addresses` (normal use case) or two (when `active_active` is `true`).
 
 * `peer_weight` - (Optional) The weight added to routes which have been learned
@@ -254,7 +249,9 @@ A `peering_addresses` supports the following:
 
 * `ip_configuration_name` - (Required) The name of the IP configuration of this Virtual Network Gateway (as you defined in the`ip_configuration`).
 
-* `apipa_addresses` - (Optional) A list of Azure custom APIPA addresses assigned to the BGP peer of the Virtual Network Gateway. The valid range for the Azure reserved APIPA address is from "169.254.21.0" to "169.254.22.255".
+* `apipa_addresses` - (Optional) A list of Azure custom APIPA addresses assigned to the BGP peer of the Virtual Network Gateway.
+  
+~> **Note:** The valid range for the reserved APIPA address in Azure Public is from "169.254.21.0" to "169.254.22.255".
 
 ---
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -247,7 +247,7 @@ A `custom_route` block supports the following:
 
 A `peering_addresses` supports the following:
 
-* `ip_configuration_name` - (Required) The name of the IP configuration of this Virtual Network Gateway (as you defined in the`ip_configuration`).
+* `ip_configuration_name` - (Optional) The name of the IP configuration of this Virtual Network Gateway. In case there are multiple `ip_configuration` blocks defined, this property is **required** to specify.
 
 * `apipa_addresses` - (Optional) A list of Azure custom APIPA addresses assigned to the BGP peer of the Virtual Network Gateway.
   

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -232,7 +232,7 @@ The `bgp_settings` block supports:
 
 * `asn` - (Optional) The Autonomous System Number (ASN) to use as part of the BGP.
 
-* `peering_addresses` - (Optional) A list of `peering_addresses` as defined below. You can specify either one `peering_addresses` (normal use case) or two (when `active_active` is `true`).
+* `peering_addresses` - (Optional) A list of `peering_addresses` as defined below. Only one `peering_addresses` block can be specified except when `active_active` of this Virtual Network Gateway is `true`.
 
 * `peer_weight` - (Optional) The weight added to routes which have been learned
     through BGP peering. Valid values can be between `0` and `100`.
@@ -251,7 +251,7 @@ A `peering_addresses` supports the following:
 
 * `apipa_addresses` - (Optional) A list of Azure custom APIPA addresses assigned to the BGP peer of the Virtual Network Gateway.
   
-~> **Note:** The valid range for the reserved APIPA address in Azure Public is from "169.254.21.0" to "169.254.22.255".
+~> **Note:** The valid range for the reserved APIPA address in Azure Public is from `169.254.21.0` to `169.254.22.255`.
 
 ---
 


### PR DESCRIPTION
Add support for `bgp_settings.peering_addresses`, which deprecates the `bgp_settings.peering_address` (in favor of `bgp_settings.peering_addresses.default_addresses`). The `bgp_settings.peering_addresses` is an extension of the `ip_configuration`.

Although the `bgp_settings.peering_address` is settable in current schema and its replacement `bgp_settings.peering_addresses.default_addresses` is read-only. Confirmed with service team that the `bgp_settings.peering_address` is actually read-only in backend side. This means this change will not incur breaking changes.

Fix #10262 

## Test Result

```bash
terraform-provider-azurerm on  vnet_gateway_apipa via 🐹 v1.15.6 took 25m20s
💤 make testacc TEST=./azurerm/internal/services/network TESTARGS='-run TestAccVirtualNetworkGateway_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network -v -run TestAccVirtualNetworkGateway_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVirtualNetworkGateway_basic
=== PAUSE TestAccVirtualNetworkGateway_basic
=== RUN   TestAccVirtualNetworkGateway_requiresImport
=== PAUSE TestAccVirtualNetworkGateway_requiresImport
=== RUN   TestAccVirtualNetworkGateway_lowerCaseSubnetName
=== PAUSE TestAccVirtualNetworkGateway_lowerCaseSubnetName
=== RUN   TestAccVirtualNetworkGateway_vpnGw1
=== PAUSE TestAccVirtualNetworkGateway_vpnGw1
=== RUN   TestAccVirtualNetworkGateway_activeActive
=== PAUSE TestAccVirtualNetworkGateway_activeActive
=== RUN   TestAccVirtualNetworkGateway_standard
=== PAUSE TestAccVirtualNetworkGateway_standard
=== RUN   TestAccVirtualNetworkGateway_vpnGw2
=== PAUSE TestAccVirtualNetworkGateway_vpnGw2
=== RUN   TestAccVirtualNetworkGateway_vpnGw3
=== PAUSE TestAccVirtualNetworkGateway_vpnGw3
=== RUN   TestAccVirtualNetworkGateway_generation
=== PAUSE TestAccVirtualNetworkGateway_generation
=== RUN   TestAccVirtualNetworkGateway_vpnClientConfig
=== PAUSE TestAccVirtualNetworkGateway_vpnClientConfig
=== RUN   TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
=== PAUSE TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
=== RUN   TestAccVirtualNetworkGateway_vpnClientConfigOpenVPN
=== PAUSE TestAccVirtualNetworkGateway_vpnClientConfigOpenVPN
=== RUN   TestAccVirtualNetworkGateway_enableBgp
=== PAUSE TestAccVirtualNetworkGateway_enableBgp
=== RUN   TestAccVirtualNetworkGateway_enableBgpWithAPIPA
=== PAUSE TestAccVirtualNetworkGateway_enableBgpWithAPIPA
=== RUN   TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA
=== PAUSE TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA
=== RUN   TestAccVirtualNetworkGateway_expressRoute
=== PAUSE TestAccVirtualNetworkGateway_expressRoute
=== RUN   TestAccVirtualNetworkGateway_privateIpAddressEnabled
=== PAUSE TestAccVirtualNetworkGateway_privateIpAddressEnabled
=== CONT  TestAccVirtualNetworkGateway_basic
=== CONT  TestAccVirtualNetworkGateway_vpnClientConfig
=== CONT  TestAccVirtualNetworkGateway_standard
=== CONT  TestAccVirtualNetworkGateway_vpnGw1
=== CONT  TestAccVirtualNetworkGateway_lowerCaseSubnetName
=== CONT  TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA
=== CONT  TestAccVirtualNetworkGateway_enableBgp
=== CONT  TestAccVirtualNetworkGateway_vpnGw3
--- PASS: TestAccVirtualNetworkGateway_enableBgp (1545.25s)
=== CONT  TestAccVirtualNetworkGateway_activeActive
--- PASS: TestAccVirtualNetworkGateway_vpnGw3 (1648.47s)
=== CONT  TestAccVirtualNetworkGateway_generation
--- PASS: TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA (1658.50s)
=== CONT  TestAccVirtualNetworkGateway_privateIpAddressEnabled
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfig (1760.13s)
=== CONT  TestAccVirtualNetworkGateway_expressRoute
--- PASS: TestAccVirtualNetworkGateway_vpnGw1 (1772.30s)
=== CONT  TestAccVirtualNetworkGateway_enableBgpWithAPIPA
--- PASS: TestAccVirtualNetworkGateway_standard (2878.69s)
=== CONT  TestAccVirtualNetworkGateway_requiresImport
--- PASS: TestAccVirtualNetworkGateway_basic (2916.15s)
=== CONT  TestAccVirtualNetworkGateway_vpnGw2
--- PASS: TestAccVirtualNetworkGateway_expressRoute (1246.93s)
=== CONT  TestAccVirtualNetworkGateway_vpnClientConfigOpenVPN
--- PASS: TestAccVirtualNetworkGateway_activeActive (1550.36s)
=== CONT  TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
--- PASS: TestAccVirtualNetworkGateway_lowerCaseSubnetName (3173.35s)
--- PASS: TestAccVirtualNetworkGateway_enableBgpWithAPIPA (1860.74s)
--- PASS: TestAccVirtualNetworkGateway_generation (2560.87s)
=== CONT  TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
    testing.go:684: Step 0 error: Check failed: Check 2/5 error: azurerm_virtual_network_gateway.test: Attribute 'vpn_client_configuration.0.aad_tenant' expected "https://login.microsoftonline.com/vv7p8/", got "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/"
--- PASS: TestAccVirtualNetworkGateway_vpnGw2 (1448.40s)
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfigOpenVPN (1934.89s)
--- FAIL: TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth (1923.98s)
--- PASS: TestAccVirtualNetworkGateway_requiresImport (2885.73s)
--- PASS: TestAccVirtualNetworkGateway_privateIpAddressEnabled (4722.24s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     6380.801s
FAIL
GNUmakefile:104: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

I guess the failed case is not introduced by this PR?