### PR TITLE
testing: removing the old test framework

### DIFF
--- a/azurerm/internal/acceptance/providers.go
+++ b/azurerm/internal/acceptance/providers.go
@@ -5,34 +5,18 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azuread/azuread"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/testclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
 
 var once sync.Once
 
 func EnsureProvidersAreInitialised() {
-	if !testclient.EnableBinaryTesting {
-		os.Setenv("TF_DISABLE_BINARY_TESTING", "true")
-	} else {
-		// require reattach testing is enabled
-		os.Setenv("TF_ACCTEST_REATTACH", "1")
-	}
+	// require reattach testing is enabled
+	os.Setenv("TF_ACCTEST_REATTACH", "1")
 
 	once.Do(func() {
-		if !testclient.EnableBinaryTesting {
-			azureProvider := provider.TestAzureProvider().(*schema.Provider)
-			testclient.AzureProvider = azureProvider
-			testclient.SupportedProviders = map[string]terraform.ResourceProvider{
-				"azurerm": azureProvider,
-				"azuread": azuread.Provider().(*schema.Provider),
-			}
-		} else {
-			acctest.UseBinaryDriver("azurerm", provider.TestAzureProvider)
-			acctest.UseBinaryDriver("azuread", azuread.Provider)
-		}
+		acctest.UseBinaryDriver("azurerm", provider.TestAzureProvider)
+		acctest.UseBinaryDriver("azuread", azuread.Provider)
 	})
 }

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azuread/azuread"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/helpers"
@@ -56,6 +58,10 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 	testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
+		"azuread": func() (terraform.ResourceProvider, error) {
+			aad := azuread.Provider()
+			return aad, nil
+		},
 		"azurerm": func() (terraform.ResourceProvider, error) {
 			azurerm := provider.TestAzureProvider()
 			return azurerm, nil

--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -55,15 +55,11 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 }
 
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
-	if testclient.EnableBinaryTesting {
-		testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
-			"azurerm": func() (terraform.ResourceProvider, error) {
-				azurerm := provider.TestAzureProvider()
-				return azurerm, nil
-			},
-		}
-	} else {
-		testCase.Providers = testclient.SupportedProviders
+	testCase.ProviderFactories = map[string]terraform.ResourceProviderFactory{
+		"azurerm": func() (terraform.ResourceProvider, error) {
+			azurerm := provider.TestAzureProvider()
+			return azurerm, nil
+		},
 	}
 
 	resource.ParallelTest(t, testCase)

--- a/azurerm/internal/acceptance/testclient/client.go
+++ b/azurerm/internal/acceptance/testclient/client.go
@@ -7,68 +7,52 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-azure-helpers/authentication"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
-)
-
-var (
-	// @tombuildsstuff: this is left in as a compatibility layer for the moment
-	// in the near future we'll remove this, and remove the "azuread" provider below
-	// but for the moment there's no need to remove the vendor here imminantly afaict
-	EnableBinaryTesting = true
-
-	AzureProvider      *schema.Provider
-	SupportedProviders map[string]terraform.ResourceProvider
 )
 
 var _client *clients.Client
 var clientLock = &sync.Mutex{}
 
 func Build() (*clients.Client, error) {
-	if EnableBinaryTesting {
-		clientLock.Lock()
-		defer clientLock.Unlock()
+	clientLock.Lock()
+	defer clientLock.Unlock()
 
-		if _client == nil {
-			environment, exists := os.LookupEnv("ARM_ENVIRONMENT")
-			if !exists {
-				environment = "public"
-			}
-
-			builder := authentication.Builder{
-				SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
-				ClientID:       os.Getenv("ARM_CLIENT_ID"),
-				TenantID:       os.Getenv("ARM_TENANT_ID"),
-				ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
-				Environment:    environment,
-				MetadataHost:   os.Getenv("ARM_METADATA_HOST"),
-
-				// we intentionally only support Client Secret auth for tests (since those variables are used all over)
-				SupportsClientSecretAuth: true,
-			}
-			config, err := builder.Build()
-			if err != nil {
-				return nil, fmt.Errorf("Error building ARM Client: %+v", err)
-			}
-
-			clientBuilder := clients.ClientBuilder{
-				AuthConfig:               config,
-				SkipProviderRegistration: true,
-				TerraformVersion:         os.Getenv("TERRAFORM_CORE_VERSION"),
-				Features:                 features.Default(),
-				StorageUseAzureAD:        false,
-			}
-			client, err := clients.Build(context.TODO(), clientBuilder)
-			if err != nil {
-				return nil, err
-			}
-			_client = client
+	if _client == nil {
+		environment, exists := os.LookupEnv("ARM_ENVIRONMENT")
+		if !exists {
+			environment = "public"
 		}
 
-		return _client, nil
+		builder := authentication.Builder{
+			SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+			ClientID:       os.Getenv("ARM_CLIENT_ID"),
+			TenantID:       os.Getenv("ARM_TENANT_ID"),
+			ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
+			Environment:    environment,
+			MetadataHost:   os.Getenv("ARM_METADATA_HOST"),
+
+			// we intentionally only support Client Secret auth for tests (since those variables are used all over)
+			SupportsClientSecretAuth: true,
+		}
+		config, err := builder.Build()
+		if err != nil {
+			return nil, fmt.Errorf("Error building ARM Client: %+v", err)
+		}
+
+		clientBuilder := clients.ClientBuilder{
+			AuthConfig:               config,
+			SkipProviderRegistration: true,
+			TerraformVersion:         os.Getenv("TERRAFORM_CORE_VERSION"),
+			Features:                 features.Default(),
+			StorageUseAzureAD:        false,
+		}
+		client, err := clients.Build(context.TODO(), clientBuilder)
+		if err != nil {
+			return nil, err
+		}
+		_client = client
 	}
 
-	return AzureProvider.Meta().(*clients.Client), nil
+	return _client, nil
 }


### PR DESCRIPTION
This PR removes the feature-toggle between the new/old test framework - and fixes an issue where the AAD Provider wasn't available at test time