### PR TITLE
`*_virtual_machine_scale_set`: Do not force recreation on `rolling_upgrade_policy`  and `health_probe_id` update.

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -602,6 +602,32 @@ func TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate(t *testi
 	})
 }
 
+func TestAccLinuxVirtualMachineScaleSet_otherHealthProbeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherHealthProbe(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"admin_password",
+		),
+		{
+			Config: r.otherHealthProbeUpdated(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"admin_password",
+		),
+	})
+}
+
 func (r LinuxVirtualMachineScaleSetResource) otherBootDiagnostics(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -2172,4 +2198,210 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   depends_on = [azurerm_lb_rule.test]
 }
 `, r.template(data), data.RandomInteger, max_batch_instance_percent, max_unhealthy_instance_percent, max_unhealthy_upgraded_instance_percent, pause_time_between_batches)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) otherHealthProbe(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+locals {
+  frontend_ip_configuration_name = "internal"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "actestvmsspip-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  allocation_method   = "Static"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "actestvmsslb-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "backend"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+}
+
+resource "azurerm_lb_probe" "test" {
+  name                = "ssh-running-probe"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+  port                = 22
+  protocol            = "Tcp"
+}
+
+resource "azurerm_lb_probe" "test2" {
+  name                = "ssh-running-probe2"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+  port                = 22
+  protocol            = "Tcp"
+}
+
+resource "azurerm_lb_rule" "test" {
+  resource_group_name            = azurerm_resource_group.test.name
+  loadbalancer_id                = azurerm_lb.test.id
+  probe_id                       = azurerm_lb_probe.test.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.test.id
+  frontend_ip_configuration_name = local.frontend_ip_configuration_name
+  name                           = "LBRule"
+  protocol                       = "Tcp"
+  frontend_port                  = 22
+  backend_port                   = 22
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 3
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  upgrade_mode    = "Automatic"
+  health_probe_id = azurerm_lb_probe.test.id
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name                                   = "internal"
+      subnet_id                              = azurerm_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
+      primary                                = true
+    }
+  }
+
+  depends_on = [azurerm_lb_rule.test]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) otherHealthProbeUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+locals {
+  frontend_ip_configuration_name = "internal"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "actestvmsspip-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  allocation_method   = "Static"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "actestvmsslb-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "backend"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+}
+
+resource "azurerm_lb_probe" "test" {
+  name                = "ssh-running-probe"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+  port                = 22
+  protocol            = "Tcp"
+}
+
+resource "azurerm_lb_probe" "test2" {
+  name                = "ssh-running-probe2"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+  port                = 22
+  protocol            = "Tcp"
+}
+
+resource "azurerm_lb_rule" "test" {
+  resource_group_name            = azurerm_resource_group.test.name
+  loadbalancer_id                = azurerm_lb.test.id
+  probe_id                       = azurerm_lb_probe.test2.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.test.id
+  frontend_ip_configuration_name = local.frontend_ip_configuration_name
+  name                           = "LBRule"
+  protocol                       = "Tcp"
+  frontend_port                  = 22
+  backend_port                   = 22
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 3
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  upgrade_mode    = "Automatic"
+  health_probe_id = azurerm_lb_probe.test2.id
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name                                   = "internal"
+      subnet_id                              = azurerm_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
+      primary                                = true
+    }
+  }
+
+  depends_on = [azurerm_lb_rule.test]
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -576,6 +576,32 @@ func TestAccLinuxVirtualMachineScaleSet_otherPlatformFaultDomainCount(t *testing
 	})
 }
 
+func TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+	r := LinuxVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherRollingUpgradePolicyUpdate(data, 10, 10, 10, "PT0S"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"admin_password",
+		),
+		{
+			Config: r.otherRollingUpgradePolicyUpdate(data, 20, 20, 20, "PT1S"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"admin_password",
+		),
+	})
+}
+
 func (r LinuxVirtualMachineScaleSetResource) otherBootDiagnostics(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -2044,4 +2070,104 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   platform_fault_domain_count = 3
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineScaleSetResource) otherRollingUpgradePolicyUpdate(data acceptance.TestData, max_batch_instance_percent, max_unhealthy_instance_percent, max_unhealthy_upgraded_instance_percent int, pause_time_between_batches string) string {
+	return fmt.Sprintf(`
+%s
+
+locals {
+  frontend_ip_configuration_name = "internal"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "actestvmsspip-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  allocation_method   = "Static"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "actestvmsslb-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "backend"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+}
+
+resource "azurerm_lb_probe" "test" {
+  name                = "ssh-running-probe"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+  port                = 22
+  protocol            = "Tcp"
+}
+
+resource "azurerm_lb_rule" "test" {
+  resource_group_name            = azurerm_resource_group.test.name
+  loadbalancer_id                = azurerm_lb.test.id
+  probe_id                       = azurerm_lb_probe.test.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.test.id
+  frontend_ip_configuration_name = local.frontend_ip_configuration_name
+  name                           = "LBRule"
+  protocol                       = "Tcp"
+  frontend_port                  = 22
+  backend_port                   = 22
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 3
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  upgrade_mode        = "Rolling"
+  health_probe_id     = azurerm_lb_probe.test.id
+
+  rolling_upgrade_policy {
+    max_batch_instance_percent              = %d
+    max_unhealthy_instance_percent          = %d
+    max_unhealthy_upgraded_instance_percent = %d
+    pause_time_between_batches              = "%s"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name                                   = "internal"
+      subnet_id                              = azurerm_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
+      primary                                = true
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, max_batch_instance_percent, max_unhealthy_instance_percent, max_unhealthy_upgraded_instance_percent, pause_time_between_batches)
 }

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -2168,6 +2168,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
       primary                                = true
     }
   }
+
+  depends_on = [azurerm_lb_rule.test]
 }
 `, r.template(data), data.RandomInteger, max_batch_instance_percent, max_unhealthy_instance_percent, max_unhealthy_upgraded_instance_percent, pause_time_between_batches)
 }

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_other_resource_test.go
@@ -2135,8 +2135,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 
   disable_password_authentication = false
 
-  upgrade_mode        = "Rolling"
-  health_probe_id     = azurerm_lb_probe.test.id
+  upgrade_mode    = "Rolling"
+  health_probe_id = azurerm_lb_probe.test.id
 
   rolling_upgrade_policy {
     max_batch_instance_percent              = %d

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -154,7 +154,6 @@ func resourceLinuxVirtualMachineScaleSet() *schema.Resource {
 			"health_probe_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: azure.ValidateResourceID,
 			},
 

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -1150,22 +1150,18 @@ func VirtualMachineScaleSetRollingUpgradePolicySchema() *schema.Schema {
 				"max_batch_instance_percent": {
 					Type:     schema.TypeInt,
 					Required: true,
-					ForceNew: true,
 				},
 				"max_unhealthy_instance_percent": {
 					Type:     schema.TypeInt,
 					Required: true,
-					ForceNew: true,
 				},
 				"max_unhealthy_upgraded_instance_percent": {
 					Type:     schema.TypeInt,
 					Required: true,
-					ForceNew: true,
 				},
 				"pause_time_between_batches": {
 					Type:         schema.TypeString,
 					Required:     true,
-					ForceNew:     true,
 					ValidateFunc: azValidate.ISO8601Duration,
 				},
 			},

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -682,6 +682,32 @@ func TestAccWindowsVirtualMachineScaleSet_otherPlatformFaultDomainCount(t *testi
 	})
 }
 
+func TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+	r := WindowsVirtualMachineScaleSetResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.otherRollingUpgradePolicyUpdate(data, 10, 10, 10, "PT0S"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"admin_password",
+		),
+		{
+			Config: r.otherRollingUpgradePolicyUpdate(data, 20, 20, 20, "PT1S"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"admin_password",
+		),
+	})
+}
+
 func (WindowsVirtualMachineScaleSetResource) otherAdditionalUnattendContent(data acceptance.TestData) string {
 	template := WindowsVirtualMachineScaleSetResource{}.template(data)
 	return fmt.Sprintf(`
@@ -2436,4 +2462,104 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   platform_fault_domain_count = 3
 }
 `, r.template(data))
+}
+
+func (r WindowsVirtualMachineScaleSetResource) otherRollingUpgradePolicyUpdate(data acceptance.TestData, max_batch_instance_percent, max_unhealthy_instance_percent, max_unhealthy_upgraded_instance_percent int, pause_time_between_batches string) string {
+	return fmt.Sprintf(`
+%s
+
+locals {
+  frontend_ip_configuration_name = "internal"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "actestvmsspip-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  allocation_method   = "Static"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "actestvmsslb-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "backend"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+}
+
+resource "azurerm_lb_probe" "test" {
+  name                = "running-probe"
+  resource_group_name = azurerm_resource_group.test.name
+  loadbalancer_id     = azurerm_lb.test.id
+  port                = 389
+  protocol            = "Tcp"
+}
+
+resource "azurerm_lb_rule" "test" {
+  resource_group_name            = azurerm_resource_group.test.name
+  loadbalancer_id                = azurerm_lb.test.id
+  probe_id                       = azurerm_lb_probe.test.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.test.id
+  frontend_ip_configuration_name = local.frontend_ip_configuration_name
+  name                           = "LBRule"
+  protocol                       = "Tcp"
+  frontend_port                  = 389
+  backend_port                   = 389
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 3
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  upgrade_mode        = "Rolling"
+  health_probe_id     = azurerm_lb_probe.test.id
+
+  rolling_upgrade_policy {
+    max_batch_instance_percent              = %d
+    max_unhealthy_instance_percent          = %d
+    max_unhealthy_upgraded_instance_percent = %d
+    pause_time_between_batches              = "%s"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name                                   = "internal"
+      subnet_id                              = azurerm_subnet.test.id
+      load_balancer_backend_address_pool_ids = [azurerm_lb_backend_address_pool.test.id]
+      primary                                = true
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, max_batch_instance_percent, max_unhealthy_instance_percent, max_unhealthy_upgraded_instance_percent, pause_time_between_batches)
 }

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -2528,7 +2528,7 @@ resource "azurerm_lb_probe" "test" {
   name                = "running-probe"
   resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
-  port                = 389
+  port                = 3389
   protocol            = "Tcp"
 }
 
@@ -2629,7 +2629,7 @@ resource "azurerm_lb_probe" "test" {
   name                = "ssh-running-probe"
   resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
-  port                = 22
+  port                = 3389
   protocol            = "Tcp"
 }
 
@@ -2637,7 +2637,7 @@ resource "azurerm_lb_probe" "test2" {
   name                = "ssh-running-probe2"
   resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
-  port                = 22
+  port                = 3389
   protocol            = "Tcp"
 }
 
@@ -2730,7 +2730,7 @@ resource "azurerm_lb_probe" "test" {
   name                = "ssh-running-probe"
   resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
-  port                = 22
+  port                = 3389
   protocol            = "Tcp"
 }
 
@@ -2738,7 +2738,7 @@ resource "azurerm_lb_probe" "test2" {
   name                = "ssh-running-probe2"
   resource_group_name = azurerm_resource_group.test.name
   loadbalancer_id     = azurerm_lb.test.id
-  port                = 22
+  port                = 3389
   protocol            = "Tcp"
 }
 

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -688,7 +688,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate(t *tes
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.otherRollingUpgradePolicyUpdate(data, 20, 20, 20, "PT0S"),
+			Config: r.otherRollingUpgradePolicyUpdate(data, 40, 40, 40, "PT0S"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -697,7 +697,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate(t *tes
 			"admin_password",
 		),
 		{
-			Config: r.otherRollingUpgradePolicyUpdate(data, 10, 10, 10, "PT1S"),
+			Config: r.otherRollingUpgradePolicyUpdate(data, 30, 100, 100, "PT1S"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -2527,8 +2527,8 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 
   disable_password_authentication = false
 
-  upgrade_mode        = "Rolling"
-  health_probe_id     = azurerm_lb_probe.test.id
+  upgrade_mode    = "Rolling"
+  health_probe_id = azurerm_lb_probe.test.id
 
   rolling_upgrade_policy {
     max_batch_instance_percent              = %d

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -721,6 +721,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherHealthProbeUpdate(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
+			"enable_automatic_updates",
 		),
 		{
 			Config: r.otherHealthProbeUpdated(data),
@@ -730,6 +731,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherHealthProbeUpdate(t *testing.T) {
 		},
 		data.ImportStep(
 			"admin_password",
+			"enable_automatic_updates",
 		),
 	})
 }

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -155,7 +155,6 @@ func resourceWindowsVirtualMachineScaleSet() *schema.Resource {
 			"health_probe_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				ValidateFunc: azure.ValidateResourceID,
 			},
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -442,13 +442,13 @@ A `public_ip_address` block supports the following:
 
 A `rolling_upgrade_policy` block supports the following:
 
-* `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. Changing this forces a new resource to be created.
+* `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
 
-* `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. Changing this forces a new resource to be created.
+* `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
 
-* `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. Changing this forces a new resource to be created.
+* `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.
 
-* `pause_time_between_batches` - (Required) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format. Changing this forces a new resource to be created.
+* `pause_time_between_batches` - (Required) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 
-* `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. Changing this forces a new resource to be created. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
+* `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
 
 * `identity` - (Optional) A `identity` block as defined below.
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -432,13 +432,13 @@ A `public_ip_address` block supports the following:
 
 A `rolling_upgrade_policy` block supports the following:
 
-* `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. Changing this forces a new resource to be created.
+* `max_batch_instance_percent` - (Required) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability.
 
-* `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. Changing this forces a new resource to be created.
+* `max_unhealthy_instance_percent` - (Required) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch.
 
-* `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. Changing this forces a new resource to be created.
+* `max_unhealthy_upgraded_instance_percent` - (Required) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts.
 
-* `pause_time_between_batches` - (Required) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format. Changing this forces a new resource to be created.
+* `pause_time_between_batches` - (Required) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -140,7 +140,7 @@ The following arguments are supported:
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 
-* `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. Changing this forces a new resource to be created. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
+* `health_probe_id` - (Optional) The ID of a Load Balancer Probe which should be used to determine the health of an instance. This is Required and can only be specified when `upgrade_mode` is set to `Automatic` or `Rolling`.
 
 * `identity` - (Optional) A `identity` block as defined below.
 


### PR DESCRIPTION
Fixes #10851

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azurerm_linux_virtual_machine_scale_set.example will be updated in-place
  ~ resource "azurerm_linux_virtual_machine_scale_set" "example" {
        id                                                = "/subscriptions/4e094144-afbc-420a-8d74-a4a0da618a3b/resourceGroups/vlad-test-resources/providers/Microsoft.Compute/virtualMachineScaleSets/vlad-test-vmss"
        name                                              = "vlad-test-vmss"
        tags                                              = {}
        # (23 unchanged attributes hidden)




      ~ rolling_upgrade_policy {
          ~ max_batch_instance_percent              = 30 -> 20
          ~ max_unhealthy_instance_percent          = 30 -> 20
          ~ max_unhealthy_upgraded_instance_percent = 30 -> 20
          ~ pause_time_between_batches              = "PT0S" -> "PT1S"
        }

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Warning: "resource_group_name": [DEPRECATED] This field is no longer used and will be removed in the next major version of the Azure Provider

  on vmss_test.tf line 42, in resource "azurerm_lb_backend_address_pool" "example":
  42: resource "azurerm_lb_backend_address_pool" "example" {


Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_linux_virtual_machine_scale_set.example: Modifying... [id=/subscriptions/4e094144-afbc-420a-8d74-a4a0da618a3b/resourceGroups/vlad-test-resources/providers/Microsoft.Compute/virtualMachineScaleSets/vlad-test-vmss]
azurerm_linux_virtual_machine_scale_set.example: Still modifying... [id=/subscriptions/4e094144-afbc-420a-8d74-...virtualMachineScaleSets/vlad-test-vmss, 10s elapsed]
[...]
azurerm_linux_virtual_machine_scale_set.example: Still modifying... [id=/subscriptions/4e094144-afbc-420a-8d74-...virtualMachineScaleSets/vlad-test-vmss, 3m50s elapsed]
azurerm_linux_virtual_machine_scale_set.example: Modifications complete after 3m51s [id=/subscriptions/4e094144-afbc-420a-8d74-a4a0da618a3b/resourceGroups/vlad-test-resources/providers/Microsoft.Compute/virtualMachineScaleSets/vlad-test-vmss]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```