### PR TITLE
Doc Fix: `azurerm_eventgrid_system_topic_event_subscription` - Fixing incorrect resource name in example

### DIFF
--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_storage_queue" "example" {
   storage_account_name = azurerm_storage_account.example.name
 }
 
-resource "azurerm_system_topic" "example" {
+resource "azurerm_eventgrid_system_topic" "example" {
   name                   = "example-system-topic"
   location               = "Global"
   resource_group_name    = azurerm_resource_group.example.name


### PR DESCRIPTION
Fixes #10871