### PR TITLE
FIX: r/frontdoor_firewall_policy - Restriction on number of match_condition elements

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
@@ -152,7 +152,7 @@ func resourceFrontDoorFirewallPolicy() *schema.Resource {
 						"match_condition": {
 							Type:     schema.TypeList,
 							Optional: true,
-							MaxItems: 100,
+							MaxItems: 10,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"match_variable": {
@@ -174,10 +174,10 @@ func resourceFrontDoorFirewallPolicy() *schema.Resource {
 									"match_values": {
 										Type:     schema.TypeList,
 										Required: true,
-										MaxItems: 100,
+										MaxItems: 600,
 										Elem: &schema.Schema{
 											Type:         schema.TypeString,
-											ValidateFunc: validation.StringIsNotEmpty,
+											ValidateFunc: validation.StringLenBetween(1, 256),
 										},
 									},
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -19,7 +19,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_frontdoor_firewall_policy" "example" {
-  name                              = "example-fdwafpolicy"
+  name                              = "examplefdwafpolicy"
   resource_group_name               = azurerm_resource_group.example.name
   enabled                           = true
   mode                              = "Prevention"
@@ -157,7 +157,7 @@ The `custom_rule` block supports the following:
 
 * `type` - (Required) The type of rule. Possible values are `MatchRule` or `RateLimitRule`.
 
-* `match_condition` - (Required) One or more `match_condition` block defined below.
+* `match_condition` - (Required) One or more `match_condition` block defined below. Can support up to `10` `match_condition` blocks.
 
 * `rate_limit_duration_in_minutes` - (Optional) The rate limit duration in minutes. Defaults to `1`.
 
@@ -169,7 +169,7 @@ The `match_condition` block supports the following:
 
 * `match_variable` - (Required) The request variable to compare with. Possible values are `Cookies`, `PostArgs`, `QueryString`, `RemoteAddr`, `RequestBody`, `RequestHeader`, `RequestMethod`, `RequestUri`, or `SocketAddr`.
 
-* `match_values` - (Required) Up to `100` possible values to match.
+* `match_values` - (Required) Up to `600` possible values to match. Limit is in total across all `match_condition` blocks and `match_values` arguments. String value itself can be up to `256` characters long.
 
 * `operator` - (Required) Comparison type to use for matching with the variable value. Possible values are `Any`, `BeginsWith`, `Contains`, `EndsWith`, `Equal`, `GeoMatch`, `GreaterThan`, `GreaterThanOrEqual`, `IPMatch`, `LessThan`, `LessThanOrEqual` or `RegEx`.
 
@@ -247,5 +247,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 FrontDoor Web Application Firewall Policy can be imported using the `resource id`, e.g.
 
 ```shell
-$ terraform import azurerm_frontdoor_firewall_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/example-fdwafpolicy
+$ terraform import azurerm_frontdoor_firewall_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/examplefdwafpolicy
 ```


### PR DESCRIPTION
Fix for: #10634

Based on this:
https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/front-door-limits.md

match_condition can support only up to 10 items
Verified in Azure it can support only up to 10 items – not more.
Otherwise error:
Error: creating Front Door Firewall Policy "examplefdwafpolicy" (Resource Group "example-rg"): frontdoor.PoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="WebApplicationFirewallPolicy validation failed. More information \"Rule Rule1 exceeds 10 match conditions\"."
Because of that I reduced limit from 100 to 10 for match_condition

match_values can support up to 600 items
Verified in Azure it can support up to 600 items for IP Addresses. (operator= "IPMatch")
Otherwise error:
Error: creating Front Door Firewall Policy "examplefdwafpolicy" (Resource Group "example-rg"): frontdoor.PoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="WebApplicationFirewallPolicy validation failed. More information \"Policy includes a rule which exceeds 600 IPMatch values\"."

match_values can support up to 10 items
Verified in Azure it can support up to 10 items for string match values. (operator= "stringOperator")
Otherwise error:
Error: creating Front Door Firewall Policy "examplefdwafpolicy" (Resource Group "example-rg"): frontdoor.PoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="WebApplicationFirewallPolicy validation failed. More information \"Match condition in Rule1 rule has more than 10 match values.\"."

Because of that I increased limit from 100 to 600 for match_values

Match string value can be up to 256 characters.
Verified in Azure - it can support up to 256 characters in string items
Otherwise error:
Error: creating Front Door Firewall Policy "examplefdwafpolicy" (Resource Group "example-rg"): frontdoor.PoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="WebApplicationFirewallPolicy validation failed. More information \"Match condition in Rule1 rule has match value with more than 256 characters\"."

I changed documentation and also changed the example name which was not valid for this resource.

More comments:
Ideally this requires conditional validation. 
For case IPMatch it can support up to 600 items. This is total number across of all match_values in all match_condition in the one policy
For case string operation it can support up to 10 items only. This is number in match_values only so total number can be higher across of all match_values in all match_condition in the one policy.
Not sure about what is the total number if mixing IPMatch and string types in multiple match_condition blocks.

Do we have any example where we use such sophisticated conditional validator? Any guidance for this?

This initial implementation of fix is conceptually the same as original implementation. It is just limiting to the highest number, lower limits will be handled by Azure as before.
