### PR TITLE
`azurerm_kusto_cluster`: Changing `virtual_network_configuration` forces a new resource to be created. 

### DIFF
--- a/azurerm/internal/services/kusto/kusto_cluster_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_resource.go
@@ -144,6 +144,7 @@ func resourceKustoCluster() *schema.Resource {
 			"virtual_network_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `enable_purge` - (Optional) Specifies if the purge operations are enabled.
 
-* `virtual_network_configuration`- (Optional) A `virtual_network_configuration` block as defined below.
+* `virtual_network_configuration`- (Optional) A `virtual_network_configuration` block as defined below. Changing this forces a new resource to be created.
 
 * `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON` and `R`.
 


### PR DESCRIPTION
ADX (Kusto) cluster's VNET config can not be updated without recreation:

```
Error: Error creating or updating Kusto Cluster "xxx" (Resource Group "xxx"): kusto.ClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="CannotModifyVirtualNetworkConfiguration" Message="Virtual Network Configuration cannot be modified."
```