### PR TITLE
r/lb_outbound_rule: fixing a crash when `frontendIPConfigurations` is omitted in the API response

### DIFF
--- a/azurerm/internal/services/loadbalancer/outbound_rule_resource.go
+++ b/azurerm/internal/services/loadbalancer/outbound_rule_resource.go
@@ -231,19 +231,21 @@ func resourceArmLoadBalancerOutboundRuleRead(d *schema.ResourceData, meta interf
 		d.Set("enable_tcp_reset", props.EnableTCPReset)
 
 		frontendIpConfigurations := make([]interface{}, 0)
-		for _, feConfig := range *props.FrontendIPConfigurations {
-			if feConfig.ID == nil {
-				continue
-			}
-			feid, err := parse.LoadBalancerFrontendIpConfigurationID(*feConfig.ID)
-			if err != nil {
-				return err
-			}
+		if configs := props.FrontendIPConfigurations; configs != nil {
+			for _, feConfig := range *configs {
+				if feConfig.ID == nil {
+					continue
+				}
+				feid, err := parse.LoadBalancerFrontendIpConfigurationID(*feConfig.ID)
+				if err != nil {
+					return err
+				}
 
-			frontendIpConfigurations = append(frontendIpConfigurations, map[string]interface{}{
-				"id":   feid.ID(),
-				"name": feid.FrontendIPConfigurationName,
-			})
+				frontendIpConfigurations = append(frontendIpConfigurations, map[string]interface{}{
+					"id":   feid.ID(),
+					"name": feid.FrontendIPConfigurationName,
+				})
+			}
 		}
 		d.Set("frontend_ip_configuration", frontendIpConfigurations)
 


### PR DESCRIPTION
Fixes #10543