### PR TITLE
azurerm_storage_container: fix error message and docs

### DIFF
--- a/azurerm/internal/services/storage/metadata.go
+++ b/azurerm/internal/services/storage/metadata.go
@@ -66,7 +66,7 @@ func ValidateMetaDataKeys(value interface{}, _ string) (warnings []string, error
 		// must begin with a letter, underscore
 		// the rest: letters, digits and underscores
 		if !regexp.MustCompile(`^([a-z_]{1}[a-z0-9_]{1,})$`).MatchString(k) {
-			errors = append(errors, fmt.Errorf("MetaData must start with letters or an underscores. Got %q.", k))
+			errors = append(errors, fmt.Errorf("MetaData must start with letters or an underscores and be all lowercase. Got %q.", k))
 		}
 	}
 

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `container_access_type` - (Optional) The Access Level configured for this Container. Possible values are `blob`, `container` or `private`. Defaults to `private`.
 
-* `metadata` - (Optional) A mapping of MetaData for this Container.
+* `metadata` - (Optional) A mapping of MetaData for this Container. All metadata keys should be lowercase.
 
 ## Attributes Reference
 


### PR DESCRIPTION
`metadata` keys should all be lowercase

Fixes #10723