### PR TITLE
azurerm_sentinel_alert_rule_ms_security_incident - support `Microsoft Defender Advanced Threat Protection` and `Office 365 Advanced Threat Protection` for the `product_filter` property

### DIFF
--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
@@ -67,6 +67,8 @@ func resourceSentinelAlertRuleMsSecurityIncident() *schema.Resource {
 					string(securityinsight.AzureActiveDirectoryIdentityProtection),
 					string(securityinsight.AzureSecurityCenterforIoT),
 					string(securityinsight.AzureAdvancedThreatProtection),
+					string(securityinsight.MicrosoftDefenderAdvancedThreatProtection),
+					string(securityinsight.Office365AdvancedThreatProtection),
 				}, false),
 			},
 

--- a/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The friendly name of this Sentinel MS Security Incident Alert Rule.
 
-* `product_filter` - (Required) The Microsoft Security Service from where the alert will be generated. Possible values are `Azure Active Directory Identity Protection`, `Azure Advanced Threat Protection`, `Azure Security Center`, `Azure Security Center for IoT` and `Microsoft Cloud App Security`.
+* `product_filter` - (Required) The Microsoft Security Service from where the alert will be generated. Possible values are `Azure Active Directory Identity Protection`, `Azure Advanced Threat Protection`, `Azure Security Center`, `Azure Security Center for IoT`, `Microsoft Cloud App Security` `Microsoft Defender Advanced Threat Protection` and `Office 365 Advanced Threat Protection`.
 
 * `severity_filter` - (Required) Only create incidents from alerts when alert severity level is contained in this list. Possible values are `High`, `Medium`, `Low` and `Informational`.
 

--- a/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The friendly name of this Sentinel MS Security Incident Alert Rule.
 
-* `product_filter` - (Required) The Microsoft Security Service from where the alert will be generated. Possible values are `Azure Active Directory Identity Protection`, `Azure Advanced Threat Protection`, `Azure Security Center`, `Azure Security Center for IoT`, `Microsoft Cloud App Security` `Microsoft Defender Advanced Threat Protection` and `Office 365 Advanced Threat Protection`.
+* `product_filter` - (Required) The Microsoft Security Service from where the alert will be generated. Possible values are `Azure Active Directory Identity Protection`, `Azure Advanced Threat Protection`, `Azure Security Center`, `Azure Security Center for IoT`, `Microsoft Cloud App Security`, `Microsoft Defender Advanced Threat Protection` and `Office 365 Advanced Threat Protection`.
 
 * `severity_filter` - (Required) Only create incidents from alerts when alert severity level is contained in this list. Possible values are `High`, `Medium`, `Low` and `Informational`.
 


### PR DESCRIPTION
Fixes #10719 