### PR TITLE
r/resource_group_template_deployment: checking for the resource name insensitively

### DIFF
--- a/azurerm/internal/services/resource/template_deployment_common.go
+++ b/azurerm/internal/services/resource/template_deployment_common.go
@@ -239,7 +239,7 @@ func findApiVersionForResourceType(resourceType string, availableResourceTypes [
 			continue
 		}
 
-		if strings.HasPrefix(resourceType, *item.ResourceType) {
+		if strings.HasPrefix(strings.ToLower(resourceType), strings.ToLower(*item.ResourceType)) {
 			apiVersions := *item.APIVersions
 			apiVersion := apiVersions[0]
 			return &apiVersion


### PR DESCRIPTION
Fixes #10439

Before this change:

```
$ TF_ACC=1 envchain azurerm go test -v ./azurerm/internal/services/resource/... -run=TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing -timeout=60m -mod=vendor
=== RUN   TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing
=== PAUSE TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing
=== CONT  TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing
   testing.go:766: Error destroying resource! WARNING: Dangling resources
       may exist. The full state and error is shown below.

       Error: errors during apply: removing items provisioned by this Template Deployment: determining API Versions for Resource Providers: unable to determine API version for Resource Type "actionGroups" (Resource Provider "microsoft.insights")

       State: azurerm_resource_group.test:
         ID = /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestrg-210212135344425112
         provider = provider.azurerm
         location = westeurope
         name = acctestrg-210212135344425112
         tags.% = 0
       azurerm_resource_group_template_deployment.test:
         ID = /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestrg-210212135344425112/providers/Microsoft.Resources/deployments/acctest
         provider = provider.azurerm
         debug_level =
         deployment_mode = Complete
         name = acctest
         output_content = {}
         parameters_content = {"someParam":{"value":"first"}}
         resource_group_name = acctestrg-210212135344425112
         tags.% = 0
         template_content = {"$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"someParam":{"allowedValues":["first","second","third"],"type":"String"}},"resources":[{"apiVersion":"2019-06-01","dependsOn":[],"location":"Global","name":"acctestTemplateDeployAG-210212135344425112","properties":{"emailReceivers":[{"emailAddress":"rick@example.com","name":"Rick Sanchez"}],"enabled":true,"groupShortName":"rick-c137","smsReceivers":[],"webhookReceivers":[]},"tags":{},"type":"microsoft.insights/actionGroups"}],"variables":{}}
--- FAIL: TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing (128.13s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource	129.826s
?   	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/client	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/parse	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/validate	(cached) [no tests to run]
FAIL
```

After this change:

```
$ TF_ACC=1 envchain azurerm go test -v ./azurerm/internal/services/resource/... -run=TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing -timeout=60m -mod=vendor
=== RUN   TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing
=== PAUSE TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing
=== CONT  TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing
--- PASS: TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing (193.09s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource	194.774s
?   	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/client	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/parse	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/validate	(cached) [no tests to run]
```