### PR TITLE
Docs: fix valid expander

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -221,7 +221,7 @@ A `auto_scaler_profile` block supports the following:
 
 * `balance_similar_node_groups` - Detect similar node groups and balance the number of nodes between them. Defaults to `false`.
 
-* `expander` - Expander to use. Possible values are `least-waste`, `priority`, `max-pods` and `random`. Defaults to `random`.
+* `expander` - Expander to use. Possible values are `least-waste`, `priority`, `most-pods` and `random`. Defaults to `random`.
 
 * `max_graceful_termination_sec` - Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. Defaults to `600`.
 


### PR DESCRIPTION
`max-pods` is not valid expander.

max-pods -> most-pods

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders

https://github.com/terraform-providers/terraform-provider-azurerm/blob/1d934f7476d2b580c181955a041f28f3097f9ef1/azurerm/internal/services/containers/kubernetes_cluster_resource.go#L111-L121