### PR TITLE
[Small] - Synapse Workspace Documentation Update

### DIFF
--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -69,11 +69,11 @@ The following arguments are supported:
 
 * `sql_administrator_login_password` - (Required) The Password associated with the `sql_administrator_login` for the SQL administrator.
 
-* `managed_virtual_network_enabled` - (Optional) Is Virtual Network enabled for all computes in this workspace? Changing this forces a new resource to be created.
+* `managed_virtual_network_enabled` - (Optional) Is Virtual Network enabled for all computes in this workspace? Defaults to `false` Changing this forces a new resource to be created.
 
 * `sql_identity_control_enabled` - (Optional) Are pipelines (running as workspace's system assigned identity) allowed to access SQL pools?
 
-* `managed_resource_group_name` - Workspace managed resource group.
+* `managed_resource_group_name` - (Optional) Workspace managed resource group.
 
 * `aad_admin` - (Optional) An `aad_admin` block as defined below.
 

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `sql_administrator_login_password` - (Required) The Password associated with the `sql_administrator_login` for the SQL administrator.
 
-* `managed_virtual_network_enabled` - (Optional) Is Virtual Network enabled for all computes in this workspace? Defaults to `false` Changing this forces a new resource to be created.
+* `managed_virtual_network_enabled` - (Optional) Is Virtual Network enabled for all computes in this workspace? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `sql_identity_control_enabled` - (Optional) Are pipelines (running as workspace's system assigned identity) allowed to access SQL pools?
 


### PR DESCRIPTION
Updates:

`managed_virtual_network_enabled` - Updated to reflect default value of `false`
`managed_resource_group_name` - Updated to reflect Optionality