### PR TITLE
Parse userAssignedIdentites insensitively

### DIFF
--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -146,7 +146,7 @@ func flattenVirtualMachineIdentity(input *compute.VirtualMachineIdentity) ([]int
 	identityIds := make([]string, 0)
 	if input.UserAssignedIdentities != nil {
 		for key := range input.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/azurerm/internal/services/compute/virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/virtual_machine_resource.go
@@ -1158,7 +1158,7 @@ func flattenAzureRmVirtualMachineIdentity(identity *compute.VirtualMachineIdenti
 			}
 		*/
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -138,7 +138,7 @@ func FlattenVirtualMachineScaleSetIdentity(input *compute.VirtualMachineScaleSet
 	identityIds := make([]string, 0)
 	if input.UserAssignedIdentities != nil {
 		for key := range input.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go
@@ -1134,7 +1134,7 @@ func flattenAzureRmVirtualMachineScaleSetIdentity(identity *compute.VirtualMachi
 	identityIds := make([]string, 0)
 	if identity.UserAssignedIdentities != nil {
 		for key := range identity.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityID(key)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
 			if err != nil {
 				return nil, err
 			}

--- a/azurerm/internal/services/msi/parse/user_assigned_identity.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity.go
@@ -67,3 +67,47 @@ func UserAssignedIdentityID(input string) (*UserAssignedIdentityId, error) {
 
 	return &resourceId, nil
 }
+
+// UserAssignedIdentityIDInsensitively parses an UserAssignedIdentity ID into an UserAssignedIdentityId struct, insensitively
+// This should only be used to parse an ID for rewriting, the UserAssignedIdentityID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func UserAssignedIdentityIDInsensitively(input string) (*UserAssignedIdentityId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := UserAssignedIdentityId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'userAssignedIdentities' segment
+	userAssignedIdentitiesKey := "userAssignedIdentities"
+	for key := range id.Path {
+		if strings.EqualFold(key, userAssignedIdentitiesKey) {
+			userAssignedIdentitiesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(userAssignedIdentitiesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/msi/parse/user_assigned_identity_test.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity_test.go
@@ -110,3 +110,120 @@ func TestUserAssignedIdentityID(t *testing.T) {
 		}
 	}
 }
+
+func TestUserAssignedIdentityIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *UserAssignedIdentityId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1",
+			Expected: &UserAssignedIdentityId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "identity1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/userassignedidentities/identity1",
+			Expected: &UserAssignedIdentityId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "identity1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/USERASSIGNEDIDENTITIES/identity1",
+			Expected: &UserAssignedIdentityId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "identity1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/UsErAsSiGnEdIdEnTiTiEs/identity1",
+			Expected: &UserAssignedIdentityId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "group1",
+				Name:           "identity1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := UserAssignedIdentityIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/msi/resourceids.go
+++ b/azurerm/internal/services/msi/resourceids.go
@@ -1,3 +1,3 @@
 package msi
 
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=UserAssignedIdentity -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=UserAssignedIdentity -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1 -rewrite=true

--- a/azurerm/internal/tools/generator-resource-id/README.md
+++ b/azurerm/internal/tools/generator-resource-id/README.md
@@ -24,5 +24,4 @@ go run main.go -path=-path=./ -name=MyResourceType -id=/subscriptions/12345678-1
 
 * `path` - The Relative Path to the Service Package.
 
-* `rewrite` - Parse Resource IDs insensitively to work aroudn bugs.
-
+* `rewrite` - should an `insensitive` parser also be generated to allow for these ID's being rewritten?

--- a/azurerm/internal/tools/generator-resource-id/README.md
+++ b/azurerm/internal/tools/generator-resource-id/README.md
@@ -24,3 +24,5 @@ go run main.go -path=-path=./ -name=MyResourceType -id=/subscriptions/12345678-1
 
 * `path` - The Relative Path to the Service Package.
 
+* `rewrite` - Parse Resource IDs insensitively to work aroudn bugs.
+


### PR DESCRIPTION
Parse userAssignedIdentities insensitively when dealing with Virtual Machines and VMSS.

Fixes #10300

Sometimes the Azure API returns `userAssignedIdentities` all lowercase in the resource ID.