### PR TITLE
azurerm_postgres_server: support for replicaset scaling

### DIFF
--- a/azurerm/internal/services/postgres/client/client.go
+++ b/azurerm/internal/services/postgres/client/client.go
@@ -14,6 +14,7 @@ type Client struct {
 	ServerSecurityAlertPoliciesClient *postgresql.ServerSecurityAlertPoliciesClient
 	VirtualNetworkRulesClient         *postgresql.VirtualNetworkRulesClient
 	ServerAdministratorsClient        *postgresql.ServerAdministratorsClient
+	ReplicasClient                    *postgresql.ReplicasClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -41,6 +42,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	serverAdministratorsClient := postgresql.NewServerAdministratorsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&serverAdministratorsClient.Client, o.ResourceManagerAuthorizer)
 
+	replicasClient := postgresql.NewReplicasClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&replicasClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		ConfigurationsClient:              &configurationsClient,
 		DatabasesClient:                   &databasesClient,
@@ -50,5 +54,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		ServerSecurityAlertPoliciesClient: &serverSecurityAlertPoliciesClient,
 		VirtualNetworkRulesClient:         &virtualNetworkRulesClient,
 		ServerAdministratorsClient:        &serverAdministratorsClient,
+		ReplicasClient:                    &replicasClient,
 	}
 }

--- a/azurerm/internal/services/postgres/postgresql_server_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource.go
@@ -634,12 +634,16 @@ func resourcePostgreSQLServerUpdate(d *schema.ResourceData, meta interface{}) er
 		new := newRaw.(string)
 
 		if indexOfSku(old) < indexOfSku(new) {
+			propertiesReplica := postgresql.ServerUpdateParameters{
+				Sku: sku,
+			}
+
 			listReplicas, err := replicasClient.ListByServer(ctx, id.ResourceGroup, id.Name)
 			if err != nil {
 				return fmt.Errorf("request error for list of replicas for PostgreSQL Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 			}
 			for _, replica := range *listReplicas.Value {
-				future, err := client.Update(ctx, id.ResourceGroup, *replica.Name, properties)
+				future, err := client.Update(ctx, id.ResourceGroup, *replica.Name, propertiesReplica)
 				if err != nil {
 					return fmt.Errorf("updating PostgreSQL Server Replica %q (Resource Group %q): %+v", *replica.Name, id.ResourceGroup, err)
 				}
@@ -666,12 +670,16 @@ func resourcePostgreSQLServerUpdate(d *schema.ResourceData, meta interface{}) er
 		new := newRaw.(string)
 
 		if indexOfSku(old) > indexOfSku(new) {
+			propertiesReplica := postgresql.ServerUpdateParameters{
+				Sku: sku,
+			}
+
 			listReplicas, err := replicasClient.ListByServer(ctx, id.ResourceGroup, id.Name)
 			if err != nil {
 				return fmt.Errorf("request error for list of replicas for PostgreSQL Server %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 			}
 			for _, replica := range *listReplicas.Value {
-				future, err := client.Update(ctx, id.ResourceGroup, *replica.Name, properties)
+				future, err := client.Update(ctx, id.ResourceGroup, *replica.Name, propertiesReplica)
 				if err != nil {
 					return fmt.Errorf("updating PostgreSQL Server Replica %q (Resource Group %q): %+v", *replica.Name, id.ResourceGroup, err)
 				}

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -326,7 +326,7 @@ func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.scaleableReplica(data, "11", "GP_Gen5_2"),
+			Config: r.scaleableReplica(data, "GP_Gen5_2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
@@ -336,7 +336,7 @@ func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.scaleableReplica(data, "11", "GP_Gen5_4"),
+			Config: r.scaleableReplica(data, "GP_Gen5_4"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_4"),
@@ -346,7 +346,7 @@ func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.scaleableReplica(data, "11", "GP_Gen5_2"),
+			Config: r.scaleableReplica(data, "GP_Gen5_2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
@@ -890,7 +890,7 @@ resource "azurerm_postgresql_server" "test" {
 `, data.RandomInteger, data.Locations.Primary, version, tlsVersion)
 }
 
-func (r PostgreSQLServerResource) scaleableReplica(data acceptance.TestData, version string, sku string) string {
+func (r PostgreSQLServerResource) scaleableReplica(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -899,13 +899,13 @@ resource "azurerm_postgresql_server" "replica" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  version  = "%[3]s"
-  sku_name = "%[4]s"
+  sku_name = "%[3]s"
+  version  = "11"
 
   create_mode               = "Replica"
   creation_source_server_id = azurerm_postgresql_server.test.id
 
   ssl_enforcement_enabled = true
 }
-`, r.template(data, sku, version), data.RandomInteger, version, sku)
+`, r.template(data, sku, "11"), data.RandomInteger, sku)
 }

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -329,6 +329,9 @@ func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
 			Config: r.scaleableReplica(data, "11", "GP_Gen5_2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
+				check.That("azurerm_postgresql_server.replica").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica").Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
 		data.ImportStep("administrator_login_password"),
@@ -336,6 +339,9 @@ func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
 			Config: r.scaleableReplica(data, "11", "GP_Gen5_4"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_4"),
+				check.That("azurerm_postgresql_server.replica").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica").Key("sku_name").HasValue("GP_Gen5_4"),
 			),
 		},
 		data.ImportStep("administrator_login_password"),
@@ -343,6 +349,9 @@ func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
 			Config: r.scaleableReplica(data, "11", "GP_Gen5_2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
+				check.That("azurerm_postgresql_server.replica").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica").Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
 		data.ImportStep("administrator_login_password"),

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -321,37 +321,43 @@ func TestAccPostgreSQLServer_createReplica(t *testing.T) {
 	})
 }
 
-func TestAccPostgreSQLServer_scaleReplica(t *testing.T) {
+func TestAccPostgreSQLServer_scaleReplicas(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_server", "test")
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.createReplica(data, "GP_Gen5_2"),
+			Config: r.createReplicas(data, "GP_Gen5_2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
-				check.That("azurerm_postgresql_server.replica").ExistsInAzure(r),
-				check.That("azurerm_postgresql_server.replica").Key("sku_name").HasValue("GP_Gen5_2"),
+				check.That("azurerm_postgresql_server.replica1").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica1").Key("sku_name").HasValue("GP_Gen5_2"),
+				check.That("azurerm_postgresql_server.replica2").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica2").Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.createReplica(data, "GP_Gen5_4"),
+			Config: r.createReplicas(data, "GP_Gen5_4"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_4"),
-				check.That("azurerm_postgresql_server.replica").ExistsInAzure(r),
-				check.That("azurerm_postgresql_server.replica").Key("sku_name").HasValue("GP_Gen5_4"),
+				check.That("azurerm_postgresql_server.replica1").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica1").Key("sku_name").HasValue("GP_Gen5_4"),
+				check.That("azurerm_postgresql_server.replica2").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica2").Key("sku_name").HasValue("GP_Gen5_4"),
 			),
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.createReplica(data, "GP_Gen5_2"),
+			Config: r.createReplicas(data, "GP_Gen5_2"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
-				check.That("azurerm_postgresql_server.replica").ExistsInAzure(r),
-				check.That("azurerm_postgresql_server.replica").Key("sku_name").HasValue("GP_Gen5_2"),
+				check.That("azurerm_postgresql_server.replica1").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica1").Key("sku_name").HasValue("GP_Gen5_2"),
+				check.That("azurerm_postgresql_server.replica2").ExistsInAzure(r),
+				check.That("azurerm_postgresql_server.replica2").Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
 		data.ImportStep("administrator_login_password"),
@@ -763,6 +769,40 @@ resource "azurerm_postgresql_server" "replica" {
 
   ssl_enforcement_enabled = true
 }
+`, r.template(data, sku, "11"), data.RandomInteger, sku)
+}
+
+func (r PostgreSQLServerResource) createReplicas(data acceptance.TestData, sku string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_postgresql_server" "replica1" {
+  name                = "acctest-psql-server-%[2]d-replica1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "%[3]s"
+  version  = "11"
+
+  create_mode               = "Replica"
+  creation_source_server_id = azurerm_postgresql_server.test.id
+
+  ssl_enforcement_enabled = true
+}
+
+resource "azurerm_postgresql_server" "replica2" {
+	name                = "acctest-psql-server-%[2]d-replica2"
+	location            = azurerm_resource_group.test.location
+	resource_group_name = azurerm_resource_group.test.name
+  
+	sku_name = "%[3]s"
+	version  = "11"
+  
+	create_mode               = "Replica"
+	creation_source_server_id = azurerm_postgresql_server.test.id
+  
+	ssl_enforcement_enabled = true
+  }
 `, r.template(data, sku, "11"), data.RandomInteger, sku)
 }
 

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -791,18 +791,18 @@ resource "azurerm_postgresql_server" "replica1" {
 }
 
 resource "azurerm_postgresql_server" "replica2" {
-	name                = "acctest-psql-server-%[2]d-replica2"
-	location            = azurerm_resource_group.test.location
-	resource_group_name = azurerm_resource_group.test.name
-  
-	sku_name = "%[3]s"
-	version  = "11"
-  
-	create_mode               = "Replica"
-	creation_source_server_id = azurerm_postgresql_server.test.id
-  
-	ssl_enforcement_enabled = true
-  }
+  name                = "acctest-psql-server-%[2]d-replica2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "%[3]s"
+  version  = "11"
+
+  create_mode               = "Replica"
+  creation_source_server_id = azurerm_postgresql_server.test.id
+
+  ssl_enforcement_enabled = true
+}
 `, r.template(data, sku, "11"), data.RandomInteger, sku)
 }
 

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the `tier` + `family` + `cores` pattern (e.g. `B_Gen4_1`, `GP_Gen5_8`). For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create#sku).
 
-~> **NOTE:** When replication is set up and `sku_name` is changed to a higher tier or more capacity for de primary, all replicas are scaled up to the same tier/capacity. This is an Azure requirement, for more information see the [replica scaling documentation](https://docs.microsoft.com/en-us/azure/postgresql/concepts-read-replicas#scaling)
+~> **NOTE:** When replication is set up and `sku_name` is changed to a higher tier or more capacity for the primary, all replicas are scaled up to the same tier/capacity. This is an Azure requirement, for more information see the [replica scaling documentation](https://docs.microsoft.com/en-us/azure/postgresql/concepts-read-replicas#scaling)
 
 * `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5`, `9.6`, `10`, `10.0`, and `11`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the `tier` + `family` + `cores` pattern (e.g. `B_Gen4_1`, `GP_Gen5_8`). For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create#sku).
 
+~> **NOTE:** When replication is set up and `sku_name` is changed to a higher tier or more capacity for de primary, all replicas are scaled up to the same tier/capacity. This is an Azure requirement, for more information see the [replica scaling documentation](https://docs.microsoft.com/en-us/azure/postgresql/concepts-read-replicas#scaling)
+
 * `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5`, `9.6`, `10`, `10.0`, and `11`. Changing this forces a new resource to be created.
 
 * `administrator_login` - (Optional) The Administrator Login for the PostgreSQL Server. Required when `create_mode` is `Default`. Changing this forces a new resource to be created.


### PR DESCRIPTION
Fixes #10284 

## Implementation
- [x] Lock based on (primary) database server id to prevent replica from updating until primary is completed
- [x] Checks if SKU has changed and if its an scale-up
  - [x] Update of SKU of both the replicas and primary based on scale-up changes in the primary. This is done by a lookup of all the replicas and SKU scale-up of these
- [x] AccTest which scales up and down successfully