### PR TITLE
r/kubernetes_cluster: validating the casing on the Log Analytics Workspace ID

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	azureHelpers "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	logAnalyticsValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 
 	laparse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
@@ -129,7 +129,7 @@ func schemaKubernetesAddOnProfiles() *schema.Schema {
 							"log_analytics_workspace_id": {
 								Type:         schema.TypeString,
 								Optional:     true,
-								ValidateFunc: azureHelpers.ValidateResourceID,
+								ValidateFunc: logAnalyticsValidate.LogAnalyticsWorkspaceID,
 							},
 							"oms_agent_identity": {
 								Type:     schema.TypeList,


### PR DESCRIPTION
Now we've got a more specific validation function here we can switch to using this, rather than the generic Resource ID validator

Fixes #10517