### PR TITLE
azurerm_ssh_public_key: using suppress.CaseDifference for resource_group_name

### DIFF
--- a/azurerm/internal/services/compute/ssh_public_key_resource.go
+++ b/azurerm/internal/services/compute/ssh_public_key_resource.go
@@ -49,7 +49,9 @@ func resourceSshPublicKey() *schema.Resource {
 					"Public SSH Key name must be 1 - 128 characters long, can contain letters, numbers, underscores, and hyphens (but the first and last character must be a letter or number).",
 				),
 			},
-
+			// We have to ignore case due to incorrect capitalisation of resource group name in
+			// ID in the response we get from the API request.
+			// Related issue: https://github.com/Azure/azure-rest-api-specs/issues/13491
 			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/internal/services/compute/ssh_public_key_resource.go
+++ b/azurerm/internal/services/compute/ssh_public_key_resource.go
@@ -50,7 +50,7 @@ func resourceSshPublicKey() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"location": azure.SchemaLocation(),
 

--- a/azurerm/internal/services/compute/ssh_public_key_resource_test.go
+++ b/azurerm/internal/services/compute/ssh_public_key_resource_test.go
@@ -65,7 +65,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "ACCTESTRG-%d"
+  name     = "AcctestRG-%d"
   location = "%s"
 }
 


### PR DESCRIPTION
Suppress case difference for resource group name as the api is always returning it in uppercase.

closes #10957 

```bash
$ make acctests SERVICE="compute" TESTARGS='-run=TestAccSshPublicKey_CreateUpdate'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/compute -run=TestAccSshPublicKey_CreateUpdate -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/13 18:02:07 [DEBUG] not using binary driver name, it's no longer needed
2021/03/13 18:02:09 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccSshPublicKey_CreateUpdate
=== PAUSE TestAccSshPublicKey_CreateUpdate
=== CONT  TestAccSshPublicKey_CreateUpdate

--- PASS: TestAccSshPublicKey_CreateUpdate (175.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute     180.450s
```