### PR TITLE
azurerm_key_vault_certificate: Support curve property for EC keys

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -68,6 +68,10 @@ func dataSourceKeyVaultCertificate() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"curve": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"exportable": {
 										Type:     schema.TypeBool,
 										Computed: true,
@@ -323,9 +327,10 @@ func flattenKeyVaultCertificatePolicyForDataSource(input *keyvault.CertificatePo
 
 	// key properties
 	if props := input.KeyProperties; props != nil {
+		var curve, keyType string
 		var exportable, reuseKey bool
 		var keySize int
-		var keyType string
+		curve = string(props.Curve)
 		if props.Exportable != nil {
 			exportable = *props.Exportable
 		}
@@ -341,6 +346,7 @@ func flattenKeyVaultCertificatePolicyForDataSource(input *keyvault.CertificatePo
 
 		policy["key_properties"] = []interface{}{
 			map[string]interface{}{
+				"curve":      curve,
 				"exportable": exportable,
 				"key_size":   keySize,
 				"key_type":   keyType,

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_source_test.go
@@ -54,6 +54,32 @@ func TestAccDataSourceKeyVaultCertificate_generated(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceKeyVaultCertificate_generatedEllipticCurve(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_certificate", "test")
+	r := KeyVaultCertificateDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.generatedEllipticCurve(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("certificate_data").Exists(),
+				check.That(data.ResourceName).Key("certificate_data_base64").Exists(),
+				check.That(data.ResourceName).Key("certificate_policy.0.issuer_parameters.0.name").HasValue("Self"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.curve").HasValue("P-256K"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.exportable").HasValue("true"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("256"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("EC"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.reuse_key").HasValue("true"),
+				check.That(data.ResourceName).Key("certificate_policy.0.lifetime_action.0.action.0.action_type").HasValue("AutoRenew"),
+				check.That(data.ResourceName).Key("certificate_policy.0.lifetime_action.0.trigger.0.days_before_expiry").HasValue("30"),
+				check.That(data.ResourceName).Key("certificate_policy.0.secret_properties.0.content_type").HasValue("application/x-pkcs12"),
+				check.That(data.ResourceName).Key("certificate_policy.0.x509_certificate_properties.0.subject").HasValue("CN=hello-world"),
+				check.That(data.ResourceName).Key("certificate_policy.0.x509_certificate_properties.0.validity_in_months").HasValue("12"),
+			),
+		},
+	})
+}
+
 func (KeyVaultCertificateDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -74,4 +100,15 @@ data "azurerm_key_vault_certificate" "test" {
   key_vault_id = azurerm_key_vault.test.id
 }
 `, KeyVaultCertificateResource{}.basicGenerate(data))
+}
+
+func (KeyVaultCertificateDataSource) generatedEllipticCurve(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_certificate" "test" {
+  name         = azurerm_key_vault_certificate.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+`, KeyVaultCertificateResource{}.basicGenerateEllipticCurve(data))
 }

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
@@ -148,7 +149,7 @@ func resourceKeyVaultCertificate() *schema.Resource {
 											string(keyvault.RSA),
 											string(keyvault.RSAHSM),
 											string(keyvault.Oct),
-										}, false),
+										}, true),
 									},
 									"reuse_key": {
 										Type:     schema.TypeBool,

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -184,6 +184,29 @@ func TestAccKeyVaultCertificate_basicGenerateTags(t *testing.T) {
 	})
 }
 
+func TestAccKeyVaultCertificate_basicGenerateEllipticCurve(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
+	r := KeyVaultCertificateResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basicGenerateEllipticCurve(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("secret_id").Exists(),
+				check.That(data.ResourceName).Key("certificate_data").Exists(),
+				check.That(data.ResourceName).Key("certificate_data_base64").Exists(),
+				check.That(data.ResourceName).Key("thumbprint").Exists(),
+				check.That(data.ResourceName).Key("certificate_attribute.0.created").Exists(),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.curve").HasValue("P-256K"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("EC"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("256"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKeyVaultCertificate_basicExtendedKeyUsage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
 	r := KeyVaultCertificateResource{}
@@ -628,6 +651,58 @@ resource "azurerm_key_vault_certificate" "test" {
 
   tags = {
     "hello" = "world"
+  }
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r KeyVaultCertificateResource) basicGenerateEllipticCurve(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_certificate" "test" {
+  name         = "acctestcert%s"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      curve      = "P-256K"
+      exportable = true
+      key_size   = 256
+      key_type   = "EC"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "digitalSignature",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
   }
 }
 `, r.template(data), data.RandomString)

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -207,6 +207,29 @@ func TestAccKeyVaultCertificate_basicGenerateEllipticCurve(t *testing.T) {
 	})
 }
 
+func TestAccKeyVaultCertificate_basicGenerateEllipticCurveAutoKeySize(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
+	r := KeyVaultCertificateResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basicGenerateEllipticCurveAutoKeySize(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("secret_id").Exists(),
+				check.That(data.ResourceName).Key("certificate_data").Exists(),
+				check.That(data.ResourceName).Key("certificate_data_base64").Exists(),
+				check.That(data.ResourceName).Key("thumbprint").Exists(),
+				check.That(data.ResourceName).Key("certificate_attribute.0.created").Exists(),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.curve").HasValue("P-521"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("EC"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("521"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKeyVaultCertificate_basicExtendedKeyUsage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
 	r := KeyVaultCertificateResource{}
@@ -677,6 +700,57 @@ resource "azurerm_key_vault_certificate" "test" {
       curve      = "P-256K"
       exportable = true
       key_size   = 256
+      key_type   = "EC"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "digitalSignature",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r KeyVaultCertificateResource) basicGenerateEllipticCurveAutoKeySize(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_certificate" "test" {
+  name         = "acctestcert%s"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      curve      = "P-521"
+      exportable = true
       key_type   = "EC"
       reuse_key  = true
     }

--- a/azurerm/internal/services/keyvault/key_vault_key_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource.go
@@ -102,9 +102,9 @@ func resourceKeyVaultKey() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(keyvault.P256),
+					string(keyvault.P256K),
 					string(keyvault.P384),
 					string(keyvault.P521),
-					string(keyvault.P256K),
 				}, false),
 				// TODO: the curve name should probably be mandatory for EC in the future,
 				// but handle the diff so that we don't break existing configurations and

--- a/azurerm/internal/services/keyvault/key_vault_key_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
@@ -100,11 +101,15 @@ func resourceKeyVaultKey() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return old == "SECP256K1" && new == string(keyvault.P256K)
+				},
 				ValidateFunc: validation.StringInSlice([]string{
 					string(keyvault.P256),
 					string(keyvault.P256K),
 					string(keyvault.P384),
 					string(keyvault.P521),
+					"SECP256K1", // TODO: remove this in v3.0 as it was renamed to keyvault.P256K
 				}, false),
 				// TODO: the curve name should probably be mandatory for EC in the future,
 				// but handle the diff so that we don't break existing configurations and

--- a/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource_test.go
@@ -82,6 +82,21 @@ func TestAccKeyVaultKey_curveEC(t *testing.T) {
 	})
 }
 
+func TestAccKeyVaultKey_curveECDeprecated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
+	r := KeyVaultKeyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.curveECDeprecated(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKeyVaultKey_basicRSA(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
 	r := KeyVaultKeyResource{}
@@ -566,6 +581,28 @@ resource "azurerm_key_vault_key" "test" {
   key_vault_id = azurerm_key_vault.test.id
   key_type     = "EC"
   curve        = "P-521"
+
+  key_opts = [
+    "sign",
+    "verify",
+  ]
+}
+`, r.templateStandard(data), data.RandomString)
+}
+
+func (r KeyVaultKeyResource) curveECDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "EC"
+  curve        = "SECP256K1"
 
   key_opts = [
     "sign",

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault/CHANGELOG.md~merged
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault/CHANGELOG.md~merged
@@ -1,0 +1,2 @@
+# Change History
+

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault/CHANGELOG.md~merged
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault/CHANGELOG.md~merged
@@ -1,2 +1,0 @@
-# Change History
-

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -270,9 +270,10 @@ The following arguments are supported:
 
 `key_properties` supports the following:
 
-* `exportable` - (Required) Is this Certificate Exportable? Changing this forces a new resource to be created.
-* `key_size` - (Required) The size of the Key used in the Certificate. Possible values include `2048`, `3072`, and `4096`. Changing this forces a new resource to be created.
-* `key_type` - (Required) Specifies the Type of Key, such as `RSA`. Changing this forces a new resource to be created.
+* `curve` - (Optional) Specifies the curve to use when creating an `EC` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field will be required in a future release if `key_type` is `EC` or `EC-HSM`. Changing this forces a new resource to be created.
+* `exportable` - (Required) Is this certificate exportable? Changing this forces a new resource to be created.
+* `key_size` - (Required) The size of the key used in the certificate. Possible values include `2048`, `3072`, and `4096` for `RSA` keys, or `256`, `384`, and `521` for `EC` keys. Changing this forces a new resource to be created.
+* `key_type` - (Required) Specifies the type of key, such as `RSA` or `EC`. Changing this forces a new resource to be created.
 * `reuse_key` - (Required) Is the key reusable? Changing this forces a new resource to be created.
 
 `lifetime_action` supports the following:

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `key_size` - (Optional) Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA` or `RSA-HSM`. Changing this forces a new resource to be created.
 
-* `curve` - (Optional) Specifies the curve to use when creating an `EC` key. Possible values are `P-256`, `P-384`, `P-521`, and `SECP256K1`. This field will be required in a future release if `key_type` is `EC` or `EC-HSM`. The API will default to `P-256` if nothing is specified. Changing this forces a new resource to be created.
+* `curve` - (Optional) Specifies the curve to use when creating an `EC` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field will be required in a future release if `key_type` is `EC` or `EC-HSM`. The API will default to `P-256` if nothing is specified. Changing this forces a new resource to be created.
 
 * `key_opts` - (Required) A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case sensitive.
 


### PR DESCRIPTION
The `azurerm_key_vault_certificate` resource allows for ECDSA certificates with a key type of `EC`, but unlike `azurerm_key_vault_key` it doesn't let the user specify which elliptic curve to use.

The [v7.1 Create Certificate API](https://docs.microsoft.com/en-us/rest/api/keyvault/createcertificate/createcertificate) adds a `crv` attribute to the [KeyProperties](https://docs.microsoft.com/en-us/rest/api/keyvault/createcertificate/createcertificate#keyproperties) type, so this PR updates the `keyvault` service to the v7.1 API and adds `curve` to the allowed key properties, matching the behaviour of `azurerm_key_vault_key` wherever possible.

All the `keyvault` acceptance tests pass (including new coverage for `curve`), but I'm raising this as a draft PR to get feedback on some implications of the change.