### PR TITLE
azurerm_cosmosdb_account_resource - marking `connection_string` as sensitive

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -356,6 +356,7 @@ func resourceCosmosDbAccount() *schema.Resource {
 				Sensitive: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+					Sensitive: true,
 				},
 			},
 

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -355,7 +355,7 @@ func resourceCosmosDbAccount() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:      schema.TypeString,
 					Sensitive: true,
 				},
 			},


### PR DESCRIPTION
I _believe_ this will resolve #10941, but I've never written Go or worked on a tf provider before.