### PR TITLE
Doc Fix: `azurerm_sql_virtual_network_rule` - `name` requirements correctly reflected in docs

### DIFF
--- a/website/docs/r/sql_virtual_network_rule.html.markdown
+++ b/website/docs/r/sql_virtual_network_rule.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the SQL virtual network rule. Changing this forces a new resource to be created. Cannot be empty and must only contain alphanumeric characters and hyphens. Cannot start with a number, and cannot start or end with a hyphen.
 
-~> **NOTE:** `name` must be between 1-128 characters long and must satisfy all of the requirements below:
+~> **NOTE:** `name` must be between 1-64 characters long and must satisfy all of the requirements below:
 1. Contains only alphanumeric and hyphen characters
 2. Cannot start with a number or hyphen
 3. Cannot end with a hyphen


### PR DESCRIPTION
Fixes #10878 