### PR TITLE
`azurerm_media_streaming_endpoint`: Expose `host_name`

### DIFF
--- a/azurerm/internal/services/media/media_streaming_endpoint_resource.go
+++ b/azurerm/internal/services/media/media_streaming_endpoint_resource.go
@@ -193,6 +193,11 @@ func resourceMediaStreamingEndpoint() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 2147483647),
 			},
 
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -405,6 +410,7 @@ func resourceMediaStreamingEndpointRead(d *schema.ResourceData, meta interface{}
 		d.Set("cdn_enabled", props.CdnEnabled)
 		d.Set("cdn_profile", props.CdnProfile)
 		d.Set("cdn_provider", props.CdnProvider)
+		d.Set("host_name", props.HostName)
 
 		crossSiteAccessPolicies := flattenCrossSiteAccessPolicies(resp.CrossSiteAccessPolicies)
 		if err := d.Set("cross_site_access_policy", crossSiteAccessPolicies); err != nil {

--- a/azurerm/internal/services/media/media_streaming_endpoint_resource_test.go
+++ b/azurerm/internal/services/media/media_streaming_endpoint_resource_test.go
@@ -26,6 +26,7 @@ func TestAccMediaStreamingEndpoint_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: resource.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).Key("scale_units").HasValue("1"),
+				check.That(data.ResourceName).Key("host_name").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/media_streaming_endpoint.html.markdown
+++ b/website/docs/r/media_streaming_endpoint.html.markdown
@@ -184,6 +184,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Streaming Endpoint.
 
+* `host_name` - The host name of the Streaming Endpoint.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
Fixes #10458

=== RUN   TestAccMediaStreamingEndpoint_basic
=== PAUSE TestAccMediaStreamingEndpoint_basic
=== CONT  TestAccMediaStreamingEndpoint_basic
--- PASS: TestAccMediaStreamingEndpoint_basic (126.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/media       129.755s