### PR TITLE
`azurerm_app_service`: `ip_restriction.x.ip_address` now accepts anything other than an empty string.

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -836,7 +836,7 @@ func schemaAppServiceIpRestriction() *schema.Schema {
 				"ip_address": {
 					Type:         schema.TypeString,
 					Optional:     true,
-					ValidateFunc: validation.IsCIDR,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
 				"service_tag": {


### PR DESCRIPTION
**AppService IP Restrictions may also include Strings like: "AzureFrontDoor.Backend" and not just IP-Addresses (CIDRs).** 

When importing an AppService into a Terraform-State one can see also this.
The datasource schema also allows a string here.

Further improvement would also be to not just allow any string but to allow only valid strings, but for it would not prevent a valid app service configuration.

Imported state looks like:

```
               "ip_restriction": [
                  {
                    "action": "Allow",
                    "ip_address": "AzureFrontDoor.Backend",
                    "name": "Allow FD only",
                    "priority": 100,
                    "virtual_network_subnet_id": ""
                  }
                ],
```