### PR TITLE
`r/azurerm_data_factory_linked_service_azure_blob_storage`: Fixing managed identity implementation

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
@@ -57,7 +57,7 @@ func resourceDataFactoryLinkedServiceAzureBlobStorage() *schema.Resource {
 				Optional:     true,
 				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
-				ExactlyOneOf: []string{"connection_string", "sas_uri"},
+				ExactlyOneOf: []string{"connection_string", "sas_uri", "service_endpoint"},
 			},
 
 			"sas_uri": {
@@ -65,7 +65,7 @@ func resourceDataFactoryLinkedServiceAzureBlobStorage() *schema.Resource {
 				Optional:     true,
 				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
-				ExactlyOneOf: []string{"connection_string", "sas_uri"},
+				ExactlyOneOf: []string{"connection_string", "sas_uri", "service_endpoint"},
 			},
 
 			"description": {
@@ -87,6 +87,15 @@ func resourceDataFactoryLinkedServiceAzureBlobStorage() *schema.Resource {
 				ConflictsWith: []string{
 					"service_principal_id",
 				},
+			},
+
+			"service_endpoint": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"use_managed_identity"},
+				ExactlyOneOf: []string{"connection_string", "sas_uri", "service_endpoint"},
 			},
 
 			"service_principal_id": {
@@ -178,7 +187,9 @@ func resourceDataFactoryLinkedServiceBlobStorageCreateUpdate(d *schema.ResourceD
 	}
 
 	if d.Get("use_managed_identity").(bool) {
-		blobStorageProperties.Tenant = utils.String(d.Get("tenant_id").(string))
+		if v, ok := d.GetOk("service_endpoint"); ok {
+			blobStorageProperties.ServiceEndpoint = utils.String(v.(string))
+		}
 	} else {
 		secureString := datafactory.SecureString{
 			Value: utils.String(d.Get("service_principal_key").(string)),
@@ -276,6 +287,7 @@ func resourceDataFactoryLinkedServiceBlobStorageRead(d *schema.ResourceData, met
 			d.Set("service_principal_id", blobStorage.ServicePrincipalID)
 			d.Set("use_managed_identity", false)
 		} else {
+			d.Set("service_endpoint", blobStorage.ServiceEndpoint)
 			d.Set("use_managed_identity", true)
 		}
 	}

--- a/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_blob_storage.html.markdown
@@ -62,11 +62,13 @@ The following supported arguments are common across all Azure Data Factory Linke
 
 The following supported arguments are specific to Azure Blob Storage Linked Service:
 
-* `connection_string` - (Optional) The connection string. Conflicts with `sas_uri`.
+* `connection_string` - (Optional) The connection string. Conflicts with `sas_uri` and `service_endpoint`.
 
-* `sas_uri` - (Optional) The SAS URI. Conflicts with `connection_string`.
+* `sas_uri` - (Optional) The SAS URI. Conflicts with `connection_string` and `service_endpoint`.
 
-* `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure Blob Storage account. Incompatible with `service_principal_id` and `service_principal_key`
+* `service_endpoint` - (Optional) The Service Endpoint. Conflicts with `connection_string` and `sas_uri`. Required with `use_managed_identity`.
+
+* `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure Blob Storage account. Incompatible with `service_principal_id` and `service_principal_key`.
 
 * `service_principal_id` - (Optional) The service principal id in which to authenticate against the Azure Blob Storage account. Required if `service_principal_key` is set.
 


### PR DESCRIPTION
Unfortunately it seems that the initial [managed identity implementation](https://github.com/terraform-providers/terraform-provider-azurerm/pull/10551) is not implemented properly. It's still necessary to provide a connection string containing the storage account key, which should not be the case when using the managed identity of the Data Factory for storage authorization.

```
make acctests SERVICE='datafactory' TESTARGS='-run=TestAccDataFactoryLinkedServiceAzureBlobStorage_managed_id' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/datafactory -run=TestAccDataFactoryLinkedServiceAzureBlobStorage_managed_id -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/04 08:55:17 [DEBUG] not using binary driver name, it's no longer needed
2021/03/04 08:55:17 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataFactoryLinkedServiceAzureBlobStorage_managed_id
=== PAUSE TestAccDataFactoryLinkedServiceAzureBlobStorage_managed_id
=== CONT  TestAccDataFactoryLinkedServiceAzureBlobStorage_managed_id
--- PASS: TestAccDataFactoryLinkedServiceAzureBlobStorage_managed_id (169.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory 171.536s
```