### PR TITLE
azurerm_frontdoor: sort resources

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/sorter"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -1273,6 +1274,9 @@ func flattenFrontDoorBackendPools(input *[]frontdoor.BackendPool, frontDoorId pa
 		})
 	}
 
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(output)
+
 	return &output, nil
 }
 
@@ -1342,6 +1346,9 @@ func flattenFrontDoorBackend(input *[]frontdoor.Backend) []interface{} {
 
 		output = append(output, result)
 	}
+
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(output)
 
 	return output
 }
@@ -1430,6 +1437,9 @@ func flattenFrontEndEndpoints(input *[]frontdoor.FrontendEndpoint, frontDoorId p
 		})
 	}
 
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(results)
+
 	return &results, nil
 }
 
@@ -1482,6 +1492,9 @@ func flattenFrontDoorHealthProbeSettingsModel(input *[]frontdoor.HealthProbeSett
 		})
 	}
 
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(results)
+
 	return results
 }
 
@@ -1523,6 +1536,9 @@ func flattenFrontDoorLoadBalancingSettingsModel(input *[]frontdoor.LoadBalancing
 			"successful_samples_required":     successfulSamplesRequired,
 		})
 	}
+
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(results)
 
 	return results
 }
@@ -1581,6 +1597,9 @@ func flattenFrontDoorRoutingRule(input *[]frontdoor.RoutingRule, oldBlocks inter
 			"redirect_configuration":   redirectConfiguration,
 		})
 	}
+
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(output)
 
 	return &output, nil
 }
@@ -1722,6 +1741,9 @@ func flattenFrontDoorFrontendEndpointsSubResources(input *[]frontdoor.SubResourc
 
 		output = append(output, id.Name)
 	}
+
+	sorter := sorter.NewSorter().ByKeys([]string{"id"})
+	sorter.Sort(output)
 
 	return &output, nil
 }

--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -1274,8 +1274,8 @@ func flattenFrontDoorBackendPools(input *[]frontdoor.BackendPool, frontDoorId pa
 		})
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(output)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(output)
 
 	return &output, nil
 }
@@ -1347,8 +1347,8 @@ func flattenFrontDoorBackend(input *[]frontdoor.Backend) []interface{} {
 		output = append(output, result)
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(output)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(output)
 
 	return output
 }
@@ -1437,8 +1437,8 @@ func flattenFrontEndEndpoints(input *[]frontdoor.FrontendEndpoint, frontDoorId p
 		})
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(results)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(results)
 
 	return &results, nil
 }
@@ -1492,8 +1492,8 @@ func flattenFrontDoorHealthProbeSettingsModel(input *[]frontdoor.HealthProbeSett
 		})
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(results)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(results)
 
 	return results
 }
@@ -1537,8 +1537,8 @@ func flattenFrontDoorLoadBalancingSettingsModel(input *[]frontdoor.LoadBalancing
 		})
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(results)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(results)
 
 	return results
 }
@@ -1598,8 +1598,8 @@ func flattenFrontDoorRoutingRule(input *[]frontdoor.RoutingRule, oldBlocks inter
 		})
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(output)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(output)
 
 	return &output, nil
 }
@@ -1742,8 +1742,8 @@ func flattenFrontDoorFrontendEndpointsSubResources(input *[]frontdoor.SubResourc
 		output = append(output, id.Name)
 	}
 
-	sorter := sorter.NewSorter().ByKeys([]string{"id"})
-	sorter.Sort(output)
+	sorter := sorter.FDSorter().ByKeys([]string{"id"})
+	sorter.DoSort(output)
 
 	return &output, nil
 }

--- a/azurerm/internal/services/frontdoor/sorter/sorter.go
+++ b/azurerm/internal/services/frontdoor/sorter/sorter.go
@@ -106,36 +106,8 @@ func Descending(a, b interface{}) CompareResult {
 	if a == b {
 		return EQUAL
 	}
-	switch a.(type) {
-	case string:
-		return lg(a.(string) > b.(string))
-	case int:
-		return lg(a.(int) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int))
-	case int8:
-		return lg(a.(int8) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int8))
-	case int16:
-		return lg(a.(int16) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int16))
-	case int32:
-		return lg(a.(int32) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int32))
-	case int64:
-		return lg(a.(int64) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int64))
-	case uint:
-		return lg(a.(uint) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint))
-	case uint8:
-		return lg(a.(uint8) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint8))
-	case uint16:
-		return lg(a.(uint16) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint16))
-	case uint32:
-		return lg(a.(uint32) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint32))
-	case uint64:
-		return lg(a.(uint64) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint64))
-	case float32:
-		return lg(a.(float32) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(float32))
-	case float64:
-		return lg(a.(float64) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(float64))
-	default:
-		panic(fmt.Sprintf("dont know how to compare: %T", a))
-	}
+
+	return lg(a.(string) > b.(string))
 }
 
 func lg(b bool) CompareResult {

--- a/azurerm/internal/services/frontdoor/sorter/sorter.go
+++ b/azurerm/internal/services/frontdoor/sorter/sorter.go
@@ -8,58 +8,42 @@ import (
 
 type sorter struct {
 	data  interface{}
-	order KeyComps
+	order Comparators
 }
 
-// NewSorter create a new sorter struct which Sort() can be called on.
-func NewSorter() *sorter {
+func FDSorter() *sorter {
 	return &sorter{}
 }
 
-// ByKeys is used to provide a list of string to indicate which keys to sort by and in which
-// order.  If the key name starts with "-" it will be sorted in Descending order otherwise
-// it will be sorted in Ascending order.
 func (s *sorter) ByKeys(order []string) *sorter {
-	keyComps := make(KeyComps, 0)
+	comparators := make(Comparators, 0)
 	for _, key := range order {
-		switch key[0] {
-		case '-':
-			keyComps = append(keyComps, KeyComp{key[1:], Descending})
-		case '+':
-			keyComps = append(keyComps, KeyComp{key[1:], Ascending})
-		default:
-			keyComps = append(keyComps, KeyComp{key, Ascending})
-		}
+		comparators = append(comparators, Comparator{key, Ascending})
 	}
-	return s.ByKeyComps(keyComps)
+	return s.ByKeyComparators(comparators)
 }
 
-// KeyComp struct to provide custom compaitor functions
-type KeyComp struct {
+type Comparator struct {
 	Name string
 	Comp func(interface{}, interface{}) CompareResult
 }
 
-type KeyComps []KeyComp
+type Comparators []Comparator
 
-// ByKeyComps is used to provide a list of KeyComp to sort by key with an explicit comparitor.
-func (s *sorter) ByKeyComps(keyComps KeyComps) *sorter {
-	s.order = keyComps
+func (s *sorter) ByKeyComparators(comparators Comparators) *sorter {
+	s.order = comparators
 	return s
 }
 
-// Sort will sort the data provided.  The data should be a slice of something.
-func (s *sorter) Sort(data interface{}) {
+func (s *sorter) DoSort(data interface{}) {
 	s.data = data
 	sort.Sort(s)
 }
 
-// Len is required to implement sort.Interface
 func (s *sorter) Len() int {
 	return reflect.ValueOf(s.data).Len()
 }
 
-// Swap is required to implement sort.Interface
 func (s *sorter) Swap(i, j int) {
 	if i > j {
 		i, j = j, i
@@ -71,7 +55,6 @@ func (s *sorter) Swap(i, j int) {
 	arr.Index(j).Set(reflect.ValueOf(tmp))
 }
 
-// Less is required to implement sort.Interface
 func (s *sorter) Less(i, j int) bool {
 	arr := reflect.ValueOf(s.data)
 	a := reflect.ValueOf(arr.Index(i).Interface())

--- a/azurerm/internal/services/frontdoor/sorter/sorter.go
+++ b/azurerm/internal/services/frontdoor/sorter/sorter.go
@@ -1,0 +1,163 @@
+package sorter
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+type sorter struct {
+	data  interface{}
+	order KeyComps
+}
+
+// NewSorter create a new sorter struct which Sort() can be called on.
+func NewSorter() *sorter {
+	return &sorter{}
+}
+
+// ByKeys is used to provide a list of string to indicate which keys to sort by and in which
+// order.  If the key name starts with "-" it will be sorted in Descending order otherwise
+// it will be sorted in Ascending order.
+func (s *sorter) ByKeys(order []string) *sorter {
+	keyComps := make(KeyComps, 0)
+	for _, key := range order {
+		switch key[0] {
+		case '-':
+			keyComps = append(keyComps, KeyComp{key[1:], Descending})
+		case '+':
+			keyComps = append(keyComps, KeyComp{key[1:], Ascending})
+		default:
+			keyComps = append(keyComps, KeyComp{key, Ascending})
+		}
+	}
+	return s.ByKeyComps(keyComps)
+}
+
+// KeyComp struct to provide custom compaitor functions
+type KeyComp struct {
+	Name string
+	Comp func(interface{}, interface{}) CompareResult
+}
+
+type KeyComps []KeyComp
+
+// ByKeyComps is used to provide a list of KeyComp to sort by key with an explicit comparitor.
+func (s *sorter) ByKeyComps(keyComps KeyComps) *sorter {
+	s.order = keyComps
+	return s
+}
+
+// Sort will sort the data provided.  The data should be a slice of something.
+func (s *sorter) Sort(data interface{}) {
+	s.data = data
+	sort.Sort(s)
+}
+
+// Len is required to implement sort.Interface
+func (s *sorter) Len() int {
+	return reflect.ValueOf(s.data).Len()
+}
+
+// Swap is required to implement sort.Interface
+func (s *sorter) Swap(i, j int) {
+	if i > j {
+		i, j = j, i
+	}
+	arr := reflect.ValueOf(s.data)
+
+	tmp := arr.Index(i).Interface()
+	arr.Index(i).Set(arr.Index(j))
+	arr.Index(j).Set(reflect.ValueOf(tmp))
+}
+
+// Less is required to implement sort.Interface
+func (s *sorter) Less(i, j int) bool {
+	arr := reflect.ValueOf(s.data)
+	a := reflect.ValueOf(arr.Index(i).Interface())
+	b := reflect.ValueOf(arr.Index(j).Interface())
+	if a.Kind() != reflect.Map {
+		iface := a.Interface()
+		panic(fmt.Sprintf("[A] Kind: %s, Expected a map, but got a %T for %v", a.Kind(), iface, iface))
+	}
+	if b.Kind() != reflect.Map {
+		iface := b.Interface()
+		panic(fmt.Sprintf("[B] Kind: %s, Expected a map, but got a %T for %v", b.Kind(), iface, iface))
+	}
+
+	for i := 0; i < len(s.order); i += 1 {
+		keyComp := s.order[i]
+		af := a.MapIndex(reflect.ValueOf(keyComp.Name)).Interface()
+		bf := b.MapIndex(reflect.ValueOf(keyComp.Name)).Interface()
+
+		switch keyComp.Comp(af, bf) {
+		case LESSER:
+			return true
+		case GREATER:
+			return false
+		}
+	}
+	return true
+}
+
+type CompareResult int8
+
+const (
+	LESSER CompareResult = -1 + iota
+	EQUAL
+	GREATER
+)
+
+func Ascending(a, b interface{}) CompareResult {
+	switch Descending(a, b) {
+	case LESSER:
+		return GREATER
+	case GREATER:
+		return LESSER
+	default:
+		return EQUAL
+	}
+}
+
+func Descending(a, b interface{}) CompareResult {
+	if a == b {
+		return EQUAL
+	}
+	switch a.(type) {
+	case string:
+		return lg(a.(string) > b.(string))
+	case int:
+		return lg(a.(int) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int))
+	case int8:
+		return lg(a.(int8) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int8))
+	case int16:
+		return lg(a.(int16) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int16))
+	case int32:
+		return lg(a.(int32) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int32))
+	case int64:
+		return lg(a.(int64) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(int64))
+	case uint:
+		return lg(a.(uint) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint))
+	case uint8:
+		return lg(a.(uint8) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint8))
+	case uint16:
+		return lg(a.(uint16) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint16))
+	case uint32:
+		return lg(a.(uint32) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint32))
+	case uint64:
+		return lg(a.(uint64) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(uint64))
+	case float32:
+		return lg(a.(float32) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(float32))
+	case float64:
+		return lg(a.(float64) > reflect.ValueOf(b).Convert(reflect.TypeOf(a)).Interface().(float64))
+	default:
+		panic(fmt.Sprintf("dont know how to compare: %T", a))
+	}
+}
+
+func lg(b bool) CompareResult {
+	if b {
+		return LESSER
+	}
+	return GREATER
+}


### PR DESCRIPTION
@WodansSon here goes nothing :)

A bit more elaborate description is that this is a band-aid to stop sporadic subresource reshuffling while we're trying to work with FrontDoor Service Team on a more sane (deterministic) solution (if exists).

Will partially fix #9153, however, since order in the state is alphabetically sorted by id - inserting new subresource in configuration that would cause it to be in the middle of an alphabetically sorted list will push the the rest of the list.

This is by far not ideal, but by giving people a way to deterministically sort their subresource names we are providing a way out for the time being.