### PR TITLE
provider: removing the unused default value for `skip_credentials_registration`

### DIFF
--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -238,7 +238,6 @@ func azureProvider(supportLegacyTestSuite bool) terraform.ResourceProvider {
 		p.Schema["skip_credentials_validation"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,
-			DefaultFunc: schema.EnvDefaultFunc("ARM_SKIP_CREDENTIALS_VALIDATION", false),
 			Description: "[DEPRECATED] This will cause the AzureRM Provider to skip verifying the credentials being used are valid.",
 			Deprecated:  "This field is deprecated and will be removed in version 3.0 of the Azure Provider",
 		}


### PR DESCRIPTION
This field is no longer necessary, in testing it appears that we can remove this default value outright - which fixes #10560