### PR TITLE
azurerm_api_management: Enable Tenant Access

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -531,13 +531,22 @@ func resourceApiManagementService() *schema.Resource {
 			"tenant_access": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
 							Required: true,
+						},
+						"primary_key": {
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
+						},
+						"secondary_key": {
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
 						},
 					},
 				},
@@ -849,7 +858,7 @@ func resourceApiManagementServiceRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("sign_up", []interface{}{})
 	}
 
-	tenantAccessInformationContract, err := tenantAccessClient.Get(ctx, resourceGroup, name)
+	tenantAccessInformationContract, err := tenantAccessClient.ListSecrets(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("retrieving tenant access properties for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
@@ -1651,13 +1660,20 @@ func expandApiManagementTenantAccessSettings(input []interface{}) apimanagement.
 func flattenApiManagementTenantAccessSettings(input apimanagement.AccessInformationContract) []interface{} {
 	enabled := false
 
+	result := make(map[string]interface{})
+
 	if input.Enabled != nil {
 		enabled = *input.Enabled
 	}
+	result["enabled"] = enabled
 
-	return []interface{}{
-		map[string]interface{}{
-			"enabled": enabled,
-		},
+	if input.PrimaryKey != nil {
+		result["primary_key"] = *input.PrimaryKey
 	}
+
+	if input.SecondaryKey != nil {
+		result["secondary_key"] = *input.SecondaryKey
+	}
+
+	return []interface{}{result}
 }

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -528,6 +528,21 @@ func resourceApiManagementService() *schema.Resource {
 				Computed: true,
 			},
 
+			"tenant_access": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			"tags": tags.Schema(),
 		},
 
@@ -702,6 +717,15 @@ func resourceApiManagementServiceCreateUpdate(d *schema.ResourceData, meta inter
 		}
 	}
 
+	if d.HasChange("tenant_access") {
+		tenantAccessInformationParametersRaw := d.Get("tenant_access").([]interface{})
+		tenantAccessInformationParameters := expandApiManagementTenantAccessSettings(tenantAccessInformationParametersRaw)
+		tenantAccessClient := meta.(*clients.Client).ApiManagement.TenantAccessClient
+		if _, err := tenantAccessClient.Update(ctx, resourceGroup, name, tenantAccessInformationParameters, ""); err != nil {
+			return fmt.Errorf(" updating tenant access settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+	}
+
 	return resourceApiManagementServiceRead(d, meta)
 }
 
@@ -709,6 +733,7 @@ func resourceApiManagementServiceRead(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*clients.Client).ApiManagement.ServiceClient
 	signInClient := meta.(*clients.Client).ApiManagement.SignInClient
 	signUpClient := meta.(*clients.Client).ApiManagement.SignUpClient
+	tenantAccessClient := meta.(*clients.Client).ApiManagement.TenantAccessClient
 	environment := meta.(*clients.Client).Account.Environment
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -822,6 +847,14 @@ func resourceApiManagementServiceRead(d *schema.ResourceData, meta interface{}) 
 	} else {
 		d.Set("sign_in", []interface{}{})
 		d.Set("sign_up", []interface{}{})
+	}
+
+	tenantAccessInformationContract, err := tenantAccessClient.Get(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("retrieving tenant access properties for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	if err := d.Set("tenant_access", flattenApiManagementTenantAccessSettings(tenantAccessInformationContract)); err != nil {
+		return fmt.Errorf("setting `tenant_access`: %+v", err)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -1598,4 +1631,33 @@ func flattenApiManagementPolicies(d *schema.ResourceData, input apimanagement.Po
 	}
 
 	return []interface{}{output}
+}
+
+func expandApiManagementTenantAccessSettings(input []interface{}) apimanagement.AccessInformationUpdateParameters {
+	enabled := false
+
+	if len(input) > 0 {
+		vs := input[0].(map[string]interface{})
+		enabled = vs["enabled"].(bool)
+	}
+
+	return apimanagement.AccessInformationUpdateParameters{
+		AccessInformationUpdateParameterProperties: &apimanagement.AccessInformationUpdateParameterProperties{
+			Enabled: utils.Bool(enabled),
+		},
+	}
+}
+
+func flattenApiManagementTenantAccessSettings(input apimanagement.AccessInformationContract) []interface{} {
+	enabled := false
+
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled": enabled,
+		},
+	}
 }

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -539,7 +539,7 @@ func resourceApiManagementService() *schema.Resource {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
-						"id": {
+						"tenant_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -1668,7 +1668,7 @@ func flattenApiManagementTenantAccessSettings(input apimanagement.AccessInformat
 	result["enabled"] = *input.Enabled
 
 	if input.ID != nil {
-		result["id"] = *input.ID
+		result["tenant_id"] = *input.ID
 	}
 
 	if input.PrimaryKey != nil {

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -531,12 +531,17 @@ func resourceApiManagementService() *schema.Resource {
 			"tenant_access": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
 							Required: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"primary_key": {
 							Type:      schema.TypeString,
@@ -1658,14 +1663,13 @@ func expandApiManagementTenantAccessSettings(input []interface{}) apimanagement.
 }
 
 func flattenApiManagementTenantAccessSettings(input apimanagement.AccessInformationContract) []interface{} {
-	enabled := false
-
 	result := make(map[string]interface{})
 
-	if input.Enabled != nil {
-		enabled = *input.Enabled
+	result["enabled"] = *input.Enabled
+
+	if input.ID != nil {
+		result["id"] = *input.ID
 	}
-	result["enabled"] = enabled
 
 	if input.PrimaryKey != nil {
 		result["primary_key"] = *input.PrimaryKey

--- a/azurerm/internal/services/apimanagement/api_management_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource_test.go
@@ -510,6 +510,9 @@ func TestAccApiManagement_tenantAccess(t *testing.T) {
 			Config: r.tenantAccess(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tenant_access.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("tenant_access.0.primary_key").Exists(),
+				check.That(data.ResourceName).Key("tenant_access.0.secondary_key").Exists(),
 			),
 		},
 		data.ImportStep(),
@@ -1283,10 +1286,6 @@ resource "azurerm_api_management" "test" {
   publisher_email     = "pub1@email.com"
 
   sku_name = "Developer_1"
-
-  sign_in {
-    enabled = true
-  }
 
   tenant_access {
     enabled = true

--- a/azurerm/internal/services/apimanagement/api_management_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource_test.go
@@ -501,6 +501,21 @@ func TestAccApiManagement_identitySystemAssignedUserAssignedUpdateUserAssigned(t
 	})
 }
 
+func TestAccApiManagement_tenantAccess(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management", "test")
+	r := ApiManagementResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.tenantAccess(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ApiManagementResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1245,6 +1260,37 @@ resource "azurerm_api_management" "test" {
   publisher_name      = "pub1"
   publisher_email     = "pub1@email.com"
   sku_name            = "Consumption_0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ApiManagementResource) tenantAccess(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku_name = "Developer_1"
+
+  sign_in {
+    enabled = true
+  }
+
+  tenant_access {
+    enabled = true
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/apimanagement/api_management_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource_test.go
@@ -511,6 +511,7 @@ func TestAccApiManagement_tenantAccess(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("tenant_access.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("tenant_access.0.id").Exists(),
 				check.That(data.ResourceName).Key("tenant_access.0.primary_key").Exists(),
 				check.That(data.ResourceName).Key("tenant_access.0.secondary_key").Exists(),
 			),

--- a/azurerm/internal/services/apimanagement/api_management_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource_test.go
@@ -511,7 +511,7 @@ func TestAccApiManagement_tenantAccess(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("tenant_access.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("tenant_access.0.id").Exists(),
+				check.That(data.ResourceName).Key("tenant_access.0.tenant_id").Exists(),
 				check.That(data.ResourceName).Key("tenant_access.0.primary_key").Exists(),
 				check.That(data.ResourceName).Key("tenant_access.0.secondary_key").Exists(),
 			),

--- a/azurerm/internal/services/apimanagement/client/client.go
+++ b/azurerm/internal/services/apimanagement/client/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	SignInClient               *apimanagement.SignInSettingsClient
 	SignUpClient               *apimanagement.SignUpSettingsClient
 	SubscriptionsClient        *apimanagement.SubscriptionClient
+	TenantAccessClient         *apimanagement.TenantAccessClient
 	UsersClient                *apimanagement.UserClient
 }
 
@@ -114,6 +115,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	subscriptionsClient := apimanagement.NewSubscriptionClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&subscriptionsClient.Client, o.ResourceManagerAuthorizer)
 
+	tenantAccessClient := apimanagement.NewTenantAccessClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&tenantAccessClient.Client, o.ResourceManagerAuthorizer)
+
 	usersClient := apimanagement.NewUserClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&usersClient.Client, o.ResourceManagerAuthorizer)
 
@@ -144,6 +148,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		SignInClient:               &signInClient,
 		SignUpClient:               &signUpClient,
 		SubscriptionsClient:        &subscriptionsClient,
+		TenantAccessClient:         &tenantAccessClient,
 		UsersClient:                &usersClient,
 	}
 }

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `sign_up` - (Optional) A `sign_up` block as defined below.
 
+* `tenant_access` - (Optional) A `tenant_access` block as defined below.
+
 * `virtual_network_type` - (Optional) The type of virtual network you want to use, valid values include: `None`, `External`, `Internal`. 
 > **NOTE:** Please ensure that in the subnet, inbound port 3443 is open when `virtual_network_type` is `Internal` or `External`. And please ensure other necessary ports are open according to [api management network configuration](https://docs.microsoft.com/en-us/azure/api-management/api-management-using-with-vnet#-common-network-configuration-issues).
 
@@ -296,6 +298,12 @@ A `sign_up` block supports the following:
 * `enabled` - (Required) Can users sign up on the development portal?
 
 * `terms_of_service` - (Required) A `terms_of_service` block as defined below.
+
+---
+
+A `tenant_access` block supports the following:
+
+* `enabled` - (Required) Should the access to the management api be enabled?
 
 ---
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -348,6 +348,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `scm_url` - The URL for the SCM (Source Code Management) Endpoint associated with this API Management service.
 
+* `tenant_access` - The `tenant_access` block as documented below.
+
 ---
 
 An `additional_location` block exports the following:
@@ -365,6 +367,16 @@ An `identity` block exports the following:
 * `principal_id` - The Principal ID associated with this Managed Service Identity.
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
+
+---
+
+A `tenant_access` block exports the following:
+
+* `tenant_id` - The identifier for the tenant access information contract.
+
+* `primary_key` - Primary access key for the tenant access information contract.
+
+* `secondary_key` - Secondary access key for the tenant access information contract.
 
 ## Timeouts
 


### PR DESCRIPTION
Implementation for https://github.com/terraform-providers/terraform-provider-azurerm/issues/8578 .

Management REST API can be enabled/ disabled and the primary/ secondary Keys can be used as output variables.


Feedback welcome ;-)