### PR TITLE
azurerm_data_factory_integration_runtime_managed - the administrator_login and administrator_password properties are now optional

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_managed_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_managed_resource_test.go
@@ -88,6 +88,21 @@ func TestAccDataFactoryIntegrationRuntimeManaged_customSetupScript(t *testing.T)
 	})
 }
 
+func TestAccDataFactoryIntegrationRuntimeManaged_aadAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_integration_runtime_managed", "test")
+	r := IntegrationRuntimeManagedResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.aadAuth(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (IntegrationRuntimeManagedResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -277,6 +292,65 @@ resource "azurerm_data_factory_integration_runtime_managed" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (IntegrationRuntimeManagedResource) aadAuth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdfirm%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_sql_server" "test" {
+  name                         = "acctestsql%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "ssis_catalog_admin"
+  administrator_login_password = "my-s3cret-p4ssword!"
+}
+
+data "azuread_service_principal" "test" {
+  display_name = azurerm_data_factory.test.name
+}
+
+resource "azurerm_sql_active_directory_administrator" "test" {
+  server_name         = azurerm_sql_server.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  login               = azurerm_data_factory.test.name
+  tenant_id           = azurerm_data_factory.test.identity.0.tenant_id
+  object_id           = data.azuread_service_principal.test.application_id
+}
+
+resource "azurerm_data_factory_integration_runtime_managed" "test" {
+  name                = "managed-integration-runtime"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  node_size           = "Standard_D8_v3"
+
+  catalog_info {
+    server_endpoint = azurerm_sql_server.test.fully_qualified_domain_name
+    pricing_tier    = "Basic"
+  }
+
+  depends_on = [azurerm_sql_active_directory_administrator.test]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (t IntegrationRuntimeManagedResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {

--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -72,9 +72,9 @@ A `catalog_info` block supports the following:
 
 * `server_endpoint` - (Required) The endpoint of an Azure SQL Server that will be used to host the SSIS catalog.
 
-* `administrator_login` - (Required) Administrator login name for the SQL Server.
+* `administrator_login` - (Optional) Administrator login name for the SQL Server.
 
-* `administrator_password` - (Required) Administrator login password for the SQL Server.
+* `administrator_password` - (Optional) Administrator login password for the SQL Server.
 
 * `pricing_tier` - (Optional) Pricing tier for the database that will be created for the SSIS catalog. Valid values are: `Basic`, `Standard`, `Premium` and `PremiumRS`.
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/8994

--- PASS: TestAccDataFactoryIntegrationRuntimeManaged_basic (154.86s)
--- PASS: TestAccDataFactoryIntegrationRuntimeManaged_vnetIntegration (179.44s)
--- PASS: TestAccDataFactoryIntegrationRuntimeManaged_customSetupScript (192.12s)
--- PASS: TestAccDataFactoryIntegrationRuntimeManaged_aadAuth (293.20s)
--- PASS: TestAccDataFactoryIntegrationRuntimeManaged_catalogInfo (312.68s)

