### PR TITLE
New Resource: `azurerm_data_factory_linked_service_azure_databricks`

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
@@ -1,7 +1,10 @@
 package datafactory
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
@@ -148,13 +151,16 @@ func resourceDataFactoryLinkedServiceAzureDatabricks() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-
-						// Consider changing this to min and adding an optional max since autoscaling uses the format min:max (e.g. 1:10)
-						"number_of_workers": {
-							Type:         schema.TypeString,
+						"min_number_of_workers": {
+							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      "1",
-							ValidateFunc: validation.StringIsNotEmpty,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"max_number_of_workers": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 10),
 						},
 						"cluster_version": {
 							Type:         schema.TypeString,
@@ -206,13 +212,16 @@ func resourceDataFactoryLinkedServiceAzureDatabricks() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-
-						// Consider changing this to min and adding an optional max since autoscaling uses the format min:max (e.g. 1:10)
-						"number_of_workers": {
-							Type:         schema.TypeString,
+						"min_number_of_workers": {
+							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      "1",
-							ValidateFunc: validation.StringIsNotEmpty,
+							Default:      1,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"max_number_of_workers": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 10), //TODO: Confirm real number max workers
 						},
 						"instance_pool_id": {
 							Type:         schema.TypeString,
@@ -280,29 +289,33 @@ func resourceDataFactoryLinkedServiceDatabricksCreateUpdate(d *schema.ResourceDa
 		}
 
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_data_factory_linked_service_data_lake_storage_gen2", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_data_factory_linked_service_azure_databricks", *existing.ID)
 		}
 	}
 
-	var DatabricksProperties *datafactory.AzureDatabricksLinkedServiceTypeProperties
+	var databricksProperties *datafactory.AzureDatabricksLinkedServiceTypeProperties
 
 	// Check if the MSI authentication block is set
 	msiAuth := d.Get("authentication_msi").([]interface{})
 	accessTokenAuth := d.Get("authentication_access_token").([]interface{})
 	accessTokenKeyVaultAuth := d.Get("authentication_key_vault_password").([]interface{})
 
+	// Set the properties based on the authentication type that was provided
 	if len(msiAuth) > 0 {
-		// MSI Auth map has data
+		if msiAuth[0] == nil {
+			return fmt.Errorf("`authentication_msi` missing data at index 0")
+		}
 		workspaceResourceID := msiAuth[0].(map[string]interface{})["workspace_resource_id"].(string)
 
-		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+		databricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
 			Authentication:      "MSI",
 			WorkspaceResourceID: workspaceResourceID,
 		}
-	}
-	if len(accessTokenAuth) > 0 {
+	} else if len(accessTokenAuth) > 0 {
 		// Setup authentication using access tokens
-
+		if accessTokenAuth[0] == nil {
+			return fmt.Errorf("`authentication_access_token` missing data at index 0")
+		}
 		accessToken := accessTokenAuth[0].(map[string]interface{})["access_token"].(string)
 
 		accessTokenAsSecureString := datafactory.SecureString{
@@ -311,86 +324,103 @@ func resourceDataFactoryLinkedServiceDatabricksCreateUpdate(d *schema.ResourceDa
 		}
 
 		// Assign the access token in the properties block
-		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+		databricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
 			AccessToken: &accessTokenAsSecureString,
 		}
 	} else {
-		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+		if accessTokenKeyVaultAuth[0] == nil {
+			return fmt.Errorf("`authentication_key_vault_password` missing data at index 0")
+		}
+		databricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
 			AccessToken: expandAzureKeyVaultPassword(accessTokenKeyVaultAuth),
 		}
 	}
 
 	// Set the other type properties
-	// Domain
-	DatabricksProperties.Domain = d.Get("adb_domain").(string)
+	databricksProperties.Domain = d.Get("adb_domain").(string)
 
-	// Check if the
 	if v, ok := d.GetOk("existing_cluster_id"); ok {
-		DatabricksProperties.ExistingClusterID = v.(string)
+		databricksProperties.ExistingClusterID = v.(string)
 	}
 
 	if v, ok := d.GetOk("instance_pool"); ok {
+		if v.([]interface{})[0] == nil {
+			return fmt.Errorf("`instance_pool` missing data at index 0")
+		}
 		instancePoolMap := v.([]interface{})[0].(map[string]interface{})
 
-		// Process the instance pool identifier
 		if data := instancePoolMap["instance_pool_id"]; data != nil {
-			DatabricksProperties.InstancePoolID = data
+			databricksProperties.InstancePoolID = data
 		}
 
-		// Process the cluster version
 		if data := instancePoolMap["cluster_version"]; data != nil {
-			DatabricksProperties.NewClusterVersion = data
+			databricksProperties.NewClusterVersion = data
 		}
 
-		// Process the number of workers
-		if data := instancePoolMap["number_of_workers"]; data != nil {
-			DatabricksProperties.NewClusterNumOfWorker = data
+		if minWorkersProperty := instancePoolMap["min_number_of_workers"]; minWorkersProperty != nil {
+			maxWorkersProperty := instancePoolMap["max_number_of_workers"]
+			if numOfWorkersProperty, errorMessage := constructNumberOfWorkersProperties(minWorkersProperty, maxWorkersProperty); errorMessage != nil {
+				databricksProperties.NewClusterNumOfWorker = numOfWorkersProperty
+			} else {
+				return fmt.Errorf(errorMessage.(string))
+			}
 		}
 	} else if v, ok := d.GetOk("new_cluster_config"); ok {
+		if v.([]interface{})[0] == nil {
+			return fmt.Errorf("`new_cluster_config` missing data at index 0")
+		}
 		newClusterMap := v.([]interface{})[0].(map[string]interface{})
 
-		// Process the cluster version
 		if data := newClusterMap["cluster_version"]; data != nil {
-			DatabricksProperties.NewClusterVersion = data
+			databricksProperties.NewClusterVersion = data
 		}
 
-		// Process the number of workers
-		if data := newClusterMap["number_of_workers"]; data != nil {
-			DatabricksProperties.NewClusterNumOfWorker = data
+		if minWorkersProperty := newClusterMap["min_number_of_workers"]; minWorkersProperty != nil {
+			maxWorkersProperty := newClusterMap["max_number_of_workers"]
+			if numOfWorkersProperty, errorMessage := constructNumberOfWorkersProperties(minWorkersProperty, maxWorkersProperty); errorMessage != nil {
+				databricksProperties.NewClusterNumOfWorker = numOfWorkersProperty
+			} else {
+				return fmt.Errorf(errorMessage.(string))
+			}
 		}
 
-		// Process the node type
 		if data := newClusterMap["node_type"]; data != nil {
-			DatabricksProperties.NewClusterNodeType = data
+			databricksProperties.NewClusterNodeType = data
 		}
 
 		if data := newClusterMap["driver_node_type"]; data != nil {
-			DatabricksProperties.NewClusterDriverNodeType = data
+			databricksProperties.NewClusterDriverNodeType = data
 		}
 
 		if data := newClusterMap["log_destination"]; data != nil {
-			DatabricksProperties.NewClusterLogDestination = data
+			databricksProperties.NewClusterLogDestination = data
 		}
 
-		if sparkConfig := newClusterMap["spark_config"].(map[string]interface{}); len(sparkConfig) > 0 {
-			DatabricksProperties.NewClusterSparkConf = sparkConfig
+		if newClusterMap["spark_config"] != nil {
+			if sparkConfig := newClusterMap["spark_config"].(map[string]interface{}); len(sparkConfig) > 0 {
+				databricksProperties.NewClusterSparkConf = sparkConfig
+			}
 		}
 
-		if sparkEnvVars := newClusterMap["spark_environment_variables"].(map[string]interface{}); len(sparkEnvVars) > 0 {
-			DatabricksProperties.NewClusterSparkEnvVars = sparkEnvVars
+		if newClusterMap["spark_environment_variables"] != nil {
+			if sparkEnvVars := newClusterMap["spark_environment_variables"].(map[string]interface{}); len(sparkEnvVars) > 0 {
+				databricksProperties.NewClusterSparkEnvVars = sparkEnvVars
+			}
 		}
 
-		if customTags := newClusterMap["custom_tags"].(map[string]interface{}); len(customTags) > 0 {
-			DatabricksProperties.NewClusterCustomTags = customTags
+		if newClusterMap["custom_tags"] != nil {
+			if customTags := newClusterMap["custom_tags"].(map[string]interface{}); len(customTags) > 0 {
+				databricksProperties.NewClusterCustomTags = customTags
+			}
 		}
 
 		initScripts := newClusterMap["init_scripts"]
-		DatabricksProperties.NewClusterInitScripts = &initScripts
+		databricksProperties.NewClusterInitScripts = &initScripts
 	}
 
 	DatabricksLinkedService := &datafactory.AzureDatabricksLinkedService{
 		Description: utils.String(d.Get("description").(string)),
-		AzureDatabricksLinkedServiceTypeProperties: DatabricksProperties,
+		AzureDatabricksLinkedServiceTypeProperties: databricksProperties,
 		Type: datafactory.TypeAzureDatabricks,
 	}
 
@@ -466,7 +496,7 @@ func resourceDataFactoryLinkedServiceDatabricksRead(d *schema.ResourceData, meta
 		return fmt.Errorf("Error classifiying Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", name, dataFactoryName, resourceGroup, datafactory.TypeAzureDatabricks, *resp.Type)
 	}
 
-	// Check the properties and verify is authentication is set to MSI
+	// Check the properties and verify if authentication is set to MSI
 	if props := Databricks.AzureDatabricksLinkedServiceTypeProperties; props != nil {
 		if props.Authentication != nil && props.Authentication == "MSI" {
 			authenticationMsi := make(map[string]interface{})
@@ -475,8 +505,9 @@ func resourceDataFactoryLinkedServiceDatabricksRead(d *schema.ResourceData, meta
 			d.Set("authentication_msi", authenticationMsiArray)
 		} else if props.AccessToken != nil {
 			// Check the data type of the access token so we know how to process it.
-
 			if accessToken := props.AccessToken; accessToken != nil {
+				// We only process AzureKeyVaultSecreReference because a string based access token is masked with asterisks in the GET response
+				// so we can't set it
 				if keyVaultPassword, ok := accessToken.AsAzureKeyVaultSecretReference(); ok {
 					if err := d.Set("authentication_key_vault_password", flattenAzureKeyVaultPassword(keyVaultPassword)); err != nil {
 						return fmt.Errorf("setting `authentication_key_vault_password`: %+v", err)
@@ -485,37 +516,56 @@ func resourceDataFactoryLinkedServiceDatabricksRead(d *schema.ResourceData, meta
 			}
 		}
 
-		// Process the domain
 		if props.Domain != nil {
 			d.Set("adb_domain", props.Domain)
 		}
 
-		// Process the cluster information
 		if props.ExistingClusterID != nil {
-			d.Set("existing_cluster_id", props.ExistingClusterID)
+			if err := d.Set("existing_cluster_id", props.ExistingClusterID); err != nil {
+				return fmt.Errorf("setting `existing_cluster_id`: %+v", err)
+			}
 		} else if id := props.InstancePoolID; id != nil {
-			// Process the values for instance pool configuration
 			numOfWorkers := props.NewClusterNumOfWorker
 			clusterVersion := props.NewClusterVersion
 
+			minWorkers, maxWorkers, err := parseNumberOfWorkersProperties(numOfWorkers.(string))
+			if err != nil {
+				return fmt.Errorf("%+v", err)
+			}
+
 			instancePoolMap := map[string]interface{}{
-				"instance_pool_id":  id,
-				"number_of_workers": numOfWorkers,
-				"cluster_version":   clusterVersion,
+				"instance_pool_id":      id,
+				"min_number_of_workers": minWorkers.(int),
+				"cluster_version":       clusterVersion,
+			}
+
+			if maxWorkers != nil {
+				instancePoolMap["max_number_of_workers"] = maxWorkers.(int)
 			}
 
 			instancePoolArray := []interface{}{instancePoolMap}
-			d.Set("instance_pool", instancePoolArray)
+			if err := d.Set("instance_pool", instancePoolArray); err != nil {
+				return fmt.Errorf("setting `instance_pool`: %+v", err)
+			}
 		} else {
 			// Process assuming it's a new cluster config
 			numOfWorkers := props.NewClusterNumOfWorker
 			clusterVersion := props.NewClusterVersion
 			nodeType := props.NewClusterNodeType
 
+			minWorkers, maxWorkers, err := parseNumberOfWorkersProperties(numOfWorkers.(string))
+			if err != nil {
+				return fmt.Errorf("%+v", err)
+			}
+
 			newClusterMap := map[string]interface{}{
-				"number_of_workers": numOfWorkers,
-				"cluster_version":   clusterVersion,
-				"node_type":         nodeType,
+				"min_number_of_workers": minWorkers.(int),
+				"cluster_version":       clusterVersion,
+				"node_type":             nodeType,
+			}
+
+			if maxWorkers != nil {
+				newClusterMap["max_number_of_workers"] = maxWorkers.(int)
 			}
 
 			// Retrieve all the optional arguments
@@ -546,7 +596,9 @@ func resourceDataFactoryLinkedServiceDatabricksRead(d *schema.ResourceData, meta
 			// Set the ResourceData with the map
 			newClusterArray := []interface{}{newClusterMap}
 
-			d.Set("new_cluster_config", newClusterArray)
+			if err := d.Set("new_cluster_config", newClusterArray); err != nil {
+				return fmt.Errorf("setting `new_cluster_config`: %+v", err)
+			}
 		}
 	}
 
@@ -595,4 +647,44 @@ func resourceDataFactoryLinkedServiceDatabricksDelete(d *schema.ResourceData, me
 		}
 	}
 	return nil
+}
+
+func constructNumberOfWorkersProperties(minWorkersProperty interface{}, maxWorkersProperty interface{}) (string, interface{}) {
+	var errorMessage string
+
+	// Default settings
+	minWorkers := minWorkersProperty.(int)
+	workersConfig := fmt.Sprintf("%d", minWorkers)
+
+	// If max workers are set, we'll assume they want to setup autoscaling and throw an error if the configuration looks invalid
+	if maxWorkersProperty != nil {
+		maxWorkers := maxWorkersProperty.(int)
+
+		if maxWorkers < minWorkers {
+			errorMessage = "`max_number_of_workers` cannot be less than `min_number_of_workers"
+		} else if maxWorkers > minWorkers {
+			workersConfig = fmt.Sprintf("%d:%d", minWorkers, maxWorkers)
+		}
+	}
+	return workersConfig, errorMessage
+}
+
+func parseNumberOfWorkersProperties(numberOfWorkersProperty string) (interface{}, interface{}, interface{}) {
+	// The number of workers should be either a fixed number (no autoscaling) or have a format of min:max if autoscaling is set.
+	numOfWorkersParts := strings.Split(numberOfWorkersProperty, ":")
+
+	var min interface{}
+	var max interface{}
+	var err error
+	if len(numOfWorkersParts) == 1 {
+		min, err = strconv.Atoi(numOfWorkersParts[0])
+	} else if len(numOfWorkersParts) == 2 {
+		if min, err = strconv.Atoi(numOfWorkersParts[0]); err == nil {
+			max, err = strconv.Atoi(numOfWorkersParts[1])
+		}
+	} else {
+		err = errors.New("Unknown format for number of workers property")
+	}
+
+	return min, max, err
 }

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
@@ -1,0 +1,621 @@
+package datafactory
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	databricksValidator "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/databricks/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDataFactoryLinkedServiceAzureDatabricks() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDataFactoryLinkedServiceDatabricksCreateUpdate,
+		Read:   resourceDataFactoryLinkedServiceDatabricksRead,
+		Update: resourceDataFactoryLinkedServiceDatabricksCreateUpdate,
+		Delete: resourceDataFactoryLinkedServiceDatabricksDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAzureRMDataFactoryLinkedServiceDatasetName,
+			},
+
+			"data_factory_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataFactoryName(),
+			},
+
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			//Authentication types
+			"authentication_msi": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"workspaceResourceId": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: databricksValidator.WorkspaceID,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"authentication_access_token", "authentication_msi", "authentication_key_vault_password"},
+			},
+
+			"authentication_access_token": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_token": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Sensitive:    true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"authentication_access_token", "authentication_msi", "authentication_key_vault_password"},
+			},
+
+			"authentication_key_vault_password": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"linked_service_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"secret_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"authentication_access_token", "authentication_msi", "authentication_key_vault_password"},
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"adb_domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			//Cluster types [existing cluster, new cluster, interactive pools]
+			"existing_cluster_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"existing_cluster_id", "new_cluster_config", "instance_pool"},
+			},
+
+			"new_cluster_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"custom_tags": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						//Consider changing this to min and adding an optional max since autoscaling uses the format min:max (e.g. 1:10)
+						"number_of_workers": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "1",
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"cluster_version": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"spark_config": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"spark_environment_variables": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						"log_destination": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"init_scripts": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						"driver_node_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"existing_cluster_id", "new_cluster_config", "instance_pool"},
+			},
+
+			"instance_pool": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+
+						//Consider changing this to min and adding an optional max since autoscaling uses the format min:max (e.g. 1:10)
+						"number_of_workers": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "1",
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"instance_pool_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"cluster_version": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+				ExactlyOneOf: []string{"existing_cluster_id", "new_cluster_config", "instance_pool"},
+			},
+
+			"integration_runtime_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"annotations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"additional_properties": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceDataFactoryLinkedServiceDatabricksCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	dataFactoryName := d.Get("data_factory_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_data_factory_linked_service_data_lake_storage_gen2", *existing.ID)
+		}
+	}
+
+	var DatabricksProperties *datafactory.AzureDatabricksLinkedServiceTypeProperties
+
+	// Check if the MSI authentication block is set
+	msiAuth := d.Get("authentication_msi").(map[string]interface{})
+	accessTokenAuth := d.Get("authentication_access_token").(map[string]interface{})
+	accessTokenKeyVaultAuth := d.Get("authentication_key_vault_password").([]interface{})
+
+	if len(msiAuth) > 0 {
+		//MSI Auth map has data
+		workspaceResourceID := msiAuth["workspaceResourceId"].(string)
+
+		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+			Authentication:      "MSI",
+			WorkspaceResourceID: workspaceResourceID,
+		}
+	} else if len(accessTokenAuth) > 0 {
+		//Setup authentication using access tokens
+
+		accessTokenAsSecureString := datafactory.SecureString{
+			Value: utils.String(accessTokenAuth["access_token"].(string)),
+			Type:  datafactory.TypeSecureString,
+		}
+
+		//Assign the access token in the properties block
+		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+			AccessToken: &accessTokenAsSecureString,
+		}
+	} else {
+		DatabricksProperties = &datafactory.AzureDatabricksLinkedServiceTypeProperties{
+			AccessToken: expandAzureKeyVaultPassword(accessTokenKeyVaultAuth),
+		}
+	}
+
+	//Set the other type properties
+	//Domain
+	DatabricksProperties.Domain = d.Get("adb_domain").(string)
+
+	//Check if the
+	if v, ok := d.GetOk("existing_cluster_id"); ok {
+		DatabricksProperties.ExistingClusterID = v.(string)
+	}
+
+	if v, ok := d.GetOk("instance_pool"); ok {
+
+		instancePoolMap := v.(map[string]interface{})
+		DatabricksProperties.InstancePoolID = instancePoolMap["instance_pool_id"]
+
+		//Process the instance pool identifier
+		if data := instancePoolMap["instance_pool_id"]; data != nil {
+			DatabricksProperties.InstancePoolID = data
+		} else {
+			// Throw an error
+		}
+
+		//Process the cluster version
+		if data := instancePoolMap["cluster_version"]; data != nil {
+			DatabricksProperties.NewClusterVersion = data
+		} else {
+			// Throw an error
+		}
+
+		//Process the number of workers
+		if data := instancePoolMap["number_of_workers"]; data != nil {
+			DatabricksProperties.NewClusterNumOfWorker = data
+		} else {
+			// Throw an error
+		}
+	} else {
+		//Process assuming it's a new cluster config
+		if v, ok := d.GetOk("new_cluster_config"); ok {
+			newClusterMap := v.([]interface{})[0].(map[string]interface{})
+
+			//Process the cluster version
+			if data := newClusterMap["cluster_version"]; data != nil {
+				DatabricksProperties.NewClusterVersion = data
+			} else {
+				// Throw an error
+			}
+
+			//Process the number of workers
+			if data := newClusterMap["number_of_workers"]; data != nil {
+				DatabricksProperties.NewClusterNumOfWorker = data
+			} else {
+				// Throw an error
+			}
+
+			//Process the node type
+			if data := newClusterMap["node_type"]; data != nil {
+				DatabricksProperties.NewClusterNodeType = data
+			} else {
+				// Throw an error
+			}
+
+			if data := newClusterMap["driver_node_type"]; data != nil {
+				DatabricksProperties.NewClusterDriverNodeType = data
+			}
+
+			if data := newClusterMap["log_destination"]; data != nil {
+				DatabricksProperties.NewClusterLogDestination = data
+			}
+
+			if sparkConfig := newClusterMap["spark_config"].(map[string]interface{}); len(sparkConfig) > 0 {
+				DatabricksProperties.NewClusterSparkConf = sparkConfig
+			}
+
+			// sparkConfig := newClusterMap["spark_config"].(map[string]interface{})
+			// if sparkConfig := expandKeyValuePairs(sparkConfigRaw); len(sparkConfig) > 0 {
+			// 	DatabricksProperties.NewClusterSparkConf = sparkConfig
+			// }
+
+			if sparkEnvVars := newClusterMap["spark_environment_variables"].(map[string]interface{}); len(sparkEnvVars) > 0 {
+				DatabricksProperties.NewClusterSparkEnvVars = sparkEnvVars
+			}
+
+			if customTags := newClusterMap["custom_tags"].(map[string]interface{}); len(customTags) > 0 {
+				DatabricksProperties.NewClusterCustomTags = customTags
+			}
+
+			initScripts := newClusterMap["init_scripts"]
+			DatabricksProperties.NewClusterInitScripts = &initScripts
+		}
+
+	}
+
+	//EncryptedCredential
+	//POlicy ID
+
+	DatabricksLinkedService := &datafactory.AzureDatabricksLinkedService{
+		Description: utils.String(d.Get("description").(string)),
+		AzureDatabricksLinkedServiceTypeProperties: DatabricksProperties,
+		Type: datafactory.TypeAzureDatabricks,
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		DatabricksLinkedService.Parameters = expandDataFactoryParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("integration_runtime_name"); ok {
+		DatabricksLinkedService.ConnectVia = expandDataFactoryLinkedServiceIntegrationRuntime(v.(string))
+	}
+
+	if v, ok := d.GetOk("additional_properties"); ok {
+		DatabricksLinkedService.AdditionalProperties = v.(map[string]interface{})
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		annotations := v.([]interface{})
+		DatabricksLinkedService.Annotations = &annotations
+	}
+
+	linkedService := datafactory.LinkedServiceResource{
+		Properties: DatabricksLinkedService,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, dataFactoryName, name, linkedService, ""); err != nil {
+		return fmt.Errorf("Error creating/updating Data Factory Linked Service Azure Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceDataFactoryLinkedServiceDatabricksRead(d, meta)
+}
+
+func resourceDataFactoryLinkedServiceDatabricksRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("data_factory_name", dataFactoryName)
+
+	Databricks, ok := resp.Properties.AsAzureDatabricksLinkedService()
+
+	if !ok {
+		return fmt.Errorf("Error classifiying Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", name, dataFactoryName, resourceGroup, datafactory.TypeAzureDatabricks, *resp.Type)
+	}
+
+	//Check the properties and verify is authentication is set to MSI
+	if props := Databricks.AzureDatabricksLinkedServiceTypeProperties; props != nil {
+		if props.Authentication != nil && props.Authentication == "MSI" {
+
+			authenticationMsi := make(map[string]interface{})
+			authenticationMsi["workspaceResourceId"] = props.WorkspaceResourceID
+			d.Set("authentication_msi", authenticationMsi)
+
+		} else if props.AccessToken != nil {
+			//Check the data type of the access token so we know how to process it.
+
+			if accessToken := props.AccessToken; accessToken != nil {
+				if keyVaultPassword, ok := accessToken.AsAzureKeyVaultSecretReference(); ok {
+					if err := d.Set("authentication_key_vault_password", flattenAzureKeyVaultPassword(keyVaultPassword)); err != nil {
+						return fmt.Errorf("setting `authentication_key_vault_password`: %+v", err)
+					}
+				}
+			}
+		}
+
+		//Process the domain
+		if props.Domain != nil {
+			d.Set("adb_domain", props.Domain)
+		}
+
+		//Process the cluster information
+		if props.ExistingClusterID != nil {
+			d.Set("existing_cluster_id", props.ExistingClusterID)
+
+		} else if id := props.InstancePoolID; id != nil {
+			//Process the values for instance pool configuration
+			numOfWorkers := props.NewClusterNumOfWorker
+			clusterVersion := props.NewClusterVersion
+
+			instancePoolMap := map[string]interface{}{
+				"instance_pool_id":  id,
+				"number_of_workers": numOfWorkers,
+				"cluster_version":   clusterVersion,
+			}
+			d.Set("instance_pool", instancePoolMap)
+
+		} else {
+
+			//Process assuming it's a new cluster config
+			numOfWorkers := props.NewClusterNumOfWorker
+			clusterVersion := props.NewClusterVersion
+			nodeType := props.NewClusterNodeType
+
+			newClusterMap := map[string]interface{}{
+				"number_of_workers": numOfWorkers,
+				"cluster_version":   clusterVersion,
+				"node_type":         nodeType,
+			}
+
+			//Retrieve all the optional arguments
+			if data := props.NewClusterDriverNodeType; data != nil {
+				newClusterMap["driver_node_type"] = data
+			}
+
+			if data := props.NewClusterLogDestination; data != nil {
+				newClusterMap["log_destination"] = data
+			}
+
+			if data := props.NewClusterSparkConf; data != nil {
+				newClusterMap["spark_config"] = data
+			}
+
+			if data := props.NewClusterCustomTags; data != nil {
+				newClusterMap["custom_tags"] = data
+			}
+
+			if data := props.NewClusterSparkEnvVars; data != nil {
+				newClusterMap["spark_environment_variables"] = data
+			}
+
+			if data := props.NewClusterInitScripts; data != nil {
+				newClusterMap["init_scripts"] = data
+			}
+
+			//Set the ResourceData with the map
+			newClusterArray := []interface{}{newClusterMap}
+
+			d.Set("new_cluster_config", newClusterArray)
+		}
+	}
+
+	d.Set("additional_properties", Databricks.AdditionalProperties)
+
+	if Databricks.Description != nil {
+		d.Set("description", Databricks.Description)
+	}
+
+	annotations := flattenDataFactoryAnnotations(Databricks.Annotations)
+	if err := d.Set("annotations", annotations); err != nil {
+		return fmt.Errorf("Error setting `annotations`: %+v", err)
+	}
+
+	parameters := flattenDataFactoryParameters(Databricks.Parameters)
+	if err := d.Set("parameters", parameters); err != nil {
+		return fmt.Errorf("Error setting `parameters`: %+v", err)
+	}
+
+	if connectVia := Databricks.ConnectVia; connectVia != nil {
+		if connectVia.ReferenceName != nil {
+			d.Set("integration_runtime_name", connectVia.ReferenceName)
+		}
+	}
+
+	return nil
+}
+
+func resourceDataFactoryLinkedServiceDatabricksDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	response, err := client.Delete(ctx, resourceGroup, dataFactoryName, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(response) {
+			return fmt.Errorf("Error deleting Data Factory Linked Service Databricks %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
@@ -18,108 +18,62 @@ type LinkedServiceDatabricksResource struct {
 }
 
 func TestAccDataFactoryLinkedServiceDatabricks_authViaMSI(t *testing.T) {
-	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
-
-	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_msi(data),
-			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
-				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
-		// If it was created with a managed identity, then this shouldn't exist?
-		data.ImportStep(""),
+		data.ImportStep(),
 	})
 }
 
 func TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken(t *testing.T) {
-	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
-
-	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_access_token(data),
-			//  Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
-				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
-		// If it was created with a managed identity, then this shouldn't exist?
-		data.ImportStep(""),
+		data.ImportStep("authentication_access_token"),
 	})
 }
 
 func TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault(t *testing.T) {
-	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
-
-	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_key_vault(data),
-			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
-				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
-		// If it was created with a managed identity, then this shouldn't exist?
-		data.ImportStep(""),
+		data.ImportStep(),
 	})
 }
 
 func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
-	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
-
-	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.newClusterConfig(data),
-			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
-				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("5.5.x-gpu-scala2.11"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC12"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("5"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC13"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("sct_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("sct_value_2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("sc_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("sc_value_2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("sev_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
 			),
 		},
-		data.ImportStep(""),
+		data.ImportStep(),
 	})
 }
 func TestAccDataFactoryLinkedServiceDatabricks_update(t *testing.T) {
@@ -131,53 +85,15 @@ func TestAccDataFactoryLinkedServiceDatabricks_update(t *testing.T) {
 			Config: r.update1(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("parameters.%").HasValue("2"),
-				check.That(data.ResourceName).Key("parameters.key1").HasValue("u1k1"),
-				check.That(data.ResourceName).Key("parameters.key2").HasValue("u1k2"),
-				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
-				check.That(data.ResourceName).Key("annotations.0").HasValue("a1"),
-				check.That(data.ResourceName).Key("annotations.1").HasValue("a2"),
-				check.That(data.ResourceName).Key("description").HasValue("Initial Description"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("5.5.x-gpu-scala2.11"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC12"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("1:10"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC12"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("sct_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("sct_value_2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("sc_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("sc_value_2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("sev_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
 			),
 		},
 		{
 			Config: r.update2(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("parameters.%").HasValue("2"),
-				check.That(data.ResourceName).Key("parameters.key1").HasValue("u2k1"),
-				check.That(data.ResourceName).Key("parameters.key2").HasValue("u2k2"),
-				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
-				check.That(data.ResourceName).Key("annotations.0").HasValue("b1"),
-				check.That(data.ResourceName).Key("annotations.1").HasValue("b2"),
-				check.That(data.ResourceName).Key("description").HasValue("Updated Description"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("6.5.x-gpu-scala2.11"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC20"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("5"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC13"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs_updated"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("3"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("updated_sct_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("updated_sct_value_2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("updated_sc_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("updated_sc_value_2"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("updated_sev_value_1"),
-				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("updated_sev_value_2"),
 			),
 		},
-		data.ImportStep(""),
+		data.ImportStep(),
 	})
 }
 
@@ -321,9 +237,9 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
   annotations = ["test1", "test2"]
   adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
   instance_pool {
-    instance_pool_id  = "0308-201055-safes631-pool-EHfwukQo"
-    number_of_workers = "1"
-    cluster_version   = "5.5.x-gpu-scala2.11"
+    instance_pool_id      = "0308-201055-safes631-pool-EHfwukQo"
+    min_number_of_workers = 3
+    cluster_version       = "5.5.x-gpu-scala2.11"
   }
 
 }
@@ -361,11 +277,11 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
   annotations = ["test1", "test2"]
   adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
   new_cluster_config {
-    cluster_version   = "5.5.x-gpu-scala2.11"
-    number_of_workers = "5"
-    node_type         = "Standard_NC12"
-    driver_node_type  = "Standard_NC13"
-    log_destination   = "dbfs:/logs"
+    cluster_version       = "5.5.x-gpu-scala2.11"
+    min_number_of_workers = 5
+    node_type             = "Standard_NC12"
+    driver_node_type      = "Standard_NC13"
+    log_destination       = "dbfs:/logs"
 
     custom_tags = {
       sct1 = "sct_value_1"
@@ -421,12 +337,12 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
   adb_domain = "https://someFakeDomain"
 
   new_cluster_config {
-    node_type         = "Standard_NC12"
-    cluster_version   = "5.5.x-gpu-scala2.11"
-    number_of_workers = "1:10"
-
-    driver_node_type = "Standard_NC12"
-    log_destination  = "dbfs:/logs"
+    node_type             = "Standard_NC12"
+    cluster_version       = "5.5.x-gpu-scala2.11"
+    min_number_of_workers = 3
+    max_number_of_workers = 5
+    driver_node_type      = "Standard_NC12"
+    log_destination       = "dbfs:/logs"
 
     custom_tags = {
       sct1 = "sct_value_1"
@@ -483,9 +399,9 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
   adb_domain = "https://someFakedomain"
 
   new_cluster_config {
-    node_type         = "Standard_NC20"
-    cluster_version   = "6.5.x-gpu-scala2.11"
-    number_of_workers = "5"
+    node_type             = "Standard_NC20"
+    cluster_version       = "6.5.x-gpu-scala2.11"
+    min_number_of_workers = 5
 
     driver_node_type = "Standard_NC13"
     log_destination  = "dbfs:/logs_updated"

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
@@ -1,0 +1,514 @@
+package datafactory_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type LinkedServiceDatabricksResource struct {
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_authViaMSI(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.authentication_msi(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.authentication_access_token(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.authentication_key_vault(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
+	// Build random test data.
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+
+	//Create an instance of this class so we can reference the functions.
+	r := LinkedServiceDatabricksResource{}
+
+	//Execute a test case
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			Config: r.newClusterConfig(data),
+			// Create a composition of validations to perform post-creation
+			Check: resource.ComposeTestCheckFunc(
+				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("5.5.x-gpu-scala2.11"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC12"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("5"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC13"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("sct_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("sct_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("sc_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("sc_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("sev_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
+			),
+		},
+		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
+		// If it was created with a managed identity, then this shouldn't exist?
+		data.ImportStep(""),
+	})
+}
+func TestAccDataFactoryLinkedServiceDatabricks_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
+	r := LinkedServiceDatabricksResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.update1(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("parameters.%").HasValue("2"),
+				check.That(data.ResourceName).Key("parameters.key1").HasValue("u1k1"),
+				check.That(data.ResourceName).Key("parameters.key2").HasValue("u1k2"),
+				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
+				check.That(data.ResourceName).Key("annotations.0").HasValue("a1"),
+				check.That(data.ResourceName).Key("annotations.1").HasValue("a2"),
+				check.That(data.ResourceName).Key("description").HasValue("Initial Description"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("5.5.x-gpu-scala2.11"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC12"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("1:10"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC12"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("sct_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("sct_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("sc_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("sc_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("sev_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
+			),
+		},
+		{
+			Config: r.update2(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("parameters.%").HasValue("2"),
+				check.That(data.ResourceName).Key("parameters.key1").HasValue("u2k1"),
+				check.That(data.ResourceName).Key("parameters.key2").HasValue("u2k2"),
+				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
+				check.That(data.ResourceName).Key("annotations.0").HasValue("b1"),
+				check.That(data.ResourceName).Key("annotations.1").HasValue("b2"),
+				check.That(data.ResourceName).Key("description").HasValue("Updated Description"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.cluster_version").HasValue("6.5.x-gpu-scala2.11"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.node_type").HasValue("Standard_NC20"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.number_of_workers").HasValue("5"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.driver_node_type").HasValue("Standard_NC13"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.log_destination").HasValue("dbfs:/logs_updated"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.init_scripts.#").HasValue("3"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct1").HasValue("updated_sct_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.custom_tags.sct2").HasValue("updated_sct_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc1").HasValue("updated_sc_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_config.sc2").HasValue("updated_sc_value_2"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev1").HasValue("updated_sev_value_1"),
+				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("updated_sev_value_2"),
+			),
+		},
+		data.ImportStep(""),
+	})
+}
+
+func (t LinkedServiceDatabricksResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := azure.ParseAzureResourceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	resp, err := clients.DataFactory.LinkedServiceClient.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		return nil, fmt.Errorf("reading Data Factory LinkedServiceDatabricksResource (%s): %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (LinkedServiceDatabricksResource) authentication_msi(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_msi = {
+		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+	}
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+	existing_cluster_id		= "test"
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) authentication_access_token(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_access_token = {
+		access_token	= "SomeFakeAccessToken"
+	}
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	existing_cluster_id = "1234"
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) authentication_key_vault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+// Create the RG
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+// Create a key vault so we can setup a KV linked service
+resource "azurerm_key_vault" "test" {
+	name                = "acctkv%d"
+	location            = azurerm_resource_group.test.location
+	resource_group_name = azurerm_resource_group.test.name
+	tenant_id           = data.azurerm_client_config.current.tenant_id
+	sku_name            = "standard"
+  }
+
+// Create the KV linked service so we can test out integration the Databricks linked service
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+	name                = "linkkv"
+	resource_group_name = azurerm_resource_group.test.name
+	data_factory_name   = azurerm_data_factory.test.name
+	key_vault_id        = azurerm_key_vault.test.id
+  }
+
+//   Create a databricks linked service that leveraged the KV linked service for password management
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_key_vault_password {
+		linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+		secret_name         = "secret"
+	  }
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	instance_pool = {
+		instance_pool_id = "0308-201055-safes631-pool-EHfwukQo",
+		number_of_workers = "1",
+		cluster_version = "5.5.x-gpu-scala2.11"
+	  }
+	
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) newClusterConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name   = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	authentication_msi = {
+		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+	}
+	description				= "Initial description"
+	annotations				= ["test1", "test2"]
+	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
+	new_cluster_config  {
+		cluster_version = "5.5.x-gpu-scala2.11"
+		number_of_workers = "5"
+		node_type = "Standard_NC12"
+		driver_node_type = "Standard_NC13"
+		log_destination = "dbfs:/logs"
+		
+		custom_tags = {
+			sct1 = "sct_value_1"
+			sct2 = "sct_value_2"
+		}
+		spark_config = {
+			 sc1 = "sc_value_1"
+			 sc2 = "sc_value_2"
+		}
+		spark_environment_variables = {
+			sev1 = "sev_value_1"
+			sev2 = "sev_value_2"
+		}
+
+		init_scripts = ["init.sh", "init2.sh"]
+	}
+	
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) update1(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+    description = "Initial Description"
+	annotations = ["a1", "a2"]
+	parameters = {
+		key1 = "u1k1"
+		key2 = "u1k2"
+	}
+    authentication_msi = {
+      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+    }
+    adb_domain = "https://someFakeDomain"
+
+    new_cluster_config {
+      node_type = "Standard_NC12"
+      cluster_version = "5.5.x-gpu-scala2.11"
+      number_of_workers = "1:10"
+     
+      driver_node_type = "Standard_NC12"
+      log_destination = "dbfs:/logs"
+      
+      custom_tags = {
+        sct1 = "sct_value_1"
+        sct2 = "sct_value_2"
+      }
+      spark_config = {
+        sc1 = "sc_value_1"
+        sc2 = "sc_value_2"
+      }
+      spark_environment_variables = {
+        sev1 = "sev_value_1"
+        sev2 = "sev_value_2"
+      }
+
+      init_scripts = ["init.sh", "init2.sh"]
+    }
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDatabricksResource) update2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
+	name                  = "acctestDatabricksLinkedService%d"
+	resource_group_name = azurerm_resource_group.test.name
+	data_factory_name     = azurerm_data_factory.test.name
+	description = "Updated Description"
+	annotations = ["b1", "b2"]
+	parameters = {
+		key1 = "u2k1"
+		key2 = "u2k2"
+	}
+    authentication_msi = {
+      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+    }
+    adb_domain = "https://someFakedomain"
+
+    new_cluster_config {
+      node_type = "Standard_NC20"
+      cluster_version = "6.5.x-gpu-scala2.11"
+      number_of_workers = "5"
+     
+      driver_node_type = "Standard_NC13"
+      log_destination = "dbfs:/logs_updated"
+      
+      custom_tags = {
+        sct1 = "updated_sct_value_1"
+        sct2 = "updated_sct_value_2"
+      }
+      spark_config = {
+        sc1 = "updated_sc_value_1"
+        sc2 = "updated_sc_value_2"
+      }
+      spark_environment_variables = {
+        sev1 = "updated_sev_value_1"
+        sev2 = "updated_sev_value_2"
+      }
+
+      init_scripts = ["updated_init.sh", "updated_init2.sh", "updated_init3.sh"]
+    }
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
@@ -21,13 +21,13 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaMSI(t *testing.T) {
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_msi(data),
 			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
@@ -45,15 +45,15 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken(t *testing.T) 
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_access_token(data),
-			// Create a composition of validations to perform post-creation
+			//  Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
 				// This verifies that the resource now exists in Azure (i.e. Creation was successful)
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -69,13 +69,13 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault(t *testing.T) {
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.authentication_key_vault(data),
 			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
@@ -93,13 +93,13 @@ func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
 	// Build random test data.
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_azure_databricks", "test")
 
-	//Create an instance of this class so we can reference the functions.
+	// Create an instance of this class so we can reference the functions.
 	r := LinkedServiceDatabricksResource{}
 
-	//Execute a test case
+	// Execute a test case
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			//Define the configuration to use the resource definition returned by the "basic" function (below)
+			// Define the configuration to use the resource definition returned by the "basic" function (below)
 			Config: r.newClusterConfig(data),
 			// Create a composition of validations to perform post-creation
 			Check: resource.ComposeTestCheckFunc(
@@ -119,8 +119,6 @@ func TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig(t *testing.T) {
 				check.That(data.ResourceName).Key("new_cluster_config.0.spark_environment_variables.sev2").HasValue("sev_value_2"),
 			),
 		},
-		// ?? Is this just validating that the service_principal_key exists on the resource. This should be true because this was not created with a managed identity.
-		// If it was created with a managed identity, then this shouldn't exist?
 		data.ImportStep(""),
 	})
 }
@@ -221,17 +219,17 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_msi = {
-		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
-	}
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
-	existing_cluster_id		= "test"
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+  }
+  description         = "Initial description"
+  annotations         = ["test1", "test2"]
+  existing_cluster_id = "test"
+  adb_domain          = "https://adb-111111111.11.azuredatabricks.net"
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -257,17 +255,17 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_access_token = {
-		access_token	= "SomeFakeAccessToken"
-	}
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_access_token {
+    access_token = "SomeFakeAccessToken"
+  }
+  description = "Initial description"
+  annotations = ["test1", "test2"]
 
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	existing_cluster_id = "1234"
+  adb_domain          = "https://adb-111111111.11.azuredatabricks.net"
+  existing_cluster_id = "1234"
 
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -295,39 +293,39 @@ resource "azurerm_data_factory" "test" {
 
 // Create a key vault so we can setup a KV linked service
 resource "azurerm_key_vault" "test" {
-	name                = "acctkv%d"
-	location            = azurerm_resource_group.test.location
-	resource_group_name = azurerm_resource_group.test.name
-	tenant_id           = data.azurerm_client_config.current.tenant_id
-	sku_name            = "standard"
-  }
+  name                = "acctkv%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
 
 // Create the KV linked service so we can test out integration the Databricks linked service
 resource "azurerm_data_factory_linked_service_key_vault" "test" {
-	name                = "linkkv"
-	resource_group_name = azurerm_resource_group.test.name
-	data_factory_name   = azurerm_data_factory.test.name
-	key_vault_id        = azurerm_key_vault.test.id
-  }
+  name                = "linkkv"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  key_vault_id        = azurerm_key_vault.test.id
+}
 
 //   Create a databricks linked service that leveraged the KV linked service for password management
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_key_vault_password {
-		linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
-		secret_name         = "secret"
-	  }
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	instance_pool = {
-		instance_pool_id = "0308-201055-safes631-pool-EHfwukQo",
-		number_of_workers = "1",
-		cluster_version = "5.5.x-gpu-scala2.11"
-	  }
-	
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_key_vault_password {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "secret"
+  }
+  description = "Initial description"
+  annotations = ["test1", "test2"]
+  adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
+  instance_pool {
+    instance_pool_id  = "0308-201055-safes631-pool-EHfwukQo"
+    number_of_workers = "1"
+    cluster_version   = "5.5.x-gpu-scala2.11"
+  }
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -353,38 +351,38 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name   = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	authentication_msi = {
-		workspaceResourceId="/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
-	}
-	description				= "Initial description"
-	annotations				= ["test1", "test2"]
-	adb_domain = "https://adb-111111111.11.azuredatabricks.net"
-	new_cluster_config  {
-		cluster_version = "5.5.x-gpu-scala2.11"
-		number_of_workers = "5"
-		node_type = "Standard_NC12"
-		driver_node_type = "Standard_NC13"
-		log_destination = "dbfs:/logs"
-		
-		custom_tags = {
-			sct1 = "sct_value_1"
-			sct2 = "sct_value_2"
-		}
-		spark_config = {
-			 sc1 = "sc_value_1"
-			 sc2 = "sc_value_2"
-		}
-		spark_environment_variables = {
-			sev1 = "sev_value_1"
-			sev2 = "sev_value_2"
-		}
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+  }
+  description = "Initial description"
+  annotations = ["test1", "test2"]
+  adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
+  new_cluster_config {
+    cluster_version   = "5.5.x-gpu-scala2.11"
+    number_of_workers = "5"
+    node_type         = "Standard_NC12"
+    driver_node_type  = "Standard_NC13"
+    log_destination   = "dbfs:/logs"
 
-		init_scripts = ["init.sh", "init2.sh"]
-	}
-	
+    custom_tags = {
+      sct1 = "sct_value_1"
+      sct2 = "sct_value_2"
+    }
+    spark_config = {
+      sc1 = "sc_value_1"
+      sc2 = "sc_value_2"
+    }
+    spark_environment_variables = {
+      sev1 = "sev_value_1"
+      sev2 = "sev_value_2"
+    }
+
+    init_scripts = ["init.sh", "init2.sh"]
+  }
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -408,43 +406,43 @@ resource "azurerm_data_factory" "test" {
 
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-    description = "Initial Description"
-	annotations = ["a1", "a2"]
-	parameters = {
-		key1 = "u1k1"
-		key2 = "u1k2"
-	}
-    authentication_msi = {
-      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
-    }
-    adb_domain = "https://someFakeDomain"
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  description         = "Initial Description"
+  annotations         = ["a1", "a2"]
+  parameters = {
+    key1 = "u1k1"
+    key2 = "u1k2"
+  }
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+  }
+  adb_domain = "https://someFakeDomain"
 
-    new_cluster_config {
-      node_type = "Standard_NC12"
-      cluster_version = "5.5.x-gpu-scala2.11"
-      number_of_workers = "1:10"
-     
-      driver_node_type = "Standard_NC12"
-      log_destination = "dbfs:/logs"
-      
-      custom_tags = {
-        sct1 = "sct_value_1"
-        sct2 = "sct_value_2"
-      }
-      spark_config = {
-        sc1 = "sc_value_1"
-        sc2 = "sc_value_2"
-      }
-      spark_environment_variables = {
-        sev1 = "sev_value_1"
-        sev2 = "sev_value_2"
-      }
+  new_cluster_config {
+    node_type         = "Standard_NC12"
+    cluster_version   = "5.5.x-gpu-scala2.11"
+    number_of_workers = "1:10"
 
-      init_scripts = ["init.sh", "init2.sh"]
+    driver_node_type = "Standard_NC12"
+    log_destination  = "dbfs:/logs"
+
+    custom_tags = {
+      sct1 = "sct_value_1"
+      sct2 = "sct_value_2"
     }
+    spark_config = {
+      sc1 = "sc_value_1"
+      sc2 = "sc_value_2"
+    }
+    spark_environment_variables = {
+      sev1 = "sev_value_1"
+      sev2 = "sev_value_2"
+    }
+
+    init_scripts = ["init.sh", "init2.sh"]
+  }
 }
 
 
@@ -470,43 +468,43 @@ resource "azurerm_data_factory" "test" {
 
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-	name                  = "acctestDatabricksLinkedService%d"
-	resource_group_name = azurerm_resource_group.test.name
-	data_factory_name     = azurerm_data_factory.test.name
-	description = "Updated Description"
-	annotations = ["b1", "b2"]
-	parameters = {
-		key1 = "u2k1"
-		key2 = "u2k2"
-	}
-    authentication_msi = {
-      workspaceResourceId = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
-    }
-    adb_domain = "https://someFakedomain"
+  name                = "acctestDatabricksLinkedService%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  description         = "Updated Description"
+  annotations         = ["b1", "b2"]
+  parameters = {
+    key1 = "u2k1"
+    key2 = "u2k2"
+  }
+  authentication_msi {
+    workspace_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+  }
+  adb_domain = "https://someFakedomain"
 
-    new_cluster_config {
-      node_type = "Standard_NC20"
-      cluster_version = "6.5.x-gpu-scala2.11"
-      number_of_workers = "5"
-     
-      driver_node_type = "Standard_NC13"
-      log_destination = "dbfs:/logs_updated"
-      
-      custom_tags = {
-        sct1 = "updated_sct_value_1"
-        sct2 = "updated_sct_value_2"
-      }
-      spark_config = {
-        sc1 = "updated_sc_value_1"
-        sc2 = "updated_sc_value_2"
-      }
-      spark_environment_variables = {
-        sev1 = "updated_sev_value_1"
-        sev2 = "updated_sev_value_2"
-      }
+  new_cluster_config {
+    node_type         = "Standard_NC20"
+    cluster_version   = "6.5.x-gpu-scala2.11"
+    number_of_workers = "5"
 
-      init_scripts = ["updated_init.sh", "updated_init2.sh", "updated_init3.sh"]
+    driver_node_type = "Standard_NC13"
+    log_destination  = "dbfs:/logs_updated"
+
+    custom_tags = {
+      sct1 = "updated_sct_value_1"
+      sct2 = "updated_sct_value_2"
     }
+    spark_config = {
+      sc1 = "updated_sc_value_1"
+      sc2 = "updated_sc_value_2"
+    }
+    spark_environment_variables = {
+      sev1 = "updated_sev_value_1"
+      sev2 = "updated_sev_value_2"
+    }
+
+    init_scripts = ["updated_init.sh", "updated_init2.sh", "updated_init3.sh"]
+  }
 }
 
 

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource_test.go
@@ -23,7 +23,7 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaMSI(t *testing.T) {
 	r := LinkedServiceDatabricksResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.authentication_msi(data),
+			Config: r.msi(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -38,12 +38,12 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken(t *testing.T) 
 	r := LinkedServiceDatabricksResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.authentication_access_token(data),
+			Config: r.access_token(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("authentication_access_token"),
+		data.ImportStep("access_token"),
 	})
 }
 
@@ -53,7 +53,7 @@ func TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault(t *testing.T) {
 	r := LinkedServiceDatabricksResource{}
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.authentication_key_vault(data),
+			Config: r.key_vault(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -114,7 +114,7 @@ func (t LinkedServiceDatabricksResource) Exists(ctx context.Context, clients *cl
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func (LinkedServiceDatabricksResource) authentication_msi(data acceptance.TestData) string {
+func (LinkedServiceDatabricksResource) msi(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -135,22 +135,20 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-  name                = "acctestDatabricksLinkedService%d"
-  resource_group_name = azurerm_resource_group.test.name
-  data_factory_name   = azurerm_data_factory.test.name
-  authentication_msi {
-    workspace_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
-  }
+  name                       = "acctestDatabricksLinkedService%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  data_factory_name          = azurerm_data_factory.test.name
+  msi_work_space_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+
   description         = "Initial description"
   annotations         = ["test1", "test2"]
   existing_cluster_id = "test"
   adb_domain          = "https://adb-111111111.11.azuredatabricks.net"
-
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (LinkedServiceDatabricksResource) authentication_access_token(data acceptance.TestData) string {
+func (LinkedServiceDatabricksResource) access_token(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -174,20 +172,16 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
   name                = "acctestDatabricksLinkedService%d"
   resource_group_name = azurerm_resource_group.test.name
   data_factory_name   = azurerm_data_factory.test.name
-  authentication_access_token {
-    access_token = "SomeFakeAccessToken"
-  }
-  description = "Initial description"
-  annotations = ["test1", "test2"]
-
+  access_token        = "SomeFakeAccessToken"
+  description         = "Initial description"
+  annotations         = ["test1", "test2"]
   adb_domain          = "https://adb-111111111.11.azuredatabricks.net"
   existing_cluster_id = "1234"
-
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (LinkedServiceDatabricksResource) authentication_key_vault(data acceptance.TestData) string {
+func (LinkedServiceDatabricksResource) key_vault(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -224,12 +218,12 @@ resource "azurerm_data_factory_linked_service_key_vault" "test" {
   key_vault_id        = azurerm_key_vault.test.id
 }
 
-//   Create a databricks linked service that leveraged the KV linked service for password management
+// Create a databricks linked service that leveraged the KV linked service for password management
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
   name                = "acctestDatabricksLinkedService%d"
   resource_group_name = azurerm_resource_group.test.name
   data_factory_name   = azurerm_data_factory.test.name
-  authentication_key_vault_password {
+  key_vault_password {
     linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
     secret_name         = "secret"
   }
@@ -241,7 +235,6 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
     min_number_of_workers = 3
     cluster_version       = "5.5.x-gpu-scala2.11"
   }
-
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -267,12 +260,11 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
-  name                = "acctestDatabricksLinkedService%d"
-  resource_group_name = azurerm_resource_group.test.name
-  data_factory_name   = azurerm_data_factory.test.name
-  authentication_msi {
-    workspace_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
-  }
+  name                       = "acctestDatabricksLinkedService%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  data_factory_name          = azurerm_data_factory.test.name
+  msi_work_space_resource_id = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/test/providers/Microsoft.Databricks/workspaces/testworkspace"
+
   description = "Initial description"
   annotations = ["test1", "test2"]
   adb_domain  = "https://adb-111111111.11.azuredatabricks.net"
@@ -331,10 +323,9 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
     key1 = "u1k1"
     key2 = "u1k2"
   }
-  authentication_msi {
-    workspace_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
-  }
-  adb_domain = "https://someFakeDomain"
+
+  msi_work_space_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+  adb_domain                 = "https://someFakeDomain"
 
   new_cluster_config {
     node_type             = "Standard_NC12"
@@ -393,10 +384,8 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "test" {
     key1 = "u2k1"
     key2 = "u2k2"
   }
-  authentication_msi {
-    workspace_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
-  }
-  adb_domain = "https://someFakedomain"
+  msi_work_space_resource_id = "/subscriptions/d111111-1111-1111-1111-111111111111/resourceGroups/Testing-rg-creation/providers/Microsoft.Databricks/workspaces/databricks-test"
+  adb_domain                 = "https://someFakedomain"
 
   new_cluster_config {
     node_type             = "Standard_NC20"

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -43,6 +43,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_data_factory_integration_runtime_azure_ssis":        resourceDataFactoryIntegrationRuntimeAzureSsis(),
 		"azurerm_data_factory_integration_runtime_self_hosted":       resourceDataFactoryIntegrationRuntimeSelfHosted(),
 		"azurerm_data_factory_linked_service_azure_blob_storage":     resourceDataFactoryLinkedServiceAzureBlobStorage(),
+		"azurerm_data_factory_linked_service_azure_databricks":       resourceDataFactoryLinkedServiceAzureDatabricks(),
 		"azurerm_data_factory_linked_service_azure_table_storage":    resourceDataFactoryLinkedServiceAzureTableStorage(),
 		"azurerm_data_factory_linked_service_azure_file_storage":     resourceDataFactoryLinkedServiceAzureFileStorage(),
 		"azurerm_data_factory_linked_service_azure_sql_database":     resourceDataFactoryLinkedServiceAzureSQLDatabase(),

--- a/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
@@ -49,11 +49,12 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
   }
 
   new_cluster_config {
-    node_type         = "Standard_NC12"
-    cluster_version   = "5.5.x-gpu-scala2.11"
-    number_of_workers = "1:10"
-    driver_node_type  = "Standard_NC12"
-    log_destination   = "dbfs:/logs"
+    node_type             = "Standard_NC12"
+    cluster_version       = "5.5.x-gpu-scala2.11"
+    min_number_of_workers = 1
+    max_number_of_workers = 5
+    driver_node_type      = "Standard_NC12"
+    log_destination       = "dbfs:/logs"
 
     custom_tags = {
       custom_tag1 = "sct_value_1"
@@ -123,19 +124,19 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "at_linked" {
 
 The following arguments are supported:
 
-* `adb_domain` - (Required) The domain URL of the databricks instance
+* `adb_domain` - (Required) The domain URL of the databricks instance.
 
 * `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
 
 * `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data factory. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service. Changing this forces a new resource
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service. Changing this forces a new resource.
 
 ---
 
 You must specify exactly one of the following authentication blocks:
 
-* `authentication_access_token` - (Optional) Authenticate to ADB via access token as defined in the `authentication_access_token` block below
+* `authentication_access_token` - (Optional) Authenticate to ADB via access token as defined in the `authentication_access_token` block below.
 
 * `authentication_key_vault_password` - (Optional) Authenticate to ADB via Azure Key Vault Linked Service as defined in the `authentication_key_vault_password` block below.
 
@@ -145,7 +146,7 @@ You must specify exactly one of the following authentication blocks:
 
 You must specify exactly one of the following modes for cluster integration:
 
-* `existing_cluster_id` - (Optional) The cluster_id of an existing cluster within the linked ADB instance
+* `existing_cluster_id` - (Optional) The cluster_id of an existing cluster within the linked ADB instance.
 
 * `instance_pool` - (Optional) Leverages an instance pool within the linked ADB instance as defined by  `instance_pool` block below.
 
@@ -153,7 +154,7 @@ You must specify exactly one of the following modes for cluster integration:
 
 ---
 
-* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service.
 
 * `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service.
 
@@ -175,46 +176,45 @@ A `authentication_key_vault_password` block supports the following:
 
 A `authentication_access_token` block supports the following:
 
-* `access_token` - (Required) The access token to authenticate to databricks
+* `access_token` - (Required) The access token to authenticate to databricks.
 
 ---
 
 A `authentication_msi` block supports the following:
 
-* `workspace_resource_id` - (Required) The resource identifier of the databricks workspace
+* `workspace_resource_id` - (Required) The resource identifier of the databricks workspace.
 
 ---
 
-
 A `new_cluster_config` block supports the following:
 
-* `cluster_version` - (Required) Spark version of a the cluster
+* `cluster_version` - (Required) Spark version of a the cluster.
 
-* `node_type` - (Required) Node type for the new cluster
+* `node_type` - (Required) Node type for the new cluster.
 
-* `custom_tags` - (Optional) Tags for the cluster resource
+* `custom_tags` - (Optional) Tags for the cluster resource.
 
-* `driver_node_type` - (Optional) Driver node type for the cluster
+* `driver_node_type` - (Optional) Driver node type for the cluster.
 
-* `init_scripts` - (Optional) User defined initialization scripts for the cluster
+* `init_scripts` - (Optional) User defined initialization scripts for the cluster.
 
-* `log_destination` - (Optional) Location to deliver Spark driver, worker, and event logs
+* `log_destination` - (Optional) Location to deliver Spark driver, worker, and event logs.
 
-* `number_of_workers` - (Optional) The number of worker nodes. For a fixed number of workers, use a single value (e.g. "1") for autoscaling provide the min:max (e.g. "1:10"). Defaults to 1.
+* `spark_config` - (Optional) User-specified Spark configuration variables key-value pairs.
 
-* `spark_config` - (Optional) User-specified Spark configuration variables key-value pairs
+* `spark_environment_variables` - (Optional) User-specified Spark environment variables key-value pairs.
 
-* `spark_environment_variables` - (Optional) User-specified Spark environment variables key-value pairs
-* 
 ---
 
 A `instance_pool` block supports the following:
 
-* `instnace_pool_id` - (Required) Identifier of the instance pool within the linked ADB instance
+* `instance_pool_id` - (Required) Identifier of the instance pool within the linked ADB instance.
 
-* `number_of_workers` - (Optional) Fixed number of workers to use 
+* `cluster_version` - (Required) Spark version of a the cluster.
 
-* `cluster_version` - (Required) Spark version of a the cluster
+* `min_number_of_workers` - (Optional) The minimum number of worker nodes. Defaults to 1.
+
+* `max_number_of_workers` - (Optional) The max number of worker nodes. Set this value if you want to enable autoscaling between the `min_number_of_workers` and this value. Omit this value to use a fixed number of workers defined in the `min_number_of_workers` property.
 
 ---
 ## Attributes Reference

--- a/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
@@ -37,16 +37,13 @@ resource "azurerm_databricks_workspace" "example" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
-
   name                = "ADBLinkedServiceViaMSI"
   data_factory_name   = azurerm_data_factory.example.name
   resource_group_name = azurerm_resource_group.example.name
   description         = "ADB Linked Service via MSI"
   adb_domain          = "https://${azurerm_databricks_workspace.example.workspace_url}"
 
-  authentication_msi = {
-    workspace_resource_id = azurerm_databricks_workspace.example.id
-  }
+  msi_work_space_resource_id = azurerm_databricks_workspace.example.id
 
   new_cluster_config {
     node_type             = "Standard_NC12"
@@ -102,22 +99,15 @@ resource "azurerm_databricks_workspace" "example" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "at_linked" {
-
   name                = "ADBLinkedServiceViaAccessToken"
   data_factory_name   = azurerm_data_factory.example.name
   resource_group_name = azurerm_resource_group.example.name
   description         = "ADB Linked Service via Access Token"
   existing_cluster_id = "0308-201146-sly615"
 
-  authentication_access_token = {
-    access_token = "SomeDatabricksAccessToken"
-  }
-
-  adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
-
-
+  access_token = "SomeDatabricksAccessToken"
+  adb_domain   = "https://${azurerm_databricks_workspace.example.workspace_url}"
 }
-
 ```
 
 ## Arguments Reference
@@ -136,11 +126,11 @@ The following arguments are supported:
 
 You must specify exactly one of the following authentication blocks:
 
-* `authentication_access_token` - (Optional) Authenticate to ADB via access token as defined in the `authentication_access_token` block below.
+* `access_token` - (Optional) Authenticate to ADB via an access token.
 
-* `authentication_key_vault_password` - (Optional) Authenticate to ADB via Azure Key Vault Linked Service as defined in the `authentication_key_vault_password` block below.
+* `key_vault_password` - (Optional) Authenticate to ADB via Azure Key Vault Linked Service as defined in the `key_vault_password` block below.
 
-* `authentication_msi` - (Optional) Authenticate to ADB via managed service identity as defined in the `authentication_msi` blocks as defined below.
+* `msi_work_space_resource_id` - (Optional) Authenticate to ADB via managed service identity.
 
 ---
 
@@ -166,23 +156,11 @@ You must specify exactly one of the following modes for cluster integration:
 
 ---
 
-A `authentication_key_vault_password` block supports the following:
+A `key_vault_password` block supports the following:
 
 * `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
 
 * `secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores ADB access token.
-
----
-
-A `authentication_access_token` block supports the following:
-
-* `access_token` - (Required) The access token to authenticate to databricks.
-
----
-
-A `authentication_msi` block supports the following:
-
-* `workspace_resource_id` - (Required) The resource identifier of the databricks workspace.
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
@@ -24,8 +24,8 @@ resource "azurerm_data_factory" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   identity {
-      type = "SystemAssigned"
-    }
+    type = "SystemAssigned"
+  }
 }
 
 #Create a databricks instance
@@ -37,41 +37,41 @@ resource "azurerm_databricks_workspace" "example" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
-    
-    name = "ADBLinkedServiceViaMSI"
-    data_factory_name = azurerm_data_factory.example.name
-    resource_group_name = azurerm_resource_group.example.name
-    description = "ADB Linked Service via MSI"
-    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
 
-    authentication_msi = {
-      workspaceResourceId = azurerm_databricks_workspace.example.id
+  name                = "ADBLinkedServiceViaMSI"
+  data_factory_name   = azurerm_data_factory.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  description         = "ADB Linked Service via MSI"
+  adb_domain          = "https://${azurerm_databricks_workspace.example.workspace_url}"
+
+  authentication_msi = {
+    workspace_resource_id = azurerm_databricks_workspace.example.id
+  }
+
+  new_cluster_config {
+    node_type         = "Standard_NC12"
+    cluster_version   = "5.5.x-gpu-scala2.11"
+    number_of_workers = "1:10"
+    driver_node_type  = "Standard_NC12"
+    log_destination   = "dbfs:/logs"
+
+    custom_tags = {
+      custom_tag1 = "sct_value_1"
+      custom_tag2 = "sct_value_2"
     }
 
-    new_cluster_config {
-      node_type = "Standard_NC12"
-      cluster_version = "5.5.x-gpu-scala2.11"
-      number_of_workers = "1:10"
-      driver_node_type = "Standard_NC12"
-      log_destination = "dbfs:/logs"
-      
-      custom_tags = {
-        custom_tag1 = "sct_value_1"
-        custom_tag2 = "sct_value_2"
-      }
-
-      spark_config = {
-        config1 = "value1"
-        config2 = "value2"
-      }
-
-      spark_environment_variables = {
-        envVar1 = "value1"
-        envVar2 = "value2"
-      }
-
-      init_scripts = ["init.sh", "init2.sh"]
+    spark_config = {
+      config1 = "value1"
+      config2 = "value2"
     }
+
+    spark_environment_variables = {
+      envVar1 = "value1"
+      envVar2 = "value2"
+    }
+
+    init_scripts = ["init.sh", "init2.sh"]
+  }
 }
 
 
@@ -101,20 +101,20 @@ resource "azurerm_databricks_workspace" "example" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_databricks" "at_linked" {
-    
-    name = "ADBLinkedServiceViaAccessToken"
-    data_factory_name = azurerm_data_factory.example.name
-    resource_group_name = azurerm_resource_group.example.name
-    description = "ADB Linked Service via Access Token"
-    existing_cluster_id = "0308-201146-sly615"
 
-    authentication_access_token = {
-      access_token = "dapi3c0233ca29fac114e4806ca883768df1-3"
-    }
+  name                = "ADBLinkedServiceViaAccessToken"
+  data_factory_name   = azurerm_data_factory.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  description         = "ADB Linked Service via Access Token"
+  existing_cluster_id = "0308-201146-sly615"
 
-    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
-    
-    
+  authentication_access_token = {
+    access_token = "SomeDatabricksAccessToken"
+  }
+
+  adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
+
+
 }
 
 ```
@@ -181,7 +181,7 @@ A `authentication_access_token` block supports the following:
 
 A `authentication_msi` block supports the following:
 
-* `workspaceResourceId` - (Required) The resource identifier of the databricks workspace
+* `workspace_resource_id` - (Required) The resource identifier of the databricks workspace
 
 ---
 

--- a/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_databricks.html.markdown
@@ -1,0 +1,241 @@
+---
+subcategory: "Data Factory"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_azure_databricks"
+description: |-
+  Manages a Linked Service (connection) between Azure Databricks and Azure Data Factory.
+---
+
+# azurerm_data_factory_linked_service_azure_databricks
+
+Manages a Linked Service (connection) between Azure Databricks and Azure Data Factory.
+
+## Example Usage with managed identity & new cluster
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "East US"
+}
+
+#Create a Linked Service using managed identity and new cluster config
+resource "azurerm_data_factory" "example" {
+  name                = "TestDtaFactory92783401247"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  identity {
+      type = "SystemAssigned"
+    }
+}
+
+#Create a databricks instance
+resource "azurerm_databricks_workspace" "example" {
+  name                = "databricks-test"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku                 = "standard"
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
+    
+    name = "ADBLinkedServiceViaMSI"
+    data_factory_name = azurerm_data_factory.example.name
+    resource_group_name = azurerm_resource_group.example.name
+    description = "ADB Linked Service via MSI"
+    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
+
+    authentication_msi = {
+      workspaceResourceId = azurerm_databricks_workspace.example.id
+    }
+
+    new_cluster_config {
+      node_type = "Standard_NC12"
+      cluster_version = "5.5.x-gpu-scala2.11"
+      number_of_workers = "1:10"
+      driver_node_type = "Standard_NC12"
+      log_destination = "dbfs:/logs"
+      
+      custom_tags = {
+        custom_tag1 = "sct_value_1"
+        custom_tag2 = "sct_value_2"
+      }
+
+      spark_config = {
+        config1 = "value1"
+        config2 = "value2"
+      }
+
+      spark_environment_variables = {
+        envVar1 = "value1"
+        envVar2 = "value2"
+      }
+
+      init_scripts = ["init.sh", "init2.sh"]
+    }
+}
+
+
+```
+
+## Example Usage with access token & existing cluster
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "East US"
+}
+
+#Link to an existing cluster via access token
+resource "azurerm_data_factory" "example" {
+  name                = "TestDtaFactory92783401247"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+#Create a databricks instance
+resource "azurerm_databricks_workspace" "example" {
+  name                = "databricks-test"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku                 = "standard"
+}
+
+resource "azurerm_data_factory_linked_service_azure_databricks" "at_linked" {
+    
+    name = "ADBLinkedServiceViaAccessToken"
+    data_factory_name = azurerm_data_factory.example.name
+    resource_group_name = azurerm_resource_group.example.name
+    description = "ADB Linked Service via Access Token"
+    existing_cluster_id = "0308-201146-sly615"
+
+    authentication_access_token = {
+      access_token = "dapi3c0233ca29fac114e4806ca883768df1-3"
+    }
+
+    adb_domain = "https://${azurerm_databricks_workspace.example.workspace_url}"
+    
+    
+}
+
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `adb_domain` - (Required) The domain URL of the databricks instance
+
+* `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
+
+* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data factory. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service. Changing this forces a new resource
+
+---
+
+You must specify exactly one of the following authentication blocks:
+
+* `authentication_access_token` - (Optional) Authenticate to ADB via access token as defined in the `authentication_access_token` block below
+
+* `authentication_key_vault_password` - (Optional) Authenticate to ADB via Azure Key Vault Linked Service as defined in the `authentication_key_vault_password` block below.
+
+* `authentication_msi` - (Optional) Authenticate to ADB via managed service identity as defined in the `authentication_msi` blocks as defined below.
+
+---
+
+You must specify exactly one of the following modes for cluster integration:
+
+* `existing_cluster_id` - (Optional) The cluster_id of an existing cluster within the linked ADB instance
+
+* `instance_pool` - (Optional) Leverages an instance pool within the linked ADB instance as defined by  `instance_pool` block below.
+
+* `new_cluster_config` - (Optional) Creates new clusters within the linked ADB instance as defined in the  `new_cluster_config` block below.
+
+---
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service.
+
+* `description` - (Optional) The description for the Data Factory Linked Service.
+
+* `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
+
+---
+
+A `authentication_key_vault_password` block supports the following:
+
+* `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
+
+* `secret_name` - (Required) Specifies the secret name in Azure Key Vault that stores ADB access token.
+
+---
+
+A `authentication_access_token` block supports the following:
+
+* `access_token` - (Required) The access token to authenticate to databricks
+
+---
+
+A `authentication_msi` block supports the following:
+
+* `workspaceResourceId` - (Required) The resource identifier of the databricks workspace
+
+---
+
+
+A `new_cluster_config` block supports the following:
+
+* `cluster_version` - (Required) Spark version of a the cluster
+
+* `node_type` - (Required) Node type for the new cluster
+
+* `custom_tags` - (Optional) Tags for the cluster resource
+
+* `driver_node_type` - (Optional) Driver node type for the cluster
+
+* `init_scripts` - (Optional) User defined initialization scripts for the cluster
+
+* `log_destination` - (Optional) Location to deliver Spark driver, worker, and event logs
+
+* `number_of_workers` - (Optional) The number of worker nodes. For a fixed number of workers, use a single value (e.g. "1") for autoscaling provide the min:max (e.g. "1:10"). Defaults to 1.
+
+* `spark_config` - (Optional) User-specified Spark configuration variables key-value pairs
+
+* `spark_environment_variables` - (Optional) User-specified Spark environment variables key-value pairs
+* 
+---
+
+A `instance_pool` block supports the following:
+
+* `instnace_pool_id` - (Required) Identifier of the instance pool within the linked ADB instance
+
+* `number_of_workers` - (Optional) Fixed number of workers to use 
+
+* `cluster_version` - (Required) Spark version of a the cluster
+
+---
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Data Factory Linked Service.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Linked Service.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Linked Service.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Linked Service.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Linked Service.
+
+## Import
+
+Data Factory Linked Services can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_factory_linked_service_azure_databricks.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+```


### PR DESCRIPTION
Fixes #7553

Adds support for creating Databricks Linked Service:
- Auth methods supported: MSI, Access Token or Key Vault Linked Service 
- Cluster Configurations: New, existing and instance pools
```
TF_ACC=1 go test -v ./azurerm/internal/services/datafactory -run=TestAccDataFactoryLinkedServiceDatabricks -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/08 17:35:00 [DEBUG] not using binary driver name, it's no longer needed
2021/03/08 17:35:03 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_authViaMSI
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_authViaMSI
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig
=== RUN   TestAccDataFactoryLinkedServiceDatabricks_update
=== PAUSE TestAccDataFactoryLinkedServiceDatabricks_update
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_authViaMSI
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken
=== CONT  TestAccDataFactoryLinkedServiceDatabricks_update
2021/03/08 17:36:37 [DEBUG] TF_ACCTEST_REATTACH set to 1 and acctest.TestHelper is not nil, using reattach-based testing
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_newClusterConfig (161.82s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_authViaAccessToken (163.27s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_authViaMSI (189.53s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_update (201.92s)
--- PASS: TestAccDataFactoryLinkedServiceDatabricks_authViaKeyVault (270.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory 274.021s
```

Note: Closed similar PR (#10884) as I moved the changes over to a feature branch and needed to re-create.