### PR TITLE
r/azurerm_kusto_eventhub_data_connection: allow for empty table_name and data_format

### DIFF
--- a/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -80,7 +80,7 @@ func resourceKustoEventHubDataConnection() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				ValidateFunc: eventhubValidate.EventHubID,
 			},
 
 			"consumer_group": {
@@ -119,17 +119,6 @@ func resourceKustoEventHubDataConnection() *schema.Resource {
 					string(kusto.TXT),
 				}, false),
 			},
-		},
-		CustomizeDiff: func(d *schema.ResourceDiff, _ interface{}) error {
-			_, hasTableName := d.GetOk("table_name")
-			_, hasMappingRuleName := d.GetOk("mapping_rule_name")
-			_, hasDataFormat := d.GetOk("data_format")
-
-			if !(utils.AllEquals(hasTableName, hasMappingRuleName, hasDataFormat)) {
-				return fmt.Errorf("if one of the target table properties `table_name`, `mapping_rule_name` or `data_format` are set, the other values must also be defined")
-			}
-
-			return nil
 		},
 	}
 }

--- a/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -132,7 +132,7 @@ resource "azurerm_kusto_eventhub_data_connection" "test" {
   consumer_group = azurerm_eventhub_consumer_group.test.name
 
   mapping_rule_name = "Json_Mapping"
-  data_format = "MULTIJSON"
+  data_format       = "MULTIJSON"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -32,7 +32,112 @@ func TestAccKustoEventHubDataConnection_basic(t *testing.T) {
 	})
 }
 
-func (KustoEventHubDataConnectionResource) basic(data acceptance.TestData) string {
+func TestAccKustoEventHubDataConnection_unboundMapping1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.unboundMapping1(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoEventHubDataConnection_unboundMapping2(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.unboundMapping2(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (KustoEventHubDataConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.DataConnectionID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Kusto.DataConnectionsClient.Get(ctx, id.ResourceGroup, id.ClusterName, id.DatabaseName, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+
+	value, ok := resp.Value.AsEventHubDataConnection()
+	if !ok {
+		return nil, fmt.Errorf("%s is not an EventHubDataConnection", id.String())
+	}
+
+	return utils.Bool(value.EventHubConnectionProperties != nil), nil
+}
+
+func (r KustoEventHubDataConnectionResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    = azurerm_eventhub.test.id
+  consumer_group = azurerm_eventhub_consumer_group.test.name
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoEventHubDataConnectionResource) unboundMapping1(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    = azurerm_eventhub.test.id
+  consumer_group = azurerm_eventhub_consumer_group.test.name
+
+  mapping_rule_name = "Json_Mapping"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoEventHubDataConnectionResource) unboundMapping2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    = azurerm_eventhub.test.id
+  consumer_group = azurerm_eventhub_consumer_group.test.name
+
+  mapping_rule_name = "Json_Mapping"
+  data_format = "MULTIJSON"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (KustoEventHubDataConnectionResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -82,35 +187,5 @@ resource "azurerm_eventhub_consumer_group" "test" {
   eventhub_name       = azurerm_eventhub.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-
-resource "azurerm_kusto_eventhub_data_connection" "test" {
-  name                = "acctestkedc-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  cluster_name        = azurerm_kusto_cluster.test.name
-  database_name       = azurerm_kusto_database.test.name
-
-  eventhub_id    = azurerm_eventhub.test.id
-  consumer_group = azurerm_eventhub_consumer_group.test.name
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (KustoEventHubDataConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.DataConnectionID(state.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := clients.Kusto.DataConnectionsClient.Get(ctx, id.ResourceGroup, id.ClusterName, id.DatabaseName, id.Name)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
-	}
-
-	value, ok := resp.Value.AsEventHubDataConnection()
-	if !ok {
-		return nil, fmt.Errorf("%s is not an EventHubDataConnection", id.String())
-	}
-
-	return utils.Bool(value.EventHubConnectionProperties != nil), nil
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
Fixes #10838

```
$ make acctests SERVICE='kusto' TESTARGS='-run=TestAccKustoEventHubDataConnection_unbound' TESTTIMEOUT='600m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/kusto -run=TestAccKustoEventHubDataConnection_unbound -timeout 600m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/10 09:45:41 [DEBUG] not using binary driver name, it's no longer needed
2021/03/10 09:45:41 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccKustoEventHubDataConnection_unboundMapping1
=== PAUSE TestAccKustoEventHubDataConnection_unboundMapping1
=== RUN   TestAccKustoEventHubDataConnection_unboundMapping2
=== PAUSE TestAccKustoEventHubDataConnection_unboundMapping2
=== CONT  TestAccKustoEventHubDataConnection_unboundMapping1
=== CONT  TestAccKustoEventHubDataConnection_unboundMapping2
--- PASS: TestAccKustoEventHubDataConnection_unboundMapping1 (1574.67s)
--- PASS: TestAccKustoEventHubDataConnection_unboundMapping2 (1747.31s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/kusto	1748.615s
```