### PR TITLE
feature: Binary Testing

### DIFF
--- a/azurerm/internal/acceptance/check/that.go
+++ b/azurerm/internal/acceptance/check/that.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/testclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 type thatType struct {
@@ -28,7 +27,10 @@ func That(resourceName string) thatType {
 // DoesNotExistInAzure validates that the specified resource does not exist within Azure
 func (t thatType) DoesNotExistInAzure(testResource types.TestResource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client)
+		client, err := testclient.Build()
+		if err != nil {
+			return fmt.Errorf("building client: %+v", err)
+		}
 		return helpers.DoesNotExistInAzure(client, testResource, t.resourceName)(s)
 	}
 }
@@ -36,7 +38,10 @@ func (t thatType) DoesNotExistInAzure(testResource types.TestResource) resource.
 // ExistsInAzure validates that the specified resource exists within Azure
 func (t thatType) ExistsInAzure(testResource types.TestResource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client)
+		client, err := testclient.Build()
+		if err != nil {
+			return fmt.Errorf("building client: %+v", err)
+		}
 		return helpers.ExistsInAzure(client, testResource, t.resourceName)(s)
 	}
 }

--- a/azurerm/internal/acceptance/providers.go
+++ b/azurerm/internal/acceptance/providers.go
@@ -8,13 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/testclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
 
 var once sync.Once
 
 func EnsureProvidersAreInitialised() {
-	if !enableBinaryTesting {
+	if !testclient.EnableBinaryTesting {
 		os.Setenv("TF_DISABLE_BINARY_TESTING", "true")
 	} else {
 		// require reattach testing is enabled
@@ -22,10 +23,10 @@ func EnsureProvidersAreInitialised() {
 	}
 
 	once.Do(func() {
-		if !enableBinaryTesting {
+		if !testclient.EnableBinaryTesting {
 			azureProvider := provider.TestAzureProvider().(*schema.Provider)
-			AzureProvider = azureProvider
-			SupportedProviders = map[string]terraform.ResourceProvider{
+			testclient.AzureProvider = azureProvider
+			testclient.SupportedProviders = map[string]terraform.ResourceProvider{
 				"azurerm": azureProvider,
 				"azuread": azuread.Provider().(*schema.Provider),
 			}

--- a/azurerm/internal/acceptance/steps.go
+++ b/azurerm/internal/acceptance/steps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/testclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
@@ -30,14 +31,14 @@ func (td TestData) DisappearsStep(data DisappearsStepData) resource.TestStep {
 		Config: config,
 		Check: resource.ComposeTestCheckFunc(
 			func(state *terraform.State) error {
-				client, err := buildClient()
+				client, err := testclient.Build()
 				if err != nil {
 					return fmt.Errorf("building client: %+v", err)
 				}
 				return helpers.ExistsInAzure(client, data.TestResource, td.ResourceName)(state)
 			},
 			func(state *terraform.State) error {
-				client, err := buildClient()
+				client, err := testclient.Build()
 				if err != nil {
 					return fmt.Errorf("building client: %+v", err)
 				}
@@ -66,7 +67,7 @@ func (td TestData) CheckWithClientForResource(check ClientCheckFunc, resourceNam
 				return fmt.Errorf("Resource not found: %s", resourceName)
 			}
 
-			client, err := buildClient()
+			client, err := testclient.Build()
 			if err != nil {
 				return fmt.Errorf("building client: %+v", err)
 			}

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -17,10 +17,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
 
-// NOTE: when Binary Testing is enabled the Check functions will need to build a client rather than relying on the
-// shared one. For the moment we init the shared client when Binary Testing is Enabled & Disabled - but this needs
-// fixing when we move to Binary Testing so that we can test across provider instances
-var enableBinaryTesting = false
+// @tombuildsstuff: this is left in as a compatibility layer for the moment
+// in the near future we'll remove this, and remove the "azuread" provider below
+// but for the moment there's no need to remove the vendor here imminantly afaict
+var enableBinaryTesting = true
 
 // lintignore:AT001
 func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -1,26 +1,16 @@
 package acceptance
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"sync"
 	"testing"
 
-	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/testclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/types"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
-
-// @tombuildsstuff: this is left in as a compatibility layer for the moment
-// in the near future we'll remove this, and remove the "azuread" provider below
-// but for the moment there's no need to remove the vendor here imminantly afaict
-var enableBinaryTesting = true
 
 // lintignore:AT001
 func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {
@@ -38,7 +28,7 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 	testCase := resource.TestCase{
 		PreCheck: func() { PreCheck(t) },
 		CheckDestroy: func(s *terraform.State) error {
-			client, err := buildClient()
+			client, err := testclient.Build()
 			if err != nil {
 				return fmt.Errorf("building client: %+v", err)
 			}
@@ -64,59 +54,8 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 	}
 }
 
-var _client *clients.Client
-var clientLock = &sync.Mutex{}
-
-func buildClient() (*clients.Client, error) {
-	if enableBinaryTesting {
-		clientLock.Lock()
-		defer clientLock.Unlock()
-
-		if _client == nil {
-			environment, exists := os.LookupEnv("ARM_ENVIRONMENT")
-			if !exists {
-				environment = "public"
-			}
-
-			builder := authentication.Builder{
-				SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
-				ClientID:       os.Getenv("ARM_CLIENT_ID"),
-				TenantID:       os.Getenv("ARM_TENANT_ID"),
-				ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
-				Environment:    environment,
-				MetadataHost:   os.Getenv("ARM_METADATA_HOST"),
-
-				// we intentionally only support Client Secret auth for tests (since those variables are used all over)
-				SupportsClientSecretAuth: true,
-			}
-			config, err := builder.Build()
-			if err != nil {
-				return nil, fmt.Errorf("Error building ARM Client: %+v", err)
-			}
-
-			clientBuilder := clients.ClientBuilder{
-				AuthConfig:               config,
-				SkipProviderRegistration: true,
-				TerraformVersion:         os.Getenv("TERRAFORM_CORE_VERSION"),
-				Features:                 features.Default(),
-				StorageUseAzureAD:        false,
-			}
-			client, err := clients.Build(context.TODO(), clientBuilder)
-			if err != nil {
-				return nil, err
-			}
-			_client = client
-		}
-
-		return _client, nil
-	}
-
-	return AzureProvider.Meta().(*clients.Client), nil
-}
-
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
-	if enableBinaryTesting {
-		testCase.DisableBinaryDriver = false //nolint:SA1019
+	if testclient.EnableBinaryTesting {
 		testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
 			"azurerm": func() (terraform.ResourceProvider, error) {
 				azurerm := provider.TestAzureProvider()
@@ -124,7 +63,7 @@ func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 			},
 		}
 	} else {
-		testCase.Providers = SupportedProviders
+		testCase.Providers = testclient.SupportedProviders
 	}
 
 	resource.ParallelTest(t, testCase)

--- a/azurerm/internal/acceptance/testclient/client.go
+++ b/azurerm/internal/acceptance/testclient/client.go
@@ -1,0 +1,74 @@
+package testclient
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/hashicorp/go-azure-helpers/authentication"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+var (
+	// @tombuildsstuff: this is left in as a compatibility layer for the moment
+	// in the near future we'll remove this, and remove the "azuread" provider below
+	// but for the moment there's no need to remove the vendor here imminantly afaict
+	EnableBinaryTesting = true
+
+	AzureProvider      *schema.Provider
+	SupportedProviders map[string]terraform.ResourceProvider
+)
+
+var _client *clients.Client
+var clientLock = &sync.Mutex{}
+
+func Build() (*clients.Client, error) {
+	if EnableBinaryTesting {
+		clientLock.Lock()
+		defer clientLock.Unlock()
+
+		if _client == nil {
+			environment, exists := os.LookupEnv("ARM_ENVIRONMENT")
+			if !exists {
+				environment = "public"
+			}
+
+			builder := authentication.Builder{
+				SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+				ClientID:       os.Getenv("ARM_CLIENT_ID"),
+				TenantID:       os.Getenv("ARM_TENANT_ID"),
+				ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
+				Environment:    environment,
+				MetadataHost:   os.Getenv("ARM_METADATA_HOST"),
+
+				// we intentionally only support Client Secret auth for tests (since those variables are used all over)
+				SupportsClientSecretAuth: true,
+			}
+			config, err := builder.Build()
+			if err != nil {
+				return nil, fmt.Errorf("Error building ARM Client: %+v", err)
+			}
+
+			clientBuilder := clients.ClientBuilder{
+				AuthConfig:               config,
+				SkipProviderRegistration: true,
+				TerraformVersion:         os.Getenv("TERRAFORM_CORE_VERSION"),
+				Features:                 features.Default(),
+				StorageUseAzureAD:        false,
+			}
+			client, err := clients.Build(context.TODO(), clientBuilder)
+			if err != nil {
+				return nil, err
+			}
+			_client = client
+		}
+
+		return _client, nil
+	}
+
+	return AzureProvider.Meta().(*clients.Client), nil
+}

--- a/azurerm/internal/acceptance/testing.go
+++ b/azurerm/internal/acceptance/testing.go
@@ -10,13 +10,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-)
-
-var (
-	AzureProvider      *schema.Provider
-	SupportedProviders map[string]terraform.ResourceProvider
 )
 
 func PreCheck(t *testing.T) {

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -324,14 +324,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		client.StopContext = p.StopContext()
 
-		// replaces the context between tests
-		p.MetaReset = func() error {
-			client.StopContext = p.StopContext()
-			return nil
-		}
-
 		if !skipProviderRegistration {
-			// List all the available providers and their registration state to avoid unnecessary requests.
+			// List all the available providers and their registration state to avoid unnecessary
+			// requests. This also lets us check if the provider credentials are correct.
 			ctx := client.StopContext
 			providerList, err := client.Resource.ProvidersClient.List(ctx, nil, "")
 			if err != nil {


### PR DESCRIPTION
This commit enables the feature toggle for Binary Testing - which switches to using the real Terraform Binary when running Acceptance Tests and allows for different versions of Core to be used.

Due to the use of Service Packages, we require that Reattach testing is used - as such this requires using Terraform Core 0.12.26 or later.

This commit depends on - and must be rebased on top of - #10521 and #10519 due to the removal of `acceptance.AzureProvider` when Binary Testing is being used.

A future commit will remove support for the legacy testing framework after a suitable transition period, but for the moment disabling this functionality is sufficient.