### PR TITLE
Support for `skip_metric_validation` in `azurerm_monitor_metric_alert`

### DIFF
--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
@@ -153,6 +153,12 @@ func resourceMonitorMetricAlert() *schema.Resource {
 							Type:     schema.TypeFloat,
 							Required: true,
 						},
+
+						"skip_metric_validation": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -254,6 +260,10 @@ func resourceMonitorMetricAlert() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.IsRFC3339Time,
+						},
+						"skip_metric_validation": {
+							Type:     schema.TypeBool,
+							Optional: true,
 						},
 					},
 				},
@@ -592,13 +602,14 @@ func expandMonitorMetricAlertSingleResourceMultiMetricCriteria(input []interface
 		v := item.(map[string]interface{})
 		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
 		criteria = append(criteria, insights.MetricCriteria{
-			Name:            utils.String(fmt.Sprintf("Metric%d", i+1)),
-			MetricNamespace: utils.String(v["metric_namespace"].(string)),
-			MetricName:      utils.String(v["metric_name"].(string)),
-			TimeAggregation: v["aggregation"].(string),
-			Dimensions:      &dimensions,
-			Operator:        insights.Operator(v["operator"].(string)),
-			Threshold:       utils.Float(v["threshold"].(float64)),
+			Name:                 utils.String(fmt.Sprintf("Metric%d", i+1)),
+			MetricNamespace:      utils.String(v["metric_namespace"].(string)),
+			MetricName:           utils.String(v["metric_name"].(string)),
+			TimeAggregation:      v["aggregation"].(string),
+			Dimensions:           &dimensions,
+			Operator:             insights.Operator(v["operator"].(string)),
+			Threshold:            utils.Float(v["threshold"].(float64)),
+			SkipMetricValidation: utils.Bool(v["skip_metric_validation"].(bool)),
 		})
 	}
 	return &insights.MetricAlertSingleResourceMultipleMetricCriteria{
@@ -613,13 +624,14 @@ func expandMonitorMetricAlertMultiResourceMultiMetricForStaticMetricCriteria(inp
 		v := item.(map[string]interface{})
 		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
 		criteria = append(criteria, insights.MetricCriteria{
-			Name:            utils.String(fmt.Sprintf("Metric%d", i+1)),
-			MetricNamespace: utils.String(v["metric_namespace"].(string)),
-			MetricName:      utils.String(v["metric_name"].(string)),
-			TimeAggregation: v["aggregation"].(string),
-			Dimensions:      &dimensions,
-			Operator:        insights.Operator(v["operator"].(string)),
-			Threshold:       utils.Float(v["threshold"].(float64)),
+			Name:                 utils.String(fmt.Sprintf("Metric%d", i+1)),
+			MetricNamespace:      utils.String(v["metric_namespace"].(string)),
+			MetricName:           utils.String(v["metric_name"].(string)),
+			TimeAggregation:      v["aggregation"].(string),
+			Dimensions:           &dimensions,
+			Operator:             insights.Operator(v["operator"].(string)),
+			Threshold:            utils.Float(v["threshold"].(float64)),
+			SkipMetricValidation: utils.Bool(v["skip_metric_validation"].(bool)),
 		})
 	}
 	return &insights.MetricAlertMultipleResourceMultipleMetricCriteria{
@@ -651,7 +663,8 @@ func expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(in
 				NumberOfEvaluationPeriods: utils.Float(float64(v["evaluation_total_count"].(int))),
 				MinFailingPeriodsToAlert:  utils.Float(float64(v["evaluation_failure_count"].(int))),
 			},
-			IgnoreDataBefore: ignoreDataBefore,
+			IgnoreDataBefore:     ignoreDataBefore,
+			SkipMetricValidation: utils.Bool(v["skip_metric_validation"].(bool)),
 		})
 	}
 	return &insights.MetricAlertMultipleResourceMultipleMetricCriteria{
@@ -760,14 +773,20 @@ func flattenMonitorMetricAlertSingleResourceMultiMetricCriteria(input *[]insight
 		threshold = *criteria.Threshold
 	}
 
+	var skipMetricValidation bool
+	if criteria.SkipMetricValidation != nil {
+		skipMetricValidation = *criteria.SkipMetricValidation
+	}
+
 	return []interface{}{
 		map[string]interface{}{
-			"metric_namespace": metricNamespace,
-			"metric_name":      metricName,
-			"aggregation":      timeAggregation,
-			"dimension":        dimResult,
-			"operator":         operator,
-			"threshold":        threshold,
+			"metric_namespace":       metricNamespace,
+			"metric_name":            metricName,
+			"aggregation":            timeAggregation,
+			"dimension":              dimResult,
+			"operator":               operator,
+			"threshold":              threshold,
+			"skip_metric_validation": skipMetricValidation,
 		},
 	}
 }
@@ -781,10 +800,11 @@ func flattenMonitorMetricAlertMultiResourceMultiMetricCriteria(input *[]insights
 	for _, criteria := range *input {
 		v := make(map[string]interface{})
 		var (
-			metricName      string
-			metricNamespace string
-			timeAggregation interface{}
-			dimensions      []insights.MetricDimension
+			metricName           string
+			metricNamespace      string
+			timeAggregation      interface{}
+			dimensions           []insights.MetricDimension
+			skipMetricValidation bool
 		)
 
 		switch criteria := criteria.(type) {
@@ -808,6 +828,9 @@ func flattenMonitorMetricAlertMultiResourceMultiMetricCriteria(input *[]insights
 				threshold = *criteria.Threshold
 			}
 			v["threshold"] = threshold
+			if criteria.SkipMetricValidation != nil {
+				skipMetricValidation = *criteria.SkipMetricValidation
+			}
 		case insights.DynamicMetricCriteria:
 			if criteria.MetricName != nil {
 				metricName = *criteria.MetricName
@@ -818,6 +841,9 @@ func flattenMonitorMetricAlertMultiResourceMultiMetricCriteria(input *[]insights
 			timeAggregation = criteria.TimeAggregation
 			if criteria.Dimensions != nil {
 				dimensions = *criteria.Dimensions
+			}
+			if criteria.SkipMetricValidation != nil {
+				skipMetricValidation = *criteria.SkipMetricValidation
 			}
 			// DynamicMetricCriteria specific properties
 			v["operator"] = string(criteria.Operator)
@@ -848,6 +874,7 @@ func flattenMonitorMetricAlertMultiResourceMultiMetricCriteria(input *[]insights
 		v["metric_name"] = metricName
 		v["metric_namespace"] = metricNamespace
 		v["aggregation"] = timeAggregation
+		v["skip_metric_validation"] = skipMetricValidation
 		if dimensions != nil {
 			dimResult := make([]map[string]interface{}, 0)
 			for _, dimension := range dimensions {

--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
@@ -153,7 +153,6 @@ func resourceMonitorMetricAlert() *schema.Resource {
 							Type:     schema.TypeFloat,
 							Required: true,
 						},
-
 						"skip_metric_validation": {
 							Type:     schema.TypeBool,
 							Optional: true,

--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -316,14 +316,13 @@ resource "azurerm_network_interface" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  count                           = %[3]d
-  name                            = "acctestVM-${count.index}"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  disable_password_authentication = false
+  count               = %[3]d
+  name                = "acctestVM-${count.index}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test[count.index].id,
   ]

--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -357,14 +357,14 @@ resource "azurerm_monitor_metric_alert" "test" {
   scopes              = azurerm_linux_virtual_machine.test.*.id
   dynamic_criteria {
     metric_namespace = "Microsoft.Compute/virtualMachines"
-    metric_name      = "Network In"
-    aggregation      = "Total"
+    metric_name      = "CPU Credits Consumed"
+    aggregation      = "Average"
 
     operator               = "GreaterOrLessThan"
     alert_sensitivity      = "Medium"
     skip_metric_validation = true
   }
-  window_size              = "PT1H"
+  window_size              = "PT5M"
   frequency                = "PT5M"
   target_resource_type     = "Microsoft.Compute/virtualMachines"
   target_resource_location = "%s"

--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -252,11 +252,12 @@ resource "azurerm_monitor_metric_alert" "test" {
   window_size         = "PT12H"
 
   criteria {
-    metric_namespace = "Microsoft.Storage/storageAccounts"
-    metric_name      = "Transactions"
-    aggregation      = "Total"
-    operator         = "GreaterThan"
-    threshold        = 99
+    metric_namespace       = "Microsoft.Storage/storageAccounts"
+    metric_name            = "Transactions"
+    aggregation            = "Total"
+    operator               = "GreaterThan"
+    threshold              = 99
+    skip_metric_validation = true
 
     dimension {
       name     = "GeoType"
@@ -327,6 +328,11 @@ resource "azurerm_linux_virtual_machine" "test" {
     azurerm_network_interface.test[count.index].id,
   ]
 
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  }
+
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
@@ -355,8 +361,9 @@ resource "azurerm_monitor_metric_alert" "test" {
     metric_name      = "Network In"
     aggregation      = "Total"
 
-    operator          = "GreaterOrLessThan"
-    alert_sensitivity = "Medium"
+    operator               = "GreaterOrLessThan"
+    alert_sensitivity      = "Medium"
+    skip_metric_validation = true
   }
   window_size              = "PT1H"
   frequency                = "PT5M"

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -116,6 +116,7 @@ A `criteria` block supports the following:
 * `operator` - (Required) The criteria operator. Possible values are `Equals`, `NotEquals`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual`.
 * `threshold` - (Required) The criteria threshold value that activates the alert.
 * `dimension` - (Optional) One or more `dimension` blocks as defined below.
+* `skip_metric_validation` - (Optional) Skip the metric validation to allow creating an alert rule on a custom metric that isn't yet emitted? 
 
 ---
 
@@ -130,6 +131,7 @@ A `dynamic_criteria` block supports the following:
 * `evaluation_total_count` - (Optional) The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (`window_size`) and the selected number of aggregated points.
 * `evaluation_failure_count` - (Optional) The number of violations to trigger an alert. Should be smaller or equal to `evaluation_total_count`.
 * `ignore_data_before` - (Optional) The [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date from which to start learning the metric historical data and calculate the dynamic thresholds.
+* `skip_metric_validation` - (Optional) Skip the metric validation to allow creating an alert rule on a custom metric that isn't yet emitted? 
 
 ---
 

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -116,7 +116,7 @@ A `criteria` block supports the following:
 * `operator` - (Required) The criteria operator. Possible values are `Equals`, `NotEquals`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan` and `LessThanOrEqual`.
 * `threshold` - (Required) The criteria threshold value that activates the alert.
 * `dimension` - (Optional) One or more `dimension` blocks as defined below.
-* `skip_metric_validation` - (Optional) Skip the metric validation to allow creating an alert rule on a custom metric that isn't yet emitted? 
+* `skip_metric_validation` - (Optional) Skip the metric validation to allow creating an alert rule on a custom metric that isn't yet emitted? Defaults to `false`.
 
 ---
 
@@ -131,7 +131,7 @@ A `dynamic_criteria` block supports the following:
 * `evaluation_total_count` - (Optional) The number of aggregated lookback points. The lookback time window is calculated based on the aggregation granularity (`window_size`) and the selected number of aggregated points.
 * `evaluation_failure_count` - (Optional) The number of violations to trigger an alert. Should be smaller or equal to `evaluation_total_count`.
 * `ignore_data_before` - (Optional) The [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) date from which to start learning the metric historical data and calculate the dynamic thresholds.
-* `skip_metric_validation` - (Optional) Skip the metric validation to allow creating an alert rule on a custom metric that isn't yet emitted? 
+* `skip_metric_validation` - (Optional) Skip the metric validation to allow creating an alert rule on a custom metric that isn't yet emitted? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/10421

=== RUN   TestAccMonitorMetricAlert_basic
=== PAUSE TestAccMonitorMetricAlert_basic
=== CONT  TestAccMonitorMetricAlert_basic
--- PASS: TestAccMonitorMetricAlert_basic (306.26s)
=== RUN   TestAccMonitorMetricAlert_requiresImport
=== PAUSE TestAccMonitorMetricAlert_requiresImport
=== CONT  TestAccMonitorMetricAlert_requiresImport
--- PASS: TestAccMonitorMetricAlert_requiresImport (329.54s)
=== RUN   TestAccMonitorMetricAlert_complete
=== PAUSE TestAccMonitorMetricAlert_complete
=== CONT  TestAccMonitorMetricAlert_complete
--- PASS: TestAccMonitorMetricAlert_complete (306.20s)
=== RUN   TestAccMonitorMetricAlert_basicAndCompleteUpdate
=== PAUSE TestAccMonitorMetricAlert_basicAndCompleteUpdate
=== CONT  TestAccMonitorMetricAlert_basicAndCompleteUpdate
--- PASS: TestAccMonitorMetricAlert_basicAndCompleteUpdate (747.31s)
=== RUN   TestAccMonitorMetricAlert_multiScope
=== PAUSE TestAccMonitorMetricAlert_multiScope
=== CONT  TestAccMonitorMetricAlert_multiScope
--- PASS: TestAccMonitorMetricAlert_multiScope (1170.62s)
=== RUN   TestAccMonitorMetricAlert_applicationInsightsWebTest
=== PAUSE TestAccMonitorMetricAlert_applicationInsightsWebTest
=== CONT  TestAccMonitorMetricAlert_applicationInsightsWebTest
--- PASS: TestAccMonitorMetricAlert_applicationInsightsWebTest (308.82s)
