### PR TITLE
case-insensitive resource_group_name schema by default

### DIFF
--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -11,10 +11,11 @@ import (
 
 func SchemaResourceGroupName() *schema.Schema {
 	return &schema.Schema{
-		Type:         schema.TypeString,
-		Required:     true,
-		ForceNew:     true,
-		ValidateFunc: validateResourceGroupName,
+		Type:             schema.TypeString,
+		Required:         true,
+		ForceNew:         true,
+		DiffSuppressFunc: suppress.CaseDifference,
+		ValidateFunc:     validateResourceGroupName,
 	}
 }
 


### PR DESCRIPTION
As the resource group name is case-insensitive in Azure,

it might be a good idea to use `DiffSuppressFunc: suppress.CaseDifference` in the default `SchemaResourceGroupName` schema instead of explicitly using `SchemaResourceGroupNameDiffSuppress` schema for specific resources.

related to #10077
