### PR TITLE
azurerm_sql_database: deprecate `use_server_default`

### DIFF
--- a/azurerm/internal/services/sql/sql_database_resource.go
+++ b/azurerm/internal/services/sql/sql_database_resource.go
@@ -307,6 +307,7 @@ func resourceSqlDatabase() *schema.Resource {
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
+						// TODO - 3.0: Remove this property
 						"use_server_default": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -316,6 +317,7 @@ func resourceSqlDatabase() *schema.Resource {
 								string(sql.SecurityAlertPolicyUseServerDefaultDisabled),
 								string(sql.SecurityAlertPolicyUseServerDefaultEnabled),
 							}, true),
+							Deprecated: "This field is non-functional and will be removed in version 3.0 of the Azure Provider",
 						},
 					},
 				},

--- a/azurerm/internal/services/sql/sql_database_resource.go
+++ b/azurerm/internal/services/sql/sql_database_resource.go
@@ -317,7 +317,7 @@ func resourceSqlDatabase() *schema.Resource {
 								string(sql.SecurityAlertPolicyUseServerDefaultDisabled),
 								string(sql.SecurityAlertPolicyUseServerDefaultEnabled),
 							}, true),
-							Deprecated: "This field is non-functional and will be removed in version 3.0 of the Azure Provider",
+							Deprecated: "This field is now non-functional and thus will be removed in version 3.0 of the Azure Provider",
 						},
 					},
 				},

--- a/azurerm/internal/services/sql/sql_database_resource_test.go
+++ b/azurerm/internal/services/sql/sql_database_resource_test.go
@@ -792,7 +792,6 @@ resource "azurerm_sql_database" "test" {
     email_account_admins       = "Enabled"
     storage_account_access_key = azurerm_storage_account.test.primary_access_key
     storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
-    use_server_default         = "Disabled"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, state)

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -126,7 +126,6 @@ The following arguments are supported:
 * `retention_days` - (Optional) Specifies the number of days to keep in the Threat Detection audit logs.
 * `storage_account_access_key` - (Optional) Specifies the identifier key of the Threat Detection audit storage account. Required if `state` is `Enabled`.
 * `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all Threat Detection audit logs. Required if `state` is `Enabled`.
-* `use_server_default` - (Optional) Should the default server policy be used? Defaults to `Disabled`.
 
 ---
 


### PR DESCRIPTION
Per this [comment](https://github.com/Azure/azure-rest-api-specs/issues/9762#issuecomment-751857677), the `useServerDefault` in Swagger (i.e. `use_server_default` in TF) is now deprecated and should be ignored.

This further fixes #7215, #4556.