### PR TITLE
vm feature: `power_off_on_deletion`

### DIFF
--- a/azurerm/internal/features/defaults.go
+++ b/azurerm/internal/features/defaults.go
@@ -15,6 +15,7 @@ func Default() UserFeatures {
 		},
 		VirtualMachine: VirtualMachineFeatures{
 			DeleteOSDiskOnDeletion: true,
+			PowerOffOnDeletion:     true,
 			GracefulShutdown:       false,
 		},
 		VirtualMachineScaleSet: VirtualMachineScaleSetFeatures{

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -10,6 +10,7 @@ type UserFeatures struct {
 
 type VirtualMachineFeatures struct {
 	DeleteOSDiskOnDeletion bool
+	PowerOffOnDeletion     bool
 	GracefulShutdown       bool
 }
 

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -164,6 +164,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			if v, ok := virtualMachinesRaw["graceful_shutdown"]; ok {
 				features.VirtualMachine.GracefulShutdown = v.(bool)
 			}
+			if v, ok := virtualMachinesRaw["power_off_on_deletion"]; ok {
+				features.VirtualMachine.PowerOffOnDeletion = v.(bool)
+			}
 		}
 	}
 

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -30,6 +30,7 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					PowerOffOnDeletion:     true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 					RollInstancesWhenRequired: true,
@@ -59,6 +60,7 @@ func TestExpandFeatures(t *testing.T) {
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion": true,
+							"power_off_on_deletion":      true,
 							"graceful_shutdown":          true,
 						},
 					},
@@ -82,6 +84,7 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					PowerOffOnDeletion:     true,
 					GracefulShutdown:       true,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
@@ -96,6 +99,7 @@ func TestExpandFeatures(t *testing.T) {
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion": false,
+							"power_off_on_deletion":      false,
 							"graceful_shutdown":          false,
 						},
 					},
@@ -135,6 +139,7 @@ func TestExpandFeatures(t *testing.T) {
 				},
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: false,
+					PowerOffOnDeletion:     false,
 					GracefulShutdown:       false,
 				},
 				VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
@@ -370,17 +375,19 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					PowerOffOnDeletion:     true,
 					GracefulShutdown:       false,
 				},
 			},
 		},
 		{
-			Name: "Delete OS Disk and Graceful Shutdown Enabled",
+			Name: "Delete OS Disk, Power Off and Graceful Shutdown Enabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion": true,
+							"power_off_on_deletion":      true,
 							"graceful_shutdown":          true,
 						},
 					},
@@ -389,17 +396,19 @@ func TestExpandFeaturesVirtualMachine(t *testing.T) {
 			Expected: features.UserFeatures{
 				VirtualMachine: features.VirtualMachineFeatures{
 					DeleteOSDiskOnDeletion: true,
+					PowerOffOnDeletion:     true,
 					GracefulShutdown:       true,
 				},
 			},
 		},
 		{
-			Name: "Delete OS Disk and Graceful Shutdown Disabled",
+			Name: "Delete OS Disk, Power Off and Graceful Shutdown Disabled",
 			Input: []interface{}{
 				map[string]interface{}{
 					"virtual_machine": []interface{}{
 						map[string]interface{}{
 							"delete_os_disk_on_deletion": false,
+							"power_off_on_deletion":      false,
 							"graceful_shutdown":          false,
 						},
 					},

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -1089,24 +1089,29 @@ func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("retrieving Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	// If the VM was in a Failed state we can skip powering off, since that'll fail
-	if strings.EqualFold(*existing.ProvisioningState, "failed") {
-		log.Printf("[DEBUG] Powering Off Linux Virtual Machine was skipped because the VM was in %q state %q (Resource Group %q).", *existing.ProvisioningState, id.Name, id.ResourceGroup)
+	skipPowerOff := !meta.(*clients.Client).Features.VirtualMachine.PowerOffOnDeletion
+	if skipPowerOff {
+		log.Printf("[DEBUG] Powering Off Linux Virtual Machine was skipped.")
 	} else {
-		//ISSUE: 4920
-		// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
-		// thus this can be a large cost-saving when deleting larger instances
-		// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
-		log.Printf("[DEBUG] Powering Off Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
-		skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
-		powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(skipShutdown))
-		if err != nil {
-			return fmt.Errorf("powering off Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		// If the VM was in a Failed state we can skip powering off, since that'll fail
+		if strings.EqualFold(*existing.ProvisioningState, "failed") {
+			log.Printf("[DEBUG] Powering Off Linux Virtual Machine was skipped because the VM was in %q state %q (Resource Group %q).", *existing.ProvisioningState, id.Name, id.ResourceGroup)
+		} else {
+			//ISSUE: 4920
+			// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
+			// thus this can be a large cost-saving when deleting larger instances
+			// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
+			log.Printf("[DEBUG] Powering Off Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+			skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
+			powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(skipShutdown))
+			if err != nil {
+				return fmt.Errorf("powering off Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+			if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for power off of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+			log.Printf("[DEBUG] Powered Off Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
 		}
-		if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for power off of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-		}
-		log.Printf("[DEBUG] Powered Off Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
 	}
 
 	log.Printf("[DEBUG] Deleting Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1174,24 +1174,29 @@ func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("retrieving Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	// If the VM was in a Failed state we can skip powering off, since that'll fail
-	if strings.EqualFold(*existing.ProvisioningState, "failed") {
-		log.Printf("[DEBUG] Powering Off Windows Virtual Machine was skipped because the VM was in %q state %q (Resource Group %q).", *existing.ProvisioningState, id.Name, id.ResourceGroup)
+	skipPowerOff := !meta.(*clients.Client).Features.VirtualMachine.PowerOffOnDeletion
+	if skipPowerOff {
+		log.Printf("[DEBUG] Powering Off Windows Virtual Machine was skipped.")
 	} else {
-		//ISSUE: 4920
-		// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
-		// thus this can be a large cost-saving when deleting larger instances
-		// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
-		log.Printf("[DEBUG] Powering Off Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
-		skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
-		powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(skipShutdown))
-		if err != nil {
-			return fmt.Errorf("powering off Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		// If the VM was in a Failed state we can skip powering off, since that'll fail
+		if strings.EqualFold(*existing.ProvisioningState, "failed") {
+			log.Printf("[DEBUG] Powering Off Windows Virtual Machine was skipped because the VM was in %q state %q (Resource Group %q).", *existing.ProvisioningState, id.Name, id.ResourceGroup)
+		} else {
+			//ISSUE: 4920
+			// shutting down the Virtual Machine prior to removing it means users are no longer charged for some Azure resources
+			// thus this can be a large cost-saving when deleting larger instances
+			// https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
+			log.Printf("[DEBUG] Powering Off Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+			skipShutdown := !meta.(*clients.Client).Features.VirtualMachine.GracefulShutdown
+			powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(skipShutdown))
+			if err != nil {
+				return fmt.Errorf("powering off Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+			if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for power off of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+			log.Printf("[DEBUG] Powered Off Windows Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
 		}
-		if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for power off of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-		}
-		log.Printf("[DEBUG] Powered Off Windows Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
 	}
 
 	log.Printf("[DEBUG] Deleting Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -196,7 +196,11 @@ The `virtual_machine` block supports the following:
 
 ~> **Note:** This does not affect the older `azurerm_virtual_machine` resource, which has its own flags for managing this within the resource.
 
-* `graceful_shutdown` - (Optional) Should the `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` request a graceful shutdown when the Virtual Machine is destroyed? Defaults to `false`.
+* `power_off_on_deletion` - (Optional) Should the `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` resources power off before the Virtual Machine is destroyed? Defaults to `true`.
+
+* `graceful_shutdown` - (Optional) Should the `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` request a graceful shutdown when the Virtual Machine is power off? Defaults to `false`.
+
+~> **Note:** This only takes effect if `power_off_on_deletion` is enabled. 
 
 ~> **Note:** When using a graceful shutdown, Azure gives the Virtual Machine a 5 minutes window in which to complete the shutdown process, at which point the machine will be force powered off - [more information can be found in this blog post](https://azure.microsoft.com/en-us/blog/linux-and-graceful-shutdowns-2/).
 


### PR DESCRIPTION
Introduce a new feature flag for vm `power_off_on_deletion` which allows users to speed up destroying vm instance in case it is a relatively small ones or those who don't care too much about chargings during deletion.

This flag defaults to `true`, which aligns with current behavior.

This PR also modifies the wordings for the `graceful_shutdown` a bit to emphasize to avoid confusion like "if it is set to false, there will be no poweroff happens during destroy". 