### PR TITLE
Documentation: Change managed_rule_set to Required

### DIFF
--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -180,7 +180,7 @@ The `managed_rules` block supports the following:
 
 * `exclusion` - (Optional) One or more `exclusion` block defined below.
 
-* `managed_rule_set` - (Optional) One or more `managed_rule_set` block defined below.
+* `managed_rule_set` - (Required) One or more `managed_rule_set` block defined below.
 
 ---
 


### PR DESCRIPTION
Hi,

This PR changes the documentation for `azurerm_web_application_firewall_policy`, more spesific the `managed_rule_set` argument block and set it to "Required" instead of "Optional". According to the source code the `managed_rule_set` is required.

```hcl
# azurerm/internal/services/network/web_application_firewall_policy_resource.go

# ...

"managed_rule_set": {
  Type:     schema.TypeList,
  Required: true,
  Elem: &schema.Resource{

# ...
```