### PR TITLE
`azurerm_postgresql_server` - fix for `TestAccPostgreSQLServer_updated` test case

### DIFF
--- a/azurerm/internal/services/postgres/postgresql_server_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource.go
@@ -1048,6 +1048,10 @@ func postgreSqlStateRefreshFunc(ctx context.Context, client *postgresql.ServersC
 			return res, string(postgresql.ServerStateInaccessible), nil
 		}
 
-		return res, string(res.ServerProperties.UserVisibleState), nil
+		if res.ServerProperties != nil && res.ServerProperties.UserVisibleState != "" {
+			return res, string(res.ServerProperties.UserVisibleState), nil
+		}
+
+		return res, string(postgresql.ServerStateInaccessible), nil
 	}
 }

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -179,7 +179,7 @@ func TestAccPostgreSQLServer_complete(t *testing.T) {
 	r := PostgreSQLServerResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.complete(data, "9.6"),
+			Config: r.complete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -228,7 +228,7 @@ func TestAccPostgreSQLServer_updated(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.complete(data, "9.6"),
+			Config: r.complete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -242,7 +242,7 @@ func TestAccPostgreSQLServer_updated(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.complete(data, "9.6"),
+			Config: r.complete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -263,7 +263,7 @@ func TestAccPostgreSQLServer_completeDeprecatedUpdate(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.complete(data, "9.6"),
+			Config: r.complete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -625,7 +625,7 @@ resource "azurerm_postgresql_server" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, version)
 }
 
-func (PostgreSQLServerResource) complete(data acceptance.TestData, version string) string {
+func (PostgreSQLServerResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -645,7 +645,7 @@ resource "azurerm_postgresql_server" "test" {
   administrator_login_password = "H@Sh1CoR3!updated"
 
   sku_name   = "GP_Gen5_4"
-  version    = "%[3]s"
+  version    = "9.6"
   storage_mb = 640000
 
   backup_retention_days        = 7
@@ -666,7 +666,7 @@ resource "azurerm_postgresql_server" "test" {
     retention_days = 7
   }
 }
-`, data.RandomInteger, data.Locations.Primary, version)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (PostgreSQLServerResource) complete2(data acceptance.TestData, version string) string {

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -242,7 +242,7 @@ func TestAccPostgreSQLServer_updated(t *testing.T) {
 		},
 		data.ImportStep("administrator_login_password"),
 		{
-			Config: r.gp(data, "9.6"),
+			Config: r.complete(data, "9.6"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -707,7 +707,6 @@ resource "azurerm_postgresql_server" "test" {
   infrastructure_encryption_enabled = false
   public_network_access_enabled     = true
   ssl_enforcement_enabled           = false
-  ssl_minimal_tls_version_enforced  = "TLS1_1"
 
   threat_detection_policy {
     enabled              = true
@@ -716,9 +715,6 @@ resource "azurerm_postgresql_server" "test" {
     email_addresses      = ["kt@example.com"]
 
     retention_days = 7
-
-    storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
-    storage_account_access_key = azurerm_storage_account.test.primary_access_key
   }
 }
 `, data.RandomInteger, data.Locations.Primary, version)


### PR DESCRIPTION
Fix `TestAccPostgreSQLServer_updated` test case. The configuration was bad for this test case, so I fixed the issues and the test passes now.

Issues with Test Case:
* The `complete2` test configuration disabled `ssl_enforcement_enabled` but still sent the `ssl_minimal_tls_version_enforced` field causing the error:
```
Code="InvalidParameterValue" Message="Invalid value given for parameter 'MinimalTlsVersion'. Specify a valid parameter value."
```

* The `complete2` test configuration attempts to assign the `storage_endpoint` and `storage_account_access_key` fields after the initial creation of the `threat_detection_policy` causing the error:
```
    TestAccPostgreSQLServer_updated: testing_new_import_state.go:249: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) (len=1) {
         (string) (len=52) "threat_detection_policy.0.storage_account_access_key": (string) ""
        }


        (map[string]string) (len=1) {
         (string) (len=52) "threat_detection_policy.0.storage_account_access_key": (string) (len=88) "9eRwWdJ+XyIlp5lXmiBLPm1b7j1cLvyje/Lx4b9AvXDNP4xC/3EXux0wwaUYebrZ7Exg0+7BuAQSgRJdLzCCJw=="
        }
```

* The final step of the `TestAccPostgreSQLServer_updated` test case attempts to revert to the original `gp` sku which has a `storage_profile` defined with a `storage_mb` value of `51200` MB, however the configuration `complete` scales the `storage_profile`'s `storage_mb` up to `640000` MB. So when the test case attempt to revert to the original `gp` sku you recieve the below error. Due to this constraint the last test step can only be revert to the previous sku `complete` which has the same `storage_profile` configuration:
```
Code="UnsupportedUpdate" Message="Cannot update StorageMB Downscaling for server"
```
