### PR TITLE
Docs: AAAA record - add example and fix typo

### DIFF
--- a/website/docs/r/dns_aaaa_record.html.markdown
+++ b/website/docs/r/dns_aaaa_record.html.markdown
@@ -28,6 +28,7 @@ resource "azurerm_dns_aaaa_record" "example" {
   zone_name           = azurerm_dns_zone.example.name
   resource_group_name = azurerm_resource_group.example.name
   ttl                 = 300
+  records             = ["2001:db8::1:0:0:1"]
 }
 ```
 
@@ -73,7 +74,7 @@ The following arguments are supported:
 
 * `TTL` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 
-* `records` - (Optional) List of IPv4 Addresses. Conflicts with `target_resource_id`.
+* `records` - (Optional) List of IPv6 Addresses. Conflicts with `target_resource_id`.
 
 * `target_resource_id` - (Optional) The Azure resource id of the target object. Conflicts with `records`
 


### PR DESCRIPTION
Since the second example is using alias, I feel like `records` should be included in the first.

Fixed IPv4 → IPv6 typo
