### PR TITLE
azurerm_api_management_logger:  add resource_id attribute

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_logger_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_logger_resource.go
@@ -42,6 +42,12 @@ func resourceApiManagementLogger() *schema.Resource {
 
 			"api_management_name": schemaz.SchemaApiManagementName(),
 
+			"resource_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
 			"eventhub": {
 				Type:          schema.TypeList,
 				MaxItems:      1,
@@ -142,6 +148,9 @@ func resourceApiManagementLoggerCreate(d *schema.ResourceData, meta interface{})
 		parameters.Credentials = expandApiManagementLoggerApplicationInsights(appInsightsRaw)
 	}
 
+	resourceId := utils.String(d.Get("resource_id").(string))
+	parameters.ResourceID = resourceId
+
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, name, parameters, ""); err != nil {
 		return fmt.Errorf("creating Logger %q (Resource Group %q / API Management Service %q): %+v", name, resourceGroup, serviceName, err)
 	}
@@ -184,6 +193,7 @@ func resourceApiManagementLoggerRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resourceGroup)
 	d.Set("api_management_name", serviceName)
+	d.Set("resource_id", resp.ResourceID)
 
 	if properties := resp.LoggerContractProperties; properties != nil {
 		d.Set("buffered", properties.IsBuffered)

--- a/azurerm/internal/services/apimanagement/api_management_logger_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_logger_resource.go
@@ -149,7 +149,9 @@ func resourceApiManagementLoggerCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	resourceId := utils.String(d.Get("resource_id").(string))
-	parameters.ResourceID = resourceId
+	if resourceId := d.Get("resource_id").(string); resourceId != "" {
+		parameters.ResourceID = utils.String(resourceId)
+	}
 
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, name, parameters, ""); err != nil {
 		return fmt.Errorf("creating Logger %q (Resource Group %q / API Management Service %q): %+v", name, resourceGroup, serviceName, err)

--- a/azurerm/internal/services/apimanagement/api_management_logger_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_logger_resource.go
@@ -148,7 +148,6 @@ func resourceApiManagementLoggerCreate(d *schema.ResourceData, meta interface{})
 		parameters.Credentials = expandApiManagementLoggerApplicationInsights(appInsightsRaw)
 	}
 
-	resourceId := utils.String(d.Get("resource_id").(string))
 	if resourceId := d.Get("resource_id").(string); resourceId != "" {
 		parameters.ResourceID = utils.String(resourceId)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -98,6 +98,7 @@ func TestAccApiManagementLogger_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("eventhub.#").HasValue("0"),
 				check.That(data.ResourceName).Key("application_insights.#").HasValue("1"),
 				check.That(data.ResourceName).Key("application_insights.0.instrumentation_key").Exists(),
+				check.That(data.ResourceName).Key("resource_id").Exists(),
 			),
 		},
 		{
@@ -340,6 +341,7 @@ resource "azurerm_api_management_logger" "test" {
   resource_group_name = azurerm_resource_group.test.name
   description         = "%s"
   buffered            = %s
+  resource_id         = azurerm_application_insights.test.id
 
   application_insights {
     instrumentation_key = azurerm_application_insights.test.instrumentation_key

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -68,6 +68,7 @@ The following arguments are supported:
 * `eventhub` - (Optional) An `eventhub` block as documented below.
 
 * `resource_id` - (Optional) The target resource id which will be linked in the API-Management portal page.
+
 ---
 
 An `application_insights` block supports the following:

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -40,6 +40,7 @@ resource "azurerm_api_management_logger" "example" {
   name                = "example-logger"
   api_management_name = azurerm_api_management.example.name
   resource_group_name = azurerm_resource_group.example.name
+  resource_id         = azurerm_application_insights.example.id
 
   application_insights {
     instrumentation_key = azurerm_application_insights.example.instrumentation_key
@@ -66,6 +67,7 @@ The following arguments are supported:
 
 * `eventhub` - (Optional) An `eventhub` block as documented below.
 
+* `resource_id` - (Optional) The target resource id which will be linked in the API-Management portal page.
 ---
 
 An `application_insights` block supports the following:


### PR DESCRIPTION
This adds the link to a resource to the logger configuration (https://github.com/terraform-providers/terraform-provider-azurerm/issues/10548). This way you can jump in the Azure Portal to the configured logger.

I wasn't sure about the naming (`resource_id`), maybe it could be more prescriptive.

The test case passed:

```
make testacc TEST='./azurerm/internal/services/apimanagement/api_management_logger_resource_test.go' TESTARGS='-run=TestAccApiManagementLogger_complete' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_logger_resource_test.go -v -run=TestAccApiManagementLogger_complete -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementLogger_complete
=== PAUSE TestAccApiManagementLogger_complete
=== CONT  TestAccApiManagementLogger_complete
--- PASS: TestAccApiManagementLogger_complete (2757.20s)
PASS
ok      command-line-arguments  2759.035s
```

Fixes #10548