### PR TITLE
Minor tweak for SDK: return nil instead of return err

### DIFF
--- a/azurerm/internal/sdk/wrapper_resource.go
+++ b/azurerm/internal/sdk/wrapper_resource.go
@@ -92,7 +92,7 @@ func (rw *ResourceWrapper) Resource() (*schema.Resource, error) {
 				return fmt.Errorf(out)
 			}
 
-			return err
+			return nil
 		}, func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 			if v, ok := rw.resource.(ResourceWithCustomImporter); ok {
 				ctx, metaData := runArgs(d, meta, rw.logger)


### PR DESCRIPTION
We do not have a `err` variable in this scope, therefore we are actually returning the `err` on line 29