### PR TITLE
key_vault_secret: Set value of recoverd key vault secret

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -170,6 +170,11 @@ func resourceKeyVaultSecretCreate(d *schema.ResourceData, meta interface{}) erro
 					return fmt.Errorf("Error waiting for Key Vault Secret %q to become available: %s", name, err)
 				}
 				log.Printf("[DEBUG] Secret %q recovered with ID: %q", name, *recoveredSecret.ID)
+
+				_, err := client.SetSecret(ctx, *keyVaultBaseUrl, name, parameters)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			// If the error response was anything else, or `recover_soft_deleted_key_vaults` is `false` just return the error

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -156,22 +156,22 @@ func TestAccKeyVaultSecret_recovery(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.softDeleteRecovery(data, false),
+			Config: r.softDeleteRecovery(data, false, "first"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				check.That(data.ResourceName).Key("value").HasValue("first"),
 			),
 		},
 		{
-			Config:  r.softDeleteRecovery(data, false),
+			Config:  r.softDeleteRecovery(data, false, "first"),
 			Destroy: true,
 		},
 		{
 			// purge true here to make sure when we end the test there's no soft-deleted items left behind
-			Config: r.softDeleteRecovery(data, true),
+			Config: r.softDeleteRecovery(data, true, "second"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				check.That(data.ResourceName).Key("value").HasValue("second"),
 			),
 		},
 	})
@@ -395,7 +395,7 @@ resource "azurerm_key_vault_secret" "test" {
 `, r.template(data), data.RandomString)
 }
 
-func (r KeyVaultSecretResource) softDeleteRecovery(data acceptance.TestData, purge bool) string {
+func (r KeyVaultSecretResource) softDeleteRecovery(data acceptance.TestData, purge bool, value string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -410,10 +410,10 @@ provider "azurerm" {
 
 resource "azurerm_key_vault_secret" "test" {
   name         = "secret-%s"
-  value        = "rick-and-morty"
+  value        = "%s"
   key_vault_id = azurerm_key_vault.test.id
 }
-`, purge, r.template(data), data.RandomString)
+`, purge, r.template(data), data.RandomString, value)
 }
 
 func (KeyVaultSecretResource) withExternalAccessPolicy(data acceptance.TestData) string {


### PR DESCRIPTION
Currently if you create a secret for which already a soft-deleted secret exists the soft-deleted secret is only recoverd but the value is not set. This change also sets the value after the secret is recovered.