### PR TITLE
azurerm_api_management: tenant_access only when not in consumption SKU

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -730,7 +730,11 @@ func resourceApiManagementServiceCreateUpdate(d *schema.ResourceData, meta inter
 		}
 	}
 
-	if d.HasChange("tenant_access") {
+	tenantAccessRaw := d.Get("tenant_access").([]interface{})
+	if sku.Name == apimanagement.SkuTypeConsumption && len(tenantAccessRaw) > 0 {
+		return fmt.Errorf("`tenant_access` is not supported for sku tier `Consumption`")
+	}
+	if sku.Name != apimanagement.SkuTypeConsumption && d.HasChange("tenant_access") {
 		tenantAccessInformationParametersRaw := d.Get("tenant_access").([]interface{})
 		tenantAccessInformationParameters := expandApiManagementTenantAccessSettings(tenantAccessInformationParametersRaw)
 		tenantAccessClient := meta.(*clients.Client).ApiManagement.TenantAccessClient
@@ -862,12 +866,14 @@ func resourceApiManagementServiceRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("sign_up", []interface{}{})
 	}
 
-	tenantAccessInformationContract, err := tenantAccessClient.ListSecrets(ctx, resourceGroup, name)
-	if err != nil {
-		return fmt.Errorf("retrieving tenant access properties for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-	if err := d.Set("tenant_access", flattenApiManagementTenantAccessSettings(tenantAccessInformationContract)); err != nil {
-		return fmt.Errorf("setting `tenant_access`: %+v", err)
+	if resp.Sku.Name != apimanagement.SkuTypeConsumption {
+		tenantAccessInformationContract, err := tenantAccessClient.ListSecrets(ctx, resourceGroup, name)
+		if err != nil {
+			return fmt.Errorf("retrieving tenant access properties for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+		if err := d.Set("tenant_access", flattenApiManagementTenantAccessSettings(tenantAccessInformationContract)); err != nil {
+			return fmt.Errorf("setting `tenant_access`: %+v", err)
+		}
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/10750 .

My addition of the `tenant_access` configuration with https://github.com/terraform-providers/terraform-provider-azurerm/pull/10475 did not take into consideration that the `Consumption` SKU does not allow this settings.

The tests I ran to make sure the changes are working:

```
make testacc TEST='./azurerm/internal/services/apimanagement/api_management_resource_test.go' TESTARGS='-run=TestAccApiManagement_tenantAccess' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_resource_test.go -v -run=TestAccApiManagement_tenantAccess -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/01 12:00:23 [DEBUG] not using binary driver name, it's no longer needed
2021/03/01 12:00:23 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccApiManagement_tenantAccess
=== PAUSE TestAccApiManagement_tenantAccess
=== CONT  TestAccApiManagement_tenantAccess
--- PASS: TestAccApiManagement_tenantAccess (2577.55s)
PASS
ok      command-line-arguments  2579.167s


make testacc TEST='./azurerm/internal/services/apimanagement/api_management_resource_test.go' TESTARGS='-run=TestAccApiManagement_consumption' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_resource_test.go -v -run=TestAccApiManagement_consumption -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/01 11:59:52 [DEBUG] not using binary driver name, it's no longer needed
2021/03/01 11:59:52 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccApiManagement_consumption
=== PAUSE TestAccApiManagement_consumption
=== CONT  TestAccApiManagement_consumption
--- PASS: TestAccApiManagement_consumption (218.10s)
PASS
ok      command-line-arguments  219.843s
```
