### PR TITLE
`azurerm_role_assignment` - support enrollment ids in `scope` argument

### DIFF
--- a/azurerm/internal/services/authorization/role_assignment_resource.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	billingValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/billing/validate"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-09-01-preview/authorization"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -53,6 +55,7 @@ func resourceArmRoleAssignment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.Any(
+					billingValidate.EnrollmentID,
 					managementGroupValidate.ManagementGroupID,
 					subscriptionValidate.SubscriptionID,
 					resourceValidate.ResourceGroupID,

--- a/azurerm/internal/services/billing/parse/enrollment.go
+++ b/azurerm/internal/services/billing/parse/enrollment.go
@@ -1,0 +1,84 @@
+package parse
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type EnrollmentId struct {
+	EnrollmentAccountName string
+}
+
+func NewEnrollmentID(enrollmentAccountName string) EnrollmentId {
+	return EnrollmentId{
+		EnrollmentAccountName: enrollmentAccountName,
+	}
+}
+
+func (id EnrollmentId) String() string {
+	segments := []string{
+		fmt.Sprintf("Enrollment Account Name %q", id.EnrollmentAccountName),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Enrollment", segmentsStr)
+}
+
+func (id EnrollmentId) ID() string {
+	fmtString := "/providers/Microsoft.Billing/enrollmentAccounts/%s"
+	return fmt.Sprintf(fmtString, id.EnrollmentAccountName)
+}
+
+// EnrollmentID parses a Enrollment ID into an EnrollmentId struct
+func EnrollmentID(input string) (*EnrollmentId, error) {
+	idURL, err := url.ParseRequestURI(input)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot parse Azure ID: %s", err)
+	}
+
+	path := idURL.Path
+
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	components := strings.Split(path, "/")
+
+	if len(components)%2 != 0 {
+		return nil, fmt.Errorf("The number of path segments is not divisible by 2 in %q", path)
+	}
+
+	componentMap := make(map[string]string, len(components)/2)
+	for current := 0; current < len(components); current += 2 {
+		key := components[current]
+		value := components[current+1]
+
+		// Check key/value for empty strings.
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("Key/Value cannot be empty strings. Key: '%s', Value: '%s'", key, value)
+		}
+		componentMap[key] = value
+	}
+
+	// Build up a TargetResourceID from the map
+	id := &azure.ResourceID{}
+	id.Path = componentMap
+
+	if provider, ok := componentMap["providers"]; ok {
+		id.Provider = provider
+		delete(componentMap, "providers")
+	}
+
+	resourceId := EnrollmentId{}
+
+	if resourceId.EnrollmentAccountName, err = id.PopSegment("enrollmentAccounts"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/billing/parse/enrollment_test.go
+++ b/azurerm/internal/services/billing/parse/enrollment_test.go
@@ -1,0 +1,78 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = EnrollmentId{}
+
+func TestEnrollmentIDFormatter(t *testing.T) {
+	actual := NewEnrollmentID("12345678-1234-9876-4563-123456789012").ID()
+	expected := "/providers/Microsoft.Billing/enrollmentAccounts/12345678-1234-9876-4563-123456789012"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestEnrollmentID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EnrollmentId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing EnrollmentAccountName
+			Input: "/providers/Microsoft.Billing/",
+			Error: true,
+		},
+
+		{
+			// missing value for EnrollmentAccountName
+			Input: "/providers/Microsoft.Billing/enrollmentAccounts/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/providers/Microsoft.Billing/enrollmentAccounts/12345678-1234-9876-4563-123456789012",
+			Expected: &EnrollmentId{
+				EnrollmentAccountName: "12345678-1234-9876-4563-123456789012",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/PROVIDERS/MICROSOFT.BILLING/ENROLLMENTACCOUNTS/12345678-1234-9876-4563-123456789012",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EnrollmentID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.EnrollmentAccountName != v.Expected.EnrollmentAccountName {
+			t.Fatalf("Expected %q but got %q for EnrollmentAccountName", v.Expected.EnrollmentAccountName, actual.EnrollmentAccountName)
+		}
+	}
+}

--- a/azurerm/internal/services/billing/validate/enrollment_id.go
+++ b/azurerm/internal/services/billing/validate/enrollment_id.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/billing/parse"
+)
+
+func EnrollmentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.EnrollmentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/billing/validate/enrollment_id_test.go
+++ b/azurerm/internal/services/billing/validate/enrollment_id_test.go
@@ -1,0 +1,50 @@
+package validate
+
+import "testing"
+
+func TestEnrollmentID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing EnrollmentAccountName
+			Input: "/providers/Microsoft.Billing/",
+			Valid: false,
+		},
+
+		{
+			// missing value for EnrollmentAccountName
+			Input: "/providers/Microsoft.Billing/enrollmentAccounts/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/providers/Microsoft.Billing/enrollmentAccounts/12345678-1234-9876-4563-123456789012",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/PROVIDERS/MICROSOFT.BILLING/ENROLLMENTACCOUNTS/12345678-1234-9876-4563-123456789012",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := EnrollmentID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
fixes #10547 
