### PR TITLE
`azurerm_cosmosdb_cassandra_table` - Fixes crash when setting non-existent `account_name`

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -220,7 +220,6 @@ func resourceCosmosDbCassandraTableRead(d *schema.ResourceData, meta interface{}
 
 	keyspaceId := parse.NewCassandraKeyspaceID(subscriptionId, id.ResourceGroup, id.DatabaseAccountName, id.CassandraKeyspaceName)
 
-	d.Set("account_name", id.DatabaseAccountName)
 	d.Set("cassandra_keyspace_id", keyspaceId.ID())
 	if props := resp.CassandraTableGetProperties; props != nil {
 		if res := props.Resource; res != nil {


### PR DESCRIPTION
Before
```
panic: Invalid address to set: []string{"account_name"}
```

After:
```
--- PASS: TestAccCosmosDbCassandraTable_basic (1056.44s)
```