### PR TITLE
keyvault: adjusting the caching setup

### DIFF
--- a/azurerm/internal/common/client_options.go
+++ b/azurerm/internal/common/client_options.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -69,6 +68,4 @@ func setUserAgent(client *autorest.Client, tfVersion, partnerID string, disableT
 	if partnerID != "" {
 		client.UserAgent = fmt.Sprintf("%s pid-%s", client.UserAgent, partnerID)
 	}
-
-	log.Printf("[DEBUG] AzureRM Client User Agent: %s\n", client.UserAgent)
 }


### PR DESCRIPTION
This commit changes the cache setup to add a write lock around the key vault write/lock meaning we shouldn't get keys cancelling one another out.

This commit also adds an additional cache read, which improves performance since we've already got the information and don't need to look this up - improving performance.

Fixes #10371

<img width="491" alt="Screenshot 2021-02-03 at 12 31 01" src="https://user-images.githubusercontent.com/666005/106741203-aeef4a80-661b-11eb-8e98-c2a5de21497e.png">