### PR TITLE
`sentinel_alert_rule_xxx` acctests add dependency on log analytics solution

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	loganalyticsParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -206,7 +207,15 @@ func resourceLogAnalyticsSolutionRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	if props := resp.Properties; props != nil {
-		d.Set("workspace_resource_id", props.WorkspaceResourceID)
+		var workspaceId string
+		if props.WorkspaceResourceID != nil {
+			id, err := loganalyticsParse.LogAnalyticsWorkspaceID(*props.WorkspaceResourceID)
+			if err != nil {
+				return err
+			}
+			workspaceId = id.ID()
+		}
+		d.Set("workspace_resource_id", workspaceId)
 	}
 
 	if err := d.Set("plan", flattenAzureRmLogAnalyticsSolutionPlan(resp.Plan)); err != nil {

--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_data_source_test.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_data_source_test.go
@@ -32,7 +32,7 @@ func (SentinelAlertRuleDataSource) basic(data acceptance.TestData) string {
 
 data "azurerm_sentinel_alert_rule" "test" {
   name                       = azurerm_sentinel_alert_rule_ms_security_incident.test.name
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 `, SentinelAlertRuleMsSecurityIncidentResource{}.basic(data))
 }

--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -122,12 +122,12 @@ func (r SentinelAlertRuleFusionResource) basic(data acceptance.TestData) string 
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
 }
 `, r.template(data), data.RandomInteger)
@@ -139,12 +139,12 @@ func (r SentinelAlertRuleFusionResource) complete(data acceptance.TestData) stri
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   enabled                    = false
 }
@@ -179,6 +179,19 @@ resource "azurerm_log_analytics_workspace" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
@@ -161,7 +161,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) basic(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
@@ -175,7 +175,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) complete(data acceptance.Te
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   product_filter             = "Azure Security Center"
   display_name               = "updated rule"
   severity_filter            = ["High", "Low"]
@@ -205,7 +205,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) alertRuleTemplateGuid(data 
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
@@ -220,7 +220,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) displayNameExcludeFilter(da
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                        = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id  = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id  = azurerm_log_analytics_solution.test.workspace_resource_id
   product_filter              = "Microsoft Cloud App Security"
   display_name                = "some rule"
   severity_filter             = ["High"]
@@ -246,6 +246,19 @@ resource "azurerm_log_analytics_workspace" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -154,7 +154,7 @@ func (r SentinelAlertRuleScheduledResource) basic(data acceptance.TestData) stri
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -173,7 +173,7 @@ func (r SentinelAlertRuleScheduledResource) complete(data acceptance.TestData) s
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   display_name               = "Updated Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
@@ -225,7 +225,7 @@ func (r SentinelAlertRuleScheduledResource) alertRuleTemplateGuid(data acceptanc
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -245,7 +245,7 @@ func (r SentinelAlertRuleScheduledResource) eventGroupingSetting(data acceptance
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -269,7 +269,7 @@ func (r SentinelAlertRuleScheduledResource) updateEventGroupingSetting(data acce
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -303,6 +303,19 @@ resource "azurerm_log_analytics_workspace" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -92,10 +92,22 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
+}
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, displayName)
 }


### PR DESCRIPTION
Since service team starts enforcing the official requirement that a Sentinel customer (workspace) must have “SecurityInsights” solution installed. This PR added this dependency in the acctests, which should fix the test failures of sentinel alert rules.

Note that there is a change in `log_analytics_solution_resource.go`, this is to leverage the id parser so as to avoid the plan diff later observed in the sentinel alert rule resources (the case of `resourceG/group`).