### PR TITLE
azurerm_firewall: support for `private_ip_ranges`

### DIFF
--- a/azurerm/internal/services/firewall/firewall_resource.go
+++ b/azurerm/internal/services/firewall/firewall_resource.go
@@ -166,6 +166,19 @@ func resourceFirewall() *schema.Resource {
 				},
 			},
 
+			"private_ip_ranges": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.Any(
+						validation.IsCIDR,
+						validation.StringInSlice([]string{"IANAPrivateRanges"}, false),
+					),
+				},
+			},
+
 			"virtual_hub": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -245,7 +258,7 @@ func resourceFirewallCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 		AzureFirewallPropertiesFormat: &network.AzureFirewallPropertiesFormat{
 			IPConfigurations:     ipConfigs,
 			ThreatIntelMode:      network.AzureFirewallThreatIntelMode(d.Get("threat_intel_mode").(string)),
-			AdditionalProperties: expandFirewallDNSServers(d.Get("dns_servers").([]interface{})),
+			AdditionalProperties: make(map[string]*string),
 		},
 		Zones: zones,
 	}
@@ -297,6 +310,18 @@ func resourceFirewallCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 			parameters.Sku = &network.AzureFirewallSku{}
 		}
 		parameters.Sku.Tier = network.AzureFirewallSkuTier(skuTier)
+	}
+
+	if dnsServerSetting := expandFirewallDNSServers(d.Get("dns_servers").([]interface{})); dnsServerSetting != nil {
+		for k, v := range dnsServerSetting {
+			parameters.AdditionalProperties[k] = v
+		}
+	}
+
+	if privateIpRangeSetting := expandFirewallPrivateIpRange(d.Get("private_ip_ranges").(*schema.Set).List()); privateIpRangeSetting != nil {
+		for k, v := range privateIpRangeSetting {
+			parameters.AdditionalProperties[k] = v
+		}
 	}
 
 	locks.ByName(name, azureFirewallResourceName)
@@ -395,6 +420,10 @@ func resourceFirewallRead(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("dns_servers", flattenFirewallDNSServers(props.AdditionalProperties)); err != nil {
 			return fmt.Errorf("Error setting `dns_servers`: %+v", err)
+		}
+
+		if err := d.Set("private_ip_ranges", flattenFirewallPrivateIpRange(props.AdditionalProperties)); err != nil {
+			return fmt.Errorf("Error setting `private_ip_ranges`: %+v", err)
 		}
 
 		if policy := props.FirewallPolicy; policy != nil {
@@ -628,6 +657,34 @@ func flattenFirewallDNSServers(input map[string]*string) []interface{} {
 		servers = strings.Split(*serversPtr, ",")
 	}
 	return utils.FlattenStringSlice(&servers)
+}
+
+func expandFirewallPrivateIpRange(input []interface{}) map[string]*string {
+	if len(input) == 0 {
+		return nil
+	}
+
+	rangeSlice := *utils.ExpandStringSlice(input)
+	if len(rangeSlice) == 0 {
+		return nil
+	}
+
+	// Swagger issue asking finalize these properties: https://github.com/Azure/azure-rest-api-specs/issues/10015
+	return map[string]*string{
+		"Network.SNAT.PrivateRanges": utils.String(strings.Join(rangeSlice, ",")),
+	}
+}
+
+func flattenFirewallPrivateIpRange(input map[string]*string) []interface{} {
+	if len(input) == 0 {
+		return nil
+	}
+
+	rangeSlice := []string{}
+	if privateIpRanges := input["Network.SNAT.PrivateRanges"]; privateIpRanges != nil {
+		rangeSlice = strings.Split(*privateIpRanges, ",")
+	}
+	return utils.FlattenStringSlice(&rangeSlice)
 }
 
 func expandFirewallVirtualHubSetting(existing network.AzureFirewall, input []interface{}) (vhub *network.SubResource, ipAddresses *network.HubIPAddresses, ok bool) {

--- a/azurerm/internal/services/firewall/firewall_resource_test.go
+++ b/azurerm/internal/services/firewall/firewall_resource_test.go
@@ -266,6 +266,41 @@ func TestAccFirewall_inVirtualHub(t *testing.T) {
 	})
 }
 
+func TestAccFirewall_privateRanges(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_configuration.0.name").HasValue("configuration"),
+				check.That(data.ResourceName).Key("ip_configuration.0.private_ip_address").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.privateRanges(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_configuration.0.name").HasValue("configuration"),
+				check.That(data.ResourceName).Key("ip_configuration.0.private_ip_address").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_configuration.0.name").HasValue("configuration"),
+				check.That(data.ResourceName).Key("ip_configuration.0.private_ip_address").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (FirewallResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	var id, err = azure.ParseAzureResourceID(state.ID)
 	if err != nil {
@@ -860,4 +895,53 @@ resource "azurerm_firewall" "test" {
   threat_intel_mode  = ""
 }
 `, data.RandomInteger, data.Locations.Primary, pipCount)
+}
+
+func (FirewallResource) privateRanges(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+  private_ip_ranges = ["IANAPrivateRanges", "255.255.0.0/16"]
+  threat_intel_mode = "Deny"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `dns_servers` - (Optional) A list of DNS servers that the Azure Firewall will direct DNS traffic to the for name resolution.
 
+* `private_ip_ranges` - (Optional) A list of SNAT private CIDR IP ranges, or the special string `IANAPrivateRanges`, which indicates Azure Firewall does not SNAT when the destination IP address is a private range per IANA RFC 1918.
+
 * `management_ip_configuration` - (Optional) A `management_ip_configuration` block as documented below, which allows force-tunnelling of traffic to be performed by the firewall. Adding or removing this block or changing the `subnet_id` in an existing block forces a new resource to be created.
 
 * `threat_intel_mode` - (Optional) The operation mode for threat intelligence-based filtering. Possible values are: `Off`, `Alert`,`Deny` and `""`(empty string). Defaults to `Alert`.


### PR DESCRIPTION
The `private_ip_ranges` is implemented using the same method as is done in #8878, via `additionalProperties`. I basicly rebase the code from #7535 onto the master.
There seems to be multiple users seeking for this feature in issue #7504.

Fixes #7504 
Supersede #7535

## Test Result

```bash
💤 make testacc TEST=./azurerm/internal/services/firewall TESTARGS='-run TestAccFirewall_privateRanges'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/firewall -v -run TestAccFirewall_privateRanges -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFirewall_privateRanges
=== PAUSE TestAccFirewall_privateRanges
=== CONT  TestAccFirewall_privateRanges
--- PASS: TestAccFirewall_privateRanges (1964.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/firewall    1964.924s
```