### PR TITLE
testing: groundwork for Binary Testing

### DIFF
--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -29,9 +29,9 @@ fun BuildSteps.ConfigureGoEnv() {
 
 fun BuildSteps.DownloadTerraformBinary() {
     // https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_linux_amd64.zip
-    var terraformUrl = "https://releases.hashicorp.com/terraform/%TERRAFORM_CORE_VERSION%/terraform_%TERRAFORM_CORE_VERSION%_linux_amd64.zip"
+    var terraformUrl = "https://releases.hashicorp.com/terraform/%env.TERRAFORM_CORE_VERSION%/terraform_%env.TERRAFORM_CORE_VERSION%_linux_amd64.zip"
     step(ScriptBuildStep {
-        name = "Download Terraform Core v%TERRAFORM_CORE_VERSION%.."
+        name = "Download Terraform Core v%env.TERRAFORM_CORE_VERSION%.."
         scriptContent = "mkdir -p tools && wget -O tf.zip %s && unzip tf.zip && mv terraform tools/".format(terraformUrl)
     })
 }
@@ -107,7 +107,7 @@ fun ParametrizedWithType.TerraformAcceptanceTestsFlag() {
 }
 
 fun ParametrizedWithType.TerraformCoreBinaryTesting() {
-    text("TERRAFORM_CORE_VERSION", defaultTerraformCoreVersion, "The version of Terraform Core which should be used for testing")
+    text("env.TERRAFORM_CORE_VERSION", defaultTerraformCoreVersion, "The version of Terraform Core which should be used for testing")
     hiddenVariable("env.TF_ACC_TERRAFORM_PATH", "%system.teamcity.build.checkoutDir%/tools/terraform", "The path where the Terraform Binary is located")
 }
 

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -5,7 +5,7 @@ var defaultStartHour = 0
 var defaultParallelism = 20
 
 // specifies the default version of Terraform Core which should be used for testing
-var defaultTerraformCoreVersion = "0.14.5"
+var defaultTerraformCoreVersion = "0.14.6"
 
 var locations = mapOf(
         "public" to LocationConfiguration("westeurope", "eastus2", "francecentral", false),

--- a/azurerm/internal/acceptance/required_test.go
+++ b/azurerm/internal/acceptance/required_test.go
@@ -34,7 +34,7 @@ func TestAccEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 	}
 
 	client := armClient.Resource.ProvidersClient
-	ctx := AzureProvider.StopContext()
+	ctx := armClient.StopContext
 	providerList, err := client.List(ctx, nil, "")
 	if err != nil {
 		t.Fatalf("Unable to list provider registration status, it is possible that this is due to invalid "+

--- a/azurerm/internal/acceptance/steps.go
+++ b/azurerm/internal/acceptance/steps.go
@@ -30,11 +30,17 @@ func (td TestData) DisappearsStep(data DisappearsStepData) resource.TestStep {
 		Config: config,
 		Check: resource.ComposeTestCheckFunc(
 			func(state *terraform.State) error {
-				client := buildClient()
+				client, err := buildClient()
+				if err != nil {
+					return fmt.Errorf("building client: %+v", err)
+				}
 				return helpers.ExistsInAzure(client, data.TestResource, td.ResourceName)(state)
 			},
 			func(state *terraform.State) error {
-				client := buildClient()
+				client, err := buildClient()
+				if err != nil {
+					return fmt.Errorf("building client: %+v", err)
+				}
 				return helpers.DeleteResourceFunc(client, data.TestResource, td.ResourceName)(state)
 			},
 		),
@@ -60,8 +66,11 @@ func (td TestData) CheckWithClientForResource(check ClientCheckFunc, resourceNam
 				return fmt.Errorf("Resource not found: %s", resourceName)
 			}
 
-			clients := buildClient()
-			return check(clients.StopContext, clients, rs.Primary)
+			client, err := buildClient()
+			if err != nil {
+				return fmt.Errorf("building client: %+v", err)
+			}
+			return check(client.StopContext, client, rs.Primary)
 		},
 	)
 }

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -116,7 +116,7 @@ func buildClient() (*clients.Client, error) {
 
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 	if enableBinaryTesting {
-		testCase.DisableBinaryDriver = false
+		testCase.DisableBinaryDriver = false //nolint:SA1019
 		testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
 			"azurerm": func() (terraform.ResourceProvider, error) {
 				azurerm := provider.TestAzureProvider()

--- a/azurerm/internal/features/defaults.go
+++ b/azurerm/internal/features/defaults.go
@@ -1,0 +1,24 @@
+package features
+
+func Default() UserFeatures {
+	return UserFeatures{
+		// NOTE: ensure all nested objects are fully populated
+		KeyVault: KeyVaultFeatures{
+			PurgeSoftDeleteOnDestroy:    true,
+			RecoverSoftDeletedKeyVaults: true,
+		},
+		Network: NetworkFeatures{
+			RelaxedLocking: false,
+		},
+		TemplateDeployment: TemplateDeploymentFeatures{
+			DeleteNestedItemsDuringDeletion: true,
+		},
+		VirtualMachine: VirtualMachineFeatures{
+			DeleteOSDiskOnDeletion: true,
+			GracefulShutdown:       false,
+		},
+		VirtualMachineScaleSet: VirtualMachineScaleSetFeatures{
+			RollInstancesWhenRequired: true,
+		},
+	}
+}

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -113,26 +113,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 
 func expandFeatures(input []interface{}) features.UserFeatures {
 	// these are the defaults if omitted from the config
-	features := features.UserFeatures{
-		// NOTE: ensure all nested objects are fully populated
-		KeyVault: features.KeyVaultFeatures{
-			PurgeSoftDeleteOnDestroy:    true,
-			RecoverSoftDeletedKeyVaults: true,
-		},
-		Network: features.NetworkFeatures{
-			RelaxedLocking: false,
-		},
-		TemplateDeployment: features.TemplateDeploymentFeatures{
-			DeleteNestedItemsDuringDeletion: true,
-		},
-		VirtualMachine: features.VirtualMachineFeatures{
-			DeleteOSDiskOnDeletion: true,
-			GracefulShutdown:       false,
-		},
-		VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
-			RollInstancesWhenRequired: true,
-		},
-	}
+	features := features.Default()
 
 	if len(input) == 0 || input[0] == nil {
 		return features


### PR DESCRIPTION
This PR adds the necessary groundwork for Binary Testing to work in a feature-toggled manner. There's a few components necessary for this to work:

1. Removing the remaining dependencies on `acceptance.AzureProvider` (in flight)
2. Upgrading the Plugin SDK to use `v1.16.0`
3. Turning on the feature toggle

As such whilst this work isn't immediately usable, after rebasing this on top of the changes from 1, including 2 and turning on 3 - both Binary Testing and the current testing framework both work.

Note to reviewers: the `features` block defined below is intentionally using the default feature-set - since the Exists functions within the test framework don't (and shouldn't) make use of them (but they are available during Terraform runtime)