### PR TITLE
azurerm_mssql_virtual_machine - Fix Crash When Setting 'KeyVault' nil

### DIFF
--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -421,7 +421,7 @@ func expandSqlVirtualMachineKeyVaultCredential(input []interface{}) *sqlvirtualm
 }
 
 func flattenSqlVirtualMachineKeyVaultCredential(keyVault *sqlvirtualmachine.KeyVaultCredentialSettings, d *schema.ResourceData) []interface{} {
-	if keyVault == nil || !*keyVault.Enable {
+	if keyVault == nil || keyVault.Enable == nil || !*keyVault.Enable {
 		return []interface{}{}
 	}
 


### PR DESCRIPTION
Similar to the fix for https://github.com/terraform-providers/terraform-provider-azurerm/pull/9388

Solves this issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/10462

We ran into this problem today and although we're still not sure how it happened, we noticed on the Azure SQL Virtual Machine that some of the settings are "Not Available", as shown in the screenshot. We're still trying to figure out why this happens and I'm pretty sure it's the root cause.

![image](https://user-images.githubusercontent.com/8815903/106862894-98c5a680-667c-11eb-9b09-c4ef61a044f0.png)


Fixes #10462