### PR TITLE
testing: upgrading to use Terraform Core v0.14.7

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -5,7 +5,7 @@ var defaultStartHour = 0
 var defaultParallelism = 20
 
 // specifies the default version of Terraform Core which should be used for testing
-var defaultTerraformCoreVersion = "0.14.6"
+var defaultTerraformCoreVersion = "0.14.7"
 
 var locations = mapOf(
         "public" to LocationConfiguration("westeurope", "eastus2", "francecentral", false),


### PR DESCRIPTION
Updating the Test Framework to use [Terraform Core v0.14.7](https://releases.hashicorp.com/terraform/0.14.7/) - applicable once #10523 has been merged