### PR TITLE
`azurerm_keyvault_secret`: support `versionless_id` attribute

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
@@ -77,6 +78,11 @@ func resourceKeyVaultSecret() *schema.Resource {
 			},
 
 			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"versionless_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -336,6 +342,7 @@ func resourceKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("value", resp.Value)
 	d.Set("version", respID.Version)
 	d.Set("content_type", resp.ContentType)
+	d.Set("versionless_id", fmt.Sprintf("%s/%s/%s", strings.TrimSuffix(id.KeyVaultBaseUrl, "/"), id.NestedItemType, id.Name))
 
 	if attributes := resp.Attributes; attributes != nil {
 		if v := attributes.NotBefore; v != nil {

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -93,6 +93,7 @@ func TestAccKeyVaultSecret_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("expiration_date").HasValue("2020-01-01T01:02:03Z"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
+				check.That(data.ResourceName).Key("versionless_id").HasValue(fmt.Sprintf("https://acctestkv-%s.vault.azure.net/secrets/secret-%s", data.RandomString, data.RandomString)),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -84,6 +84,7 @@ The following attributes are exported:
 
 * `id` - The Key Vault Secret ID.
 * `version` - The current version of the Key Vault Secret.
+* `versionless_id` - The Base ID of the Key Vault Secret.
 
 ## Timeouts
 


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./azurerm/internal/services/keyvault -timeout=1000m -run=TestAccKeyVaultSecret_complete
2021/02/25 14:26:14 [DEBUG] not using binary driver name, it's no longer needed
2021/02/25 14:26:14 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccKeyVaultSecret_complete
=== PAUSE TestAccKeyVaultSecret_complete
=== CONT  TestAccKeyVaultSecret_complete
--- PASS: TestAccKeyVaultSecret_complete (286.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault	287.582s
```

Fixes #10736