### PR TITLE
Add Arm and Dns pricing options for Azure Security Center

### DIFF
--- a/azurerm/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -65,6 +65,8 @@ func resourceSecurityCenterSubscriptionPricing() *schema.Resource {
 					"SqlServerVirtualMachines",
 					"StorageAccounts",
 					"VirtualMachines",
+					"Arm",
+					"Dns",
 				}, false),
 			},
 		},

--- a/website/docs/r/security_center_subscription_pricing.markdown
+++ b/website/docs/r/security_center_subscription_pricing.markdown
@@ -28,7 +28,7 @@ resource "azurerm_security_center_subscription_pricing" "example" {
 The following arguments are supported:
 
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
-* `resource_type` - (Required) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, and `VirtualMachines`. 
+* `resource_type` - (Required) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm` and `Dns`. 
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.
 


### PR DESCRIPTION
Adding support for `Arm` and `Dns` pricing settings for Azure Subscriptions, as per following output from `Get-AzSecurityPricing` powershell cmdlet:

```powershell
Get-AzSecurityPricing | select Name

Name
----
VirtualMachines
SqlServers
AppServices
StorageAccounts
SqlServerVirtualMachines
KubernetesService
ContainerRegistry
KeyVaults
Dns
Arm

```