### PR TITLE
Documentation: Change default value for policy_settings.enabled argument

### DIFF
--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -164,7 +164,7 @@ The `match_variables` block supports the following:
 
 The `policy_settings` block supports the following:
 
-* `enabled` - (Optional) Describes if the policy is in enabled state or disabled state. Defaults to `Enabled`.
+* `enabled` - (Optional) Describes if the policy is in enabled state or disabled state. Defaults to `true`.
 
 * `mode` - (Optional) Describes if it is in detection mode or prevention mode at the policy level. Defaults to `Prevention`.
 


### PR DESCRIPTION
Hi,

This PR changes the documentation for `azurerm_web_application_firewall_policy`. More specific the `enabled` argument on the `policy_settings` block from the string version "Enabled" to a bool type "true".

According to the source code the correct type is bool and not string as implied by the documentation.

```hcl
# ./azurerm/internal/services/network/web_application_firewall_policy_resource.go

# ...

"policy_settings": {
  Type:     schema.TypeList,
  Optional: true,
  MaxItems: 1,
  Elem: &schema.Resource{
    Schema: map[string]*schema.Schema{
      "enabled": {
        Type:     schema.TypeBool,
        Optional: true,
        Default:  true,
      },

      # ...
```