### PR TITLE
Remove failing `kubernetes_cluster` test for deprecated bridge network mode

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -178,24 +178,6 @@ func TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyNetworkModeTran
 	})
 }
 
-func TestAccKubernetesCluster_advancedNetworkingAzureCalicoPolicyNetworkModeBridge(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
-	r := KubernetesClusterResource{}
-
-	data.ResourceTest(t, r, []resource.TestStep{
-		{
-			Config: r.advancedNetworkingWithPolicyNetworkMode(data, "azure", "calico", "bridge"),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("network_profile.0.network_plugin").HasValue("azure"),
-				check.That(data.ResourceName).Key("network_profile.0.network_policy").HasValue("calico"),
-				check.That(data.ResourceName).Key("network_profile.0.network_mode").HasValue("bridge"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccKubernetesCluster_advancedNetworkingAzureNPMPolicy(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
 	testAccKubernetesCluster_advancedNetworkingAzureNPMPolicy(t)

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -285,6 +285,9 @@ func resourceKubernetesCluster() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								// https://github.com/Azure/AKS/issues/1954#issuecomment-759306712
+								// Transparent is already the default and only option for CNI
+								// Bridge is only kept for backward compatibility
 								string(containerservice.Bridge),
 								string(containerservice.Transparent),
 							}, false),

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -304,11 +304,9 @@ A `network_profile` block supports the following:
 
 -> **NOTE:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `default_node_pool` block must be set and `pod_cidr` must not be set.
 
-* `network_mode` - (Optional) Network mode to be used with Azure CNI. Possible values are `bridge` or `transparent`. Changing this forces a new resource to be created.
+* `network_mode` - (Optional) Network mode to be used with Azure CNI. Possible value is `transparent`, which is also the AKS default for Azure CNI. Changing this forces a new resource to be created. `network_mode` will probably be deprecated by Azure.
 
 ~> **NOTE:** This property can only be set when `network_plugin` is set to `azure`.
-
--> **NOTE:** `network_mode` Is currently in Preview on an opt-in basis. To use it, enable feature `AKSNetworkModePreview` for `namespace Microsoft.ContainerService`.
 
 * `network_policy` - (Optional) Sets up network policy to be used with Azure CNI. [Network policy allows us to control the traffic flow between pods](https://docs.microsoft.com/en-us/azure/aks/use-network-policies). Currently supported values are `calico` and `azure`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -304,7 +304,9 @@ A `network_profile` block supports the following:
 
 -> **NOTE:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `default_node_pool` block must be set and `pod_cidr` must not be set.
 
-* `network_mode` - (Optional) Network mode to be used with Azure CNI. Possible value is `transparent`, which is also the AKS default for Azure CNI. Changing this forces a new resource to be created. `network_mode` will probably be deprecated by Azure.
+* `network_mode` - (Optional) Network mode to be used with Azure CNI. Possible values are `bridge` and `transparent`. Changing this forces a new resource to be created.
+
+~> **Note:** `network_mode` can only be set to `bridge` for existing Kubernetes Clusters and cannot be used to provision new Clusters - this will be removed by Azure in the future.
 
 ~> **NOTE:** This property can only be set when `network_plugin` is set to `azure`.
 


### PR DESCRIPTION
While running the acctests for AKS I bumped into this one.

According to [AKS PM comments](https://github.com/Azure/AKS/issues/1954) `transparent` is now the only and default `network_mode` for Azure CNI.

When running the test this is confirmed: `Code="NetworkModeInvalid" Message="Network mode bridge is not valid, the valid values are 'transparent' or ''. We are looking to deprecate network mode"`