### PR TITLE
azurerm_eventhub_namespace: fix downgrade scenario

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -308,7 +308,7 @@ func resourceEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta interfac
 	//
 	// See: https://github.com/terraform-providers/terraform-provider-azurerm/issues/10244
 	//
-	if parameters.Sku.Tier == eventhub.SkuTierBasic && autoInflateEnabled == false {
+	if parameters.Sku.Tier == eventhub.SkuTierBasic && !autoInflateEnabled {
 		parameters.EHNamespaceProperties.MaximumThroughputUnits = utils.Int32(0)
 	}
 

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -389,6 +389,29 @@ func TestAccEventHubNamespace_BasicWithSkuUpdate(t *testing.T) {
 	})
 }
 
+func TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
+	r := EventHubNamespaceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.maximumThroughputUnits(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
+				check.That(data.ResourceName).Key("capacity").HasValue("2"),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("Basic"),
+			),
+		},
+	})
+}
+
 func TestAccEventHubNamespace_maximumThroughputUnitsUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
 	r := EventHubNamespaceResource{}


### PR DESCRIPTION
Fixes #10244.

In a corner case when we are downgrading from Standard to Basic SKU and namespace had both autoInflate enabled and
maximumThroughputUnits set - we need to force throughput units back to 0, otherwise downgrade fails

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/eventhub -timeout=1000m -run=TestAccEventHubNamespace_TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput -run=TestAccEventHubNamespace_basicWithIdentity
=== RUN   TestAccEventHubNamespace_basicWithIdentity
=== PAUSE TestAccEventHubNamespace_basicWithIdentity
=== CONT  TestAccEventHubNamespace_basicWithIdentity
--- PASS: TestAccEventHubNamespace_basicWithIdentity (269.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub	270.272s
$ TF_ACC=1 go test -v ./azurerm/internal/services/eventhub -timeout=1000m -run=TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput
=== RUN   TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput
=== PAUSE TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput
=== CONT  TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput
--- PASS: TestAccEventHubNamespace_SkuDowngradeFromAutoInflateWithMaxThroughput (678.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub	679.681s
```