### PR TITLE
Fix for Data source name and example usage

### DIFF
--- a/website/docs/d/key_vault_certificate_data.html.markdown
+++ b/website/docs/d/key_vault_certificate_data.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Gets data contained in an existing Key Vault Certificate.
 ---
 
-# Data Source: azurerm_key_vault_secret_data
+# Data Source: azurerm_key_vault_certificate_data
 
 Use this data source to access data stored in an existing Key Vault Certificate.
 
@@ -29,7 +29,7 @@ data "azurerm_key_vault_certificate_data" "example" {
 }
 
 output "example_pem" {
-  value = data.azurerm_key_vault_certificate.example.pem
+  value = data.azurerm_key_vault_certificate_data.example.pem
 }
 ```
 


### PR DESCRIPTION
Fix data source name to match to title 
Fix example usage in output 
From
data.azurerm_key_vault_certificate.example.pem
To
data.azurerm_key_vault_certificate_data.example.pem