### PR TITLE
r/role_assignment: adding validation for `scope`

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -22,6 +22,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // Spring Cloud only allows a max of 10 provisioned
         "appplatform" to testConfiguration(5, defaultStartHour),
 
+        // these tests all conflict with one another
+        "authorization": to testConfiguration(1, defaultStartHour),
+
         // The AKS API has a low rate limit
         "containers" to testConfiguration(5, defaultStartHour),
 

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -23,7 +23,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "appplatform" to testConfiguration(5, defaultStartHour),
 
         // these tests all conflict with one another
-        "authorization": to testConfiguration(1, defaultStartHour),
+        "authorization" to testConfiguration(1, defaultStartHour),
 
         // The AKS API has a low rate limit
         "containers" to testConfiguration(5, defaultStartHour),

--- a/azurerm/internal/services/authorization/role_assignment_resource.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource.go
@@ -12,8 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	managementGroupValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/validate"
+	resourceValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/validate"
+	subscriptionValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/subscription/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -48,6 +52,12 @@ func resourceArmRoleAssignment() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.Any(
+					managementGroupValidate.ManagementGroupID,
+					subscriptionValidate.SubscriptionID,
+					resourceValidate.ResourceGroupID,
+					azure.ValidateResourceID,
+				),
 			},
 
 			"role_definition_id": {

--- a/azurerm/internal/services/authorization/role_assignment_resource_test.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource_test.go
@@ -17,38 +17,7 @@ import (
 
 type RoleAssignmentResource struct{}
 
-func TestAccRoleAssignment(t *testing.T) {
-	// NOTE: this is a combined test rather than separate split out tests due to
-	// Azure only being happy about provisioning a couple at a time
-	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
-		"basic": {
-			"roleName": testAccRoleAssignment_roleName,
-			"custom":   testAccRoleAssignment_custom,
-		},
-		"basic_empty_name": {
-			"emptyName": testAccRoleAssignment_emptyName,
-		},
-		"built_in": {
-			"builtin": testAccRoleAssignment_builtin,
-		},
-		"data_actions": {
-			"dataActions": testAccRoleAssignment_dataActions,
-		},
-		"requires_import": {
-			"requiresImport": testAccRoleAssignment_requiresImport,
-		},
-		"assignment": {
-			"sp":     testAccActiveDirectoryServicePrincipal_servicePrincipal,
-			"spType": testAccActiveDirectoryServicePrincipal_servicePrincipalWithType,
-			"group":  testAccActiveDirectoryServicePrincipal_group,
-		},
-		"management": {
-			"assign": testAccRoleAssignment_managementGroup,
-		},
-	})
-}
-
-func testAccRoleAssignment_emptyName(t *testing.T) {
+func TestAccRoleAssignment_emptyName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	r := RoleAssignmentResource{}
 
@@ -64,7 +33,7 @@ func testAccRoleAssignment_emptyName(t *testing.T) {
 	})
 }
 
-func testAccRoleAssignment_roleName(t *testing.T) {
+func TestAccRoleAssignment_roleName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	id := uuid.New().String()
 
@@ -83,7 +52,7 @@ func testAccRoleAssignment_roleName(t *testing.T) {
 	})
 }
 
-func testAccRoleAssignment_requiresImport(t *testing.T) {
+func TestAccRoleAssignment_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	id := uuid.New().String()
 
@@ -105,7 +74,7 @@ func testAccRoleAssignment_requiresImport(t *testing.T) {
 	})
 }
 
-func testAccRoleAssignment_dataActions(t *testing.T) {
+func TestAccRoleAssignment_dataActions(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	id := uuid.New().String()
 
@@ -123,7 +92,7 @@ func testAccRoleAssignment_dataActions(t *testing.T) {
 	})
 }
 
-func testAccRoleAssignment_builtin(t *testing.T) {
+func TestAccRoleAssignment_builtin(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	id := uuid.New().String()
 
@@ -140,7 +109,7 @@ func testAccRoleAssignment_builtin(t *testing.T) {
 	})
 }
 
-func testAccRoleAssignment_custom(t *testing.T) {
+func TestAccRoleAssignment_custom(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	roleDefinitionId := uuid.New().String()
 	roleAssignmentId := uuid.New().String()
@@ -159,7 +128,7 @@ func testAccRoleAssignment_custom(t *testing.T) {
 	})
 }
 
-func testAccActiveDirectoryServicePrincipal_servicePrincipal(t *testing.T) {
+func TestAccRoleAssignment_ServicePrincipal(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	ri := acceptance.RandTimeInt()
 	id := uuid.New().String()
@@ -177,7 +146,7 @@ func testAccActiveDirectoryServicePrincipal_servicePrincipal(t *testing.T) {
 	})
 }
 
-func testAccActiveDirectoryServicePrincipal_servicePrincipalWithType(t *testing.T) {
+func TestAccRoleAssignment_ServicePrincipalWithType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	ri := acceptance.RandTimeInt()
 	id := uuid.New().String()
@@ -194,7 +163,7 @@ func testAccActiveDirectoryServicePrincipal_servicePrincipalWithType(t *testing.
 	})
 }
 
-func testAccActiveDirectoryServicePrincipal_group(t *testing.T) {
+func TestAccRoleAssignment_ServicePrincipalGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	ri := acceptance.RandTimeInt()
 	id := uuid.New().String()
@@ -212,7 +181,7 @@ func testAccActiveDirectoryServicePrincipal_group(t *testing.T) {
 }
 
 // TODO - "real" management group with appropriate required for testing
-func testAccRoleAssignment_managementGroup(t *testing.T) {
+func TestAccRoleAssignment_managementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_role_assignment", "test")
 	groupId := uuid.New().String()
 


### PR DESCRIPTION
This commit introduces validation to the `scope` field, validating that it's either a Management Group ID, Resource Group ID, Subscription ID or otherwise a Resource ID - to workaround the API usability issues identified in #9569.

This isn't perfect, but the error messages coming back from the API are particularly unhelpful to users unfamiliar with how the API works.

I've also taken the opportunity to split the tests out, since we can limit them one at a time in TC.

Ignoring one temporary failure due to a conflicting role assignment, the tests pass:

```
$ TF_ACC=1 envchain azurerm go test -v ./azurerm/internal/services/authorization/... -run=TestAccRoleAssignment_ -test.parallel=1 -timeout=60m
=== RUN   TestAccRoleAssignment_emptyName
=== PAUSE TestAccRoleAssignment_emptyName
=== RUN   TestAccRoleAssignment_roleName
=== PAUSE TestAccRoleAssignment_roleName
=== RUN   TestAccRoleAssignment_requiresImport
=== PAUSE TestAccRoleAssignment_requiresImport
=== RUN   TestAccRoleAssignment_dataActions
=== PAUSE TestAccRoleAssignment_dataActions
=== RUN   TestAccRoleAssignment_builtin
=== PAUSE TestAccRoleAssignment_builtin
=== RUN   TestAccRoleAssignment_custom
=== PAUSE TestAccRoleAssignment_custom
=== RUN   TestAccRoleAssignment_ServicePrincipal
=== PAUSE TestAccRoleAssignment_ServicePrincipal
=== RUN   TestAccRoleAssignment_ServicePrincipalWithType
=== PAUSE TestAccRoleAssignment_ServicePrincipalWithType
=== RUN   TestAccRoleAssignment_ServicePrincipalGroup
=== PAUSE TestAccRoleAssignment_ServicePrincipalGroup
=== RUN   TestAccRoleAssignment_managementGroup
=== PAUSE TestAccRoleAssignment_managementGroup
=== CONT  TestAccRoleAssignment_emptyName
--- PASS: TestAccRoleAssignment_emptyName (99.56s)
=== CONT  TestAccRoleAssignment_ServicePrincipal
--- PASS: TestAccRoleAssignment_ServicePrincipal (112.94s)
=== CONT  TestAccRoleAssignment_managementGroup
--- PASS: TestAccRoleAssignment_managementGroup (171.08s)
=== CONT  TestAccRoleAssignment_ServicePrincipalGroup
--- PASS: TestAccRoleAssignment_ServicePrincipalGroup (101.36s)
=== CONT  TestAccRoleAssignment_ServicePrincipalWithType
--- PASS: TestAccRoleAssignment_ServicePrincipalWithType (126.43s)
=== CONT  TestAccRoleAssignment_dataActions
    testing.go:684: Step 0 error: errors during apply:

        Error: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="RoleAssignmentExists" Message="The role assignment already exists."

          on /var/folders/09/6xztm5651pgbc_0mq7p265sw0000gn/T/tf-test666009848/main.tf line 12:
          (source code not available)


--- FAIL: TestAccRoleAssignment_dataActions (31.27s)
=== CONT  TestAccRoleAssignment_custom
--- PASS: TestAccRoleAssignment_custom (152.03s)
=== CONT  TestAccRoleAssignment_builtin
--- PASS: TestAccRoleAssignment_builtin (95.05s)
=== CONT  TestAccRoleAssignment_requiresImport
--- PASS: TestAccRoleAssignment_requiresImport (112.09s)
=== CONT  TestAccRoleAssignment_roleName
--- PASS: TestAccRoleAssignment_roleName (92.40s)
FAIL
```