### PR TITLE
tests: adding `azuread` provider blocks

### DIFF
--- a/azurerm/internal/services/authorization/role_assignment_resource_test.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource_test.go
@@ -354,6 +354,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 data "azurerm_subscription" "current" {
 }
 
@@ -379,6 +381,8 @@ func (RoleAssignmentResource) servicePrincipalWithType(rInt int, roleAssignmentI
 provider "azurerm" {
   features {}
 }
+
+provider "azuread" {}
 
 data "azurerm_subscription" "current" {
 }
@@ -406,6 +410,8 @@ func (RoleAssignmentResource) group(rInt int, roleAssignmentID string) string {
 provider "azurerm" {
   features {}
 }
+
+provider "azuread" {}
 
 data "azurerm_subscription" "current" {
 }

--- a/azurerm/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
+++ b/azurerm/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
@@ -176,6 +176,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 data "azurerm_client_config" "current" {}
 
 resource "azuread_application" "test" {

--- a/azurerm/internal/services/batch/batch_account_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_account_data_source_test.go
@@ -134,6 +134,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 data "azuread_service_principal" "test" {
   display_name = "Microsoft Azure Batch"
 }

--- a/azurerm/internal/services/batch/batch_account_resource_test.go
+++ b/azurerm/internal/services/batch/batch_account_resource_test.go
@@ -242,6 +242,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 data "azuread_service_principal" "test" {
   display_name = "Microsoft Azure Batch"
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -1136,6 +1136,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-cosmos-%d"
   location = "%s"

--- a/azurerm/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -1242,6 +1242,8 @@ func (r HDInsightKafkaClusterResource) restProxy(data acceptance.TestData) strin
 	return fmt.Sprintf(`
 %s
 
+provider "azuread" {}
+
 resource "azuread_group" "test" {
   name = "acctesthdi-%d"
 }

--- a/azurerm/internal/services/hpccache/hpc_cache_blob_target_resource_test.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_blob_target_resource_test.go
@@ -131,6 +131,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-storage-%d"
   location = "%s"

--- a/azurerm/internal/services/mssql/mssql_server_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_server_resource_test.go
@@ -484,6 +484,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"
   location = "%[2]s"
@@ -515,6 +517,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"
   location = "%[2]s"
@@ -545,6 +549,8 @@ func (MsSqlServerResource) blobAuditingPoliciesWithFirewall(data acceptance.Test
 provider "azurerm" {
   features {}
 }
+
+provider "azuread" {}
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"

--- a/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -167,6 +167,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-mssql-%[1]d"
   location = "%[2]s"

--- a/azurerm/internal/services/servicefabric/service_fabric_cluster_resource_test.go
+++ b/azurerm/internal/services/servicefabric/service_fabric_cluster_resource_test.go
@@ -1280,6 +1280,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/azurerm/internal/services/springcloud/spring_cloud_certificate_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_certificate_resource_test.go
@@ -94,6 +94,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-spring-%d"
   location = "%s"

--- a/azurerm/internal/services/springcloud/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_service_resource_test.go
@@ -238,6 +238,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-spring-%d"
   location = "%s"

--- a/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -247,6 +247,8 @@ func (r StorageDataLakeGen2FileSystemResource) withExecuteACLForSPN(data accepta
 	return fmt.Sprintf(`
 %s
 
+provider "azuread" {}
+
 data "azurerm_client_config" "current" {
 }
 

--- a/azurerm/internal/services/storage/storage_data_lake_gen2_path_resource_test.go
+++ b/azurerm/internal/services/storage/storage_data_lake_gen2_path_resource_test.go
@@ -224,6 +224,8 @@ func (r StorageDataLakeGen2PathResource) withACLWithSpecificUserAndDefaults(data
 	return fmt.Sprintf(`
 %s
 
+provider "azuread" {}
+
 resource "azuread_application" "test" {
   name = "acctestspa%[2]d"
 }
@@ -292,6 +294,8 @@ func (r StorageDataLakeGen2PathResource) withOwner(data acceptance.TestData) str
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azuread" {}
 
 resource "azurerm_role_assignment" "storage_blob_owner" {
   role_definition_name = "Storage Blob Data Owner"

--- a/azurerm/internal/services/web/app_service_certificate_resource_test.go
+++ b/azurerm/internal/services/web/app_service_certificate_resource_test.go
@@ -125,6 +125,8 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 data "azurerm_client_config" "test" {}
 
 data "azuread_service_principal" "test" {


### PR DESCRIPTION
This becomes necessary for Binary Testing to be able to download the AzureAD Provider on demand rather than having this vendored into the codebase. Whilst the AzureAD Provider is available for the moment, it won't be going forwards - as such these provider blocks need to be defined.