### PR TITLE
azurerm_api_management_custom_domain: resource gets updated every time

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -163,6 +163,7 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 
 func apiManagementCustomDomainRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).ApiManagement.ServiceClient
+	environment := meta.(*clients.Client).Account.Environment
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -187,7 +188,8 @@ func apiManagementCustomDomainRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("api_management_id", resp.ID)
 
 	if resp.ServiceProperties != nil && resp.ServiceProperties.HostnameConfigurations != nil {
-		configs := flattenApiManagementHostnameConfiguration(resp.ServiceProperties.HostnameConfigurations, d)
+		apimHostNameSuffix := environment.APIManagementHostNameSuffix
+		configs := flattenApiManagementHostnameConfiguration(resp.ServiceProperties.HostnameConfigurations, d, *resp.Name, apimHostNameSuffix)
 		for _, config := range configs {
 			for key, v := range config.(map[string]interface{}) {
 				// lintignore:R001
@@ -305,7 +307,7 @@ func expandApiManagementCustomDomains(input *schema.ResourceData) *[]apimanageme
 	return &results
 }
 
-func flattenApiManagementHostnameConfiguration(input *[]apimanagement.HostnameConfiguration, d *schema.ResourceData) []interface{} {
+func flattenApiManagementHostnameConfiguration(input *[]apimanagement.HostnameConfiguration, d *schema.ResourceData, name, apimHostNameSuffix string) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
 		return results
@@ -319,6 +321,11 @@ func flattenApiManagementHostnameConfiguration(input *[]apimanagement.HostnameCo
 
 	for _, config := range *input {
 		output := make(map[string]interface{})
+
+		// There'll always be a default custom domain with hostName "apim_name.azure-api.net" and Type "Proxy", which should be ignored
+		if *config.HostName == strings.ToLower(name)+"."+apimHostNameSuffix && config.Type == apimanagement.HostnameTypeProxy {
+			continue
+		}
 
 		if config.HostName != nil {
 			output["host_name"] = *config.HostName

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go
@@ -72,14 +72,6 @@ func TestAccApiManagementCustomDomain_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
-		{
-			Config: r.builtinProxyOnly(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -107,10 +99,6 @@ resource "azurerm_api_management_custom_domain" "test" {
   api_management_id = azurerm_api_management.test.id
 
   proxy {
-    host_name = "${azurerm_api_management.test.name}.azure-api.net"
-  }
-
-  proxy {
     host_name    = "api.example.com"
     key_vault_id = azurerm_key_vault_certificate.test.secret_id
   }
@@ -131,10 +119,6 @@ resource "azurerm_api_management_custom_domain" "test" {
   api_management_id = azurerm_api_management.test.id
 
   proxy {
-    host_name = "${azurerm_api_management.test.name}.azure-api.net"
-  }
-
-  proxy {
     host_name    = "api.example.com"
     key_vault_id = azurerm_key_vault_certificate.test.secret_id
   }
@@ -149,27 +133,9 @@ func (r ApiManagementCustomDomainResource) developerPortalOnly(data acceptance.T
 resource "azurerm_api_management_custom_domain" "test" {
   api_management_id = azurerm_api_management.test.id
 
-  proxy {
-    host_name = "${azurerm_api_management.test.name}.azure-api.net"
-  }
-
   developer_portal {
     host_name    = "portal.example.com"
     key_vault_id = azurerm_key_vault_certificate.test.secret_id
-  }
-}
-`, r.template(data))
-}
-
-func (r ApiManagementCustomDomainResource) builtinProxyOnly(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_api_management_custom_domain" "test" {
-  api_management_id = azurerm_api_management.test.id
-
-  proxy {
-    host_name = "${azurerm_api_management.test.name}.azure-api.net"
   }
 }
 `, r.template(data))
@@ -181,10 +147,6 @@ func (r ApiManagementCustomDomainResource) requiresImport(data acceptance.TestDa
 
 resource "azurerm_api_management_custom_domain" "import" {
   api_management_id = azurerm_api_management_custom_domain.test.api_management_id
-
-  proxy {
-    host_name = "${azurerm_api_management.test.name}.azure-api.net"
-  }
 
   proxy {
     host_name    = "api.example.com"
@@ -243,6 +205,7 @@ resource "azurerm_key_vault" "test" {
       "delete",
       "get",
       "update",
+      "purge",
     ]
 
     key_permissions = [

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -363,6 +363,7 @@ func resourceApiManagementService() *schema.Resource {
 			"hostname_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -135,7 +135,7 @@ A `developer_portal`, `management`, `portal` or `scm` block supports the followi
 
 A `proxy` block supports the following:
 
--> **Tip:** The default hostname ending with `.azure-api.net` must not be added as it will be included by default and it is filtered out, so it would always show in `tf plan` but never have any effect.
+-> **Tip:** The default proxy hostname ending with `.azure-api.net` must not be added as it will be automatically created by Azure and ignored by Terraform.
 
 * `host_name` - (Required) The Hostname to use for the API Proxy Endpoint.
 

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -135,6 +135,8 @@ A `developer_portal`, `management`, `portal` or `scm` block supports the followi
 
 A `proxy` block supports the following:
 
+-> **info:** The default hostname ending with `.azure-api.net` must not be added as it will be included by default.
+
 * `host_name` - (Required) The Hostname to use for the API Proxy Endpoint.
 
 * `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -135,7 +135,7 @@ A `developer_portal`, `management`, `portal` or `scm` block supports the followi
 
 A `proxy` block supports the following:
 
--> **info:** The default hostname ending with `.azure-api.net` must not be added as it will be included by default.
+-> **Tip:** The default hostname ending with `.azure-api.net` must not be added as it will be included by default and it is filtered out, so it would always show in tf plan but never have any effect.
 
 * `host_name` - (Required) The Hostname to use for the API Proxy Endpoint.
 

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -135,7 +135,7 @@ A `developer_portal`, `management`, `portal` or `scm` block supports the followi
 
 A `proxy` block supports the following:
 
--> **Tip:** The default hostname ending with `.azure-api.net` must not be added as it will be included by default and it is filtered out, so it would always show in tf plan but never have any effect.
+-> **Tip:** The default hostname ending with `.azure-api.net` must not be added as it will be included by default and it is filtered out, so it would always show in `tf plan` but never have any effect.
 
 * `host_name` - (Required) The Hostname to use for the API Proxy Endpoint.
 


### PR DESCRIPTION
A possible solution for https://github.com/terraform-providers/terraform-provider-azurerm/issues/10253 .

As described in the issue it is unclear if the default hostname for a proxy (`<apim-name>.azure-api.net`) needs to be included in the `azurerm_api_management_custom_domain` resource. The test cases include the default hostname, the example in the docs don't.

In both cases there are problems using the `azurerm_api_management_custom_domain` resource at the moment because `tf plan` will try to apply changes on subsequent runs (see issue).

My solution filters out the default hostname (as the `azurerm_api_management` resource does as well, see https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/internal/services/apimanagement/api_management_resource.go#L986 ).

The test cases are succeeding and my local tests are successful with this behaviour:

```
make testacc TEST='./azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go' TESTARGS='-run=TestAccApiManagementCustomDomain_update' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go -v -run=TestAccApiManagementCustomDomain_update -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementCustomDomain_update
=== PAUSE TestAccApiManagementCustomDomain_update
=== CONT  TestAccApiManagementCustomDomain_update
--- PASS: TestAccApiManagementCustomDomain_update (6269.11s)
PASS
ok      command-line-arguments  6271.038s


make testacc TEST='./azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go' TESTARGS='-run=TestAccApiManagementCustomDomain_basic' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_custom_domain_resource_test.go -v -run=TestAccApiManagementCustomDomain_basic -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementCustomDomain_basic
=== PAUSE TestAccApiManagementCustomDomain_basic
=== CONT  TestAccApiManagementCustomDomain_basic
--- PASS: TestAccApiManagementCustomDomain_basic (4115.71s)
PASS
ok      command-line-arguments  4118.349s
```