### PR TITLE
r/eventhub_consumer_group: marking the consumer group as gone if it's gone

### DIFF
--- a/azurerm/internal/sdk/resource.go
+++ b/azurerm/internal/sdk/resource.go
@@ -131,7 +131,8 @@ type ResourceMetaData struct {
 }
 
 // MarkAsGone marks this resource as removed in the Remote API, so this is no longer available
-func (rmd ResourceMetaData) MarkAsGone() error {
+func (rmd ResourceMetaData) MarkAsGone(idFormatter resourceid.Formatter) error {
+	rmd.Logger.Infof("[DEBUG] %s was not found - removing from state", idFormatter)
 	rmd.ResourceData.SetId("")
 	return nil
 }

--- a/azurerm/internal/services/eventhub/eventhub_consumer_group_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_consumer_group_resource.go
@@ -156,6 +156,9 @@ func (r ConsumerGroupResource) Read() sdk.ResourceFunc {
 			metadata.Logger.Infof("retrieving Consumer Group %q..", id.ConsumergroupName)
 			resp, err := client.Get(ctx, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.ConsumergroupName)
 			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					return metadata.MarkAsGone(id)
+				}
 				return fmt.Errorf("reading Consumer Group %q (EventHub %q / Namespace %q / Resource Group %q): %+v", id.ConsumergroupName, id.EventhubName, id.NamespaceName, id.ResourceGroup, err)
 			}
 

--- a/azurerm/internal/services/loadbalancer/backend_address_pool_address_resource.go
+++ b/azurerm/internal/services/loadbalancer/backend_address_pool_address_resource.go
@@ -185,8 +185,7 @@ func (r BackendAddressPoolAddressResource) Read() sdk.ResourceFunc {
 				}
 			}
 			if backendAddress == nil {
-				metadata.Logger.Warnf("%s was not found - removing from state!")
-				return metadata.MarkAsGone()
+				return metadata.MarkAsGone(id)
 			}
 
 			backendAddressPoolId := parse.NewLoadBalancerBackendAddressPoolID(id.SubscriptionId, id.ResourceGroup, id.LoadBalancerName, id.BackendAddressPoolName)

--- a/azurerm/internal/services/resource/resource_provider_registration_resource.go
+++ b/azurerm/internal/services/resource/resource_provider_registration_resource.go
@@ -127,7 +127,7 @@ func (r ResourceProviderRegistrationResource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id.ResourceProvider, "")
 			if err != nil {
 				if utils.ResponseWasNotFound(resp.Response) {
-					return metadata.MarkAsGone()
+					return metadata.MarkAsGone(id)
 				}
 
 				return fmt.Errorf("retrieving Resource Provider %q: %+v", id.ResourceProvider, err)
@@ -135,7 +135,7 @@ func (r ResourceProviderRegistrationResource) Read() sdk.ResourceFunc {
 
 			if resp.RegistrationState != nil && !strings.EqualFold(*resp.RegistrationState, "Registered") {
 				log.Printf("[WARN] Resource Provider %q was not registered", id.ResourceProvider)
-				return metadata.MarkAsGone()
+				return metadata.MarkAsGone(id)
 			}
 
 			return metadata.Encode(&ResourceProviderRegistrationModel{


### PR DESCRIPTION
This commit introduces the ID Formatter to the MarkAsGone call so we can conditionally mark this as gone when it's removed from Azure, which ultimately fixes #10898