### PR TITLE
Fixes bug #10773

### DIFF
--- a/azurerm/internal/services/netapp/netapp_volume_data_source.go
+++ b/azurerm/internal/services/netapp/netapp_volume_data_source.go
@@ -155,7 +155,7 @@ func dataSourceNetAppVolumeRead(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf("setting `mount_ip_addresses`: %+v", err)
 		}
 
-		if props.DataProtection.Replication != nil {
+		if props.DataProtection != nil && props.DataProtection.Replication != nil {
 			if err := d.Set("data_protection_replication", flattenNetAppVolumeDataProtectionReplication(props.DataProtection)); err != nil {
 				return fmt.Errorf("setting `data_protection_replication`: %+v", err)
 			}

--- a/azurerm/internal/services/netapp/netapp_volume_data_source.go
+++ b/azurerm/internal/services/netapp/netapp_volume_data_source.go
@@ -154,11 +154,8 @@ func dataSourceNetAppVolumeRead(d *schema.ResourceData, meta interface{}) error 
 		if err := d.Set("mount_ip_addresses", flattenNetAppVolumeMountIPAddresses(props.MountTargets)); err != nil {
 			return fmt.Errorf("setting `mount_ip_addresses`: %+v", err)
 		}
-
-		if props.DataProtection != nil && props.DataProtection.Replication != nil {
-			if err := d.Set("data_protection_replication", flattenNetAppVolumeDataProtectionReplication(props.DataProtection)); err != nil {
-				return fmt.Errorf("setting `data_protection_replication`: %+v", err)
-			}
+		if err := d.Set("data_protection_replication", flattenNetAppVolumeDataProtectionReplication(props.DataProtection)); err != nil {
+			return fmt.Errorf("setting `data_protection_replication`: %+v", err)
 		}
 	}
 

--- a/azurerm/internal/services/netapp/netapp_volume_resource.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource.go
@@ -390,7 +390,7 @@ func resourceNetAppVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("mount_ip_addresses", flattenNetAppVolumeMountIPAddresses(props.MountTargets)); err != nil {
 			return fmt.Errorf("setting `mount_ip_addresses`: %+v", err)
 		}
-		if props.DataProtection.Replication != nil {
+		if props.DataProtection != nil && props.DataProtection.Replication != nil {
 			if err := d.Set("data_protection_replication", flattenNetAppVolumeDataProtectionReplication(props.DataProtection)); err != nil {
 				return fmt.Errorf("setting `data_protection_replication`: %+v", err)
 			}
@@ -789,7 +789,11 @@ func flattenNetAppVolumeMountIPAddresses(input *[]netapp.MountTargetProperties) 
 }
 
 func flattenNetAppVolumeDataProtectionReplication(input *netapp.VolumePropertiesDataProtection) []interface{} {
-	if input == nil || input.Replication == nil || strings.ToLower(string(input.Replication.EndpointType)) != "dst" {
+	if input == nil || input.Replication == nil {
+		return []interface{}{}
+	}
+
+	if strings.ToLower(string(input.Replication.EndpointType)) == "" || strings.ToLower(string(input.Replication.EndpointType)) != "dst" {
 		return []interface{}{}
 	}
 

--- a/azurerm/internal/services/netapp/netapp_volume_resource.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource.go
@@ -390,10 +390,8 @@ func resourceNetAppVolumeRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("mount_ip_addresses", flattenNetAppVolumeMountIPAddresses(props.MountTargets)); err != nil {
 			return fmt.Errorf("setting `mount_ip_addresses`: %+v", err)
 		}
-		if props.DataProtection != nil && props.DataProtection.Replication != nil {
-			if err := d.Set("data_protection_replication", flattenNetAppVolumeDataProtectionReplication(props.DataProtection)); err != nil {
-				return fmt.Errorf("setting `data_protection_replication`: %+v", err)
-			}
+		if err := d.Set("data_protection_replication", flattenNetAppVolumeDataProtectionReplication(props.DataProtection)); err != nil {
+			return fmt.Errorf("setting `data_protection_replication`: %+v", err)
 		}
 	}
 


### PR DESCRIPTION
* Fixing null check for issue related to executing plan in state generated by previous azurerm version (e.g. 2.48.0) where data_protection_replication was not part of the schema yet.
* Improvement on null and endpoint checks on flattenNetAppVolumeDataProtectionReplication function.

Note: fixes #10773