### PR TITLE
Fix acc test case failure of `TestAccLinuxVirtualMachine_imageFromImage`

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -176,7 +176,7 @@ resource "azurerm_linux_virtual_machine" "source" {
   ]
 
   admin_ssh_key {
-    username   = "adminuser"
+    username   = local.admin_username
     public_key = local.first_public_key
   }
 

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -18,7 +18,7 @@ func TestAccLinuxVirtualMachine_imageFromImage(t *testing.T) {
 			// create the original VM
 			Config: r.imageFromExistingMachinePrep(data),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That("azurerm_linux_virtual_machine.source").ExistsInAzure(r),
 				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
 			),
 		},
@@ -94,6 +94,8 @@ locals {
   first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ddAwoR0XBoT9kixLX6atgX9dovt9fpR1HO/R9jYwYnuB+SZ845KSqat+U0m6oagZhpsfcEEwjGGjQz6Z1rB6mvffsKq6i74cmm0jO564nBnZQeh31q3sFNs+XdrDtFmnYRqdPHhhr1sw0C/rxbiaE6nYZWRfHW//81nEePKMpjiN8JsrYQNbzEpz8QOBSquwBmXO+LVx//zAbY4jGTa4hjGeNzIgMJZ8Jk/11XbcxSK1PK43BrejHg6kctmEkYvMH/o12RfAeB8okGCRW3scwOozxVrHwxaPgEf03jig+Ag9V+GXNBabL5AWtxcuPN63rUfaAXEIXTHmndwVOxlpLrUf5ox1+ddGyWbLMXzd7akPioof5MNJMq/yuFGC5dY0Z6/+yGRNtShQesVo/czhKEPGIcsIi5gnKdfDB4i9ay2yz8ystnW6jbabcyqejk1Qc61wapaFdhUHL0iD/GW/5ZujDs5C3BT7EIgKLIfAaAx5TBEJyE1KQ/GEOifB8ztDl/gp99o+i2HKABtmYv12y4JVlEUkRckeLrw6luEb3ColHshsQcQGfudGFFgdEdcgBrV4Ch7IkLxVYQl3pegzZiirMPnRKh10r/Hrg6uYxn7sLeTJoD5VOKmqmeK4kFXsZMVtA6/SnxQtUKkKlfLBwBSDrrdgLjBV+KOndiwC7Q=="
   second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
   vm_name           = "acctestsourcevm-%d"
+  admin_username    = "testadmin%d"
+  admin_password    = "Password1234!%d"
 }
 
 resource "azurerm_resource_group" "test" {
@@ -153,7 +155,7 @@ resource "azurerm_shared_image_gallery" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
 }
-`, data.RandomInteger, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) imageFromExistingMachinePrep(data acceptance.TestData) string {
@@ -165,9 +167,9 @@ resource "azurerm_linux_virtual_machine" "source" {
   resource_group_name             = azurerm_resource_group.test.name
   location                        = azurerm_resource_group.test.location
   size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  admin_username                  = local.admin_username
   disable_password_authentication = false
-  admin_password                  = "Eung6ahthane2ied"
+  admin_password                  = local.admin_password
 
   network_interface_ids = [
     azurerm_network_interface.public.id,

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -18,7 +18,7 @@ func TestAccLinuxVirtualMachine_imageFromImage(t *testing.T) {
 			// create the original VM
 			Config: r.imageFromExistingMachinePrep(data),
 			Check: resource.ComposeTestCheckFunc(
-				check.That("azurerm_linux_virtual_machine.source").ExistsInAzure(r),
+				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_linux_virtual_machine.source"),
 				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
 			),
 		},
@@ -57,7 +57,7 @@ func TestAccLinuxVirtualMachine_imageFromSharedImageGallery(t *testing.T) {
 			// create the original VM
 			Config: r.imageFromExistingMachinePrep(data),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_linux_virtual_machine.source"),
 				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
 			),
 		},


### PR DESCRIPTION
and `TestAccLinuxVirtualMachine_imageFromSharedImageGallery`

We are invoking an SSH login in `generalizeVirtualMachine` function with a certain pattern of admin username and password, but those were assigned differently in the configuration of these two test cases