### PR TITLE
azurerm_lb_backend_address_pool: mark `backend_address` as computed 

### DIFF
--- a/azurerm/internal/services/loadbalancer/backend_address_pool_resource.go
+++ b/azurerm/internal/services/loadbalancer/backend_address_pool_resource.go
@@ -64,6 +64,9 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 			"backend_address": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				// Making this block optional for standard sku LB associating NIC, where the `name` will be computed after
+				// NIC associates with LB BAP by azurerm_network_interface_backend_address_pool_association.
+				Computed: true,
 				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Fix the regression caused by #10291, that [the associated NIC will be cleared by LB BAP](https://github.com/terraform-providers/terraform-provider-azurerm/pull/10291#issuecomment-773691693)