### PR TITLE
`azurerm_function_app_host_keys` - support for `event_grid_extension_config_key`

### DIFF
--- a/azurerm/internal/services/web/function_app_host_keys_data_source.go
+++ b/azurerm/internal/services/web/function_app_host_keys_data_source.go
@@ -45,6 +45,12 @@ func dataSourceFunctionAppHostKeys() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+
+			"event_grid_extension_config_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -87,6 +93,12 @@ func dataSourceFunctionAppHostKeysRead(d *schema.ResourceData, meta interface{})
 		defaultFunctionKey = *v
 	}
 	d.Set("default_function_key", defaultFunctionKey)
+
+	eventGridExtensionConfigKey := ""
+	if v, ok := res.SystemKeys["eventgridextensionconfig_extension"]; ok {
+		eventGridExtensionConfigKey = *v
+	}
+	d.Set("event_grid_extension_config_key", eventGridExtensionConfigKey)
 
 	return nil
 }

--- a/azurerm/internal/services/web/function_app_host_keys_data_source_test.go
+++ b/azurerm/internal/services/web/function_app_host_keys_data_source_test.go
@@ -20,6 +20,7 @@ func TestAccFunctionAppHostKeysDataSource_basic(t *testing.T) {
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("primary_key").Exists(),
 				check.That(data.ResourceName).Key("default_function_key").Exists(),
+				check.That(data.ResourceName).Key("event_grid_extension_config_key").Exists(),
 			),
 		},
 	})

--- a/website/docs/d/function_app_host_keys.html.markdown
+++ b/website/docs/d/function_app_host_keys.html.markdown
@@ -36,3 +36,5 @@ The following arguments are supported:
 - `default_function_key` - Function App resource's default function key.
 
 - `master_key` - Function App resource's secret key
+
+- `event_grid_extension_config_key` - Function App resource's Event Grid Extension Config system key.


### PR DESCRIPTION
Fix #8385 

## Test Result

```shell
💤 make testacc TEST=./azurerm/internal/services/web TESTARGS='-run="TestAccFunctionAppHostKeysDataSource_basic"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/web -v -run="TestAccFunctionAppHostKeysDataSource_basic" -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/04 11:38:27 [DEBUG] not using binary driver name, it's no longer needed
2021/03/04 11:38:27 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccFunctionAppHostKeysDataSource_basic
=== PAUSE TestAccFunctionAppHostKeysDataSource_basic
=== CONT  TestAccFunctionAppHostKeysDataSource_basic
--- PASS: TestAccFunctionAppHostKeysDataSource_basic (296.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web 296.618s
```