### PR TITLE
dns_zone: Compute resourceId from the parser, add state migration, switch dns package to generated IDs

### DIFF
--- a/azurerm/internal/services/dns/dns_a_record_resource.go
+++ b/azurerm/internal/services/dns/dns_a_record_resource.go
@@ -84,11 +84,14 @@ func resourceDnsARecord() *schema.Resource {
 func resourceDnsARecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewARecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.A)
@@ -133,16 +136,12 @@ func resourceDnsARecordCreateUpdate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating/updating DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.A)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.A)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Error retrieving DNS A Record %q (Zone %q / Resource Group %q): ID was nil", name, zoneName, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsARecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_a_record_resource.go
+++ b/azurerm/internal/services/dns/dns_a_record_resource.go
@@ -136,11 +136,6 @@ func resourceDnsARecordCreateUpdate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating/updating DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.A)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsARecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/dns/dns_aaaa_record_resource.go
@@ -88,11 +88,14 @@ func resourceDnsAAAARecord() *schema.Resource {
 func resourceDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewAaaaRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.AAAA)
@@ -137,16 +140,12 @@ func resourceDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error creating/updating DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.AAAA)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.AAAA)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Error retrieving DNS AAAA Record %q (Zone %q / Resource Group %q): ID was nil", name, zoneName, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsAaaaRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/dns/dns_aaaa_record_resource.go
@@ -140,11 +140,6 @@ func resourceDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error creating/updating DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.AAAA)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsAaaaRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_caa_record_resource.go
+++ b/azurerm/internal/services/dns/dns_caa_record_resource.go
@@ -101,11 +101,14 @@ func resourceDnsCaaRecord() *schema.Resource {
 func resourceDnsCaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewCaaRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.CAA)
@@ -138,16 +141,12 @@ func resourceDnsCaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS CAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.CAA)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.CAA)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS CAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS CAA Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsCaaRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_caa_record_resource.go
+++ b/azurerm/internal/services/dns/dns_caa_record_resource.go
@@ -141,11 +141,6 @@ func resourceDnsCaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS CAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.CAA)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS CAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsCaaRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_cname_record_resource.go
+++ b/azurerm/internal/services/dns/dns_cname_record_resource.go
@@ -137,11 +137,6 @@ func resourceDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error creating/updating CNAME Record %q (DNS Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.CNAME)
-	if err != nil {
-		return fmt.Errorf("Error retrieving CNAME Record %q (DNS Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsCNameRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_cname_record_resource.go
+++ b/azurerm/internal/services/dns/dns_cname_record_resource.go
@@ -81,11 +81,14 @@ func resourceDnsCNameRecord() *schema.Resource {
 func resourceDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewCnameRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.CNAME)
@@ -134,16 +137,12 @@ func resourceDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error creating/updating CNAME Record %q (DNS Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.CNAME)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.CNAME)
 	if err != nil {
 		return fmt.Errorf("Error retrieving CNAME Record %q (DNS Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Error retrieving CNAME Record %q (DNS Zone %q / Resource Group %q): ID was nil", name, zoneName, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsCNameRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_mx_record_resource.go
+++ b/azurerm/internal/services/dns/dns_mx_record_resource.go
@@ -91,11 +91,14 @@ func resourceDnsMxRecord() *schema.Resource {
 func resourceDnsMxRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewMxRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.MX)
@@ -126,16 +129,12 @@ func resourceDnsMxRecordCreateUpdate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error creating/updating DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.MX)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.MX)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS MX Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsMxRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_mx_record_resource.go
+++ b/azurerm/internal/services/dns/dns_mx_record_resource.go
@@ -129,11 +129,6 @@ func resourceDnsMxRecordCreateUpdate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error creating/updating DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.MX)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS MX Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsMxRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_ns_record_resource.go
+++ b/azurerm/internal/services/dns/dns_ns_record_resource.go
@@ -117,11 +117,6 @@ func resourceDnsNsRecordCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating DNS NS Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err = client.Get(ctx, resGroup, zoneName, name, dns.NS)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS NS Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsNsRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_ns_record_resource.go
+++ b/azurerm/internal/services/dns/dns_ns_record_resource.go
@@ -76,11 +76,14 @@ func resourceDnsNsRecord() *schema.Resource {
 func resourceDnsNsRecordCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewNsRecordID(subscriptionId, resGroup, zoneName, name)
 
 	existing, err := client.Get(ctx, resGroup, zoneName, name, dns.NS)
 	if err != nil {
@@ -114,16 +117,12 @@ func resourceDnsNsRecordCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating DNS NS Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.NS)
+	_, err = client.Get(ctx, resGroup, zoneName, name, dns.NS)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS NS Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS NS Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsNsRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_ptr_record_resource.go
+++ b/azurerm/internal/services/dns/dns_ptr_record_resource.go
@@ -113,11 +113,6 @@ func resourceDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.PTR)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsPtrRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_ptr_record_resource.go
+++ b/azurerm/internal/services/dns/dns_ptr_record_resource.go
@@ -74,11 +74,14 @@ func resourceDnsPtrRecord() *schema.Resource {
 func resourceDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewPtrRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.PTR)
@@ -110,16 +113,12 @@ func resourceDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.PTR)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.PTR)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS PTR Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS PTR Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsPtrRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_srv_record_resource.go
+++ b/azurerm/internal/services/dns/dns_srv_record_resource.go
@@ -96,11 +96,14 @@ func resourceDnsSrvRecord() *schema.Resource {
 func resourceDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewSrvRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
@@ -133,16 +136,12 @@ func resourceDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS SRV Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsSrvRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_srv_record_resource.go
+++ b/azurerm/internal/services/dns/dns_srv_record_resource.go
@@ -136,11 +136,6 @@ func resourceDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsSrvRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_txt_record_resource.go
+++ b/azurerm/internal/services/dns/dns_txt_record_resource.go
@@ -82,11 +82,14 @@ func resourceDnsTxtRecord() *schema.Resource {
 func resourceDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.RecordSetsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneName := d.Get("zone_name").(string)
+
+	resourceId := parse.NewTxtRecordID(subscriptionId, resGroup, zoneName, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.TXT)
@@ -119,16 +122,12 @@ func resourceDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS TXT Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.TXT)
+	_, err := client.Get(ctx, resGroup, zoneName, name, dns.TXT)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS TXT Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS TXT Record %s (resource group %s) ID", name, resGroup)
-	}
-
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsTxtRecordRead(d, meta)
 }

--- a/azurerm/internal/services/dns/dns_txt_record_resource.go
+++ b/azurerm/internal/services/dns/dns_txt_record_resource.go
@@ -122,11 +122,6 @@ func resourceDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating/updating DNS TXT Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, zoneName, name, dns.TXT)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS TXT Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
-	}
-
 	d.SetId(resourceId.ID())
 
 	return resourceDnsTxtRecordRead(d, meta)

--- a/azurerm/internal/services/dns/dns_zone_data_source.go
+++ b/azurerm/internal/services/dns/dns_zone_data_source.go
@@ -93,7 +93,11 @@ func dataSourceDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	if resp.ID == nil || *resp.ID == "" {
 		return fmt.Errorf("failed reading ID for DNS Zone %q (Resource Group %q)", name, resourceGroup)
 	}
-	d.SetId(*resp.ID)
+	resourceId, err := parse.DnsZoneID(*resp.ID)
+	if err != nil {
+		return fmt.Errorf("Error parsing DNS Zone ID %q", *resp.ID)
+	}
+	d.SetId(resourceId.ID())
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)

--- a/azurerm/internal/services/dns/dns_zone_data_source.go
+++ b/azurerm/internal/services/dns/dns_zone_data_source.go
@@ -59,10 +59,14 @@ func dataSourceDnsZone() *schema.Resource {
 func dataSourceDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.ZonesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
+
+	resourceId := parse.NewDnsZoneID(subscriptionId, resourceGroup, name)
 
 	var (
 		resp dns.Zone
@@ -93,10 +97,7 @@ func dataSourceDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	if resp.ID == nil || *resp.ID == "" {
 		return fmt.Errorf("failed reading ID for DNS Zone %q (Resource Group %q)", name, resourceGroup)
 	}
-	resourceId, err := parse.DnsZoneID(*resp.ID)
-	if err != nil {
-		return fmt.Errorf("Error parsing DNS Zone ID %q", *resp.ID)
-	}
+
 	d.SetId(resourceId.ID())
 
 	d.Set("name", name)

--- a/azurerm/internal/services/dns/dns_zone_resource.go
+++ b/azurerm/internal/services/dns/dns_zone_resource.go
@@ -186,11 +186,6 @@ func resourceDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating/updating DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
 	}
 
-	_, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
-	}
-
 	if v, ok := d.GetOk("soa_record"); ok {
 		soaRecord := v.([]interface{})[0].(map[string]interface{})
 		rsParameters := dns.RecordSet{

--- a/azurerm/internal/services/dns/dns_zone_resource.go
+++ b/azurerm/internal/services/dns/dns_zone_resource.go
@@ -186,7 +186,7 @@ func resourceDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating/updating DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
 	}
 
-	resp, err := client.Get(ctx, resGroup, name)
+	_, err := client.Get(ctx, resGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
 	}
@@ -208,10 +208,6 @@ func resourceDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error
 		if _, err := recordSetsClient.CreateOrUpdate(ctx, resGroup, name, "@", dns.SOA, rsParameters, etag, ifNoneMatch); err != nil {
 			return fmt.Errorf("creating/updating DNS SOA Record @ (Zone %q / Resource Group %q): %s", name, resGroup, err)
 		}
-	}
-
-	if resp.ID == nil {
-		return fmt.Errorf("Cannot read DNS Zone %q (Resource Group %q) ID", name, resGroup)
 	}
 
 	d.SetId(resourceId.ID())

--- a/azurerm/internal/services/dns/dns_zone_resource.go
+++ b/azurerm/internal/services/dns/dns_zone_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -26,6 +27,11 @@ func resourceDnsZone() *schema.Resource {
 		Read:   resourceDnsZoneRead,
 		Update: resourceDnsZoneCreateUpdate,
 		Delete: resourceDnsZoneDelete,
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			migration.DnsZoneV0ToV1(),
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -144,11 +150,14 @@ func resourceDnsZone() *schema.Resource {
 func resourceDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Dns.ZonesClient
 	recordSetsClient := meta.(*clients.Client).Dns.RecordSetsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+
+	resourceId := parse.NewDnsZoneID(subscriptionId, resGroup, name)
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name)
@@ -205,7 +214,7 @@ func resourceDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Cannot read DNS Zone %q (Resource Group %q) ID", name, resGroup)
 	}
 
-	d.SetId(*resp.ID)
+	d.SetId(resourceId.ID())
 
 	return resourceDnsZoneRead(d, meta)
 }

--- a/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
+++ b/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
@@ -130,7 +130,7 @@ func DnsZoneUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (ma
 		return rawState, err
 	}
 
-	newId := id.ID()
+	newId := parse.NewDnsZoneID(id.SubscriptionId, rawState["resource_group_name"].(string), rawState["name"].(string)).ID()
 	log.Printf("Updating `id` from %q to %q", oldId, newId)
 	rawState["id"] = newId
 	return rawState, nil

--- a/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
+++ b/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
@@ -1,0 +1,137 @@
+package migration
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"log"
+)
+
+func DnsZoneV0ToV1() schema.StateUpgrader {
+	return schema.StateUpgrader{
+		Version: 0,
+		Type:    DnsZoneV0Schema().CoreConfigSchema().ImpliedType(),
+		Upgrade: DnsZoneUpgradeV0ToV1,
+	}
+}
+
+func DnsZoneV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			"number_of_record_sets": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_number_of_record_sets": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"name_servers": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"soa_record": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"email": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validate.DnsZoneSOARecordEmail,
+						},
+
+						"host_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"expire_time": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      2419200,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+
+						"minimum_ttl": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      300,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+
+						"refresh_time": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3600,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+
+						"retry_time": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      300,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+
+						"serial_number": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      1,
+							ValidateFunc: validation.IntAtLeast(0),
+						},
+
+						"ttl": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      3600,
+							ValidateFunc: validation.IntBetween(0, 2147483647),
+						},
+
+						"tags": tags.Schema(),
+
+						"fqdn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func DnsZoneUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+	id, err := parse.DnsZoneID(oldId)
+	if err != nil {
+		return rawState, err
+	}
+
+	newId := id.ID()
+	log.Printf("Updating `id` from %q to %q", oldId, newId)
+	rawState["id"] = newId
+	return rawState, nil
+}

--- a/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
+++ b/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
@@ -3,6 +3,8 @@ package migration
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -10,7 +12,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
-	"log"
 )
 
 func DnsZoneV0ToV1() schema.StateUpgrader {


### PR DESCRIPTION
Fixes #10778 