### PR TITLE
azurerm_eventhub_namespace: Remove capacity limits

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -73,10 +73,9 @@ func resourceEventHubNamespace() *schema.Resource {
 			},
 
 			"capacity": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      1,
-				ValidateFunc: validation.IntBetween(1, 20),
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
 			},
 
 			"auto_inflate_enabled": {

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `sku` - (Required) Defines which tier to use. Valid options are `Basic` and `Standard`.
 
-* `capacity` - (Optional) Specifies the Capacity / Throughput Units for a `Standard` SKU namespace. Valid values range from `1` - `20`.
+* `capacity` - (Optional) Specifies the Capacity / Throughput Units for a `Standard` SKU namespace. Default capacity has a maximum of `20`, but can be increased in blocks of 20 on a committed purchase basis.
 
 * `auto_inflate_enabled` - (Optional) Is Auto Inflate enabled for the EventHub Namespace?
 


### PR DESCRIPTION
Adjusted the docs to reflect that default capacity has a limit of 20,
but can be increased.

Fixes #10691