### PR TITLE
Add URL Configuration support to azurerm_application_gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ ENHANCEMENTS:
 * dependencies: updating to `v52.4.0` of `github.com/Azure/azure-sdk-for-go` ([#10982](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10982))
 * `azurerm_api_management_subscription` - making `user_id` property optional [[#10638](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10638)}
 
+ENHANCEMENTS:
+
+* `azurerm_application_gateway.rewrite_rule` add support for URL rewriting with `url_configuration` block ([#10950](https://github.com/terraform-providers/terraform-provider-azurerm/pull/10950))
+
 BUG FIXES:
 
 * `azurerm_cosmosdb_account_resource` - marking `connection_string` as sensitive ([#10942](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10942))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,6 @@ ENHANCEMENTS:
 * dependencies: updating to `v52.4.0` of `github.com/Azure/azure-sdk-for-go` ([#10982](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10982))
 * `azurerm_api_management_subscription` - making `user_id` property optional [[#10638](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10638)}
 
-ENHANCEMENTS:
-
-* `azurerm_application_gateway.rewrite_rule` add support for URL rewriting with `url_configuration` block ([#10950](https://github.com/terraform-providers/terraform-provider-azurerm/pull/10950))
-
 BUG FIXES:
 
 * `azurerm_cosmosdb_account_resource` - marking `connection_string` as sensitive ([#10942](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10942))

--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -3041,6 +3041,8 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]network.ApplicationGatewa
 
 					requestConfigs := make([]interface{}, 0)
 					responseConfigs := make([]interface{}, 0)
+					urlConfigs := make([]interface{}, 0)
+
 					if rule.ActionSet != nil {
 						actionSet := *rule.ActionSet
 
@@ -3075,9 +3077,28 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]network.ApplicationGatewa
 								responseConfigs = append(responseConfigs, responseConfig)
 							}
 						}
+
+						if actionSet.URLConfiguration != nil {
+							config := *actionSet.URLConfiguration
+							urlConfig := map[string]interface{}{}
+
+							if config.ModifiedPath != nil {
+								urlConfig["path"] = *config.ModifiedPath
+							}
+
+							if config.ModifiedQueryString != nil {
+								urlConfig["query_string"] = *config.ModifiedQueryString
+							}
+
+							if config.Reroute != nil {
+								urlConfig["reroute"] = *config.Reroute
+							}
+							urlConfigs = append(urlConfigs, urlConfig)
+						}
 					}
 					ruleOutput["request_header_configuration"] = requestConfigs
 					ruleOutput["response_header_configuration"] = responseConfigs
+					ruleOutput["url_configuration"] = urlConfigs
 
 					rules = append(rules, ruleOutput)
 				}

--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -2926,6 +2926,7 @@ func expandApplicationGatewayRewriteRuleSets(d *schema.ResourceData) *[]network.
 			conditions := make([]network.ApplicationGatewayRewriteRuleCondition, 0)
 			requestConfigurations := make([]network.ApplicationGatewayHeaderConfiguration, 0)
 			responseConfigurations := make([]network.ApplicationGatewayHeaderConfiguration, 0)
+			urlConfiguration := network.ApplicationGatewayURLConfiguration{}
 
 			rule := network.ApplicationGatewayRewriteRule{
 				Name:         utils.String(r["name"].(string)),
@@ -2962,10 +2963,28 @@ func expandApplicationGatewayRewriteRuleSets(d *schema.ResourceData) *[]network.
 				responseConfigurations = append(responseConfigurations, config)
 			}
 
+			for _, rawConfig := range r["url_configuration"].([]interface{}) {
+				c := rawConfig.(map[string]interface{})
+				if c["path"] != nil {
+					urlConfiguration.ModifiedPath = utils.String(c["path"].(string))
+				}
+				if c["query_string"] != nil {
+					urlConfiguration.ModifiedQueryString = utils.String(c["query_string"].(string))
+				}
+				if c["reroute"] != nil {
+					urlConfiguration.Reroute = utils.Bool(c["reroute"].(bool))
+				}
+			}
+
 			rule.ActionSet = &network.ApplicationGatewayRewriteRuleActionSet{
 				RequestHeaderConfigurations:  &requestConfigurations,
 				ResponseHeaderConfigurations: &responseConfigurations,
 			}
+
+			if len(r["url_configuration"].([]interface{})) > 0 {
+				rule.ActionSet.URLConfiguration = &urlConfiguration
+			}
+
 			rules = append(rules, rule)
 		}
 

--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -988,6 +988,29 @@ func resourceApplicationGateway() *schema.Resource {
 											},
 										},
 									},
+
+									"url_configuration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"path": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"query_string": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"reroute": {
+													Type:     schema.TypeBool,
+													Optional: true,
+													Default:  false,
+												},
+											},
+										},
+									},
 								},
 							},
 						},

--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -989,7 +989,7 @@ func resourceApplicationGateway() *schema.Resource {
 										},
 									},
 
-									"url_configuration": {
+									"url": {
 										Type:     schema.TypeList,
 										Optional: true,
 										MaxItems: 1,
@@ -2963,7 +2963,7 @@ func expandApplicationGatewayRewriteRuleSets(d *schema.ResourceData) *[]network.
 				responseConfigurations = append(responseConfigurations, config)
 			}
 
-			for _, rawConfig := range r["url_configuration"].([]interface{}) {
+			for _, rawConfig := range r["url"].([]interface{}) {
 				c := rawConfig.(map[string]interface{})
 				if c["path"] != nil {
 					urlConfiguration.ModifiedPath = utils.String(c["path"].(string))
@@ -2981,7 +2981,7 @@ func expandApplicationGatewayRewriteRuleSets(d *schema.ResourceData) *[]network.
 				ResponseHeaderConfigurations: &responseConfigurations,
 			}
 
-			if len(r["url_configuration"].([]interface{})) > 0 {
+			if len(r["url"].([]interface{})) > 0 {
 				rule.ActionSet.URLConfiguration = &urlConfiguration
 			}
 
@@ -3117,7 +3117,7 @@ func flattenApplicationGatewayRewriteRuleSets(input *[]network.ApplicationGatewa
 					}
 					ruleOutput["request_header_configuration"] = requestConfigs
 					ruleOutput["response_header_configuration"] = responseConfigs
-					ruleOutput["url_configuration"] = urlConfigs
+					ruleOutput["url"] = urlConfigs
 
 					rules = append(rules, ruleOutput)
 				}

--- a/azurerm/internal/services/network/application_gateway_resource_test.go
+++ b/azurerm/internal/services/network/application_gateway_resource_test.go
@@ -378,6 +378,22 @@ func TestAccApplicationGateway_rewriteRuleSets_redirect(t *testing.T) {
 	})
 }
 
+func TestAccApplicationGateway_rewriteRuleSets_rewriteUrl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
+	r := ApplicationGatewayResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.rewriteRuleSets_rewriteUrl(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rewrite_rule_set.0.name").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApplicationGateway_probes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
 	r := ApplicationGatewayResource{}
@@ -5146,6 +5162,128 @@ resource "azurerm_application_gateway" "test" {
       request_header_configuration {
         header_name  = "X-custom"
         header_value = "customvalue"
+      }
+    }
+  }
+
+  redirect_configuration {
+    name                 = local.redirect_configuration_name
+    redirect_type        = "Temporary"
+    target_listener_name = local.target_listener_name
+    include_path         = true
+    include_query_string = false
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r ApplicationGatewayResource) rewriteRuleSets_rewriteUrl(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_port_name2            = "${azurerm_virtual_network.test.name}-feport2"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  target_listener_name           = "${azurerm_virtual_network.test.name}-trgthttplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+  redirect_configuration_name    = "${azurerm_virtual_network.test.name}-Port80To8888Redirect"
+  rewrite_rule_set_name          = "${azurerm_virtual_network.test.name}-rwset"
+  rewrite_rule_name              = "${azurerm_virtual_network.test.name}-rwrule"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_port {
+    name = local.frontend_port_name2
+    port = 8888
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test_standard.id
+  }
+
+  backend_address_pool {
+    name = local.backend_address_pool_name
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  http_listener {
+    name                           = local.target_listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name2
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                        = local.request_routing_rule_name
+    rule_type                   = "Basic"
+    http_listener_name          = local.listener_name
+    redirect_configuration_name = local.redirect_configuration_name
+    rewrite_rule_set_name       = local.rewrite_rule_set_name
+  }
+
+  rewrite_rule_set {
+    name = local.rewrite_rule_set_name
+
+    rewrite_rule {
+      name          = local.rewrite_rule_name
+      rule_sequence = 1
+
+      condition {
+        variable = "var_uri_path"
+        pattern  = ".*article/(.*)/(.*)"
+      }
+
+      url_configuration {
+        path         = "/article.aspx"
+        query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
       }
     }
   }

--- a/azurerm/internal/services/network/application_gateway_resource_test.go
+++ b/azurerm/internal/services/network/application_gateway_resource_test.go
@@ -5281,7 +5281,7 @@ resource "azurerm_application_gateway" "test" {
         pattern  = ".*article/(.*)/(.*)"
       }
 
-      url_configuration {
+      url {
         path         = "/article.aspx"
         query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
       }

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -545,6 +545,7 @@ A `rewrite_rule` block supports the following:
 
 * `response_header_configuration` - (Optional) One or more `response_header_configuration` blocks as defined above.
 
+* `url_configuration` - (Optional) One `url_configuration` block as defined above
 ---
 
 A `condition` block supports the following:
@@ -572,6 +573,18 @@ A `response_header_configuration` block supports the following:
 * `header_name` - (Required) Header name of the header configuration.
 
 * `header_value` - (Required) Header value of the header configuration. To delete a response header set this property to an empty string.
+
+---
+
+A `url_configuration` block supports the following:
+
+* `path` - (Optional) The URL path to rewrite.
+
+* `query_string` - (Optional) The query string to rewrite.
+
+~> **Note:** One or both of `path` and `query_string` should be specified.
+
+* `reroute` - (Optional) Should the URL path map be reevaluated after this rewrite has been applied. [More info on rewrite configutation](https://docs.microsoft.com/en-us/azure/application-gateway/rewrite-http-headers-url#rewrite-configuration)
 
 ## Attributes Reference
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -582,9 +582,9 @@ A `url_configuration` block supports the following:
 
 * `query_string` - (Optional) The query string to rewrite.
 
-~> **Note:** One or both of `path` and `query_string` should be specified.
+~> **Note:** One or both of `path` and `query_string` must be specified.
 
-* `reroute` - (Optional) Should the URL path map be reevaluated after this rewrite has been applied. [More info on rewrite configutation](https://docs.microsoft.com/en-us/azure/application-gateway/rewrite-http-headers-url#rewrite-configuration)
+* `reroute` - (Optional) Whether the URL path map should be reevaluated after this rewrite has been applied. [More info on rewrite configutation](https://docs.microsoft.com/en-us/azure/application-gateway/rewrite-http-headers-url#rewrite-configuration)
 
 ## Attributes Reference
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -545,7 +545,7 @@ A `rewrite_rule` block supports the following:
 
 * `response_header_configuration` - (Optional) One or more `response_header_configuration` blocks as defined above.
 
-* `url_configuration` - (Optional) One `url_configuration` block as defined above
+* `url` - (Optional) One `url` block as defined above
 ---
 
 A `condition` block supports the following:
@@ -576,7 +576,7 @@ A `response_header_configuration` block supports the following:
 
 ---
 
-A `url_configuration` block supports the following:
+A `url` block supports the following:
 
 * `path` - (Optional) The URL path to rewrite.
 


### PR DESCRIPTION
Fixes #7565

This is my first pass at trying to get `URLConfiguration` support into terraform (see https://docs.microsoft.com/en-us/rest/api/application-gateway/applicationgateways/get#applicationgatewayurlconfiguration).

This will allow the rewriting of URLs in application gateway.

To-dos:

- [x] Should we validate that at least one of `url_configuration.url_path` or `url_configuration.url_query` is supplied?
- [x] Update docs
- [x] tests??

---

example usage:

```hcl

resource "azurerm_application_gateway" "gateway" {
  ...
  rewrite_rule_set {
    name = local.rewrite_rule_set_name

    rewrite_rule {
      name          = local.rewrite_rule_name
      rule_sequence = 1

      condition {
        variable = "var_uri_path"
        pattern  = ".*article/(.*)/(.*)"
      }

      url {
        path         = "/article.aspx"
        query_string = "id={var_uri_path_1}&title={var_uri_path_2}"
      }
    }
  }
  ...
}

```

Test data based on example here https://docs.microsoft.com/en-us/azure/application-gateway/rewrite-url-portal