### PR TITLE
Additional Note for Allow Azure Service - Synapse Firewall

### DIFF
--- a/website/docs/r/synapse_firewall_rule.html.markdown
+++ b/website/docs/r/synapse_firewall_rule.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 
 -> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0`.
 
+-> **NOTE:** The Azure feature `Allow access to Azure services` requires the `name` to be `AllowAllWindowsAzureIps`.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
The `Allow access to Azure services` feature requires the `name` of the Synapse Firewall rule to be set as `AllowAllWindowsAzureIps`.

This not helps to prevent this error