### PR TITLE
not set `source` property when update Spring cloud deployment

### DIFF
--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -114,7 +114,7 @@ func resourceSpringCloudJavaDeploymentCreate(d *schema.ResourceData, meta interf
 	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
 	if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -152,11 +152,11 @@ func resourceSpringCloudJavaDeploymentCreate(d *schema.ResourceData, meta interf
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName, deployment)
 	if err != nil {
-		return fmt.Errorf("creating Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -19,9 +19,9 @@ import (
 
 func resourceSpringCloudJavaDeployment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceSpringCloudJavaDeploymentCreateUpdate,
+		Create: resourceSpringCloudJavaDeploymentCreate,
 		Read:   resourceSpringCloudJavaDeploymentRead,
-		Update: resourceSpringCloudJavaDeploymentCreateUpdate,
+		Update: resourceSpringCloudJavaDeploymentUpdate,
 		Delete: resourceSpringCloudJavaDeploymentDelete,
 
 		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
@@ -98,11 +98,11 @@ func resourceSpringCloudJavaDeployment() *schema.Resource {
 	}
 }
 
-func resourceSpringCloudJavaDeploymentCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceSpringCloudJavaDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppPlatform.DeploymentsClient
 	servicesClient := meta.(*clients.Client).AppPlatform.ServicesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	appId, err := parse.SpringCloudAppID(d.Get("spring_cloud_app_id").(string))
@@ -111,16 +111,14 @@ func resourceSpringCloudJavaDeploymentCreateUpdate(d *schema.ResourceData, meta 
 	}
 
 	id := parse.NewSpringCloudDeploymentID(subscriptionId, appId.ResourceGroup, appId.SpringName, appId.AppName, d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
-			}
-		}
+	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
+	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_spring_cloud_java_deployment", id.ID())
+			return fmt.Errorf("checking for presence of existing Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 		}
+	}
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_spring_cloud_java_deployment", id.ID())
 	}
 
 	service, err := servicesClient.Get(ctx, appId.ResourceGroup, appId.SpringName)
@@ -154,14 +152,53 @@ func resourceSpringCloudJavaDeploymentCreateUpdate(d *schema.ResourceData, meta 
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName, deployment)
 	if err != nil {
-		return fmt.Errorf("creating/update Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("creating Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation/update of Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for creation of Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
 	d.SetId(id.ID())
+
+	return resourceSpringCloudJavaDeploymentRead(d, meta)
+}
+
+func resourceSpringCloudJavaDeploymentUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).AppPlatform.DeploymentsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.SpringCloudDeploymentID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName)
+	if err != nil {
+		return fmt.Errorf("reading existing %s: %+v", id, err)
+	}
+	if existing.Sku == nil || existing.Properties == nil {
+		return fmt.Errorf("nil `sku` or `Properties` for %s: %+v", id, err)
+	}
+
+	existing.Sku.Capacity = utils.Int32(int32(d.Get("instance_count").(int)))
+	existing.Properties.DeploymentSettings = &appplatform.DeploymentSettings{
+		CPU:                  utils.Int32(int32(d.Get("cpu").(int))),
+		MemoryInGB:           utils.Int32(int32(d.Get("memory_in_gb").(int))),
+		JvmOptions:           utils.String(d.Get("jvm_options").(string)),
+		EnvironmentVariables: expandSpringCloudDeploymentEnvironmentVariables(d.Get("environment_variables").(map[string]interface{})),
+		RuntimeVersion:       appplatform.RuntimeVersion(d.Get("runtime_version").(string)),
+	}
+
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.AppName, id.DeploymentName, existing)
+	if err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for update of %s: %+v", id, err)
+	}
 
 	return resourceSpringCloudJavaDeploymentRead(d, meta)
 }


### PR DESCRIPTION
split createUpdate func.

fix bug: 
terraform does not support upload jar, users would do this through other tools, such as azure.cli.
when create in terraform, we would set the `source` to a default value, and for update fucntion, we should not change the `source` property


![image](https://user-images.githubusercontent.com/2786738/109108089-d2666a80-776d-11eb-9b65-29b69ddb9b9b.png)
