### PR TITLE
azurerm_api_management_subscription: make user_id optional 

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -48,7 +48,12 @@ func resourceApiManagementSubscription() *schema.Resource {
 			},
 
 			// 3.0 this seems to have been renamed to owner id?
-			"user_id": schemaz.SchemaApiManagementChildID(),
+			"user_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
@@ -133,7 +138,6 @@ func resourceApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, meta 
 	displayName := d.Get("display_name").(string)
 	productId := d.Get("product_id").(string)
 	state := d.Get("state").(string)
-	userId := d.Get("user_id").(string)
 	allowTracing := d.Get("allow_tracing").(bool)
 
 	params := apimanagement.SubscriptionCreateParameters{
@@ -141,9 +145,11 @@ func resourceApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, meta 
 			DisplayName:  utils.String(displayName),
 			Scope:        utils.String(productId),
 			State:        apimanagement.SubscriptionState(state),
-			OwnerID:      utils.String(userId),
 			AllowTracing: utils.Bool(allowTracing),
 		},
+	}
+	if v, ok := d.GetOk("user_id"); ok {
+		params.SubscriptionCreateParameterProperties.OwnerID = utils.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("primary_key"); ok {

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -122,6 +122,27 @@ func TestAccApiManagementSubscription_complete(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementSubscription_withoutUser(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
+	r := ApiManagementSubscriptionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.withoutUser(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("state").HasValue("active"),
+				check.That(data.ResourceName).Key("allow_tracing").HasValue("false"),
+				check.That(data.ResourceName).Key("subscription_id").Exists(),
+				check.That(data.ResourceName).Key("primary_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_key").Exists(),
+				check.That(data.ResourceName).Key("user_id").DoesNotExist(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ApiManagementSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.SubscriptionID(state.ID)
 	if err != nil {
@@ -190,6 +211,21 @@ resource "azurerm_api_management_subscription" "test" {
   resource_group_name = azurerm_api_management.test.resource_group_name
   api_management_name = azurerm_api_management.test.name
   user_id             = azurerm_api_management_user.test.id
+  product_id          = azurerm_api_management_product.test.id
+  display_name        = "Butter Parser API Enterprise Edition"
+  state               = "active"
+  allow_tracing       = false
+}
+`, r.template(data))
+}
+
+func (r ApiManagementSubscriptionResource) withoutUser(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_subscription" "test" {
+  resource_group_name = azurerm_api_management.test.resource_group_name
+  api_management_name = azurerm_api_management.test.name
   product_id          = azurerm_api_management_product.test.id
   display_name        = "Butter Parser API Enterprise Edition"
   state               = "active"

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -136,7 +136,7 @@ func TestAccApiManagementSubscription_withoutUser(t *testing.T) {
 				check.That(data.ResourceName).Key("subscription_id").Exists(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_key").Exists(),
-				check.That(data.ResourceName).Key("user_id").DoesNotExist(),
+				check.That(data.ResourceName).Key("user_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),

--- a/azurerm/internal/services/apimanagement/schemaz/api_management.go
+++ b/azurerm/internal/services/apimanagement/schemaz/api_management.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -27,17 +26,6 @@ func SchemaApiManagementDataSourceName() *schema.Schema {
 		Type:         schema.TypeString,
 		Required:     true,
 		ValidateFunc: validate.ApiManagementServiceName,
-	}
-}
-
-// SchemaApiManagementChildID returns the Schema for the identifier
-// used by resources within nested under the API Management Service resource
-func SchemaApiManagementChildID() *schema.Schema {
-	return &schema.Schema{
-		Type:         schema.TypeString,
-		Required:     true,
-		ForceNew:     true,
-		ValidateFunc: azure.ValidateResourceID,
 	}
 }
 

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `product_id` - (Required) The ID of the Product which should be assigned to this Subscription. Changing this forces a new resource to be created.
 
-* `user_id` - (Required) The ID of the User which should be assigned to this Subscription. Changing this forces a new resource to be created.
+* `user_id` - (Optional) The ID of the User which should be assigned to this Subscription. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
We want to create subscriptions per application. Therefore we don't want to assign a specific user to a subscription. 

The details are described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/8923 .

+ The `owner_id` is optional (see https://docs.microsoft.com/en-gb/azure/api-management/api-management-subscriptions)
+ added a new test for the userless subscription.
+ I moved the `schemaz.SchemaApiManagementChildID()` struct to the resource file because it is the only place it is referenced.

```
make testacc TEST='./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go' TESTARGS='-run=TestAccApiManagementSubscription_complete' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go -v -run=TestAccApiManagementSubscription_complete -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementSubscription_complete
=== PAUSE TestAccApiManagementSubscription_complete
=== CONT  TestAccApiManagementSubscription_complete
--- PASS: TestAccApiManagementSubscription_complete (2601.34s)
PASS
ok      command-line-arguments  2602.981s

make testacc TEST='./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go' TESTARGS='-run=TestAccApiManagementSubscription_withoutUser' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go -v -run=TestAccApiManagementSubscription_withoutUser -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementSubscription_withoutUser
=== PAUSE TestAccApiManagementSubscription_withoutUser
=== CONT  TestAccApiManagementSubscription_withoutUser
--- PASS: TestAccApiManagementSubscription_withoutUser (2657.30s)
PASS
ok      command-line-arguments  2659.031s
```

Fixes #8923