### PR TITLE
azurerm_function_app_host_keys: Retry when reading function key

### DIFF
--- a/azurerm/internal/services/web/function_app_host_keys_data_source.go
+++ b/azurerm/internal/services/web/function_app_host_keys_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -76,29 +77,31 @@ func dataSourceFunctionAppHostKeysRead(d *schema.ResourceData, meta interface{})
 	}
 	d.SetId(*functionSettings.ID)
 
-	res, err := client.ListHostKeys(ctx, resourceGroup, name)
-	if err != nil {
-		if utils.ResponseWasNotFound(res.Response) {
-			return fmt.Errorf("Error: AzureRM Function App %q (Resource Group %q) was not found", name, resourceGroup)
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		res, err := client.ListHostKeys(ctx, resourceGroup, name)
+		if err != nil {
+			if utils.ResponseWasNotFound(res.Response) {
+				return resource.NonRetryableError(fmt.Errorf("Error: AzureRM Function App %q (Resource Group %q) was not found", name, resourceGroup))
+			}
+
+			return resource.RetryableError(fmt.Errorf("Error making Read request on AzureRM Function App Hostkeys %q: %+v", name, err))
 		}
 
-		return fmt.Errorf("Error making Read request on AzureRM Function App Hostkeys %q: %+v", name, err)
-	}
+		d.Set("master_key", res.MasterKey)
+		d.Set("primary_key", res.MasterKey)
 
-	d.Set("master_key", res.MasterKey)
-	d.Set("primary_key", res.MasterKey)
+		defaultFunctionKey := ""
+		if v, ok := res.FunctionKeys["default"]; ok {
+			defaultFunctionKey = *v
+		}
+		d.Set("default_function_key", defaultFunctionKey)
 
-	defaultFunctionKey := ""
-	if v, ok := res.FunctionKeys["default"]; ok {
-		defaultFunctionKey = *v
-	}
-	d.Set("default_function_key", defaultFunctionKey)
+		eventGridExtensionConfigKey := ""
+		if v, ok := res.SystemKeys["eventgridextensionconfig_extension"]; ok {
+			eventGridExtensionConfigKey = *v
+		}
+		d.Set("event_grid_extension_config_key", eventGridExtensionConfigKey)
 
-	eventGridExtensionConfigKey := ""
-	if v, ok := res.SystemKeys["eventgridextensionconfig_extension"]; ok {
-		eventGridExtensionConfigKey = *v
-	}
-	d.Set("event_grid_extension_config_key", eventGridExtensionConfigKey)
-
-	return nil
+		return nil
+	})
 }


### PR DESCRIPTION
This looks to address the issue seen in  #9854 and #9869. 

Specifically there is a race condition between the function app being created and the keys being available to read. This appears more in premium funcs on vnets than on normal functions. 

This PR adds retry to the request to get keys, this should resolve the issue. I tested this approach with the following script to validate it, [see blog here](https://blog.gripdev.xyz/2021/03/09/azure-functions-get-key-from-terraform-without-internalservererror/)

Integration tests passing 
![image](https://user-images.githubusercontent.com/1939288/110493446-8c54c380-80ea-11eb-9709-62db81db5856.png)
