### PR TITLE
Fix 8768 corrupt ip_restrictions in App Service and add tests

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1909,7 +1909,7 @@ func expandAppServiceIpRestriction(input interface{}) ([]web.IPSecurityRestricti
 		priority := restriction["priority"].(int)
 		action := restriction["action"].(string)
 
-		if vNetSubnetID != "" && ipAddress != "" && serviceTag != "" {
+		if (vNetSubnetID != "" && (ipAddress != "" || serviceTag != "")) || (ipAddress != "" && (vNetSubnetID != "" || serviceTag != "")) {
 			return nil, fmt.Errorf("only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` can be set for an IP restriction")
 		}
 

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1884,7 +1884,10 @@ func flattenAppServiceStorageAccounts(input map[string]*web.AzureStorageInfoValu
 func expandAppServiceIpRestriction(d *schema.ResourceData, schemaKey string) ([]web.IPSecurityRestriction, error) {
 	restrictions := make([]web.IPSecurityRestriction, 0)
 
-	count := d.Get(schemaKey + ".#").(int)
+	count, castOk := d.Get(schemaKey + ".#").(int)
+	if !castOk {
+		return nil, fmt.Errorf("failed to cast counter in IP restrictions to int")
+	}
 
 	for i := 0; i < count; i++ {
 		iterKey := fmt.Sprintf("%s.%d", schemaKey, i)
@@ -1934,7 +1937,8 @@ func expandAppServiceIpRestriction(d *schema.ResourceData, schemaKey string) ([]
 			}
 		}
 
-		if (vNetSubnetID != "" && (ipAddress != "" || serviceTag != "")) || (ipAddress != "" && (vNetSubnetID != "" || serviceTag != "")) {
+		moreThanOneSet := (vNetSubnetID != "" && (ipAddress != "" || serviceTag != "")) || (ipAddress != "" && (vNetSubnetID != "" || serviceTag != ""))
+		if moreThanOneSet {
 			return nil, fmt.Errorf("only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` can be set for an IP restriction")
 		}
 

--- a/azurerm/internal/services/web/app_service_resource.go
+++ b/azurerm/internal/services/web/app_service_resource.go
@@ -258,7 +258,7 @@ func resourceAppServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	httpsOnly := d.Get("https_only").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
-	siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
+	siteConfig, err := expandAppServiceSiteConfig(d)
 	if err != nil {
 		return fmt.Errorf("Error expanding `site_config` for App Service %q (Resource Group %q): %s", name, resourceGroup, err)
 	}
@@ -374,7 +374,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	httpsOnly := d.Get("https_only").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
-	siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
+	siteConfig, err := expandAppServiceSiteConfig(d)
 	if err != nil {
 		return fmt.Errorf("Error expanding `site_config` for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
 	}
@@ -408,7 +408,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("site_config") || hasSourceControl {
 		// update the main configuration
-		siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
+		siteConfig, err := expandAppServiceSiteConfig(d)
 		if err != nil {
 			return fmt.Errorf("Error expanding `site_config` for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
 		}

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -3035,7 +3035,7 @@ resource "azurerm_subnet" "test" {
   name                 = "acctestsubnet%d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.${count.index}.0/24"
+  address_prefixes     = ["10.0.${count.index}.0/24"]
 }
 
 resource "azurerm_app_service_plan" "test" {
@@ -3102,7 +3102,7 @@ resource "azurerm_subnet" "test" {
   name                 = "acctestsubnet%d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.${count.index}.0/24"
+  address_prefixes     = ["10.0.${count.index}.0/24"]
 }
 
 resource "azurerm_app_service_plan" "test" {

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -3032,7 +3032,7 @@ resource "azurerm_virtual_network" "test" {
 
 resource "azurerm_subnet" "test" {
   count                = 3
-  name                 = "acctestsubnet%d"
+  name                 = "acctestsubnet%d-${count.index}"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.${count.index}.0/24"]
@@ -3099,7 +3099,7 @@ resource "azurerm_virtual_network" "test" {
 
 resource "azurerm_subnet" "test" {
   count                = 2
-  name                 = "acctestsubnet%d"
+  name                 = "acctestsubnet%d-${count.index}"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.${count.index}.0/24"]

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -629,7 +629,6 @@ func TestAccAppService_removeMixedIpRestrictions(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
 	})
 }
 

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -3060,19 +3060,19 @@ resource "azurerm_app_service" "test" {
     ip_restriction {
       virtual_network_subnet_id = azurerm_subnet.test[0].id
     }
-	ip_restriction {
+    ip_restriction {
       virtual_network_subnet_id = azurerm_subnet.test[1].id
     }
-	ip_restriction {
+    ip_restriction {
       virtual_network_subnet_id = azurerm_subnet.test[2].id
     }
-	ip_restriction {
+    ip_restriction {
       ip_address = "10.1.0.1/32"
     }
-	ip_restriction {
+    ip_restriction {
       ip_address = "10.1.0.2/32"
     }
-	ip_restriction {
+    ip_restriction {
       ip_address = "10.1.0.3/32"
     }
   }
@@ -3127,16 +3127,16 @@ resource "azurerm_app_service" "test" {
     ip_restriction {
       virtual_network_subnet_id = azurerm_subnet.test[0].id
     }
-	ip_restriction {
+    ip_restriction {
       virtual_network_subnet_id = azurerm_subnet.test[1].id
     }
-	ip_restriction {
+    ip_restriction {
       ip_address = "10.1.0.1/32"
     }
-	ip_restriction {
+    ip_restriction {
       ip_address = "10.1.0.2/32"
     }
-	ip_restriction {
+    ip_restriction {
       ip_address = "10.1.0.3/32"
     }
   }

--- a/azurerm/internal/services/web/app_service_slot_resource.go
+++ b/azurerm/internal/services/web/app_service_slot_resource.go
@@ -193,7 +193,7 @@ func resourceAppServiceSlotCreateUpdate(d *schema.ResourceData, meta interface{}
 	t := d.Get("tags").(map[string]interface{})
 	affinity := d.Get("client_affinity_enabled").(bool)
 
-	siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
+	siteConfig, err := expandAppServiceSiteConfig(d)
 	if err != nil {
 		return fmt.Errorf("Error expanding `site_config` for App Service Slot %q (Resource Group %q): %s", slot, resourceGroup, err)
 	}
@@ -251,7 +251,7 @@ func resourceAppServiceSlotUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	appServicePlanId := d.Get("app_service_plan_id").(string)
-	siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
+	siteConfig, err := expandAppServiceSiteConfig(d)
 	if err != nil {
 		return fmt.Errorf("Error expanding `site_config` for App Service Slot %q (Resource Group %q): %s", id.SlotName, id.ResourceGroup, err)
 	}
@@ -285,7 +285,7 @@ func resourceAppServiceSlotUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if d.HasChange("site_config") {
 		// update the main configuration
-		siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
+		siteConfig, err := expandAppServiceSiteConfig(d)
 		if err != nil {
 			return fmt.Errorf("Error expanding `site_config` for App Service Slot %q (Resource Group %q): %s", id.SlotName, id.ResourceGroup, err)
 		}

--- a/azurerm/internal/services/web/function_app.go
+++ b/azurerm/internal/services/web/function_app.go
@@ -347,9 +347,8 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) (web.SiteConfig, error)
 		siteConfig.HTTP20Enabled = utils.Bool(v.(bool))
 	}
 
-	if v, ok := config["ip_restriction"]; ok {
-		ipSecurityRestrictions := v.(interface{})
-		restrictions, err := expandAppServiceIpRestriction(ipSecurityRestrictions)
+	if _, ok := config["ip_restriction"]; ok {
+		restrictions, err := expandAppServiceIpRestriction(d, "site_config.0.ip_restriction")
 		if err != nil {
 			return siteConfig, err
 		}
@@ -360,9 +359,8 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) (web.SiteConfig, error)
 		siteConfig.ScmIPSecurityRestrictionsUseMain = utils.Bool(v.(bool))
 	}
 
-	if v, ok := config["scm_ip_restriction"]; ok {
-		scmIPSecurityRestrictions := v.([]interface{})
-		scmRestrictions, err := expandAppServiceIpRestriction(scmIPSecurityRestrictions)
+	if _, ok := config["scm_ip_restriction"]; ok {
+		scmRestrictions, err := expandAppServiceIpRestriction(d, "site_config.0.scm_ip_restriction")
 		if err != nil {
 			return siteConfig, err
 		}


### PR DESCRIPTION
- Added acceptance tests to cover the error from #8768 (the second one didn't succeed at first)
- Fixed an if condition which should have alerted about the error
- Fixed the issue itself by setting the other two of subnet/IP/tag to empty when a restriction is being reused for a new subnet/IP/tag is used

The root cause was that IP restriction lines are being reused. When a reused one had a subnet and it would be changed to an IP, then the subnet was not removed. Thus, to know what has changed, I had to pass ResourceData down the tree.

Any kind of feedback is welcome, I don't regularly use Go.