### PR TITLE
Fix IotCentralApplicaiton API breaking change

### DIFF
--- a/azurerm/internal/services/iotcentral/iotcentral_application_resource_test.go
+++ b/azurerm/internal/services/iotcentral/iotcentral_application_resource_test.go
@@ -42,7 +42,7 @@ func TestAccIoTCentralApplication_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("template").HasValue("iotc-default@1.0.0"),
+				check.That(data.ResourceName).Key("template").HasValue("iotc-pnp-preview@1.0.0"),
 				check.That(data.ResourceName).Key("tags.ENV").HasValue("Test"),
 			),
 		},
@@ -144,7 +144,7 @@ resource "azurerm_iotcentral_application" "test" {
   sub_domain          = "acctest-iotcentralapp-%[2]d"
   display_name        = "acctest-iotcentralapp-%[2]d"
   sku                 = "ST1"
-  template            = "iotc-default@1.0.0"
+  template            = "iotc-pnp-preview@1.0.0"
   tags = {
     ENV = "Test"
   }

--- a/azurerm/internal/services/iotcentral/migration/iotcentral_application_V0_to_V1.go
+++ b/azurerm/internal/services/iotcentral/migration/iotcentral_application_V0_to_V1.go
@@ -1,0 +1,84 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iotcentral/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iotcentral/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+)
+
+func IoTCentralApplicationV0ToV1() schema.StateUpgrader {
+	return schema.StateUpgrader{
+		Version: 0,
+		Type:    iotCentralApplicationV0Schema().CoreConfigSchema().ImpliedType(),
+		Upgrade: iotCentralApplicationUpgradeV0ToV1,
+	}
+}
+
+func iotCentralApplicationV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.ApplicationName,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"sub_domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.ApplicationSubdomain,
+			},
+
+			"display_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validate.ApplicationDisplayName,
+			},
+
+			"sku": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(iotcentral.F1),
+					string(iotcentral.S1),
+					string(iotcentral.ST1),
+					string(iotcentral.ST2),
+				}, true),
+				Default: iotcentral.ST1,
+			},
+			"template": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validate.ApplicationTemplateName,
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func iotCentralApplicationUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	oldId := rawState["id"].(string)
+	id, err := parse.ApplicationID(oldId)
+	if err != nil {
+		return rawState, err
+	}
+
+	newId := id.ID()
+	log.Printf("Updating `id` from %q to %q", oldId, newId)
+	rawState["id"] = newId
+	return rawState, nil
+}


### PR DESCRIPTION
The resource ID returned by service has changed, fix the API breaking change:
New ID: subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.IoTCentral/**iotApps**/{appName}
Old ID: subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.IoTCentral/**IoTApps**/{appName}

AccTest Result:
![image](https://user-images.githubusercontent.com/57888764/110903382-53af2700-8342-11eb-84cf-c75a921ae07e.png)
