### PR TITLE
r/azurerm_eventgrid_event_subscription - advanced_filter MaxItems increase from 5 to 25

### DIFF
--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -384,7 +384,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeFloat,
 								},
@@ -405,7 +405,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeFloat,
 								},
@@ -426,7 +426,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},
@@ -447,7 +447,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},
@@ -468,7 +468,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},
@@ -489,7 +489,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},
@@ -510,7 +510,7 @@ func eventSubscriptionSchemaAdvancedFilter() *schema.Schema {
 							"values": {
 								Type:     schema.TypeList,
 								Required: true,
-								MaxItems: 5,
+								MaxItems: 25,
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -196,6 +196,58 @@ func TestAccEventGridEventSubscription_advancedFilter(t *testing.T) {
 	})
 }
 
+func TestAccEventGridEventSubscription_advancedFilterMaxItems(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_event_subscription", "test")
+	r := EventGridEventSubscriptionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.advancedFilterMaxItems(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.value").HasValue("true"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.key").HasValue("data.metadataVersion"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.value").HasValue("2"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.value").HasValue("3"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.value").HasValue("4"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.key").HasValue("data.metadataVersion"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.value").HasValue("5"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("6"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.1").HasValue("7"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.2").HasValue("8"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("9"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.1").HasValue("10"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.2").HasValue("11"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("12"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.1").HasValue("13"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.2").HasValue("14"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("15"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.1").HasValue("16"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.2").HasValue("17"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("18"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.1").HasValue("19"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.2").HasValue("20"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("21"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.1").HasValue("22"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.2").HasValue("23"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("24"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.1").HasValue("25"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (EventGridEventSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.EventSubscriptionID(state.ID)
 	if err != nil {
@@ -593,6 +645,98 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     string_not_in {
       key    = "data.blobType"
       values = ["Page"]
+    }
+  }
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func (EventGridEventSubscriptionResource) advancedFilterMaxItems(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eg-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_queue" "test" {
+  name                 = "mysamplequeue-%d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+
+resource "azurerm_eventgrid_event_subscription" "test" {
+  name  = "acctesteg-%d"
+  scope = azurerm_storage_account.test.id
+
+  storage_queue_endpoint {
+    storage_account_id = azurerm_storage_account.test.id
+    queue_name         = azurerm_storage_queue.test.name
+  }
+
+  advanced_filter {
+    bool_equals {
+      key   = "subject"
+      value = true
+    }
+    number_greater_than {
+      key   = "data.metadataVersion"
+      value = 2
+    }
+    number_greater_than_or_equals {
+      key   = "data.contentLength"
+      value = 3
+    }
+    number_less_than {
+      key   = "data.contentLength"
+      value = 4
+    }
+    number_less_than_or_equals {
+      key   = "data.metadataVersion"
+      value = 5
+    }
+    number_in {
+      key    = "data.contentLength"
+      values = [6, 7, 8]
+    }
+    number_not_in {
+      key    = "data.contentLength"
+      values = [9, 10, 11]
+    }
+    string_begins_with {
+      key    = "subject"
+      values = ["12", "13", "14"]
+    }
+    string_ends_with {
+      key    = "subject"
+      values = ["15", "16", "17"]
+    }
+    string_contains {
+      key    = "data.contentType"
+      values = ["18", "19", "20"]
+    }
+    string_in {
+      key    = "data.blobType"
+      values = ["21", "22", "23"]
+    }
+    string_not_in {
+      key    = "data.blobType"
+      values = ["24", "25"]
     }
   }
 

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
@@ -196,6 +196,58 @@ func TestAccEventGridSystemTopicEventSubscription_advancedFilter(t *testing.T) {
 	})
 }
 
+func TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_system_topic_event_subscription", "test")
+	r := EventGridSystemTopicEventSubscriptionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.advancedFilterMaxItems(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.value").HasValue("true"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.key").HasValue("data.metadataVersion"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.value").HasValue("2"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.value").HasValue("3"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.value").HasValue("4"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.key").HasValue("data.metadataVersion"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.value").HasValue("5"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("6"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.1").HasValue("7"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.2").HasValue("8"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("9"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.1").HasValue("10"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.2").HasValue("11"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("12"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.1").HasValue("13"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.2").HasValue("14"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("15"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.1").HasValue("16"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.2").HasValue("17"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("18"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.1").HasValue("19"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.2").HasValue("20"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("21"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.1").HasValue("22"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.2").HasValue("23"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("24"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.1").HasValue("25"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (EventGridSystemTopicEventSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.SystemTopicEventSubscriptionID(state.ID)
 	if err != nil {
@@ -667,6 +719,107 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
     string_not_in {
       key    = "data.blobType"
       values = ["Page"]
+    }
+  }
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (EventGridSystemTopicEventSubscriptionResource) advancedFilterMaxItems(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_queue" "test" {
+  name                 = "mysamplequeue-%[1]d"
+  storage_account_name = azurerm_storage_account.test.name
+}
+
+resource "azurerm_eventgrid_system_topic" "test" {
+  name                   = "acctesteg-%[1]d"
+  location               = "Global"
+  resource_group_name    = azurerm_resource_group.test.name
+  source_arm_resource_id = azurerm_resource_group.test.id
+  topic_type             = "Microsoft.Resources.ResourceGroups"
+}
+
+resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
+  name                = "acctesteg-%[1]d"
+  system_topic        = azurerm_eventgrid_system_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  storage_queue_endpoint {
+    storage_account_id = azurerm_storage_account.test.id
+    queue_name         = azurerm_storage_queue.test.name
+  }
+
+  advanced_filter {
+    bool_equals {
+      key   = "subject"
+      value = true
+    }
+    number_greater_than {
+      key   = "data.metadataVersion"
+      value = 2
+    }
+    number_greater_than_or_equals {
+      key   = "data.contentLength"
+      value = 3
+    }
+    number_less_than {
+      key   = "data.contentLength"
+      value = 4
+    }
+    number_less_than_or_equals {
+      key   = "data.metadataVersion"
+      value = 5
+    }
+    number_in {
+      key    = "data.contentLength"
+      values = [6, 7, 8]
+    }
+    number_not_in {
+      key    = "data.contentLength"
+      values = [9, 10, 11]
+    }
+    string_begins_with {
+      key    = "subject"
+      values = ["12", "13", "14"]
+    }
+    string_ends_with {
+      key    = "subject"
+      values = ["15", "16", "17"]
+    }
+    string_contains {
+      key    = "data.contentType"
+      values = ["18", "19", "20"]
+    }
+    string_in {
+      key    = "data.blobType"
+      values = ["21", "22", "23"]
+    }
+    string_not_in {
+      key    = "data.blobType"
+      values = ["24", "25"]
     }
   }
 

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -174,7 +174,7 @@ Each nested block consists of a key and a value(s) element.
 
 * `values` - (Required) Specifies an array of values to compare to when using a multiple values operator.
 
-~> **NOTE:** A maximum of 5 advanced filters are allowed.
+~> **NOTE:** A maximum of total number of advanced filter values allowed on event subscription is 25.
 
 ---
 

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -168,7 +168,7 @@ Each nested block consists of a key and a value(s) element.
 
 * `values` - (Required) Specifies an array of values to compare to when using a multiple values operator.
 
-~> **NOTE:** A maximum of 5 advanced filters are allowed.
+~> **NOTE:** A maximum of total number of advanced filter values allowed on event subscription is 25.
 
 ---
 


### PR DESCRIPTION
Fix for #10620

-	Limit increased to 25 values per filter item.
-	Documentation was updated
-	I added acc tests to verify implementation

It would be nice to implement validation function to verify that **total** number of values inside advanced_filter block <= 25.
As a maximum of total number of advanced filter values allowed on event subscription is 25.
Any guidance on optimal approach (where to inject validation function for advanced_filter block) is welcomed.


make testacc TEST=./azurerm/internal/services/eventgrid TESTARGS='-run=TestAccEventGridEventSubscription_advancedFilterMaxItems'make testacc TEST=./azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go TESTARGS='-run=TestAccEventGridEventSubscription_advancedFilterMaxItems'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go -v -run=TestAccEventGridEventSubscription_advancedFilterMaxItems -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccEventGridEventSubscription_advancedFilterMaxItems
=== PAUSE TestAccEventGridEventSubscription_advancedFilterMaxItems
=== CONT  TestAccEventGridEventSubscription_advancedFilterMaxItems
--- PASS: TestAccEventGridEventSubscription_advancedFilterMaxItems (159.80s)
PASS
ok      command-line-arguments  159.874s

make testacc TEST=./azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go TESTARGS='-run=TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go -v -run=TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems
=== PAUSE TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems
=== CONT  TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems
--- PASS: TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems (178.36s)
PASS
ok      command-line-arguments  178.438s
