### PR TITLE
Update to docs for setting provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ Version 2.x of the AzureRM Provider requires Terraform 0.12.x and later.
 
 ## Usage Example
 
-```
+> When using the AzureRM Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the Terraform configuration for the root module, using a `required_providers` block as per the following example. For previous versions, please continue to pin the version within the provider block.
+
+```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # We recommend pinning to the specific version of the Azure Provider you're using
-  # since new versions are released frequently
-  version = "=2.40.0"
-
   features {}
 
   # More information on the authentication methods supported by

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Version 2.x of the AzureRM Provider requires Terraform 0.12.x and later.
 
 ## Usage Example
 
-> When using the AzureRM Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the Terraform configuration for the root module, using a `required_providers` block as per the following example. For previous versions, please continue to pin the version within the provider block.
+> When using the AzureRM Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the root module Terraform configuration, using a `required_providers` block as per the following example. For previous versions, please continue to pin the version within the provider block.
 
 ```hcl
 # We strongly recommend using the required_providers block to set the

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -36,11 +36,32 @@ provider "azurerm" {
 
 More information on [how to pin the version of a Terraform Provider being used can be found on the Terraform Website](https://www.terraform.io/docs/configuration/providers.html#provider-versions).
 
-Once version 2.0 of the AzureRM Provider is released - you can then upgrade to it by updating the version specified in the Provider block, like so:
+To use version 2.0 and newer of the AzureRM Provider - you can upgrade to it in a controlled manner by updating the version specified in the Provider block, like so:
 
 ```hcl
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
   version = "=2.0.0"
+  features {}
+}
+```
+
+When using the AzureRM Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the Terraform configuration for the root module, using a `required_providers` block as per the following example:
+
+```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
   features {}
 }
 ```

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -54,7 +54,7 @@ When using the AzureRM Provider with Terraform 0.13 and later, the recommended a
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -55,7 +55,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -46,7 +46,7 @@ provider "azurerm" {
 }
 ```
 
-When using the AzureRM Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the Terraform configuration for the root module, using a `required_providers` block as per the following example:
+When using the AzureRM Provider with Terraform 0.13 and later, the recommended approach is to declare Provider versions in the root module Terraform configuration, using a `required_providers` block as per the following example:
 
 ```hcl
 # We strongly recommend using the required_providers block to set the

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -83,9 +83,20 @@ Now that we're logged into the Azure CLI - we can configure Terraform to use the
 To configure Terraform to use the Default Subscription defined in the Azure CLI - we can use the following Provider block:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.44.0"
+  features {}
 }
 ```
 
@@ -98,9 +109,20 @@ At this point running either `terraform plan` or `terraform apply` should allow 
 It's also possible to configure Terraform to use a specific Subscription - for example:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.44.0"
+  features {}
 
   subscription_id = "00000000-0000-0000-0000-000000000000"
 }
@@ -115,9 +137,20 @@ At this point running either `terraform plan` or `terraform apply` should allow 
 If you're looking to use Terraform across Tenants - it's possible to do this by configuring the Tenant ID field in the Provider block, as shown below:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.44.0"
+  features {}
 
   subscription_id = "00000000-0000-0000-0000-000000000000"
   tenant_id       = "11111111-1111-1111-1111-111111111111"

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -88,7 +88,7 @@ To configure Terraform to use the Default Subscription defined in the Azure CLI 
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -114,7 +114,7 @@ It's also possible to configure Terraform to use a specific Subscription - for e
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -142,7 +142,7 @@ If you're looking to use Terraform across Tenants - it's possible to do this by 
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -89,7 +89,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -115,7 +115,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -143,7 +143,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -97,7 +97,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -119,7 +119,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -142,7 +142,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -88,11 +88,23 @@ $ export ARM_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # only necessary for
 $ export ARM_MSI_ENDPOINT=$MSI_ENDPOINT # only necessary when the msi endpoint is different than the well-known one
 ```
 
-A provider block is _technically_ optional when using environment variables. Even so, we recommend defining a provider block so that you can pin or constrain the version of the provider being used:
+A provider block is _technically_ optional when using environment variables. Even so, we recommend defining provider blocks so that you can pin or constrain the version of the provider being used, and configure other optional settings:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "~> 1.23"
+  features {}
 }
 ```
 
@@ -101,8 +113,20 @@ provider "azurerm" {
 It's also possible to configure a managed identity within the provider block:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "~> 1.23"
+  features {}
 
   use_msi = true
   #...
@@ -112,8 +136,21 @@ provider "azurerm" {
 If you intend to configure a remote backend in the provider block, put `use_msi` outside of the backend block:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  version = "~> 1.23"
+  features {}
+
   use_msi = true
 
   backend "azurerm" {

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -96,7 +96,7 @@ A provider block is _technically_ optional when using environment variables. Eve
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -118,7 +118,7 @@ It's also possible to configure a managed identity within the provider block:
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -141,7 +141,7 @@ If you intend to configure a remote backend in the provider block, put `use_msi`
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }

--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -20,21 +20,49 @@ This guide covers how to migrate from using the following Data Sources and Resou
 
 ## Updating the Provider block
 
-As the AzureAD and AzureRM Provider support the same authentication methods - it's possible to update the Provider block by setting the new Provider name and version, for example:
+As the AzureAD and AzureRM Provider support the same authentication methods, it's possible to simply add the AzureAD Provider to the `required_providers` block and declare the configuration in a Provider block as per the following example:
 
 ```hcl
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "=1.44.0"
+  features {}
 }
 ```
 
 can become:
 
 ```hcl
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+      version = "=1.3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
 provider "azuread" {
-  version = "=0.10.0"
+  features {}
 }
 ```
+
+> For modules containing only resources from the AzureAD Provider, we recommend that you also remove the AzureRM Provider settings.
 
 ## Updating the Terraform Configurations
 

--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -26,7 +26,7 @@ As the AzureAD and AzureRM Provider support the same authentication methods, it'
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -43,11 +43,11 @@ can become:
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
     azuread = {
-      source = "hashicorp/azuread"
+      source  = "hashicorp/azuread"
       version = "=1.3.0"
     }
   }

--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -44,7 +44,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -99,7 +99,7 @@ $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-The following Terraform and Provider blocks can be specified - where `2.40.1` is the version of the Azure Provider that you'd like to use:
+The following Terraform and Provider blocks can be specified - where `2.46.0` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
 # We strongly recommend using the required_providers block to set the
@@ -108,7 +108,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -139,7 +139,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -107,7 +107,7 @@ The following Terraform and Provider blocks can be specified - where `2.40.1` is
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -138,7 +138,7 @@ variable "client_certificate_password" {}
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -99,12 +99,23 @@ $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-The following Provider block can be specified - where `1.44.0` is the version of the Azure Provider that you'd like to use:
+The following Terraform and Provider blocks can be specified - where `2.40.1` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.44.0"
+  features {}
 }
 ```
 
@@ -122,9 +133,20 @@ It's also possible to configure these variables either in-line or from using var
 variable "client_certificate_path" {}
 variable "client_certificate_password" {}
 
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.44.0"
+  features {}
 
   subscription_id             = "00000000-0000-0000-0000-000000000000"
   client_id                   = "00000000-0000-0000-0000-000000000000"

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -175,12 +175,22 @@ $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-The following Provider block can be specified - where `2.5.0` is the version of the Azure Provider that you'd like to use:
+The following Terraform and Provider blocks can be specified - where `2.40.1` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=2.5.0"
   features {}
 }
 ```
@@ -199,16 +209,25 @@ It's also possible to configure these variables either in-line or from using var
 variable "client_secret" {
 }
 
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=2.4.0"
+  features {}
 
   subscription_id = "00000000-0000-0000-0000-000000000000"
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = var.client_secret
   tenant_id       = "00000000-0000-0000-0000-000000000000"
-
-  features {}
 }
 ```
 

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -183,7 +183,7 @@ The following Terraform and Provider blocks can be specified - where `2.40.1` is
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }
@@ -214,7 +214,7 @@ variable "client_secret" {
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -175,7 +175,7 @@ $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-The following Terraform and Provider blocks can be specified - where `2.40.1` is the version of the Azure Provider that you'd like to use:
+The following Terraform and Provider blocks can be specified - where `2.46.0` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
 # We strongly recommend using the required_providers block to set the
@@ -184,7 +184,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }
@@ -215,7 +215,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -28,10 +28,19 @@ We recommend using either a Service Principal or Managed Service Identity when r
 ## Example Usage
 
 ```hcl
-# Configure the Azure Provider
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "=2.40.1"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
 provider "azurerm" {
-  # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
-  version = "=2.40.0"
   features {}
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.40.1"
+      version = "=2.46.0"
     }
   }
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -33,7 +33,7 @@ We recommend using either a Service Principal or Managed Service Identity when r
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "=2.40.1"
     }
   }


### PR DESCRIPTION
This PR provides a quick update to the docs to ensure they reflect the latest recommended approach for setting provider versions in Terraform.

The update is supported by Terraform 0.13.x and newer, and generates the following deprecation warning in Terraform 0.14.x

```bash
Warning: Version constraints inside provider configuration blocks are deprecated

  on main.tf line 2, in provider "azurerm":
   2:   version = "2.42.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.
```

Some examples in the repository may also need updating, but for now I wanted to focus on the docs before going further with this.