### PR TITLE
azurerm_mssql_virtual_machine: support auto_backup

### DIFF
--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -79,9 +79,10 @@ func resourceMsSqlVirtualMachine() *schema.Resource {
 						},
 
 						"encryption_password": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"manual_schedule": {

--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -297,6 +297,13 @@ func resourceMsSqlVirtualMachine() *schema.Resource {
 }
 
 func resourceMsSqlVirtualMachineCustomDiff(d *schema.ResourceDiff, _ interface{}) error {
+	// ForceNew when removing the auto_backup block.
+	// See https://github.com/Azure/azure-rest-api-specs/issues/12818#issuecomment-773727756
+	old, new := d.GetChange("auto_backup")
+	if len(old.([]interface{})) == 1 && len(new.([]interface{})) == 0 {
+		return d.ForceNew("auto_backup")
+	}
+
 	encryptionEnabled := d.Get("auto_backup.0.encryption_enabled")
 	v, ok := d.GetOk("auto_backup.0.encryption_password")
 

--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -225,7 +225,7 @@ resource "azurerm_subnet" "test" {
   name                 = "acctest-SN-%[1]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.0.0/24"
+  address_prefixes     = ["10.0.0.0/24"]
 }
 
 resource "azurerm_subnet_network_security_group_association" "test" {
@@ -244,20 +244,6 @@ resource "azurerm_network_security_group" "test" {
   name                = "acctest-NSG-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_network_security_rule" "RDPRule" {
-  name                        = "RDPRule"
-  resource_group_name         = azurerm_resource_group.test.name
-  priority                    = 1000
-  direction                   = "Inbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = 3389
-  source_address_prefix       = "167.220.255.0/25"
-  destination_address_prefix  = "*"
-  network_security_group_name = azurerm_network_security_group.test.name
 }
 
 resource "azurerm_network_security_rule" "MSSQLRule" {
@@ -428,11 +414,12 @@ resource "azurerm_mssql_virtual_machine" "test" {
   sql_license_type   = "PAYG"
 
   auto_backup {
-    encryption_enabled         = true
-    encryption_password        = "P@55w0rD!!%[2]s"
-    retention_period           = 23
-    storage_blob_endpoint      = azurerm_storage_account.test.primary_blob_endpoint
-    storage_account_access_key = azurerm_storage_account.test.primary_access_key
+    encryption_enabled              = true
+    encryption_password             = "P@55w0rD!!%[2]s"
+    retention_period                = 23
+    storage_blob_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+    storage_account_access_key      = azurerm_storage_account.test.primary_access_key
+    system_databases_backup_enabled = false
   }
 }
 `, r.template(data), data.RandomString)
@@ -455,17 +442,19 @@ resource "azurerm_mssql_virtual_machine" "test" {
   sql_license_type   = "PAYG"
 
   auto_backup {
-    encryption_enabled         = true
-    encryption_password        = "P@55w0rD!!%[2]s"
-    retention_period           = 14
-    storage_blob_endpoint      = azurerm_storage_account.test.primary_blob_endpoint
-    storage_account_access_key = azurerm_storage_account.test.primary_access_key
-    backup_system_databases    = true
-    backup_schedule_automated  = false
-    full_backup_frequency      = "Daily"
-    full_backup_start_hour     = 3
-    full_backup_window_hours   = 4
-    log_backup_frequency       = 20
+    encryption_enabled              = true
+    encryption_password             = "P@55w0rD!!%[2]s"
+    retention_period                = 14
+    storage_blob_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+    storage_account_access_key      = azurerm_storage_account.test.primary_access_key
+    system_databases_backup_enabled = true
+
+    manual_schedule {
+      full_backup_frequency    = "Daily"
+      full_backup_start_hour   = 3
+      full_backup_window_hours = 4
+      log_backup_frequency     = 20
+    }
   }
 }
 `, r.template(data), data.RandomString)

--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -103,13 +103,6 @@ func TestAccMsSqlVirtualMachine_autoBackup(t *testing.T) {
 		data.ImportStep("auto_backup.0.encryption_password",
 			"auto_backup.0.storage_account_access_key",
 			"auto_backup.0.storage_blob_endpoint"),
-		{
-			Config: r.basic(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -416,7 +409,7 @@ resource "azurerm_mssql_virtual_machine" "test" {
   auto_backup {
     encryption_enabled              = true
     encryption_password             = "P@55w0rD!!%[2]s"
-    retention_period                = 23
+    retention_period_in_days        = 23
     storage_blob_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
     storage_account_access_key      = azurerm_storage_account.test.primary_access_key
     system_databases_backup_enabled = false
@@ -444,16 +437,16 @@ resource "azurerm_mssql_virtual_machine" "test" {
   auto_backup {
     encryption_enabled              = true
     encryption_password             = "P@55w0rD!!%[2]s"
-    retention_period                = 14
+    retention_period_in_days        = 14
     storage_blob_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
     storage_account_access_key      = azurerm_storage_account.test.primary_access_key
     system_databases_backup_enabled = true
 
     manual_schedule {
-      full_backup_frequency    = "Daily"
-      full_backup_start_hour   = 3
-      full_backup_window_hours = 4
-      log_backup_frequency     = 20
+      full_backup_frequency           = "Daily"
+      full_backup_start_hour          = 3
+      full_backup_window_in_hours     = 4
+      log_backup_frequency_in_minutes = 20
     }
   }
 }

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -34,7 +34,6 @@ resource "azurerm_mssql_virtual_machine" "example" {
     maintenance_window_duration_in_minutes = 60
     maintenance_window_starting_hour       = 2
   }
-
 }
 ```
 
@@ -70,29 +69,31 @@ The following arguments are supported:
 
 The `auto_backup` block supports the following:
 
-* `backup_system_databases` - (Optional) Include or exclude system databases from auto backup. Defaults to `false`.
-
-* `backup_schedule_automated` - (Optional) Whether the backup schedule type is Automated. Defaults to `true`.
-
--> NOTE: When `backup_shedule_automated` is true (which is the default), the scheduling properties `full_backup_frequency`, `full_backup_start_hour`, `full_backup_window_hours` and `log_backup_frequency` cannot be specified. When `backup_schedule_automated` is false, these properties must be set.
-
 * `encryption_enabled` - (Optional) Enable or disable encryption for backups. Defaults to `false`.
 
 * `encryption_password` - (Optional) Encryption password to use. Must be specified when encryption is enabled.
+
+* `manual_schedule` - (Optional) A `manual_schedule` block as documented below. When this block is present, the schedule type is set to `Manual`. Without this block, the schedule type is set to `Automated`.
+
+* `retention_period_in_days` - (Required) Retention period of backups, in days. Valid values are from `1` to `30`.
+
+* `storage_blob_endpoint` - (Required) Blob endpoint for the storage account where backups will be kept.
+
+* `storage_account_access_key` - (Required) Access key for the storage account where backups will be kept.
+
+* `system_databases_backup_enabled` - (Optional) Include or exclude system databases from auto backup. Defaults to `false`.
+
+---
+
+The `manual_schedule` block supports the following:
 
 * `full_backup_frequency` - (Optional) Frequency of full backups. Valid values include `Daily` or `Weekly`. Required when `backup_schedule_automated` is false.
 
 * `full_backup_start_hour` - (Optional) Start hour of a given day during which full backups can take place. Valid values are from `0` to `23`. Required when `backup_schedule_automated` is false.
 
-* `full_backup_window_hours` - (Optional) Duration of the time window of a given day during which full backups can take place, in hours. Valid values are between `1` and `23`. Required when `backup_schedule_automated` is false.
+* `full_backup_window_in_hours` - (Optional) Duration of the time window of a given day during which full backups can take place, in hours. Valid values are between `1` and `23`. Required when `backup_schedule_automated` is false.
 
-* `log_backup_frequency` - (Optional) Frequency of log backups, in minutes. Valid values are from `5` to `60`. Required when `backup_schedule_automated` is false.
-
-* `retention_period` - (Required) Retention period of backups, in days. Valid values are from `1` to `30`.
-
-* `storage_blob_endpoint` - (Required) Blob endpoint for the storage account where backups will be kept.
-
-* `storage_account_access_key` - (Required) Access key for the storage account where backups will be kept.
+* `log_backup_frequency_in_minutes` - (Optional) Frequency of log backups, in minutes. Valid values are from `5` to `60`. Required when `backup_schedule_automated` is false.
 
 ---
 

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `sql_license_type` - (Optional) The SQL Server license type. Possible values are `AHUB` (Azure Hybrid Benefit) and `PAYG` (Pay-As-You-Go). Changing this forces a new resource to be created.
 
+* `auto_backup` (Optional) An `auto_backup` block as defined below.
+
 * `auto_patching` - (Optional) An `auto_patching` block as defined below.
 
 * `key_vault_credential` - (Optional) (Optional) An `key_vault_credential` block as defined below.
@@ -63,6 +65,34 @@ The following arguments are supported:
 * `storage_configuration` - (Optional) An `storage_configuration` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+The `auto_backup` block supports the following:
+
+* `backup_system_databases` - (Optional) Include or exclude system databases from auto backup. Defaults to `false`.
+
+* `backup_schedule_automated` - (Optional) Whether the backup schedule type is Automated. Defaults to `true`.
+
+-> NOTE: When `backup_shedule_automated` is true (which is the default), the scheduling properties `full_backup_frequency`, `full_backup_start_hour`, `full_backup_window_hours` and `log_backup_frequency` cannot be specified. When `backup_schedule_automated` is false, these properties must be set.
+
+* `encryption_enabled` - (Optional) Enable or disable encryption for backups. Defaults to `false`.
+
+* `encryption_password` - (Optional) Encryption password to use. Must be specified when encryption is enabled.
+
+* `full_backup_frequency` - (Optional) Frequency of full backups. Valid values include `Daily` or `Weekly`. Required when `backup_schedule_automated` is false.
+
+* `full_backup_start_hour` - (Optional) Start hour of a given day during which full backups can take place. Valid values are from `0` to `23`. Required when `backup_schedule_automated` is false.
+
+* `full_backup_window_hours` - (Optional) Duration of the time window of a given day during which full backups can take place, in hours. Valid values are between `1` and `23`. Required when `backup_schedule_automated` is false.
+
+* `log_backup_frequency` - (Optional) Frequency of log backups, in minutes. Valid values are from `5` to `60`. Required when `backup_schedule_automated` is false.
+
+* `retention_period` - (Required) Retention period of backups, in days. Valid values are from `1` to `30`.
+
+* `storage_blob_endpoint` - (Required) Blob endpoint for the storage account where backups will be kept.
+
+* `storage_account_access_key` - (Required) Access key for the storage account where backups will be kept.
 
 ---
 

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `sql_license_type` - (Optional) The SQL Server license type. Possible values are `AHUB` (Azure Hybrid Benefit) and `PAYG` (Pay-As-You-Go). Changing this forces a new resource to be created.
 
-* `auto_backup` (Optional) An `auto_backup` block as defined below.
+* `auto_backup` (Optional) An `auto_backup` block as defined below. This block can be added to an existing resource, but removing this block forces a new resource to be created.
 
 * `auto_patching` - (Optional) An `auto_patching` block as defined below.
 


### PR DESCRIPTION
Replaces #10107

Support configuring auto backup for azurerm_mssql_virtual_machine

- Enabling/disabling is determined by presence of `auto_backup` block
- WaitForState func is needed as auto backup settings take awhile to take effect, whether adding/removing or updating