### PR TITLE
`azurerm_function_app`- `scm_type` is now read into state

### DIFF
--- a/azurerm/internal/services/web/function_app.go
+++ b/azurerm/internal/services/web/function_app.go
@@ -440,6 +440,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 
 	result["min_tls_version"] = string(input.MinTLSVersion)
 	result["ftps_state"] = string(input.FtpsState)
+	result["scm_type"] = string(input.ScmType)
 
 	result["cors"] = FlattenWebCorsSettings(input.Cors)
 

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -886,7 +886,7 @@ func TestAccFunctionApp_sourceControlUpdate(t *testing.T) {
 	})
 }
 
-func TestAccFunctionApp_scm1(t *testing.T) {
+func TestAccFunctionApp_scm(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 


### PR DESCRIPTION
Fixes a bug where `scm_type` was not being read into state.

```
--- PASS: TestAccFunctionApp_scm (241.75s)
```

Fixes #8676