### PR TITLE
azurerm_data_factory_linked_service_sql_database: Support managed identity and service principal auth; add keyvault_password support

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_sql_database_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_sql_database_resource.go
@@ -66,6 +66,35 @@ func resourceDataFactoryLinkedServiceAzureSQLDatabase() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			"use_managed_identity": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Default:      false,
+				ExactlyOneOf: []string{"service_principal_id", "use_managed_identity"},
+			},
+
+			"service_principal_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsUUID,
+				RequiredWith: []string{"service_principal_key"},
+				ExactlyOneOf: []string{"service_principal_id", "use_managed_identity"},
+			},
+
+			"service_principal_key": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  validation.StringIsNotEmpty,
+				RequiredWith:  []string{"service_principal_id"},
+				ConflictsWith: []string{"use_managed_identity"},
+			},
+
+			"tenant_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
 			"integration_runtime_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -121,14 +150,31 @@ func resourceDataFactoryLinkedServiceAzureSQLDatabaseCreateUpdate(d *schema.Reso
 		}
 	}
 
+	sqlDatabaseProperties := &datafactory.AzureSQLDatabaseLinkedServiceTypeProperties{}
+
+	if v, ok := d.GetOk("connection_string"); ok {
+		sqlDatabaseProperties.ConnectionString = &datafactory.SecureString{
+			Value: utils.String(v.(string)),
+			Type:  datafactory.TypeSecureString,
+		}
+	}
+
+	if d.Get("use_managed_identity").(bool) {
+		sqlDatabaseProperties.Tenant = utils.String(d.Get("tenant_id").(string))
+	} else {
+		secureString := datafactory.SecureString{
+			Value: utils.String(d.Get("service_principal_key").(string)),
+			Type:  datafactory.TypeSecureString,
+		}
+
+		sqlDatabaseProperties.ServicePrincipalID = utils.String(d.Get("service_principal_id").(string))
+		sqlDatabaseProperties.Tenant = utils.String(d.Get("tenant_id").(string))
+		sqlDatabaseProperties.ServicePrincipalKey = &secureString
+	}
+
 	azureSQLDatabaseLinkedService := &datafactory.AzureSQLDatabaseLinkedService{
 		Description: utils.String(d.Get("description").(string)),
-		AzureSQLDatabaseLinkedServiceTypeProperties: &datafactory.AzureSQLDatabaseLinkedServiceTypeProperties{
-			ConnectionString: &datafactory.SecureString{
-				Value: utils.String(d.Get("connection_string").(string)),
-				Type:  datafactory.TypeSecureString,
-			},
-		},
+		AzureSQLDatabaseLinkedServiceTypeProperties: sqlDatabaseProperties,
 		Type: datafactory.TypeAzureSQLDatabase,
 	}
 
@@ -198,6 +244,19 @@ func resourceDataFactoryLinkedServiceAzureSQLDatabaseRead(d *schema.ResourceData
 	sql, ok := resp.Properties.AsAzureSQLDatabaseLinkedService()
 	if !ok {
 		return fmt.Errorf("Error classifiying Data Factory Linked Service AzureSQLDatabase %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", id.Name, id.FactoryName, id.ResourceGroup, datafactory.TypeAzureSQLDatabase, *resp.Type)
+	}
+
+	if sql != nil {
+		if sql.Tenant != nil {
+			d.Set("tenant_id", sql.Tenant)
+		}
+
+		if sql.ServicePrincipalID != nil {
+			d.Set("service_principal_id", sql.ServicePrincipalID)
+			d.Set("use_managed_identity", false)
+		} else {
+			d.Set("use_managed_identity", true)
+		}
 	}
 
 	d.Set("additional_properties", sql.AdditionalProperties)

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_sql_database_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_sql_database_resource_test.go
@@ -91,7 +91,7 @@ func TestAccDataFactoryLinkedServiceAzureSQLDatabase_KeyVaultReference(t *testin
 				check.That(data.ResourceName).Key("key_vault_password.0.secret_name").HasValue("secret"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("connection_string"),
 	})
 }
 

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_sql_database_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_sql_database_resource_test.go
@@ -77,6 +77,24 @@ func TestAccDataFactoryLinkedServiceAzureSQLDatabase_managed_id(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryLinkedServiceAzureSQLDatabase_KeyVaultReference(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_sql_database", "test")
+	r := LinkedServiceAzureSQLDatabaseResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.key_vault_reference(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("connection_string").Exists(),
+				check.That(data.ResourceName).Key("key_vault_password.0.linked_service_name").HasValue("linkkv"),
+				check.That(data.ResourceName).Key("key_vault_password.0.secret_name").HasValue("secret"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t LinkedServiceAzureSQLDatabaseResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := azure.ParseAzureResourceID(state.ID)
 	if err != nil {
@@ -223,4 +241,52 @@ resource "azurerm_data_factory_linked_service_azure_sql_database" "test" {
   use_managed_identity = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceAzureSQLDatabaseResource) key_vault_reference(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctkv%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+  name                = "linkkv"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  key_vault_id        = azurerm_key_vault.test.id
+}
+
+resource "azurerm_data_factory_linked_service_azure_sql_database" "test" {
+  name                = "acctestlssql%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  connection_string   = "data source=serverhostname;initial catalog=master;user id=testUser;integrated security=False;encrypt=True;connection timeout=30"
+
+  key_vault_password {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "secret"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/data_factory_linked_service_azure_sql_database.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_sql_database.html.markdown
@@ -47,6 +47,14 @@ The following arguments are supported:
 
 * `connection_string` - (Required) The connection string in which to authenticate with Azure SQL Database.
 
+* `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure SQL Database. Incompatible with `service_principal_id` and `service_principal_key`
+
+* `service_principal_id` - (Optional) The service principal id in which to authenticate against the Azure SQL Database. Required if `service_principal_key` is set.
+
+* `service_principal_key` - (Optional) The service principal key in which to authenticate against the Azure SQL Database. Required if `service_principal_id` is set.
+
+* `tenant_id` - (Optional) The tenant id or name in which to authenticate against the Azure SQL Database.
+
 * `description` - (Optional) The description for the Data Factory Linked Service Azure SQL Database.
 
 * `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service Azure SQL Database.

--- a/website/docs/r/data_factory_linked_service_azure_sql_database.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_sql_database.html.markdown
@@ -65,6 +65,18 @@ The following arguments are supported:
 
 * `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service Azure SQL Database.
 
+* `key_vault_password` - (Optional) A `key_vault_password` block as defined below. Use this argument to store SQL Server password in an existing Key Vault. It needs an existing Key Vault Data Factory Linked Service.
+
+---
+
+A `key_vault_password` block supports the following:
+
+* `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
+
+* `secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores SQL Server password.
+
+---
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
```
    $ TF_ACC=1 go test -v ./azurerm/internal/services/datafactory -timeout=1000m -run=TestAccDataFactoryLinkedServiceAzureSQLDatabase_managed_id
    2021/02/25 12:19:51 [DEBUG] not using binary driver name, it's no longer needed
    2021/02/25 12:19:51 [DEBUG] not using binary driver name, it's no longer needed
    === RUN   TestAccDataFactoryLinkedServiceAzureSQLDatabase_managed_id
    === PAUSE TestAccDataFactoryLinkedServiceAzureSQLDatabase_managed_id
    === CONT  TestAccDataFactoryLinkedServiceAzureSQLDatabase_managed_id
    --- PASS: TestAccDataFactoryLinkedServiceAzureSQLDatabase_managed_id (127.43s)
    PASS
    ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory 128.870s
```

Fixes #10677