### PR TITLE
Fix case sensitivity issue for axurerm_monitor_metric_alert import command

### DIFF
--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -169,5 +169,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Metric Alerts can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_monitor_metric_alert.main /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/microsoft.insights/metricalerts/example-metricalert
+terraform import azurerm_monitor_metric_alert.main /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/microsoft.insights/metricAlerts/example-metricalert
 ```


### PR DESCRIPTION
The import example resource id contained a lowercase letter for monitorAlerts. This is actually case-sensitive and terraform will attempt to force-replace the resource if it's incorrect.