### PR TITLE
go 1.16: moving off the deprecated `ioutil`

### DIFF
--- a/azurerm/internal/azuresdkhacks/network_interface.go
+++ b/azurerm/internal/azuresdkhacks/network_interface.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
@@ -76,7 +76,7 @@ func withJsonWorkingAroundTheBrokenNetworkAPI(v network.Interface) autorest.Prep
 					b, err = json.Marshal(out)
 					if err == nil {
 						r.ContentLength = int64(len(b))
-						r.Body = ioutil.NopCloser(bytes.NewReader(b))
+						r.Body = io.NopCloser(bytes.NewReader(b))
 					}
 				}
 			}

--- a/azurerm/internal/services/automation/automation_certificate_resource_test.go
+++ b/azurerm/internal/services/automation/automation_certificate_resource_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,8 +22,8 @@ type AutomationCertificateResource struct {
 }
 
 var (
-	testCertThumbprintRaw, _ = ioutil.ReadFile(filepath.Join("testdata", "automation_certificate_test.thumb"))
-	testCertRaw, _           = ioutil.ReadFile(filepath.Join("testdata", "automation_certificate_test.pfx"))
+	testCertThumbprintRaw, _ = os.ReadFile(filepath.Join("testdata", "automation_certificate_test.thumb"))
+	testCertRaw, _           = os.ReadFile(filepath.Join("testdata", "automation_certificate_test.pfx"))
 )
 
 var testCertBase64 = base64.StdEncoding.EncodeToString(testCertRaw)

--- a/azurerm/internal/services/automation/automation_runbook_resource.go
+++ b/azurerm/internal/services/automation/automation_runbook_resource.go
@@ -3,7 +3,7 @@ package automation
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"time"
 
@@ -200,7 +200,7 @@ func resourceAutomationRunbookCreateUpdate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("content"); ok {
 		content := v.(string)
-		reader := ioutil.NopCloser(bytes.NewBufferString(content))
+		reader := io.NopCloser(bytes.NewBufferString(content))
 		draftClient := meta.(*clients.Client).Automation.RunbookDraftClient
 
 		if _, err := draftClient.ReplaceContent(ctx, resGroup, accName, name, reader); err != nil {

--- a/azurerm/internal/services/containers/kubernetes/kube_config_test.go
+++ b/azurerm/internal/services/containers/kubernetes/kube_config_test.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -185,7 +185,7 @@ func isInvalidConfig(_ KubeConfig, encodedConfig string) (bool, error) {
 
 func LoadConfig(fileName string) string {
 	filePath := filepath.Join("testdata", fileName)
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return ""
 	}

--- a/azurerm/internal/services/datalake/data_lake_store_file_resource.go
+++ b/azurerm/internal/services/datalake/data_lake_store_file_resource.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -112,7 +111,7 @@ func resourceDataLakeStoreFileCreate(d *schema.ResourceData, meta interface{}) e
 			// last chunk
 			flag = filesystem.CLOSE
 		}
-		chunk := ioutil.NopCloser(bytes.NewReader(buffer[:n]))
+		chunk := io.NopCloser(bytes.NewReader(buffer[:n]))
 
 		if _, err = client.Append(ctx, accountName, remoteFilePath, chunk, nil, flag, nil, nil); err != nil {
 			return fmt.Errorf("Error transferring chunk for Data Lake Store File %q : %+v", remoteFilePath, err)

--- a/azurerm/internal/services/datalake/data_lake_store_file_resource_test.go
+++ b/azurerm/internal/services/datalake/data_lake_store_file_resource_test.go
@@ -3,7 +3,6 @@ package datalake_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -68,7 +67,7 @@ func TestAccDataLakeStoreFile_largefiles(t *testing.T) {
 	bytes := make([]byte, largeSize)
 	rand.Read(bytes) // fill with random data
 
-	tmpfile, err := ioutil.TempFile("", "azurerm-acc-datalake-file-large")
+	tmpfile, err := os.CreateTemp("", "azurerm-acc-datalake-file-large")
 	if err != nil {
 		t.Errorf("Unable to open a temporary file.")
 	}

--- a/azurerm/internal/services/network/application_gateway_resource_test.go
+++ b/azurerm/internal/services/network/application_gateway_resource_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"regexp"
 	"testing"
 
@@ -3804,7 +3804,7 @@ func (ApplicationGatewayResource) changeCert(certificateName string) acceptance.
 			return fmt.Errorf("Bad: Get on ApplicationGatewaysClient: %+v", err)
 		}
 
-		certPfx, err := ioutil.ReadFile("testdata/application_gateway_test.pfx")
+		certPfx, err := os.ReadFile("testdata/application_gateway_test.pfx")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/azurerm/internal/services/storage/blobs.go
+++ b/azurerm/internal/services/storage/blobs.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -129,7 +128,7 @@ func (sbu BlobUpload) createEmptyBlockBlob(ctx context.Context) error {
 }
 
 func (sbu BlobUpload) uploadBlockBlobFromContent(ctx context.Context) error {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "upload-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "upload-")
 	if err != nil {
 		return fmt.Errorf("Error creating temporary file: %s", err)
 	}

--- a/azurerm/internal/services/storage/storage_blob_resource_test.go
+++ b/azurerm/internal/services/storage/storage_blob_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -197,7 +196,7 @@ func TestAccStorageBlob_blockFromExistingBlob(t *testing.T) {
 }
 
 func TestAccStorageBlob_blockFromLocalFile(t *testing.T) {
-	sourceBlob, err := ioutil.TempFile("", "")
+	sourceBlob, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
 	}
@@ -221,7 +220,7 @@ func TestAccStorageBlob_blockFromLocalFile(t *testing.T) {
 }
 
 func TestAccStorageBlob_blockFromLocalFileWithContentMd5(t *testing.T) {
-	sourceBlob, err := ioutil.TempFile("", "")
+	sourceBlob, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
 	}
@@ -343,7 +342,7 @@ func TestAccStorageBlob_pageFromExistingBlob(t *testing.T) {
 }
 
 func TestAccStorageBlob_pageFromLocalFile(t *testing.T) {
-	sourceBlob, err := ioutil.TempFile("", "")
+	sourceBlob, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
 	}
@@ -492,7 +491,7 @@ func (r StorageBlobResource) blobMatchesFile(kind blobs.BlobType, filePath strin
 		actualContents := actualProps.Contents
 
 		// local file for comparison
-		expectedContents, err := ioutil.ReadFile(filePath)
+		expectedContents, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}

--- a/azurerm/internal/services/storage/storage_share_file_resource_test.go
+++ b/azurerm/internal/services/storage/storage_share_file_resource_test.go
@@ -3,7 +3,7 @@ package storage_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -93,7 +93,7 @@ func TestAccAzureRMStorageShareFile_update(t *testing.T) {
 }
 
 func TestAccAzureRMStorageShareFile_withFile(t *testing.T) {
-	sourceBlob, err := ioutil.TempFile("", "")
+	sourceBlob, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
 	}

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -891,7 +890,7 @@ func goFmtAndWriteToFile(filePath, fileContents string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filePath, []byte(*fmt), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(*fmt), 0644); err != nil {
 		return err
 	}
 
@@ -901,7 +900,7 @@ func goFmtAndWriteToFile(filePath, fileContents string) error {
 type GolangCodeFormatter struct{}
 
 func (f GolangCodeFormatter) Format(input string) (*string, error) {
-	tmpfile, err := ioutil.TempFile("", "temp-*.go")
+	tmpfile, err := os.CreateTemp("", "temp-*.go")
 	if err != nil {
 		return nil, fmt.Errorf("creating temp file: %+v", err)
 	}
@@ -940,7 +939,7 @@ func (f GolangCodeFormatter) runGoImports(filePath string) {
 }
 
 func (f GolangCodeFormatter) readFileContents(filePath string) (*string, error) {
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Basically https://github.com/hashicorp/terraform-provider-aws/pull/17822 but for AzureRM

Reference: https://golang.org/doc/go1.16#ioutil
Reference: https://github.com/hashicorp/terraform-provider-aws/commit/bcdd3fc63af1c6db7b9f8e1897b0b33ebc91ae94

> The io/ioutil package has turned out to be a poorly defined and hard to understand collection of things. All functionality provided by the package has been moved to other packages. The io/ioutil package remains and will continue to work as before, but we encourage new code to use the new definitions in the io and os packages. Here is a list of the new locations of the names exported by io/ioutil:
>
> Discard => io.Discard
> NopCloser => io.NopCloser
> ReadAll => io.ReadAll
> ReadDir => os.ReadDir (note: returns a slice of os.DirEntry rather than a slice of fs.FileInfo)
> ReadFile => os.ReadFile
> TempDir => os.MkdirTemp
> TempFile => os.CreateTemp
> WriteFile => os.WriteFile