### PR TITLE
Implementation of Databricks Linked Service for Data Factory

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
@@ -1,0 +1,621 @@
+package datafactory
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	databricksValidator "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/databricks/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDataFactoryLinkedServiceAzureDatabricks() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDataFactoryLinkedServiceDatabricksCreateUpdate,
+		Read:   resourceDataFactoryLinkedServiceDatabricksRead,
+		Update: resourceDataFactoryLinkedServiceDatabricksCreateUpdate,
+		Delete: resourceDataFactoryLinkedServiceDatabricksDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAzureRMDataFactoryLinkedServiceDatasetName,
+			},
+
+			"data_factory_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataFactoryName(),
+			},
+
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			//Authentication types
+			"authentication_msi": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"workspaceResourceId": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: databricksValidator.WorkspaceID,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"authentication_access_token", "authentication_msi", "authentication_key_vault_password"},
+			},
+
+			"authentication_access_token": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_token": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"authentication_access_token", "authentication_msi", "authentication_key_vault_password"},
+			},
+
+			"authentication_key_vault_password": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"linked_service_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"secret_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"authentication_access_token", "authentication_msi", "authentication_key_vault_password"},
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"adb_domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			//Cluster types [existing cluster, new cluster, interactive pools]
+			"existing_cluster_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"existing_cluster_id", "new_cluster_config", "instance_pool"},
+			},
+
+			"new_cluster_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"custom_tags": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						//Consider changing this to min and adding an optional max since autoscaling uses the format min:max (e.g. 1:10)
+						"number_of_workers": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "1",
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"cluster_version": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"spark_config": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"spark_environment_variables": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						"log_destination": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"init_scripts": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						"driver_node_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"existing_cluster_id", "new_cluster_config", "instance_pool"},
+			},
+
+			"instance_pool": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						//Consider changing this to min and adding an optional max since autoscaling uses the format min:max (e.g. 1:10)
+						"number_of_workers": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "1",
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"instance_pool_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"cluster_version": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"existing_cluster_id", "new_cluster_config", "instance_pool"},
+			},
+
+			"integration_runtime_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"annotations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"additional_properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceDataFactoryLinkedServiceDatabricksCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	dataFactoryName := d.Get("data_factory_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_data_factory_linked_service_data_lake_storage_gen2", *existing.ID)
+		}
+	}
+
+	var DatabricksProperties *datafactory.AzureDatabricksLinkedServiceTypeProperties
+
+	// Check if the MSI authentication block is set
+	msiAuth := d.Get("authentication_msi").(map[string]interface{})
+	accessTokenAuth := d.Get("authentication_access_token").(map[string]interface{})
+	accessTokenKeyVaultAuth := d.Get("authentication_key_vault_password").([]interface{})
+
+	if len(msiAuth) > 0 {
+		//MSI Auth map has data
+		workspaceResourceID := msiAuth["workspaceResourceId"].(string)
+
+		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+			Authentication:      "MSI",
+			WorkspaceResourceID: workspaceResourceID,
+		}
+	} else if len(accessTokenAuth) > 0 {
+		//Setup authentication using access tokens
+
+		accessTokenAsSecureString := datafactory.SecureString{
+			Value: utils.String(accessTokenAuth["access_token"].(string)),
+			Type:  datafactory.TypeSecureString,
+		}
+
+		//Assign the access token in the properties block
+		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+			AccessToken: &accessTokenAsSecureString,
+		}
+	} else {
+		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+			AccessToken: expandAzureKeyVaultPassword(accessTokenKeyVaultAuth),
+		}
+	}
+
+	//Set the other type properties
+	//Domain
+	DatabricksProperties.Domain = d.Get("adb_domain").(string)
+
+	//Check if the
+	if v, ok := d.GetOk("existing_cluster_id"); ok {
+		DatabricksProperties.ExistingClusterID = v.(string)
+	}
+
+	if v, ok := d.GetOk("instance_pool"); ok {
+
+		instancePoolMap := v.(map[string]interface{})
+		DatabricksProperties.InstancePoolID = instancePoolMap["instance_pool_id"]
+
+		//Process the instance pool identifier
+		if data := instancePoolMap["instance_pool_id"]; data != nil {
+			DatabricksProperties.InstancePoolID = data
+		} else {
+			// Throw an error
+		}
+
+		//Process the cluster version
+		if data := instancePoolMap["cluster_version"]; data != nil {
+			DatabricksProperties.NewClusterVersion = data
+		} else {
+			// Throw an error
+		}
+
+		//Process the number of workers
+		if data := instancePoolMap["number_of_workers"]; data != nil {
+			DatabricksProperties.NewClusterNumOfWorker = data
+		} else {
+			// Throw an error
+		}
+	} else {
+		//Process assuming it's a new cluster config
+		if v, ok := d.GetOk("new_cluster_config"); ok {
+			newClusterMap := v.([]interface{})[0].(map[string]interface{})
+
+			//Process the cluster version
+			if data := newClusterMap["cluster_version"]; data != nil {
+				DatabricksProperties.NewClusterVersion = data
+			} else {
+				// Throw an error
+			}
+
+			//Process the number of workers
+			if data := newClusterMap["number_of_workers"]; data != nil {
+				DatabricksProperties.NewClusterNumOfWorker = data
+			} else {
+				// Throw an error
+			}
+
+			//Process the node type
+			if data := newClusterMap["node_type"]; data != nil {
+				DatabricksProperties.NewClusterNodeType = data
+			} else {
+				// Throw an error
+			}
+
+			if data := newClusterMap["driver_node_type"]; data != nil {
+				DatabricksProperties.NewClusterDriverNodeType = data
+			}
+
+			if data := newClusterMap["log_destination"]; data != nil {
+				DatabricksProperties.NewClusterLogDestination = data
+			}
+
+			if sparkConfig := newClusterMap["spark_config"].(map[string]interface{}); len(sparkConfig) > 0 {
+				DatabricksProperties.NewClusterSparkConf = sparkConfig
+			}
+
+			// sparkConfig := newClusterMap["spark_config"].(map[string]interface{})
+			// if sparkConfig := expandKeyValuePairs(sparkConfigRaw); len(sparkConfig) > 0 {
+			// 	DatabricksProperties.NewClusterSparkConf = sparkConfig
+			// }
+
+			if sparkEnvVars := newClusterMap["spark_environment_variables"].(map[string]interface{}); len(sparkEnvVars) > 0 {
+				DatabricksProperties.NewClusterSparkEnvVars = sparkEnvVars
+			}
+
+			if customTags := newClusterMap["custom_tags"].(map[string]interface{}); len(customTags) > 0 {
+				DatabricksProperties.NewClusterCustomTags = customTags
+			}
+
+			initScripts := newClusterMap["init_scripts"]
+			DatabricksProperties.NewClusterInitScripts = &initScripts
+		}
+
+	}
+
+	//EncryptedCredential
+	//POlicy ID
+
+	DatabricksLinkedService := &datafactory.AzureDatabricksLinkedService{
+		Description: utils.String(d.Get("description").(string)),
+		AzureDatabricksLinkedServiceTypeProperties: DatabricksProperties,
+		Type: datafactory.TypeAzureDatabricks,
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		DatabricksLinkedService.Parameters = expandDataFactoryParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("integration_runtime_name"); ok {
+		DatabricksLinkedService.ConnectVia = expandDataFactoryLinkedServiceIntegrationRuntime(v.(string))
+	}
+
+	if v, ok := d.GetOk("additional_properties"); ok {
+		DatabricksLinkedService.AdditionalProperties = v.(map[string]interface{})
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		annotations := v.([]interface{})
+		DatabricksLinkedService.Annotations = &annotations
+	}
+
+	linkedService := datafactory.LinkedServiceResource{
+		Properties: DatabricksLinkedService,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, dataFactoryName, name, linkedService, ""); err != nil {
+		return fmt.Errorf("Error creating/updating Data Factory Linked Service Azure Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceDataFactoryLinkedServiceDatabricksRead(d, meta)
+}
+
+func resourceDataFactoryLinkedServiceDatabricksRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("data_factory_name", dataFactoryName)
+
+	Databricks, ok := resp.Properties.AsAzureDatabricksLinkedService()
+
+	if !ok {
+		return fmt.Errorf("Error classifiying Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", name, dataFactoryName, resourceGroup, datafactory.TypeAzureDatabricks, *resp.Type)
+	}
+
+	//Check the properties and verify is authentication is set to MSI
+	if props := Databricks.AzureDatabricksLinkedServiceTypeProperties; props != nil {
+		if props.Authentication != nil && props.Authentication == "MSI" {
+
+			authenticationMsi := make(map[string]interface{})
+			authenticationMsi["workspaceResourceId"] = props.WorkspaceResourceID
+			d.Set("authentication_msi", authenticationMsi)
+
+		} else if props.AccessToken != nil {
+			//Check the data type of the access token so we know how to process it.
+
+			if accessToken := props.AccessToken; accessToken != nil {
+				if keyVaultPassword, ok := accessToken.AsAzureKeyVaultSecretReference(); ok {
+					if err := d.Set("authentication_key_vault_password", flattenAzureKeyVaultPassword(keyVaultPassword)); err != nil {
+						return fmt.Errorf("setting `authentication_key_vault_password`: %+v", err)
+					}
+				}
+			}
+		}
+
+		//Process the domain
+		if props.Domain != nil {
+			d.Set("adb_domain", props.Domain)
+		}
+
+		//Process the cluster information
+		if props.ExistingClusterID != nil {
+			d.Set("existing_cluster_id", props.ExistingClusterID)
+
+		} else if id := props.InstancePoolID; id != nil {
+			//Process the values for instance pool configuration
+			numOfWorkers := props.NewClusterNumOfWorker
+			clusterVersion := props.NewClusterVersion
+
+			instancePoolMap := map[string]interface{}{
+				"instance_pool_id":  id,
+				"number_of_workers": numOfWorkers,
+				"cluster_version":   clusterVersion,
+			}
+			d.Set("instance_pool", instancePoolMap)
+
+		} else {
+
+			//Process assuming it's a new cluster config
+			numOfWorkers := props.NewClusterNumOfWorker
+			clusterVersion := props.NewClusterVersion
+			nodeType := props.NewClusterNodeType
+
+			newClusterMap := map[string]interface{}{
+				"number_of_workers": numOfWorkers,
+				"cluster_version":   clusterVersion,
+				"node_type":         nodeType,
+			}
+
+			//Retrieve all the optional arguments
+			if data := props.NewClusterDriverNodeType; data != nil {
+				newClusterMap["driver_node_type"] = data
+			}
+
+			if data := props.NewClusterLogDestination; data != nil {
+				newClusterMap["log_destination"] = data
+			}
+
+			if data := props.NewClusterSparkConf; data != nil {
+				newClusterMap["spark_config"] = data
+			}
+
+			if data := props.NewClusterCustomTags; data != nil {
+				newClusterMap["custom_tags"] = data
+			}
+
+			if data := props.NewClusterSparkEnvVars; data != nil {
+				newClusterMap["spark_environment_variables"] = data
+			}
+
+			if data := props.NewClusterInitScripts; data != nil {
+				newClusterMap["init_scripts"] = data
+			}
+
+			//Set the ResourceData with the map
+			newClusterArray := []interface{}{newClusterMap}
+
+			d.Set("new_cluster_config", newClusterArray)
+		}
+	}
+
+	d.Set("additional_properties", Databricks.AdditionalProperties)
+
+	if Databricks.Description != nil {
+		d.Set("description", Databricks.Description)
+	}
+
+	annotations := flattenDataFactoryAnnotations(Databricks.Annotations)
+	if err := d.Set("annotations", annotations); err != nil {
+		return fmt.Errorf("Error setting `annotations`: %+v", err)
+	}
+
+	parameters := flattenDataFactoryParameters(Databricks.Parameters)
+	if err := d.Set("parameters", parameters); err != nil {
+		return fmt.Errorf("Error setting `parameters`: %+v", err)
+	}
+
+	if connectVia := Databricks.ConnectVia; connectVia != nil {
+		if connectVia.ReferenceName != nil {
+			d.Set("integration_runtime_name", connectVia.ReferenceName)
+		}
+	}
+
+	return nil
+}
+
+func resourceDataFactoryLinkedServiceDatabricksDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	response, err := client.Delete(ctx, resourceGroup, dataFactoryName, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(response) {
+			return fmt.Errorf("Error deleting Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
@@ -1,0 +1,514 @@
+package datafactory_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type LinkedServiceDatabricksResource struct {
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_authViaMSI(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.authentication_msi(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.authentication_access_token(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.authentication_key_vault(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.newClusterConfig(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("5.5.x-gpu-scala2.11"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC12"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("5"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC13"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("sct_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("sct_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("sc_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("sc_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("sev_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+func TestAccDataFactoryLinkedServiceDatabricks_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+	r := LinkedServiceDatabricksResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.update1(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("parameters.%").HasValue("2"),
+				check.That(data.ResourceName).Key("parameters.key1").HasValue("u1k1"),
+				check.That(data.ResourceName).Key("parameters.key2").HasValue("u1k2"),
+				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
+				check.That(data.ResourceName).Key("annotations.0").HasValue("a1"),
+				check.That(data.ResourceName).Key("annotations.1").HasValue("a2"),
+				check.That(data.ResourceName).Key("description").HasValue("Initial Description"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("5.5.x-gpu-scala2.11"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC12"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("1:10"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC12"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("sct_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("sct_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("sc_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("sc_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("sev_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
+			),
+		},
+		{
+			Config: r.update2(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("parameters.%").HasValue("2"),
+				check.That(data.ResourceName).Key("parameters.key1").HasValue("u2k1"),
+				check.That(data.ResourceName).Key("parameters.key2").HasValue("u2k2"),
+				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
+				check.That(data.ResourceName).Key("annotations.0").HasValue("b1"),
+				check.That(data.ResourceName).Key("annotations.1").HasValue("b2"),
+				check.That(data.ResourceName).Key("description").HasValue("Updated Description"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("6.5.x-gpu-scala2.11"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC20"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("5"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC13"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs_updated"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("3"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("updated_sct_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("updated_sct_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("updated_sc_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("updated_sc_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("updated_sev_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("updated_sev_value_2"),
+			),
+		},
+		data.ImportStep(""),
+	})
+}
+
+func (t LinkedServiceDatabricksResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := azure.ParseAzureResourceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	resp, err := clients.DataFactory.LinkedServiceClient.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		return nil, fmt.Errorf("reading Data Factory LinkedServiceDatabricksResource (%s): %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (LinkedServiceDatabricksResource) authentication_msi(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_msi = {
+		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+	}
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+	existing_cluster_id		= "test"
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) authentication_access_token(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_access_token = {
+		access_token	= "SomeFakeAccessToken"
+	}
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	existing_cluster_id = "1234"
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) authentication_key_vault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+// Create the RG
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+// Create a key vault so we can setup a KV linked service
+resource "azurerm_key_vault" "test" {
+	name                = "acctkv%d"
+	location            = azurerm_resource_group.test.location
+	resource_group_name = azurerm_resource_group.test.name
+	tenant_id           = data.azurerm_client_config.current.tenant_id
+	sku_name            = "standard"
+  }
+
+// Create the KV linked service so we can test out integration the Databricks linked service
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+	name                = "linkkv"
+	resource_group_name = azurerm_resource_group.test.name
+	data_factory_name   = azurerm_data_factory.test.name
+	key_vault_id        = azurerm_key_vault.test.id
+  }
+
+//   Create a databricks linked service that leveraged the KV linked service for password management
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_key_vault_password {
+		linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+		secret_name         = "secret"
+	  }
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	instance_pool = {
+		instance_pool_id = "0308-201055-safes631-pool-EHfwukQo",
+		number_of_workers = "1",
+		cluster_version = "5.5.x-gpu-scala2.11"
+	  }
+	
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) newClusterConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_msi = {
+		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+	}
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	new_cluster_config  {
+		cluster_version = "5.5.x-gpu-scala2.11"
+		number_of_workers = "5"
+		node_type = "Standard_NC12"
+		driver_node_type = "Standard_NC13"
+		log_destination = "dbfs:/logs"
+		
+		custom_tags = {
+			sct1 = "sct_value_1"
+			sct2 = "sct_value_2"
+		}
+		spark_config = {
+			 sc1 = "sc_value_1"
+			 sc2 = "sc_value_2"
+		}
+		spark_environment_variables = {
+			sev1 = "sev_value_1"
+			sev2 = "sev_value_2"
+		}
+
+		init_scripts = ["init.sh", "init2.sh"]
+	}
+	
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) update1(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+    description = "Initial Description"
+	annotations = ["a1", "a2"]
+	parameters = {
+		key1 = "u1k1"
+		key2 = "u1k2"
+	}
+    authentication_msi = {
+      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+    }
+    adb_domain = "https://someFakeDomain"
+
+    new_cluster_config {
+      node_type = "Standard_NC12"
+      cluster_version = "5.5.x-gpu-scala2.11"
+      number_of_workers = "1:10"
+     
+      driver_node_type = "Standard_NC12"
+      log_destination = "dbfs:/logs"
+      
+      custom_tags = {
+        sct1 = "sct_value_1"
+        sct2 = "sct_value_2"
+      }
+      spark_config = {
+        sc1 = "sc_value_1"
+        sc2 = "sc_value_2"
+      }
+      spark_environment_variables = {
+        sev1 = "sev_value_1"
+        sev2 = "sev_value_2"
+      }
+
+      init_scripts = ["init.sh", "init2.sh"]
+    }
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) update2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	description = "Updated Description"
+	annotations = ["b1", "b2"]
+	parameters = {
+		key1 = "u2k1"
+		key2 = "u2k2"
+	}
+    authentication_msi = {
+      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+    }
+    adb_domain = "https://someFakedomain"
+
+    new_cluster_config {
+      node_type = "Standard_NC20"
+      cluster_version = "6.5.x-gpu-scala2.11"
+      number_of_workers = "5"
+     
+      driver_node_type = "Standard_NC13"
+      log_destination = "dbfs:/logs_updated"
+      
+      custom_tags = {
+        sct1 = "updated_sct_value_1"
+        sct2 = "updated_sct_value_2"
+      }
+      spark_config = {
+        sc1 = "updated_sc_value_1"
+        sc2 = "updated_sc_value_2"
+      }
+      spark_environment_variables = {
+        sev1 = "updated_sev_value_1"
+        sev2 = "updated_sev_value_2"
+      }
+
+      init_scripts = ["updated_init.sh", "updated_init2.sh", "updated_init3.sh"]
+    }
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
@@ -21,13 +21,13 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaMSI(t *testing.T) {
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_msi(data),
 			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
@@ -45,15 +45,15 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken(t *testing.T) 
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_access_token(data),
-			// Create a composition of validations to perform post-creation
+			//  Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
 				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -69,13 +69,13 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault(t *testing.T) {
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_key_vault(data),
 			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
@@ -93,13 +93,13 @@ func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.newClusterConfig(data),
 			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
@@ -119,8 +119,6 @@ func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
 				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
 			),
 		},
-		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
-		// If it was created with a managed identity, then this shouldn't exist?
 		data.ImportStep(""),
 	})
 }
@@ -221,17 +219,17 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_msi = {
-		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
-	}
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
-	existing_cluster_id		= "test"
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+  }
+  description         = "Initial description"
+  annotations         = ["test1", "test2"]
+  existing_cluster_id = "test"
+  adb_domain          = "https://adb-111111111.11.azuredatabricks.net"
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -257,17 +255,17 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_access_token = {
-		access_token	= "SomeFakeAccessToken"
-	}
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_access_token {
+    access_token = "SomeFakeAccessToken"
+  }
+  description = "Initial description"
+  annotations = ["test1", "test2"]
 
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	existing_cluster_id = "1234"
+  adb_domain          = "https://adb-111111111.11.azuredatabricks.net"
+  existing_cluster_id = "1234"
 
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -295,39 +293,39 @@ resource "azurerm_data_factory" "test" {
 
 // Create a key vault so we can setup a KV linked service
 resource "azurerm_key_vault" "test" {
-	name                = "acctkv%d"
-	location            = azurerm_resource_group.test.location
-	resource_group_name = azurerm_resource_group.test.name
-	tenant_id           = data.azurerm_client_config.current.tenant_id
-	sku_name            = "standard"
-  }
+  name                = "acctkv%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
 
 // Create the KV linked service so we can test out integration the Databricks linked service
 resource "azurerm_data_factory_linked_service_key_vault" "test" {
-	name                = "linkkv"
-	resource_group_name = azurerm_resource_group.test.name
-	data_factory_name   = azurerm_data_factory.test.name
-	key_vault_id        = azurerm_key_vault.test.id
-  }
+  name                = "linkkv"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  key_vault_id        = azurerm_key_vault.test.id
+}
 
 //   Create a databricks linked service that leveraged the KV linked service for password management
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_key_vault_password {
-		linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
-		secret_name         = "secret"
-	  }
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	instance_pool = {
-		instance_pool_id = "0308-201055-safes631-pool-EHfwukQo",
-		number_of_workers = "1",
-		cluster_version = "5.5.x-gpu-scala2.11"
-	  }
-	
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_key_vault_password {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "secret"
+  }
+  description = "Initial description"
+  annotations = ["test1", "test2"]
+  adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
+  instance_pool {
+    instance_pool_id  = "0308-201055-safes631-pool-EHfwukQo"
+    number_of_workers = "1"
+    cluster_version   = "5.5.x-gpu-scala2.11"
+  }
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -353,38 +351,38 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_msi = {
-		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
-	}
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	new_cluster_config  {
-		cluster_version = "5.5.x-gpu-scala2.11"
-		number_of_workers = "5"
-		node_type = "Standard_NC12"
-		driver_node_type = "Standard_NC13"
-		log_destination = "dbfs:/logs"
-		
-		custom_tags = {
-			sct1 = "sct_value_1"
-			sct2 = "sct_value_2"
-		}
-		spark_config = {
-			 sc1 = "sc_value_1"
-			 sc2 = "sc_value_2"
-		}
-		spark_environment_variables = {
-			sev1 = "sev_value_1"
-			sev2 = "sev_value_2"
-		}
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+  }
+  description = "Initial description"
+  annotations = ["test1", "test2"]
+  adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
+  new_cluster_config {
+    cluster_version   = "5.5.x-gpu-scala2.11"
+    number_of_workers = "5"
+    node_type         = "Standard_NC12"
+    driver_node_type  = "Standard_NC13"
+    log_destination   = "dbfs:/logs"
 
-		init_scripts = ["init.sh", "init2.sh"]
-	}
-	
+    custom_tags = {
+      sct1 = "sct_value_1"
+      sct2 = "sct_value_2"
+    }
+    spark_config = {
+      sc1 = "sc_value_1"
+      sc2 = "sc_value_2"
+    }
+    spark_environment_variables = {
+      sev1 = "sev_value_1"
+      sev2 = "sev_value_2"
+    }
+
+    init_scripts = ["init.sh", "init2.sh"]
+  }
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -408,43 +406,43 @@ resource "azurerm_data_factory" "test" {
 
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-    description = "Initial Description"
-	annotations = ["a1", "a2"]
-	parameters = {
-		key1 = "u1k1"
-		key2 = "u1k2"
-	}
-    authentication_msi = {
-      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
-    }
-    adb_domain = "https://someFakeDomain"
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  description         = "Initial Description"
+  annotations         = ["a1", "a2"]
+  parameters = {
+    key1 = "u1k1"
+    key2 = "u1k2"
+  }
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+  }
+  adb_domain = "https://someFakeDomain"
 
-    new_cluster_config {
-      node_type = "Standard_NC12"
-      cluster_version = "5.5.x-gpu-scala2.11"
-      number_of_workers = "1:10"
-     
-      driver_node_type = "Standard_NC12"
-      log_destination = "dbfs:/logs"
-      
-      custom_tags = {
-        sct1 = "sct_value_1"
-        sct2 = "sct_value_2"
-      }
-      spark_config = {
-        sc1 = "sc_value_1"
-        sc2 = "sc_value_2"
-      }
-      spark_environment_variables = {
-        sev1 = "sev_value_1"
-        sev2 = "sev_value_2"
-      }
+  new_cluster_config {
+    node_type         = "Standard_NC12"
+    cluster_version   = "5.5.x-gpu-scala2.11"
+    number_of_workers = "1:10"
 
-      init_scripts = ["init.sh", "init2.sh"]
+    driver_node_type = "Standard_NC12"
+    log_destination  = "dbfs:/logs"
+
+    custom_tags = {
+      sct1 = "sct_value_1"
+      sct2 = "sct_value_2"
     }
+    spark_config = {
+      sc1 = "sc_value_1"
+      sc2 = "sc_value_2"
+    }
+    spark_environment_variables = {
+      sev1 = "sev_value_1"
+      sev2 = "sev_value_2"
+    }
+
+    init_scripts = ["init.sh", "init2.sh"]
+  }
 }
 
 
@@ -470,43 +468,43 @@ resource "azurerm_data_factory" "test" {
 
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	description = "Updated Description"
-	annotations = ["b1", "b2"]
-	parameters = {
-		key1 = "u2k1"
-		key2 = "u2k2"
-	}
-    authentication_msi = {
-      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
-    }
-    adb_domain = "https://someFakedomain"
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  description         = "Updated Description"
+  annotations         = ["b1", "b2"]
+  parameters = {
+    key1 = "u2k1"
+    key2 = "u2k2"
+  }
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+  }
+  adb_domain = "https://someFakedomain"
 
-    new_cluster_config {
-      node_type = "Standard_NC20"
-      cluster_version = "6.5.x-gpu-scala2.11"
-      number_of_workers = "5"
-     
-      driver_node_type = "Standard_NC13"
-      log_destination = "dbfs:/logs_updated"
-      
-      custom_tags = {
-        sct1 = "updated_sct_value_1"
-        sct2 = "updated_sct_value_2"
-      }
-      spark_config = {
-        sc1 = "updated_sc_value_1"
-        sc2 = "updated_sc_value_2"
-      }
-      spark_environment_variables = {
-        sev1 = "updated_sev_value_1"
-        sev2 = "updated_sev_value_2"
-      }
+  new_cluster_config {
+    node_type         = "Standard_NC20"
+    cluster_version   = "6.5.x-gpu-scala2.11"
+    number_of_workers = "5"
 
-      init_scripts = ["updated_init.sh", "updated_init2.sh", "updated_init3.sh"]
+    driver_node_type = "Standard_NC13"
+    log_destination  = "dbfs:/logs_updated"
+
+    custom_tags = {
+      sct1 = "updated_sct_value_1"
+      sct2 = "updated_sct_value_2"
     }
+    spark_config = {
+      sc1 = "updated_sc_value_1"
+      sc2 = "updated_sc_value_2"
+    }
+    spark_environment_variables = {
+      sev1 = "updated_sev_value_1"
+      sev2 = "updated_sev_value_2"
+    }
+
+    init_scripts = ["updated_init.sh", "updated_init2.sh", "updated_init3.sh"]
+  }
 }
 
 

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -42,6 +42,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_data_factory_integration_runtime_azure_ssis":        resourceDataFactoryIntegrationRuntimeAzureSsis(),
 		"azurerm_data_factory_integration_runtime_self_hosted":       resourceDataFactoryIntegrationRuntimeSelfHosted(),
 		"azurerm_data_factory_linked_service_azure_blob_storage":     resourceDataFactoryLinkedServiceAzureBlobStorage(),
+		"azurerm_data_factory_linked_service_azure_databricks":       resourceDataFactoryLinkedServiceAzureDatabricks(),
 		"azurerm_data_factory_linked_service_azure_table_storage":    resourceDataFactoryLinkedServiceAzureTableStorage(),
 		"azurerm_data_factory_linked_service_azure_file_storage":     resourceDataFactoryLinkedServiceAzureFileStorage(),
 		"azurerm_data_factory_linked_service_azure_sql_database":     resourceDataFactoryLinkedServiceAzureSQLDatabase(),

--- a/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
@@ -24,8 +24,8 @@ resource "azurerm_data_factory" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   identity {
-      type = "SystemAssigned"
-    }
+    type = "SystemAssigned"
+  }
 }
 
 #Create a databricks instance
@@ -37,41 +37,41 @@ resource "azurerm_databricks_workspace" "example" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
-    
-    name = "ADBLinkedServiceViaMSI"
-    data_factory_name = azurerm_data_factory.example.name
-    resource_group_name = azurerm_resource_group.example.name
-    description = "ADB Linked Service via MSI"
-    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
 
-    authentication_msi = {
-      workspaceResourceId = azurerm_databricks_workspace.example.id
+  name                = "ADBLinkedServiceViaMSI"
+  data_factory_name   = azurerm_data_factory.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  description         = "ADB Linked Service via MSI"
+  adb_domain          = "https://${azurerm_databricks_workspace.example.workspace_url}"
+
+  authentication_msi = {
+    workspace_resource_id = azurerm_databricks_workspace.example.id
+  }
+
+  new_cluster_config {
+    node_type         = "Standard_NC12"
+    cluster_version   = "5.5.x-gpu-scala2.11"
+    number_of_workers = "1:10"
+    driver_node_type  = "Standard_NC12"
+    log_destination   = "dbfs:/logs"
+
+    custom_tags = {
+      custom_tag1 = "sct_value_1"
+      custom_tag2 = "sct_value_2"
     }
 
-    new_cluster_config {
-      node_type = "Standard_NC12"
-      cluster_version = "5.5.x-gpu-scala2.11"
-      number_of_workers = "1:10"
-      driver_node_type = "Standard_NC12"
-      log_destination = "dbfs:/logs"
-      
-      custom_tags = {
-        custom_tag1 = "sct_value_1"
-        custom_tag2 = "sct_value_2"
-      }
-
-      spark_config = {
-        config1 = "value1"
-        config2 = "value2"
-      }
-
-      spark_environment_variables = {
-        envVar1 = "value1"
-        envVar2 = "value2"
-      }
-
-      init_scripts = ["init.sh", "init2.sh"]
+    spark_config = {
+      config1 = "value1"
+      config2 = "value2"
     }
+
+    spark_environment_variables = {
+      envVar1 = "value1"
+      envVar2 = "value2"
+    }
+
+    init_scripts = ["init.sh", "init2.sh"]
+  }
 }
 
 
@@ -101,20 +101,20 @@ resource "azurerm_databricks_workspace" "example" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "at_linked" {
-    
-    name = "ADBLinkedServiceViaAccessToken"
-    data_factory_name = azurerm_data_factory.example.name
-    resource_group_name = azurerm_resource_group.example.name
-    description = "ADB Linked Service via Access Token"
-    existing_cluster_id = "0308-201146-sly615"
 
-    authentication_access_token = {
-      access_token = "dapi3c0233ca29fac114e4806ca883768df1-3"
-    }
+  name                = "ADBLinkedServiceViaAccessToken"
+  data_factory_name   = azurerm_data_factory.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  description         = "ADB Linked Service via Access Token"
+  existing_cluster_id = "0308-201146-sly615"
 
-    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
-    
-    
+  authentication_access_token = {
+    access_token = "SomeDatabricksAccessToken"
+  }
+
+  adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
+
+
 }
 
 ```
@@ -181,7 +181,7 @@ A `authentication_access_token` block supports the following:
 
 A `authentication_msi` block supports the following:
 
-* `workspaceResourceId` - (Required) The resource identifier of the databricks workspace
+* `workspace_resource_id` - (Required) The resource identifier of the databricks workspace
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
@@ -1,0 +1,241 @@
+---
+subcategory: "Data Factory"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_azure_databricks"
+description: |-
+  Manages a Linked Service (connection) between Azure Databricks and Azure Data Factory.
+---
+
+# azurerm_data_factory_linked_service_azure_databricks
+
+Manages a Linked Service (connection) between Azure Databricks and Azure Data Factory.
+
+## Example Usage with managed identity & new cluster
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "East US"
+}
+
+#Create a Linked Service using managed identity and new cluster config
+resource "azurerm_data_factory" "example" {
+  name                = "TestDtaFactory92783401247"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  identity {
+      type = "SystemAssigned"
+    }
+}
+
+#Create a databricks instance
+resource "azurerm_databricks_workspace" "example" {
+  name                = "databricks-test"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku                 = "standard"
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
+    
+    name = "ADBLinkedServiceViaMSI"
+    data_factory_name = azurerm_data_factory.example.name
+    resource_group_name = azurerm_resource_group.example.name
+    description = "ADB Linked Service via MSI"
+    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
+
+    authentication_msi = {
+      workspaceResourceId = azurerm_databricks_workspace.example.id
+    }
+
+    new_cluster_config {
+      node_type = "Standard_NC12"
+      cluster_version = "5.5.x-gpu-scala2.11"
+      number_of_workers = "1:10"
+      driver_node_type = "Standard_NC12"
+      log_destination = "dbfs:/logs"
+      
+      custom_tags = {
+        custom_tag1 = "sct_value_1"
+        custom_tag2 = "sct_value_2"
+      }
+
+      spark_config = {
+        config1 = "value1"
+        config2 = "value2"
+      }
+
+      spark_environment_variables = {
+        envVar1 = "value1"
+        envVar2 = "value2"
+      }
+
+      init_scripts = ["init.sh", "init2.sh"]
+    }
+}
+
+
+```
+
+## Example Usage with access token & existing cluster
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "East US"
+}
+
+#Link to an existing cluster via access token
+resource "azurerm_data_factory" "example" {
+  name                = "TestDtaFactory92783401247"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+#Create a databricks instance
+resource "azurerm_databricks_workspace" "example" {
+  name                = "databricks-test"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku                 = "standard"
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "at_linked" {
+    
+    name = "ADBLinkedServiceViaAccessToken"
+    data_factory_name = azurerm_data_factory.example.name
+    resource_group_name = azurerm_resource_group.example.name
+    description = "ADB Linked Service via Access Token"
+    existing_cluster_id = "0308-201146-sly615"
+
+    authentication_access_token = {
+      access_token = "dapi3c0233ca29fac114e4806ca883768df1-3"
+    }
+
+    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
+    
+    
+}
+
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `adb_domain` - (Required) The domain URL of the databricks instance
+
+* `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
+
+* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data factory. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service. Changing this forces a new resource
+
+---
+
+You must specify exactly one of the following authentication blocks:
+
+* `authentication_access_token` - (Optional) Authenticate to ADB via access token as defined in the `authentication_access_token` block below
+
+* `authentication_key_vault_password` - (Optional) Authenticate to ADB via Azure Key Vault Linked Service as defined in the `authentication_key_vault_password` block below.
+
+* `authentication_msi` - (Optional) Authenticate to ADB via managed service identity as defined in the `authentication_msi` blocks as defined below.
+
+---
+
+You must specify exactly one of the following modes for cluster integration:
+
+* `existing_cluster_id` - (Optional) The cluster_id of an existing cluster within the linked ADB instance
+
+* `instance_pool` - (Optional) Leverages an instance pool within the linked ADB instance as defined by  `instance_pool` block below.
+
+* `new_cluster_config` - (Optional) Creates new clusters within the linked ADB instance as defined in the  `new_cluster_config` block below.
+
+---
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service.
+
+* `description` - (Optional) The description for the Data Factory Linked Service.
+
+* `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
+
+---
+
+A `authentication_key_vault_password` block supports the following:
+
+* `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
+
+* `secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores ADB access token.
+
+---
+
+A `authentication_access_token` block supports the following:
+
+* `access_token` - (Required) The access token to authenticate to databricks
+
+---
+
+A `authentication_msi` block supports the following:
+
+* `workspaceResourceId` - (Required) The resource identifier of the databricks workspace
+
+---
+
+
+A `new_cluster_config` block supports the following:
+
+* `cluster_version` - (Required) Spark version of a the cluster
+
+* `node_type` - (Required) Node type for the new cluster
+
+* `custom_tags` - (Optional) Tags for the cluster resource
+
+* `driver_node_type` - (Optional) Driver node type for the cluster
+
+* `init_scripts` - (Optional) User defined initialization scripts for the cluster
+
+* `log_destination` - (Optional) Location to deliver Spark driver, worker, and event logs
+
+* `number_of_workers` - (Optional) The number of worker nodes. For a fixed number of workers, use a single value (e.g. "1") for autoscaling provide the min:max (e.g. "1:10"). Defaults to 1.
+
+* `spark_config` - (Optional) User-specified Spark configuration variables key-value pairs
+
+* `spark_environment_variables` - (Optional) User-specified Spark environment variables key-value pairs
+* 
+---
+
+A `instance_pool` block supports the following:
+
+* `instnace_pool_id` - (Required) Identifier of the instance pool within the linked ADB instance
+
+* `number_of_workers` - (Optional) Fixed number of workers to use 
+
+* `cluster_version` - (Required) Spark version of a the cluster
+
+---
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Data Factory Linked Service.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Linked Service.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Linked Service.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Linked Service.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Linked Service.
+
+## Import
+
+Data Factory Linked Services can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_factory_linked_service_azure_databricks.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+```


### PR DESCRIPTION
Fixes #7553

Adds support for creating Databricks Linked Service:
- Auth methods supported: MSI, Access Token or Key Vault Linked Service 
- Cluster Configurations: New, existing and instance pools
```
TF_ACC=1 go test -v ./azurerm/internal/services/datafactory -run=TestAccDataFactoryLinkedServiceDatabricks -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/08 17:35:00 [DEBUG] not using binary driver name, it's no longer needed
2021/03/08 17:35:03 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_authViaMSI
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_authViaMSI
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_update
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_update
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_authViaMSI
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_update
2021/03/08 17:36:37 [DEBUG] TF_ACCTEST_REATTACH set to 1 and acctest.TestHelper is not nil, using reattach-based testing
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig (161.82s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken (163.27s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_authViaMSI (189.53s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_update (201.92s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault (270.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory 274.021s
```