### PR TITLE
Update azurerm_subscription Docs Page 

### DIFF
--- a/website/docs/r/subscription.html.markdown
+++ b/website/docs/r/subscription.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the Subscription.
+* `id` - The Resource ID of the Alias.
 
 * `tenant_id` - The ID of the Tenant to which the subscription belongs.
 


### PR DESCRIPTION
This PR updates the output explanation for ID, as currently it states the subscription ID is exported but actually the ARM resource ID for the alias is exported.