### PR TITLE
azurerm_container_group: support exposed_port to configure ports at group level

### DIFF
--- a/azurerm/internal/services/containers/container_group_resource.go
+++ b/azurerm/internal/services/containers/container_group_resource.go
@@ -723,23 +723,21 @@ func resourceContainerGroupRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func flattenPorts(ports []interface{}) *schema.Set {
-	if ports != nil && len(ports) > 0 {
+	if len(ports) > 0 {
 		flatPorts := make([]interface{}, 0)
 		for _, p := range ports {
 			port := make(map[string]interface{})
-			switch p.(type) {
+			switch t := p.(type) {
 			case containerinstance.Port:
-				pCast := p.(containerinstance.Port)
-				if v := pCast.Port; v != nil {
+				if v := t.Port; v != nil {
 					port["port"] = int(*v)
 				}
-				port["protocol"] = string(pCast.Protocol)
+				port["protocol"] = string(t.Protocol)
 			case containerinstance.ContainerPort:
-				pCast := p.(containerinstance.ContainerPort)
-				if v := pCast.Port; v != nil {
+				if v := t.Port; v != nil {
 					port["port"] = int(*v)
 				}
-				port["protocol"] = string(pCast.Protocol)
+				port["protocol"] = string(t.Protocol)
 			}
 			flatPorts = append(flatPorts, port)
 		}
@@ -984,7 +982,7 @@ func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstanc
 	if v, ok := d.Get("exposed_port").(*schema.Set); ok && len(v.List()) > 0 {
 		cgpMap := make(map[int32]bool)
 		for _, p := range containerInstancePorts {
-			cgpMap[int32(*p.Port)] = true
+			cgpMap[*p.Port] = true
 		}
 
 		for _, p := range v.List() {

--- a/azurerm/internal/services/containers/container_group_resource_test.go
+++ b/azurerm/internal/services/containers/container_group_resource_test.go
@@ -617,6 +617,11 @@ resource "azurerm_container_group" "test" {
   ip_address_type     = "public"
   os_type             = "Linux"
 
+  exposed_port {
+    port     = 80
+    protocol = "TCP"
+  }
+
   container {
     name   = "hw"
     image  = "microsoft/aci-helloworld:latest"
@@ -871,6 +876,15 @@ resource "azurerm_container_group" "test" {
   resource_group_name = azurerm_resource_group.test.name
   ip_address_type     = "public"
   os_type             = "Linux"
+
+  exposed_port {
+    port = 80
+  }
+
+  exposed_port {
+    port     = 5443
+    protocol = "UDP"
+  }
 
   container {
     name   = "hw"

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -82,6 +82,10 @@ The following arguments are supported:
 
 ~> **Note:** DNS label/name is not supported when deploying to virtual networks.
 
+* `exposed_port` - (Optional) A set of public ports for the container group. Changing this forces a new resource to be created. Set as documented in the `exposed_port` block below.
+
+~> **Note:** Any `exposed_port` specified at the container group level must also be specified in a `ports` block on an individual container.
+
 * `ip_address_type` - (Optional) Specifies the ip address type of the container. `Public` or `Private`. Changing this forces a new resource to be created. If set to `Private`, `network_profile_id` also needs to be set.
 
 ~> **Note:** `dns_name_label`, `identity` and `os_type` set to `windows` are not compatible with `Private` `ip_address_type`
@@ -136,6 +140,16 @@ A `container` block supports:
 
 ---
 
+A `exposed_port` block supports:
+
+* `port` - (Required) The port number the container will expose. Changing this forces a new resource to be created.
+
+* `protocol` - (Required) The network protocol associated with port. Possible values are `TCP` & `UDP`. Changing this forces a new resource to be created.
+
+~> **Note:** Removing all `exposed_port` blocks requires setting `exposed_port = []`.
+
+---
+
 A `diagnostics` block supports:
 
 * `log_analytics` - (Required) A `log_analytics` block as defined below. Changing this forces a new resource to be created.
@@ -169,6 +183,8 @@ A `ports` block supports:
 * `port` - (Required) The port number the container will expose. Changing this forces a new resource to be created.
 
 * `protocol` - (Required) The network protocol associated with port. Possible values are `TCP` & `UDP`. Changing this forces a new resource to be created.
+
+~> **Note:** If there are no `exposed_port` blocks, then all `ports` blocks will be automatically exposed on the container group level.
 
 --
 


### PR DESCRIPTION
Fixes #4413

Previous PR & discussion: #5091

* Support `exposed_port` to allow configuring ports at group level without breaking backwards compatibility (field is marked as optional for now).
* Path to mark as required in 3.0 of the provider. 
* Note: Because `exposed_port` is marked as both optional and computed, I've also set `ConfigMode: schema.SchemaConfigModeAttr`. Without this set, I don't think there would be a way to remove the last `exposed_port` block in a config and revert back to the old behavior (where the old behavior is that `ports` on the container level are automatically exposed on the group level).

Feedback is very much welcome.