### PR TITLE
Test Fix: Batch

### DIFF
--- a/azurerm/internal/services/batch/batch_certificate_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_certificate_data_source_test.go
@@ -51,7 +51,7 @@ resource "azurerm_batch_account" "test" {
 resource "azurerm_batch_certificate" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   account_name         = azurerm_batch_account.test.name
-  certificate          = filebase64("testdata/batch_certificate.pfx")
+  certificate          = filebase64("testdata/batch_certificate_password.pfx")
   format               = "Pfx"
   password             = "terraform"
   thumbprint           = "42c107874fd0e4a9583292a2f1098e8fe4b2edda"

--- a/azurerm/internal/services/batch/batch_pool_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_pool_data_source_test.go
@@ -45,8 +45,6 @@ func TestAccBatchPoolDataSource_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate.0.store_location").HasValue("CurrentUser"),
 				check.That(data.ResourceName).Key("certificate.0.store_name").HasValue(""),
 				check.That(data.ResourceName).Key("certificate.0.visibility.#").HasValue("2"),
-				check.That(data.ResourceName).Key("certificate.0.visibility.3294600504").HasValue("StartTask"),
-				check.That(data.ResourceName).Key("certificate.0.visibility.4077195354").HasValue("RemoteUser"),
 				check.That(data.ResourceName).Key("container_configuration.0.type").HasValue("DockerCompatible"),
 				check.That(data.ResourceName).Key("container_configuration.0.container_registries.#").HasValue("1"),
 				check.That(data.ResourceName).Key("container_configuration.0.container_registries.0.registry_server").HasValue("myContainerRegistry.azurecr.io"),
@@ -91,7 +89,7 @@ resource "azurerm_batch_account" "test" {
 resource "azurerm_batch_certificate" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   account_name         = azurerm_batch_account.test.name
-  certificate          = filebase64("testdata/batch_certificate.pfx")
+  certificate          = filebase64("testdata/batch_certificate_password.pfx")
   format               = "Pfx"
   password             = "terraform"
   thumbprint           = "42c107874fd0e4a9583292a2f1098e8fe4b2edda"

--- a/azurerm/internal/services/batch/batch_pool_resource_test.go
+++ b/azurerm/internal/services/batch/batch_pool_resource_test.go
@@ -222,13 +222,10 @@ func TestAccBatchPool_certificates(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate.0.store_location").HasValue("CurrentUser"),
 				check.That(data.ResourceName).Key("certificate.0.store_name").HasValue(""),
 				check.That(data.ResourceName).Key("certificate.0.visibility.#").HasValue("1"),
-				check.That(data.ResourceName).Key("certificate.0.visibility.3294600504").HasValue("StartTask"),
 				check.That(data.ResourceName).Key("certificate.1.id").HasValue(certificate1ID),
 				check.That(data.ResourceName).Key("certificate.1.store_location").HasValue("CurrentUser"),
 				check.That(data.ResourceName).Key("certificate.1.store_name").HasValue(""),
 				check.That(data.ResourceName).Key("certificate.1.visibility.#").HasValue("2"),
-				check.That(data.ResourceName).Key("certificate.1.visibility.3294600504").HasValue("StartTask"),
-				check.That(data.ResourceName).Key("certificate.1.visibility.4077195354").HasValue("RemoteUser"),
 			),
 		},
 		data.ImportStep("stop_pending_resize_operation"),
@@ -974,7 +971,7 @@ resource "azurerm_batch_certificate" "testcer" {
 resource "azurerm_batch_certificate" "testpfx" {
   resource_group_name  = azurerm_resource_group.test.name
   account_name         = azurerm_batch_account.test.name
-  certificate          = filebase64("testdata/batch_certificate.pfx")
+  certificate          = filebase64("testdata/batch_certificate_password.pfx")
   format               = "Pfx"
   password             = "terraform"
   thumbprint           = "42c107874fd0e4a9583292a2f1098e8fe4b2edda"


### PR DESCRIPTION
```
--- PASS: TestAccBatchCertificateDataSource_basic (535.20s)
--- PASS: TestAccBatchPoolDataSource_complete (662.84s)
--- PASS: TestAccBatchPool_certificates (616.90s)
```