### PR TITLE
add HPCC override, rename appplatorm override to springcloud

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -19,9 +19,6 @@ var runNightly = mapOf(
 
 // specifies a list of services which should be run with a custom test configuration
 var serviceTestConfigurationOverrides = mapOf(
-        // Spring Cloud only allows a max of 10 provisioned
-        "appplatform" to testConfiguration(5, defaultStartHour),
-
         // these tests all conflict with one another
         "authorization" to testConfiguration(1, defaultStartHour),
 
@@ -30,6 +27,9 @@ var serviceTestConfigurationOverrides = mapOf(
 
         // Data Lake has a low quota
         "datalake" to testConfiguration(2, defaultStartHour),
+
+        // HPC Cache has a 4 instance per subscription quota as of early 2021
+        "hpccache" to testConfiguration(3, defaultStartHour),
 
         // HSM has low quota and potentially slow recycle time
         "hsm" to testConfiguration(1, defaultStartHour),
@@ -43,5 +43,8 @@ var serviceTestConfigurationOverrides = mapOf(
 
         // SignalR only allows provisioning one "Free" instance at a time,
         // which is used in multiple tests
-        "signalr" to testConfiguration(1, defaultStartHour)
+        "signalr" to testConfiguration(1, defaultStartHour),
+
+        // Spring Cloud only allows a max of 10 provisioned
+        "springcloud" to testConfiguration(5, defaultStartHour)
 )


### PR DESCRIPTION
Upcoming quota limit for HPC Caches, throttling test parallelism to limit -1.

Updated override for `springcloud` that was renamed from `appplatform`
