### PR TITLE
`azurerm_[linux|windows]_virtual_machine` - add Data Disks support

### DIFF
--- a/azurerm/internal/features/beta_features_opt_in.go
+++ b/azurerm/internal/features/beta_features_opt_in.go
@@ -1,0 +1,14 @@
+package features
+
+import (
+	"os"
+	"strings"
+)
+
+// VMDataDiskBeta returns whether or not the beta for VM Data Disks for Linux and Windows VM resources is
+// enabled.
+//
+// Set the Environment Variable `ARM_PROVIDER_VM_DATADISKS_BETA` to `true`
+func VMDataDiskBeta() bool {
+	return strings.EqualFold(os.Getenv("ARM_PROVIDER_VM_DATADISKS_BETA"), "true")
+}

--- a/azurerm/internal/features/defaults.go
+++ b/azurerm/internal/features/defaults.go
@@ -17,8 +17,9 @@ func Default() UserFeatures {
 			DeleteNestedItemsDuringDeletion: true,
 		},
 		VirtualMachine: VirtualMachineFeatures{
-			DeleteOSDiskOnDeletion: true,
-			GracefulShutdown:       false,
+			DeleteDataDiskOnDeletion: true,
+			DeleteOSDiskOnDeletion:   true,
+			GracefulShutdown:         false,
 		},
 		VirtualMachineScaleSet: VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,

--- a/azurerm/internal/features/defaults.go
+++ b/azurerm/internal/features/defaults.go
@@ -17,9 +17,9 @@ func Default() UserFeatures {
 			DeleteNestedItemsDuringDeletion: true,
 		},
 		VirtualMachine: VirtualMachineFeatures{
-			DeleteDataDiskOnDeletion: true,
-			DeleteOSDiskOnDeletion:   true,
-			GracefulShutdown:         false,
+			DeleteDataDisksOnDeletion: true,
+			DeleteOSDiskOnDeletion:    true,
+			GracefulShutdown:          false,
 		},
 		VirtualMachineScaleSet: VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -10,9 +10,9 @@ type UserFeatures struct {
 }
 
 type VirtualMachineFeatures struct {
-	DeleteDataDiskOnDeletion bool
-	DeleteOSDiskOnDeletion   bool
-	GracefulShutdown         bool
+	DeleteDataDisksOnDeletion bool
+	DeleteOSDiskOnDeletion    bool
+	GracefulShutdown          bool
 }
 
 type VirtualMachineScaleSetFeatures struct {

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -10,8 +10,9 @@ type UserFeatures struct {
 }
 
 type VirtualMachineFeatures struct {
-	DeleteOSDiskOnDeletion bool
-	GracefulShutdown       bool
+	DeleteDataDiskOnDeletion bool
+	DeleteOSDiskOnDeletion   bool
+	GracefulShutdown         bool
 }
 
 type VirtualMachineScaleSetFeatures struct {

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -74,7 +74,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"delete_data_disk_on_deletion": {
+					"delete_data_disks_on_deletion": {
 						Type:     schema.TypeBool,
 						Optional: true,
 					},
@@ -185,8 +185,8 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		items := raw.([]interface{})
 		if len(items) > 0 {
 			virtualMachinesRaw := items[0].(map[string]interface{})
-			if v, ok := virtualMachinesRaw["delete_data_disk_on_deletion"]; ok {
-				features.VirtualMachine.DeleteDataDiskOnDeletion = v.(bool)
+			if v, ok := virtualMachinesRaw["delete_data_disks_on_deletion"]; ok {
+				features.VirtualMachine.DeleteDataDisksOnDeletion = v.(bool)
 			}
 			if v, ok := virtualMachinesRaw["delete_os_disk_on_deletion"]; ok {
 				features.VirtualMachine.DeleteOSDiskOnDeletion = v.(bool)

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -74,6 +74,10 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
+					"delete_data_disk_on_deletion": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 					"delete_os_disk_on_deletion": {
 						Type:     schema.TypeBool,
 						Optional: true,
@@ -181,6 +185,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		items := raw.([]interface{})
 		if len(items) > 0 {
 			virtualMachinesRaw := items[0].(map[string]interface{})
+			if v, ok := virtualMachinesRaw["delete_data_disk_on_deletion"]; ok {
+				features.VirtualMachine.DeleteDataDiskOnDeletion = v.(bool)
+			}
 			if v, ok := virtualMachinesRaw["delete_os_disk_on_deletion"]; ok {
 				features.VirtualMachine.DeleteOSDiskOnDeletion = v.(bool)
 			}

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -29,7 +29,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
+					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -93,8 +94,9 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
-					GracefulShutdown:       true,
+					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
+					GracefulShutdown:         true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -155,8 +157,9 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: false,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: false,
-					GracefulShutdown:       false,
+					DeleteDataDiskOnDeletion: false,
+					DeleteOSDiskOnDeletion:   false,
+					GracefulShutdown:         false,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: false,
@@ -390,8 +393,9 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
-					GracefulShutdown:       false,
+					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
+					GracefulShutdown:         false,
 				},
 			},
 		},
@@ -410,8 +414,9 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: true,
-					GracefulShutdown:       true,
+					DeleteDataDiskOnDeletion: true,
+					DeleteOSDiskOnDeletion:   true,
+					GracefulShutdown:         true,
 				},
 			},
 		},
@@ -430,8 +435,9 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteOSDiskOnDeletion: false,
-					GracefulShutdown:       false,
+					DeleteDataDiskOnDeletion: false,
+					DeleteOSDiskOnDeletion:   false,
+					GracefulShutdown:         false,
 				},
 			},
 		},

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -66,8 +66,9 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion": true,
-							"graceful_shutdown":          true,
+							"delete_data_disk_on_deletion": true,
+							"delete_os_disk_on_deletion":   true,
+							"graceful_shutdown":            true,
 						},
 					},
 					"virtual_machine_scale_set": []interface{}{
@@ -106,8 +107,9 @@ func TestExpandFeatures(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion": false,
-							"graceful_shutdown":          false,
+							"delete_data_disk_on_deletion": false,
+							"delete_os_disk_on_deletion":   false,
+							"graceful_shutdown":            false,
 						},
 					},
 					"network_locking": []interface{}{
@@ -399,8 +401,9 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion": true,
-							"graceful_shutdown":          true,
+							"delete_data_disk_on_deletion": true,
+							"delete_os_disk_on_deletion":   true,
+							"graceful_shutdown":            true,
 						},
 					},
 				},
@@ -418,8 +421,9 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_os_disk_on_deletion": false,
-							"graceful_shutdown":          false,
+							"delete_data_disk_on_deletion": false,
+							"delete_os_disk_on_deletion":   false,
+							"graceful_shutdown":            false,
 						},
 					},
 				},

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -29,8 +29,8 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteDataDiskOnDeletion: true,
-					DeleteOSDiskOnDeletion:   true,
+					DeleteDataDisksOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -67,9 +67,9 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_data_disk_on_deletion": true,
-							"delete_os_disk_on_deletion":   true,
-							"graceful_shutdown":            true,
+							"delete_data_disks_on_deletion": true,
+							"delete_os_disk_on_deletion":    true,
+							"graceful_shutdown":             true,
 						},
 					},
 					"virtual_machine_scale_set": []interface{}{
@@ -94,9 +94,9 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: true,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteDataDiskOnDeletion: true,
-					DeleteOSDiskOnDeletion:   true,
-					GracefulShutdown:         true,
+					DeleteDataDisksOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					GracefulShutdown:          true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -109,9 +109,9 @@ func TestExpandFeatures(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_data_disk_on_deletion": false,
-							"delete_os_disk_on_deletion":   false,
-							"graceful_shutdown":            false,
+							"delete_data_disks_on_deletion": false,
+							"delete_os_disk_on_deletion":    false,
+							"graceful_shutdown":             false,
 						},
 					},
 					"network_locking": []interface{}{
@@ -157,9 +157,9 @@ func TestExpandFeatures(t *testing.T) {
 					DeleteNestedItemsDuringDeletion: false,
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteDataDiskOnDeletion: false,
-					DeleteOSDiskOnDeletion:   false,
-					GracefulShutdown:         false,
+					DeleteDataDisksOnDeletion: false,
+					DeleteOSDiskOnDeletion:    false,
+					GracefulShutdown:          false,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: false,
@@ -393,9 +393,9 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteDataDiskOnDeletion: true,
-					DeleteOSDiskOnDeletion:   true,
-					GracefulShutdown:         false,
+					DeleteDataDisksOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					GracefulShutdown:          false,
 				},
 			},
 		},
@@ -405,18 +405,18 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_data_disk_on_deletion": true,
-							"delete_os_disk_on_deletion":   true,
-							"graceful_shutdown":            true,
+							"delete_data_disks_on_deletion": true,
+							"delete_os_disk_on_deletion":    true,
+							"graceful_shutdown":             true,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteDataDiskOnDeletion: true,
-					DeleteOSDiskOnDeletion:   true,
-					GracefulShutdown:         true,
+					DeleteDataDisksOnDeletion: true,
+					DeleteOSDiskOnDeletion:    true,
+					GracefulShutdown:          true,
 				},
 			},
 		},
@@ -426,18 +426,18 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
-							"delete_data_disk_on_deletion": false,
-							"delete_os_disk_on_deletion":   false,
-							"graceful_shutdown":            false,
+							"delete_data_disks_on_deletion": false,
+							"delete_os_disk_on_deletion":    false,
+							"graceful_shutdown":             false,
 						},
 					},
 				},
 			},
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
-					DeleteDataDiskOnDeletion: false,
-					DeleteOSDiskOnDeletion:   false,
-					GracefulShutdown:         false,
+					DeleteDataDisksOnDeletion: false,
+					DeleteOSDiskOnDeletion:    false,
+					GracefulShutdown:          false,
 				},
 			},
 		},

--- a/azurerm/internal/services/compute/helpers/managed_disk.go
+++ b/azurerm/internal/services/compute/helpers/managed_disk.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+)
+
+// DeleteManagedDisk takes a list of managed disks and attempts to delete those created from "Empty"
+// It is intended to be used with Virtual Machine resources for deletion of Data Disks that are created in-line with
+// the VM. This may be parallelised at a later date.
+func DeleteManagedDisks(ctx context.Context, client *clients.Client, dataDisks *[]compute.DataDisk) error {
+	disksClient := client.Compute.DisksClient
+	if dataDisks == nil {
+		return nil
+	}
+	for _, v := range *dataDisks {
+		if v.ManagedDisk.ID == nil {
+			return fmt.Errorf("could not read disk ID for deletion")
+		}
+		id, err := parse.ManagedDiskID(*v.ManagedDisk.ID)
+		if err != nil {
+			return fmt.Errorf("could not parse disk ID for deletion: %+v", err)
+		}
+		log.Printf("[DEBUG] Attempting to delete %s", *id)
+		deleteFuture, err := disksClient.Delete(ctx, id.ResourceGroup, id.DiskName)
+		if err != nil {
+			return fmt.Errorf("failure deleting Data Disk %q (resource group %q): %+v", id.DiskName, id.ResourceGroup, err)
+		}
+
+		if err = deleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
+			return fmt.Errorf("failure waiting for deletion of Data Disk %q (resource group %q): %+v", id.DiskName, id.ResourceGroup, err)
+		}
+		log.Printf("[DEBUG] Successfully deleted %s", *id)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/helpers/managed_disk.go
+++ b/azurerm/internal/services/compute/helpers/managed_disk.go
@@ -48,7 +48,7 @@ func DeleteManagedDisks(ctx context.Context, client *clients.Client, dataDisks *
 }
 
 func UpdateManagedDisks(ctx context.Context, client *compute.DisksClient, dataDiskUpdates []DataDiskUpdate) error {
-	if dataDiskUpdates == nil || len(dataDiskUpdates) == 0 {
+	if len(dataDiskUpdates) == 0 {
 		return nil
 	}
 

--- a/azurerm/internal/services/compute/helpers/managed_disk.go
+++ b/azurerm/internal/services/compute/helpers/managed_disk.go
@@ -10,6 +10,11 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 )
 
+type DataDiskUpdate struct {
+	ManagedDiskID *string
+	Patch         *compute.DiskUpdate
+}
+
 // DeleteManagedDisk takes a list of managed disks and attempts to delete those created from "Empty"
 // It is intended to be used with Virtual Machine resources for deletion of Data Disks that are created in-line with
 // the VM. This may be parallelised at a later date.

--- a/azurerm/internal/services/compute/helpers/managed_disk.go
+++ b/azurerm/internal/services/compute/helpers/managed_disk.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 )

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
@@ -31,7 +32,7 @@ import (
 // TODO: confirm locking as appropriate
 
 func resourceLinuxVirtualMachine() *schema.Resource {
-	return &schema.Resource{
+	linuxVirtualMachineSchema := &schema.Resource{
 		Create: resourceLinuxVirtualMachineCreate,
 		Read:   resourceLinuxVirtualMachineRead,
 		Update: resourceLinuxVirtualMachineUpdate,
@@ -300,6 +301,11 @@ func resourceLinuxVirtualMachine() *schema.Resource {
 			},
 		},
 	}
+	if features.VMDataDiskBeta() {
+		linuxVirtualMachineSchema.Schema["data_disks"] = virtualMachineDataDiskSchema()
+	}
+
+	return linuxVirtualMachineSchema
 }
 
 func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{}) error {
@@ -363,6 +369,15 @@ func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{})
 	osDiskRaw := d.Get("os_disk").([]interface{})
 	osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Linux)
 
+	dataDisks := &[]compute.DataDisk{}
+
+	if features.VMDataDiskBeta() {
+		dataDisks, err = expandVirtualMachineDataDisks(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
 	secretsRaw := d.Get("secret").([]interface{})
 	secrets := expandLinuxSecrets(secretsRaw)
 
@@ -405,10 +420,7 @@ func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{})
 			StorageProfile: &compute.StorageProfile{
 				ImageReference: sourceImageReference,
 				OsDisk:         osDisk,
-
-				// Data Disks are instead handled via the Association resource - as such we can send an empty value here
-				// but for Updates this'll need to be nil, else any associations will be overwritten
-				DataDisks: &[]compute.DataDisk{},
+				DataDisks:      dataDisks,
 			},
 
 			// Optional
@@ -688,6 +700,16 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference)); err != nil {
 			return fmt.Errorf("setting `source_image_reference`: %+v", err)
 		}
+
+		if features.VMDataDiskBeta() {
+			if profile.DataDisks != nil {
+				dataDisks, err := flattenVirtualMachineDataDisks(profile.DataDisks)
+				if err != nil {
+					return err
+				}
+				d.Set("data_disks", dataDisks)
+			}
+		}
 	}
 
 	encryptionAtHostEnabled := false
@@ -719,6 +741,7 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VMClient
+	disksClient := meta.(*clients.Client).Compute.DisksClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -871,6 +894,55 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 		osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Linux)
 		update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{
 			OsDisk: osDisk,
+		}
+	}
+
+	// list of disks for expand operations
+	dataDisksForGrow := make([]map[string]interface{}, 0)
+	// list of disks with encryption set changes
+	dataDisksForEncrypt := make([]map[string]interface{}, 0)
+	if features.VMDataDiskBeta() && d.HasChange("data_disks") {
+		shouldUpdate = true
+
+		oldRaw, newRaw := d.GetChange("data_disks.0.local")
+		oldDisks := oldRaw.(*schema.Set).List()
+		newDisks := newRaw.(*schema.Set).List()
+		for _, o := range oldDisks {
+			oldDisk := o.(map[string]interface{})
+			if oldDiskName, ok := oldDisk["name"]; ok {
+				for _, n := range newDisks {
+					newDisk := n.(map[string]interface{})
+					if newDiskName, ok := newDisk["name"]; ok && oldDiskName.(string) == newDiskName.(string) {
+						if newDisk["disk_size_gb"].(int) < oldDisk["disk_size_gb"].(int) {
+							return fmt.Errorf("new disk size cannot be smaller than existing for %q, in Virtual Machine %q (resource group %q)", oldDisk["name"], id.Name, id.ResourceGroup)
+						} else if newDisk["disk_size_gb"].(int) > oldDisk["disk_size_gb"].(int) {
+							shouldShutDown = true
+							shouldDeallocate = true
+							dataDisksForGrow = append(dataDisksForGrow, newDisk)
+						}
+						if newDisk["disk_encryption_set_id"].(string) != oldDisk["disk_encryption_set_id"].(string) {
+							dataDisksForEncrypt = append(dataDisksForEncrypt, newDisk)
+						}
+					}
+				}
+			}
+		}
+		// EncryptionSet changes for "existing" disks
+		oldExistingRaw, newExistingRaw := d.GetChange("data_disks.0.existing")
+		oldExisting := oldExistingRaw.(*schema.Set).List()
+		newExisting := newExistingRaw.(*schema.Set).List()
+		for _, o := range oldExisting {
+			oldDisk := o.(map[string]interface{})
+			if oldDiskID, ok := oldDisk["managed_disk_id"]; ok {
+				for _, n := range newExisting {
+					newDisk := n.(map[string]interface{})
+					if newDiskID, ok := newDisk["managed_disk_id"]; ok && oldDiskID.(string) == newDiskID.(string) {
+						if newDisk["disk_encryption_set_id"].(string) != oldDisk["disk_encryption_set_id"].(string) {
+							dataDisksForEncrypt = append(dataDisksForEncrypt, newDisk)
+						}
+					}
+				}
+			}
 		}
 	}
 
@@ -1029,8 +1101,6 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 		newSize := d.Get("os_disk.0.disk_size_gb").(int)
 		log.Printf("[DEBUG] Resizing OS Disk %q for Linux Virtual Machine %q (Resource Group %q) to %dGB..", diskName, id.Name, id.ResourceGroup, newSize)
 
-		disksClient := meta.(*clients.Client).Compute.DisksClient
-
 		update := compute.DiskUpdate{
 			DiskUpdateProperties: &compute.DiskUpdateProperties{
 				DiskSizeGB: utils.Int32(int32(newSize)),
@@ -1076,7 +1146,76 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 
 			log.Printf("[DEBUG] Updating encryption settings of OS Disk %q for Linux Virtual Machine %q (Resource Group %q) to %q.", diskName, id.Name, id.ResourceGroup, diskEncryptionSetId)
 		} else {
-			return fmt.Errorf("Once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
+			return fmt.Errorf("once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
+		}
+	}
+
+	if features.VMDataDiskBeta() && d.HasChanges("data_disks.0.local", "data_disks.0.existing") {
+		shouldUpdate = true
+		dataDisks, err := expandVirtualMachineDataDisks(d, meta)
+		if err != nil {
+			return err
+		}
+
+		// Do we have disks to resize or change encryption set?
+		for _, v := range dataDisksForEncrypt {
+			diskName, ok := v["name"].(string)
+			if !ok {
+				return fmt.Errorf("could not resize data disk, empty value for `name`")
+			}
+			diskEncryptionSetID, ok := v["disk_encryption_set_id"].(string)
+			if !ok {
+				return fmt.Errorf("failed to read new disk Encryption Eet ID for Data Disk %q (resource group %q)", diskName, id.ResourceGroup)
+			}
+			diskUpdate := compute.DiskUpdate{
+				DiskUpdateProperties: &compute.DiskUpdateProperties{
+					Encryption: &compute.Encryption{
+						DiskEncryptionSetID: utils.String(diskEncryptionSetID),
+					},
+				},
+			}
+
+			encryptionUpdateFuture, err := disksClient.Update(ctx, id.ResourceGroup, diskName, diskUpdate)
+			if err != nil {
+				return fmt.Errorf("failed resizing Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+			}
+			if err = encryptionUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("failed waiting for resize of Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+			}
+		}
+
+		for _, v := range dataDisksForGrow {
+			diskName, ok := v["name"].(string)
+			if !ok {
+				return fmt.Errorf("could not resize data disk, empty value for `name`")
+			}
+			diskSizeGB, ok := v["disk_size_gb"].(int)
+			if !ok {
+				return fmt.Errorf("failed to read new disk size for Data Disk %q (resource group %q)", diskName, id.ResourceGroup)
+			}
+
+			diskUpdate := compute.DiskUpdate{
+				DiskUpdateProperties: &compute.DiskUpdateProperties{
+					DiskSizeGB: utils.Int32(int32(diskSizeGB)),
+				},
+			}
+
+			resizeFuture, err := disksClient.Update(ctx, id.ResourceGroup, diskName, diskUpdate)
+			if err != nil {
+				return fmt.Errorf("failed resizing Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+			}
+			if err = resizeFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("failed waiting for resize of Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+			}
+		}
+
+		// now disks are resized, we can put the new list into the VMUpdate
+		if update.VirtualMachineProperties.StorageProfile == nil {
+			update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{
+				DataDisks: dataDisks,
+			}
+		} else {
+			update.VirtualMachineProperties.StorageProfile.DataDisks = dataDisks
 		}
 	}
 
@@ -1114,6 +1253,7 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VMClient
+	disksClient := meta.(*clients.Client).Compute.DisksClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -1172,7 +1312,6 @@ func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{})
 	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
 	if deleteOSDisk {
 		log.Printf("[DEBUG] Deleting OS Disk from Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
-		disksClient := meta.(*clients.Client).Compute.DisksClient
 		managedDiskId := ""
 		if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
 			if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.ID != nil {
@@ -1204,6 +1343,29 @@ func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{})
 		}
 	} else {
 		log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	if features.VMDataDiskBeta() {
+		deleteDataDiskOnDeletion := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+
+		// delete any disks created with the VM if feature toggled to do so. "existing" disks are not affected.
+		if deleteDataDiskOnDeletion {
+			if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.DataDisks != nil {
+				dataDisks := *props.StorageProfile.DataDisks
+				for _, v := range dataDisks {
+					if v.CreateOption == compute.DiskCreateOptionTypesEmpty && v.Name != nil {
+						deleteFuture, err := disksClient.Delete(ctx, id.ResourceGroup, *v.Name)
+						if err != nil {
+							return fmt.Errorf("failure deleting Data Disk %q (Virtual Machine %q / resource group %q): %+v", *v.Name, id.Name, id.ResourceGroup, err)
+						}
+
+						if err = deleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
+							return fmt.Errorf("failure waiting for deletion of Data Disk%q (Virtual Machine %q / resource group %q): %+v", *v.Name, id.Name, id.ResourceGroup, err)
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// Need to add a get and a state wait to avoid bug in network API where the attached disk(s) are not actually deleted

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -702,13 +702,11 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if features.VMDataDiskBeta() {
-			if profile.DataDisks != nil {
-				dataDisks, err := flattenVirtualMachineDataDisks(profile.DataDisks)
-				if err != nil {
-					return err
-				}
-				d.Set("data_disks", dataDisks)
+			dataDisks, err := flattenVirtualMachineDataDisks(profile.DataDisks)
+			if err != nil {
+				return err
 			}
+			d.Set("data_disks", dataDisks)
 		}
 	}
 

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -38,6 +38,7 @@ func resourceLinuxVirtualMachine() *schema.Resource {
 		Read:   resourceLinuxVirtualMachineRead,
 		Update: resourceLinuxVirtualMachineUpdate,
 		Delete: resourceLinuxVirtualMachineDelete,
+
 		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
 			_, err := parse.VirtualMachineID(id)
 			return err

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -902,8 +902,8 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 	if features.VMDataDiskBeta() && d.HasChange("data_disks") {
 		shouldUpdate = true
 		oldRaw, newRaw := d.GetChange("data_disks.0.create")
-		oldDisks := oldRaw.(*schema.Set).List()
-		newDisks := newRaw.(*schema.Set).List()
+		oldDisks := oldRaw.([]interface{})
+		newDisks := newRaw.([]interface{})
 		for _, o := range oldDisks {
 			oldDisk := o.(map[string]interface{})
 			if oldDiskName, ok := oldDisk["name"]; ok {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -900,10 +900,13 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 	// list of disks for supported update operations - `Attach` disks are not managed here
 	diskUpdates := make([]helpers.DataDiskUpdate, 0)
 	if features.VMDataDiskBeta() && d.HasChange("data_disks") {
+		if err := findInvalidDataDiskChanges(d); err != nil {
+			return fmt.Errorf("updating Linux Virtual Machine, invalid Data Disk property changes: %+v", err)
+		}
 		shouldUpdate = true
 		oldRaw, newRaw := d.GetChange("data_disks.0.create")
-		oldDisks := oldRaw.([]interface{})
-		newDisks := newRaw.([]interface{})
+		oldDisks := oldRaw.(*schema.Set).List()
+		newDisks := newRaw.(*schema.Set).List()
 		for _, o := range oldDisks {
 			oldDisk := o.(map[string]interface{})
 			if oldDiskName, ok := oldDisk["name"]; ok {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/helpers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
@@ -1351,19 +1352,15 @@ func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{})
 		// delete any disks created with the VM if feature toggled to do so. "existing" disks are not affected.
 		if deleteDataDiskOnDeletion {
 			if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.DataDisks != nil {
-				dataDisks := *props.StorageProfile.DataDisks
-				// TODO - pull this out to a func to allow parallel ops
-				for _, v := range dataDisks {
-					if v.CreateOption == compute.DiskCreateOptionTypesEmpty && v.Name != nil {
-						deleteFuture, err := disksClient.Delete(ctx, id.ResourceGroup, *v.Name)
-						if err != nil {
-							return fmt.Errorf("failure deleting Data Disk %q (Virtual Machine %q / resource group %q): %+v", *v.Name, id.Name, id.ResourceGroup, err)
-						}
-
-						if err = deleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
-							return fmt.Errorf("failure waiting for deletion of Data Disk %q (Virtual Machine %q / resource group %q): %+v", *v.Name, id.Name, id.ResourceGroup, err)
-						}
+				dataDisksForDelete := make([]compute.DataDisk, 0)
+				for _, v := range *props.StorageProfile.DataDisks {
+					if v.CreateOption == compute.DiskCreateOptionTypesEmpty {
+						dataDisksForDelete = append(dataDisksForDelete, v)
 					}
+				}
+				err = helpers.DeleteManagedDisks(ctx, meta.(*clients.Client), &dataDisksForDelete)
+				if err != nil {
+					return err
 				}
 			}
 		}

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
@@ -266,7 +266,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "None"
@@ -383,7 +383,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "None"
@@ -391,7 +391,7 @@ resource "azurerm_linux_virtual_machine" "test" {
       disk_size_gb         = 1
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk2"
       lun                  = 2
       caching              = "ReadOnly"
@@ -399,7 +399,7 @@ resource "azurerm_linux_virtual_machine" "test" {
       disk_size_gb         = 2
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk3"
       lun                  = 3
       caching              = "ReadWrite"
@@ -407,14 +407,14 @@ resource "azurerm_linux_virtual_machine" "test" {
       disk_size_gb         = 3
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test1.id
       lun                  = 10
       caching              = "None"
       storage_account_type = "Standard_LRS"
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test2.id
       lun                  = 11
       caching              = "ReadOnly"
@@ -492,7 +492,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "None"
@@ -500,7 +500,7 @@ resource "azurerm_linux_virtual_machine" "test" {
       disk_size_gb         = 1
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk2"
       lun                  = 2
       caching              = "ReadOnly"
@@ -508,14 +508,14 @@ resource "azurerm_linux_virtual_machine" "test" {
       disk_size_gb         = 4
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test1.id
       lun                  = 10
       caching              = "None"
       storage_account_type = "Standard_LRS"
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test2.id
       lun                  = 11
       caching              = "ReadWrite"
@@ -564,7 +564,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "ReadOnly"
@@ -610,7 +610,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                   = "acctest-localdisk"
       lun                    = 1
       caching                = "ReadOnly"
@@ -683,7 +683,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                   = "acctest-localdisk"
       lun                    = 1
       caching                = "ReadOnly"
@@ -734,7 +734,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "ReadOnly"
@@ -742,7 +742,7 @@ resource "azurerm_linux_virtual_machine" "test" {
       disk_size_gb         = 2
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk2"
       lun                  = 2
       caching              = "ReadOnly"
@@ -806,7 +806,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test.id
       lun                  = 1
       caching              = "None"
@@ -869,7 +869,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   data_disks {
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test.id
       lun                  = 1
       caching              = "None"

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
@@ -435,7 +435,7 @@ resource "azurerm_linux_virtual_machine" "test" {
 
 func (r LinuxVirtualMachineResource) dataDisksCompleteUpdate(data acceptance.TestData) string {
 	template := r.template(data)
-	// Updates localdisk2 to 4GiB, removes localdisk3, and updates existingdisk1 to LUN-15, existingdisk2 to ReadWrite caching,
+	// Updates localdisk2 to 4GiB, removes localdisk3, and existingdisk2 to ReadWrite caching,
 	return fmt.Sprintf(`
 %s
 
@@ -567,7 +567,7 @@ resource "azurerm_linux_virtual_machine" "test" {
     create {
       name                 = "acctest-localdisk"
       lun                  = 1
-      caching              = "ReadOnly"
+      caching              = "None"
       storage_account_type = "Standard_LRS"
       disk_size_gb         = 2
     }

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
@@ -1,0 +1,810 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func TestAccLinuxVirtualMachine_dataDisksBasic(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksComplete(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksComplete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksCompleteUpdate(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksBasicUpdateDataDiskSize(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksBasicUpdateDataDiskSize(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksBasicUpdateEncryptionSet(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasicWithEncryption(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksBasicWithEncryptionUpdate(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksAddLocalDataDisk(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksAddExistingDataDisk(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksExistingDisk(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksMultipleUpdateSize(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dataDisksMultipleUpdateSize(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_dataDisksExistingDisk(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksExistingDisk(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LinuxVirtualMachineResource) dataDisksBasic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksAbsent(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksComplete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_managed_disk" "test1" {
+  name                 = "acctested-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_managed_disk" "test2" {
+  name                 = "acctested2-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+
+    local {
+      name                 = "acctest-localdisk2"
+      lun                  = 2
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 2
+    }
+
+    local {
+      name                 = "acctest-localdisk3"
+      lun                  = 3
+      caching              = "ReadWrite"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 3
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test1.id
+      lun                  = 10
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test2.id
+      lun                  = 11
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksCompleteUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	// Updates localdisk2 to 4GiB, removes localdisk3, and updates existingdisk1 to LUN-15, existingdisk2 to ReadWrite caching,
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_managed_disk" "test1" {
+  name                 = "acctested-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_managed_disk" "test2" {
+  name                 = "acctested2-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+
+    local {
+      name                 = "acctest-localdisk2"
+      lun                  = 2
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 4
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test1.id
+      lun                  = 10
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test2.id
+      lun                  = 11
+      caching              = "ReadWrite"
+      storage_account_type = "Standard_LRS"
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksBasicUpdateDataDiskSize(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 2
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksBasicWithEncryption(data acceptance.TestData) string {
+	template := r.diskOSDiskDiskEncryptionSetResource(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                   = "acctest-localdisk"
+      lun                    = 1
+      caching                = "ReadOnly"
+      storage_account_type   = "Standard_LRS"
+      disk_encryption_set_id = azurerm_disk_encryption_set.test.id
+      disk_size_gb           = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksBasicWithEncryptionUpdate(data acceptance.TestData) string {
+	template := r.diskOSDiskDiskEncryptionSetResource(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_disk_encryption_set" "update" {
+  name                = "acctestdes-%d-u"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  key_vault_key_id    = azurerm_key_vault_key.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+
+resource "azurerm_key_vault_access_policy" "disk-encryption" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  key_permissions = [
+    "get",
+    "wrapkey",
+    "unwrapkey",
+  ]
+
+  tenant_id = azurerm_disk_encryption_set.update.identity.0.tenant_id
+  object_id = azurerm_disk_encryption_set.update.identity.0.principal_id
+}
+
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                   = "acctest-localdisk"
+      lun                    = 1
+      caching                = "ReadOnly"
+      storage_account_type   = "Standard_LRS"
+      disk_encryption_set_id = azurerm_disk_encryption_set.update.id
+      disk_size_gb           = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksMultipleUpdateSize(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 2
+    }
+
+    local {
+      name                 = "acctest-localdisk2"
+      lun                  = 1
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) dataDisksExistingDisk(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctested-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test.id
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_data_disk_test.go
@@ -165,13 +165,6 @@ func TestAccLinuxVirtualMachine_dataDisksAddExistingDataDisk(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.dataDisksAbsent(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -728,7 +721,7 @@ resource "azurerm_linux_virtual_machine" "test" {
 
     local {
       name                 = "acctest-localdisk2"
-      lun                  = 1
+      lun                  = 2
       caching              = "ReadOnly"
       storage_account_type = "Standard_LRS"
       disk_size_gb         = 1

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -16,7 +16,6 @@ import (
 	msiparse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
 	msivalidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -576,7 +575,7 @@ func expandVirtualMachineDataDisks(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if existingDisksRaw, ok := dataDisks["existing"]; ok {
-		existingDisks, err := expandVirtualMachineExistingDataDisksForCreate(existingDisksRaw, d, meta)
+		existingDisks, err := expandVirtualMachineExistingDataDisksForCreate(ctx, existingDisksRaw, d, meta)
 		if err != nil {
 			return nil, err
 		}
@@ -669,14 +668,12 @@ func expandVirtualMachineLocalDataDisksForUpdate(ctx context.Context, input inte
 	return dataDisks, nil
 }
 
-func expandVirtualMachineExistingDataDisksForCreate(input interface{}, d *schema.ResourceData, meta interface{}) ([]compute.DataDisk, error) {
+func expandVirtualMachineExistingDataDisksForCreate(ctx context.Context, input interface{}, d *schema.ResourceData, meta interface{}) ([]compute.DataDisk, error) {
 	if input == nil || len(input.(*schema.Set).List()) == 0 {
 		return []compute.DataDisk{}, nil
 	}
 
 	disksClient := meta.(*clients.Client).Compute.DisksClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
 
 	var dataDisks []compute.DataDisk
 

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -861,5 +861,5 @@ func findInvalidDataDiskChanges(d *schema.ResourceData) (errors []error) {
 		}
 	}
 
-	return
+	return errors
 }

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -802,9 +802,9 @@ func resourceArmVirtualMachineCreateDataDiskHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["caching"].(string)))
-		buf.WriteString(fmt.Sprintf("%d-", m["lun"].(int)))
 		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+		buf.WriteString(fmt.Sprintf("%d-", m["lun"].(int)))
+		buf.WriteString(fmt.Sprintf("%s-", m["caching"].(string)))
 		buf.WriteString(fmt.Sprintf("%s-", m["storage_account_type"].(string)))
 		buf.WriteString(fmt.Sprintf("%d-", m["disk_size_gb"].(int)))
 		// Due to potential case diff in API response needs to be normalised

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -514,7 +514,8 @@ func virtualMachineAttachDataDiskSchema() *schema.Schema {
 					ValidateFunc: validation.IntAtLeast(0),
 				},
 
-				"caching": {Type: schema.TypeString,
+				"caching": {
+					Type:     schema.TypeString,
 					Required: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						string(compute.CachingTypesNone),

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -450,21 +450,18 @@ func virtualMachineCreateDataDiskSchema() *schema.Schema {
 				"lun": {
 					Type:         schema.TypeInt,
 					Required:     true,
-					ForceNew:     true,
 					ValidateFunc: validation.IntAtLeast(0),
 				},
 
 				"name": {
 					Type:         schema.TypeString,
 					Required:     true,
-					ForceNew:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
 				"storage_account_type": {
 					Type:     schema.TypeString,
 					Required: true,
-					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						string(compute.StorageAccountTypesPremiumLRS),
 						string(compute.StorageAccountTypesStandardLRS),
@@ -508,14 +505,12 @@ func virtualMachineAttachDataDiskSchema() *schema.Schema {
 				"managed_disk_id": {
 					Type:         schema.TypeString,
 					Required:     true,
-					ForceNew:     true,
 					ValidateFunc: validate.ManagedDiskID,
 				},
 
 				"lun": {
 					Type:         schema.TypeInt,
 					Required:     true,
-					ForceNew:     true,
 					ValidateFunc: validation.IntAtLeast(0),
 				},
 
@@ -531,7 +526,6 @@ func virtualMachineAttachDataDiskSchema() *schema.Schema {
 				"storage_account_type": {
 					Type:     schema.TypeString,
 					Required: true,
-					ForceNew: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						string(compute.StorageAccountTypesPremiumLRS),
 						string(compute.StorageAccountTypesStandardLRS),

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -803,9 +803,9 @@ func resourceVirtualMachineCreateDataDiskHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		//buf.WriteString(fmt.Sprintf("%d-", m["lun"].(int)))
+		buf.WriteString(fmt.Sprintf("%d-", m["lun"].(int)))
 		buf.WriteString(fmt.Sprintf("%s-", m["caching"].(string)))
-		//buf.WriteString(fmt.Sprintf("%s-", m["storage_account_type"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", m["storage_account_type"].(string)))
 		buf.WriteString(fmt.Sprintf("%d-", m["disk_size_gb"].(int)))
 		// Due to potential case diff in API response needs to be normalised
 		buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["disk_encryption_set_id"].(string))))

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
-
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1208,7 +1208,6 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			return err
 		}
 
-		//diskUpdates := make([]helpers.DataDiskUpdate, 0)
 		// Do we have disks to resize or change encryption set?
 		err = helpers.UpdateManagedDisks(ctx, disksClient, diskUpdates)
 		if err != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -742,13 +742,11 @@ func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{})
 		}
 
 		if features.VMDataDiskBeta() {
-			if props.StorageProfile.DataDisks != nil {
-				dataDisks, err := flattenVirtualMachineDataDisks(props.StorageProfile.DataDisks)
-				if err != nil {
-					return err
-				}
-				d.Set("data_disks", dataDisks)
+			dataDisks, err := flattenVirtualMachineDataDisks(props.StorageProfile.DataDisks)
+			if err != nil {
+				return err
 			}
+			d.Set("data_disks", dataDisks)
 		}
 	}
 

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -956,12 +956,10 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	dataDisksForGrow := make([]map[string]interface{}, 0)
-	// list of disks with encryption set changes
-	dataDisksForEncrypt := make([]map[string]interface{}, 0)
+	// list of disks for supported update operations - `Attach` disks are not managed here
+	diskUpdates := make([]helpers.DataDiskUpdate, 0)
 	if features.VMDataDiskBeta() && d.HasChange("data_disks") {
 		shouldUpdate = true
-
 		oldRaw, newRaw := d.GetChange("data_disks.0.local")
 		oldDisks := oldRaw.(*schema.Set).List()
 		newDisks := newRaw.(*schema.Set).List()
@@ -969,6 +967,8 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			oldDisk := o.(map[string]interface{})
 			if oldDiskName, ok := oldDisk["name"]; ok {
 				for _, n := range newDisks {
+					var updateSize *int32
+					var updateEncryptionSetId *string
 					newDisk := n.(map[string]interface{})
 					if newDiskName, ok := newDisk["name"]; ok && oldDiskName.(string) == newDiskName.(string) {
 						if newDisk["disk_size_gb"].(int) < oldDisk["disk_size_gb"].(int) {
@@ -976,27 +976,21 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 						} else if newDisk["disk_size_gb"].(int) > oldDisk["disk_size_gb"].(int) {
 							shouldShutDown = true
 							shouldDeallocate = true
-							dataDisksForGrow = append(dataDisksForGrow, newDisk)
+							updateSize = utils.Int32(int32(newDisk["disk_size_gb"].(int)))
 						}
 						if newDisk["disk_encryption_set_id"].(string) != oldDisk["disk_encryption_set_id"].(string) {
-							dataDisksForEncrypt = append(dataDisksForEncrypt, newDisk)
+							updateEncryptionSetId = utils.String(newDisk["disk_encryption_set_id"].(string))
 						}
-					}
-				}
-			}
-		}
-		// EncryptionSet changes for "existing" disks
-		oldExistingRaw, newExistingRaw := d.GetChange("data_disks.0.existing")
-		oldExisting := oldExistingRaw.(*schema.Set).List()
-		newExisting := newExistingRaw.(*schema.Set).List()
-		for _, o := range oldExisting {
-			oldDisk := o.(map[string]interface{})
-			if oldDiskID, ok := oldDisk["managed_disk_id"]; ok {
-				for _, n := range newExisting {
-					newDisk := n.(map[string]interface{})
-					if newDiskID, ok := newDisk["managed_disk_id"]; ok && oldDiskID.(string) == newDiskID.(string) {
-						if newDisk["disk_encryption_set_id"].(string) != oldDisk["disk_encryption_set_id"].(string) {
-							dataDisksForEncrypt = append(dataDisksForEncrypt, newDisk)
+						if existing.StorageProfile.DataDisks != nil {
+							for _, disk := range *existing.StorageProfile.DataDisks {
+								if newDiskName == *disk.Name {
+									diskUpdates = append(diskUpdates, helpers.DataDiskUpdate{
+										ManagedDiskID:      disk.ManagedDisk.ID,
+										NewDiskSize:        updateSize,
+										NewEncryptionSetID: updateEncryptionSetId,
+									})
+								}
+							}
 						}
 					}
 				}
@@ -1214,56 +1208,11 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			return err
 		}
 
+		//diskUpdates := make([]helpers.DataDiskUpdate, 0)
 		// Do we have disks to resize or change encryption set?
-		for _, v := range dataDisksForEncrypt {
-			diskName, ok := v["name"].(string)
-			if !ok {
-				return fmt.Errorf("could not resize data disk, empty value for `name`")
-			}
-			diskEncryptionSetID, ok := v["disk_encryption_set_id"].(string)
-			if !ok {
-				return fmt.Errorf("failed to read new disk Encryption Eet ID for Data Disk %q (resource group %q)", diskName, id.ResourceGroup)
-			}
-			diskUpdate := compute.DiskUpdate{
-				DiskUpdateProperties: &compute.DiskUpdateProperties{
-					Encryption: &compute.Encryption{
-						DiskEncryptionSetID: utils.String(diskEncryptionSetID),
-					},
-				},
-			}
-
-			encryptionUpdateFuture, err := disksClient.Update(ctx, id.ResourceGroup, diskName, diskUpdate)
-			if err != nil {
-				return fmt.Errorf("failed resizing Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
-			}
-			if err = encryptionUpdateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("failed waiting for resize of Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
-			}
-		}
-
-		for _, v := range dataDisksForGrow {
-			diskName, ok := v["name"].(string)
-			if !ok {
-				return fmt.Errorf("could not resize data disk, empty value for `name`")
-			}
-			diskSizeGB, ok := v["disk_size_gb"].(int)
-			if !ok {
-				return fmt.Errorf("failed to read new disk size for Data Disk %q (resource group %q)", diskName, id.ResourceGroup)
-			}
-
-			diskUpdate := compute.DiskUpdate{
-				DiskUpdateProperties: &compute.DiskUpdateProperties{
-					DiskSizeGB: utils.Int32(int32(diskSizeGB)),
-				},
-			}
-
-			resizeFuture, err := disksClient.Update(ctx, id.ResourceGroup, diskName, diskUpdate)
-			if err != nil {
-				return fmt.Errorf("failed resizing Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
-			}
-			if err = resizeFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("failed waiting for resize of Data Disk %q for Virtual Machine %q (resource group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
-			}
+		err = helpers.UpdateManagedDisks(ctx, disksClient, diskUpdates)
+		if err != nil {
+			return err
 		}
 
 		// now disks are resized, we can put the new list into the VMUpdate

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -405,7 +405,7 @@ func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{
 	dataDisks := &[]compute.DataDisk{}
 
 	if features.VMDataDiskBeta() {
-		dataDisks, err = expandVirtualMachineDataDisks(d, meta)
+		dataDisks, err = expandVirtualMachineDataDisks(ctx, d, meta)
 		if err != nil {
 			return err
 		}
@@ -1210,7 +1210,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 
 	if features.VMDataDiskBeta() && d.HasChanges("data_disks.0.local", "data_disks.0.existing") {
 		shouldUpdate = true
-		dataDisks, err := expandVirtualMachineDataDisks(d, meta)
+		dataDisks, err := expandVirtualMachineDataDisks(ctx, d, meta)
 		if err != nil {
 			return err
 		}
@@ -1404,7 +1404,7 @@ func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{
 	}
 
 	if features.VMDataDiskBeta() {
-		deleteDataDiskOnDeletion := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDiskOnDeletion
+		deleteDataDiskOnDeletion := meta.(*clients.Client).Features.VirtualMachine.DeleteDataDisksOnDeletion
 
 		// delete any disks created with the VM if feature toggled to do so. "existing" disks are not affected.
 		if deleteDataDiskOnDeletion {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
@@ -263,7 +263,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "None"
@@ -371,7 +371,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "None"
@@ -379,7 +379,7 @@ resource "azurerm_windows_virtual_machine" "test" {
       disk_size_gb         = 1
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk2"
       lun                  = 2
       caching              = "ReadOnly"
@@ -387,7 +387,7 @@ resource "azurerm_windows_virtual_machine" "test" {
       disk_size_gb         = 2
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk3"
       lun                  = 3
       caching              = "ReadWrite"
@@ -395,14 +395,14 @@ resource "azurerm_windows_virtual_machine" "test" {
       disk_size_gb         = 3
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test1.id
       lun                  = 10
       caching              = "None"
       storage_account_type = "Standard_LRS"
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test2.id
       lun                  = 11
       caching              = "ReadOnly"
@@ -477,7 +477,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "None"
@@ -485,7 +485,7 @@ resource "azurerm_windows_virtual_machine" "test" {
       disk_size_gb         = 1
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk2"
       lun                  = 2
       caching              = "ReadOnly"
@@ -493,14 +493,14 @@ resource "azurerm_windows_virtual_machine" "test" {
       disk_size_gb         = 4
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test1.id
       lun                  = 10
       caching              = "None"
       storage_account_type = "Standard_LRS"
     }
 
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test2.id
       lun                  = 11
       caching              = "ReadWrite"
@@ -546,7 +546,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "ReadOnly"
@@ -589,7 +589,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                   = "acctest-localdisk"
       lun                    = 1
       caching                = "ReadOnly"
@@ -659,7 +659,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                   = "acctest-localdisk"
       lun                    = 1
       caching                = "ReadOnly"
@@ -707,7 +707,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    local {
+    create {
       name                 = "acctest-localdisk"
       lun                  = 1
       caching              = "ReadOnly"
@@ -715,7 +715,7 @@ resource "azurerm_windows_virtual_machine" "test" {
       disk_size_gb         = 2
     }
 
-    local {
+    create {
       name                 = "acctest-localdisk2"
       lun                  = 2
       caching              = "ReadOnly"
@@ -776,7 +776,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test.id
       lun                  = 1
       caching              = "None"
@@ -836,7 +836,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   data_disks {
-    existing {
+    attach {
       managed_disk_id      = azurerm_managed_disk.test.id
       lun                  = 1
       caching              = "None"

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
@@ -163,13 +163,6 @@ func TestAccWindowsVirtualMachine_dataDisksAddExistingDataDisk(t *testing.T) {
 			),
 		},
 		data.ImportStep("admin_password"),
-		{
-			Config: r.dataDisksAbsent(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("admin_password"),
 	})
 }
 
@@ -336,7 +329,7 @@ resource "azurerm_managed_disk" "test2" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
+  name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   size                = "Standard_F2"
@@ -441,7 +434,7 @@ resource "azurerm_managed_disk" "test2" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
+  name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   size                = "Standard_F2"
@@ -553,7 +546,7 @@ func (r WindowsVirtualMachineResource) dataDisksBasicWithEncryption(data accepta
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
+  name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   size                = "Standard_F2"
@@ -588,7 +581,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 }
 
-`, template, data.RandomInteger)
+`, template)
 }
 
 func (r WindowsVirtualMachineResource) dataDisksBasicWithEncryptionUpdate(data acceptance.TestData) string {
@@ -623,7 +616,7 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
 
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d"
+  name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   size                = "Standard_F2"
@@ -698,7 +691,7 @@ resource "azurerm_windows_virtual_machine" "test" {
 
     local {
       name                 = "acctest-localdisk2"
-      lun                  = 1
+      lun                  = 2
       caching              = "ReadOnly"
       storage_account_type = "Standard_LRS"
       disk_size_gb         = 1

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
@@ -549,7 +549,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     create {
       name                 = "acctest-localdisk"
       lun                  = 1
-      caching              = "ReadOnly"
+      caching              = "None"
       storage_account_type = "Standard_LRS"
       disk_size_gb         = 2
     }

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_data_disk_test.go
@@ -1,0 +1,777 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func TestAccWindowsVirtualMachine_dataDisksBasic(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksComplete(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksComplete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksCompleteUpdate(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksBasicUpdateDataDiskSize(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksBasicUpdateDataDiskSize(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksBasicUpdateEncryptionSet(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasicWithEncryption(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksBasicWithEncryptionUpdate(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksAddLocalDataDisk(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksAddExistingDataDisk(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksExistingDisk(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksAbsent(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksMultipleUpdateSize(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksBasic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.dataDisksMultipleUpdateSize(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func TestAccWindowsVirtualMachine_dataDisksExistingDisk(t *testing.T) {
+	if !features.VMDataDiskBeta() {
+		t.Skip("skipping as In-line Data Disk beta is not enabled")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.dataDisksExistingDisk(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
+func (r WindowsVirtualMachineResource) dataDisksBasic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksAbsent(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksComplete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_managed_disk" "test1" {
+  name                 = "acctested-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_managed_disk" "test2" {
+  name                 = "acctested2-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+
+    local {
+      name                 = "acctest-localdisk2"
+      lun                  = 2
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 2
+    }
+
+    local {
+      name                 = "acctest-localdisk3"
+      lun                  = 3
+      caching              = "ReadWrite"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 3
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test1.id
+      lun                  = 10
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test2.id
+      lun                  = 11
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksCompleteUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	// Updates localdisk2 to 4GiB, removes localdisk3, and updates existingdisk1 to LUN-15, existingdisk2 to ReadWrite caching,
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_managed_disk" "test1" {
+  name                 = "acctested-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_managed_disk" "test2" {
+  name                 = "acctested2-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+
+    local {
+      name                 = "acctest-localdisk2"
+      lun                  = 2
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 4
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test1.id
+      lun                  = 10
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+    }
+
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test2.id
+      lun                  = 11
+      caching              = "ReadWrite"
+      storage_account_type = "Standard_LRS"
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksBasicUpdateDataDiskSize(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 2
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksBasicWithEncryption(data acceptance.TestData) string {
+	template := r.diskOSDiskDiskEncryptionSetResource(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                   = "acctest-localdisk"
+      lun                    = 1
+      caching                = "ReadOnly"
+      storage_account_type   = "Standard_LRS"
+      disk_encryption_set_id = azurerm_disk_encryption_set.test.id
+      disk_size_gb           = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksBasicWithEncryptionUpdate(data acceptance.TestData) string {
+	template := r.diskOSDiskDiskEncryptionSetResource(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_disk_encryption_set" "update" {
+  name                = "acctestdes-%d-u"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  key_vault_key_id    = azurerm_key_vault_key.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+
+resource "azurerm_key_vault_access_policy" "disk-encryption" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  key_permissions = [
+    "get",
+    "wrapkey",
+    "unwrapkey",
+  ]
+
+  tenant_id = azurerm_disk_encryption_set.update.identity.0.tenant_id
+  object_id = azurerm_disk_encryption_set.update.identity.0.principal_id
+}
+
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = "acctestVM-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                   = "acctest-localdisk"
+      lun                    = 1
+      caching                = "ReadOnly"
+      storage_account_type   = "Standard_LRS"
+      disk_encryption_set_id = azurerm_disk_encryption_set.update.id
+      disk_size_gb           = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksMultipleUpdateSize(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    local {
+      name                 = "acctest-localdisk"
+      lun                  = 1
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 2
+    }
+
+    local {
+      name                 = "acctest-localdisk2"
+      lun                  = 1
+      caching              = "ReadOnly"
+      storage_account_type = "Standard_LRS"
+      disk_size_gb         = 1
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template)
+}
+
+func (r WindowsVirtualMachineResource) dataDisksExistingDisk(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctested-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "1"
+
+  tags = {
+    environment = "acctest"
+    cost-center = "ops"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  data_disks {
+    existing {
+      managed_disk_id      = azurerm_managed_disk.test.id
+      lun                  = 1
+      caching              = "None"
+      storage_account_type = "Standard_LRS"
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_test.go
@@ -50,7 +50,7 @@ resource "azurerm_subnet" "test" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 `, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -30,7 +30,7 @@ Database
 Database Migration
 Databox Edge
 Databricks
-Desktop Virtualization
+DesktopVirtualization
 Dev Test
 DevSpace
 Digital Twins

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -30,7 +30,7 @@ Database
 Database Migration
 Databox Edge
 Databricks
-DesktopVirtualization
+Desktop Virtualization
 Dev Test
 DevSpace
 Digital Twins

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -22,6 +22,8 @@ Manages a Linux Virtual Machine.
 
 ~> In this release there's a known issue where the `public_ip_address` and `public_ip_addresses` fields may not be fully populated for Dynamic Public IP's.
 
+!> **Note:** Data Disks can be specified in-line with the Virtual Machine by opting into the beta feature by setting `ARM_PROVIDER_VM_DATADISKS_BETA=true` This feature should be used with caution and may be subject to change without notice. Mixing of in-line Data Disks and `azurerm_virtual_machine_data_disk_attachment` resources is not supported. 
+
 ## Example Usage
 
 This example provisions a basic Linux Virtual Machine on an internal network. Additional examples of how to use the `azurerm_linux_virtual_machine` resource can be found [in the ./examples/virtual-machines/linux directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machines/linux).
@@ -134,6 +136,10 @@ The following arguments are supported:
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
 
+* `data_disks` - (Optional) A `data_disks` block as defined below.
+
+~> **Note:** This block is only valid when the Beta Opt-In environment variable `ARM_PROVIDER_VM_DATADISKS_BETA` is set to `true`
+
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on.
 
 * `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
@@ -213,6 +219,56 @@ A `certificate` block supports the following:
 * `url` - (Required) The Secret URL of a Key Vault Certificate.
 
 -> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
+
+---
+
+A `data_disks` block supports the following:
+
+* `create` - (Optional) A `create` block, as defined below.
+
+* `attach` - (Optional) An `attach` block as defined below.
+
+---
+
+A `create` block supports the following:
+
+~> **Note:** Data Disks defined here are managed with the Virtual Machine and are subject to deletion if the `delete_data_disks_on_deletion` Virtual Machine feature is enabled in the provider. 
+
+* `name` - (Required) The name of the Managed Disk to create. Changing this value after creation is not supported.
+
+* `lun` - (Required) The Logical Unit Number of the disk. Changing this value after creation is not supported.
+
+~> **Note:** LUN's must be unique per disk on a Virtual Machine.
+
+* `caching` - (Required) The Type of Caching which should be used for the Data Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`. 
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Data Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`. Changing this value after creation is not supported.
+
+* `disk_size_gb`- (Required) The size of the Data Disk in GB.  
+
+~> **Note:** Managed disks can only be grown, so changes to this value can only be greater than the existing value.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this Data Disk.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this Data Disk? Defaults to `false`.
+
+---
+
+An `attach` block supports the following:
+
+~> **Note:** Data Disks defined here are not managed by the Virtual Machine and are attached in similar manner to `azurerm_virtual_machine_data_disk_attachment`. 
+
+* `managed_disk_id` - The ID of the Managed Disk that should be attached to this Virtual Machine. Changing this value after creation is not supported.
+
+* `lun` - (Required) The Logical Unit Number of the disk. Changing this value after creation is not supported.
+
+~> **Note:** LUN's must be unique per disk on a Virtual Machine.
+
+* `caching` - (Required) The Type of Caching which should be used for the existing Data Disk being attached. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which backs this the Data Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`. Changing this value after creation is not supported.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this Data Disk? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -22,6 +22,8 @@ Manages a Windows Virtual Machine.
 
 ~> In this release there's a known issue where the `public_ip_address` and `public_ip_addresses` fields may not be fully populated for Dynamic Public IP's.
 
+!> **Note:** Data Disks can be specified in-line with the Virtual Machine by opting into the beta feature by setting `ARM_PROVIDER_VM_DATADISKS_BETA=true` This feature should be used with caution and may be subject to change without notice.
+
 ## Example Usage
 
 This example provisions a basic Windows Virtual Machine on an internal network. Additional examples of how to use the `azurerm_windows_virtual_machine` resource can be found [in the ./examples/virtual-machines/windows directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machines/windows).
@@ -123,6 +125,10 @@ The following arguments are supported:
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
 
+* `data_disks` - (Optional) A `data_disks` block as defined below
+
+~> **Note:** This block is only valid when the Beta Opt-In environment variable `ARM_PROVIDER_VM_DATADISKS_BETA` is set to `true`
+
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on.
 
 * `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created.
@@ -208,6 +214,52 @@ A `certificate` block supports the following:
 * `url` - (Required) The Secret URL of a Key Vault Certificate.
 
 -> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
+
+---
+
+A `data_disks` block supports the following:
+
+* `create` - (Optional) A `create` block, as defined below.
+
+* `attach` - (Optional) An `attach` block as defined below.
+
+---
+
+A `create` block supports the following:
+
+* `name` - (Required) The name of the Managed Disk to create. Changing this value after creation is not supported.
+
+* `lun` - (Required) The Logical Unit Number of the disk. Changing this value after creation is not supported.
+
+~> **Note:** LUN's must be unique per disk on a Virtual Machine.
+
+* `caching` - (Required) The Type of Caching which should be used for the Data Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Data Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`. Changing this value after creation is not supported.
+
+* `disk_size_gb`- (Required) The size of the Data Disk in GB.
+
+~> **Note:** Managed disks can only be grown, so changes to this value can only be greater than the existing value.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this Data Disk.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this Data Disk? Defaults to `false`.
+
+---
+
+An `attach` block supports the following:
+
+* `managed_disk_id` - The ID of the Managed Disk that should be attached to this Virtual Machine. Changing this value after creation is not supported.
+
+* `lun` - (Required) The Logical Unit Number of the disk. Changing this value after creation is not supported.
+
+~> **Note:** LUN's must be unique per disk on a Virtual Machine.
+
+* `caching` - (Required) The Type of Caching which should be used for the existing Data Disk being attached. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which backs this the Data Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`. Changing this value after creation is not supported.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this Data Disk? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
This PR creates an Opt-in beta for allowing the use of Data Disks in-line with the Linux and Windows Virtual Machine resources. Support for local disk creation and attachment of existing disks is included. 

`create` disks are new disks created with the VM and can be partially managed (e.g. can be grown)
`attach` disks are exiting managed disks, which cannot be managed via the VM configuration.

By default, `create` data disks are deleted on VM deletion, which is controlled by the features block in the provider configuration. `attach` disks are always left intact by the VM.


resolves #6117 
Fixes #8794