### PR TITLE
upgrade aks api version

### DIFF
--- a/azurerm/internal/services/containers/client/client.go
+++ b/azurerm/internal/services/containers/client/client.go
@@ -3,7 +3,8 @@ package client
 import (
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	legacy "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-08-01/containerservice"
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/preview/containerregistry/mgmt/2020-11-01-preview/containerregistry"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"

--- a/azurerm/internal/services/containers/client/client.go
+++ b/azurerm/internal/services/containers/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance"
 	legacy "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-08-01/containerservice"
-
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/preview/containerregistry/mgmt/2020-11-01-preview/containerregistry"
 	"github.com/Azure/go-autorest/autorest/azure"

--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -88,7 +88,6 @@ func schemaKubernetesAddOnProfiles() *schema.Schema {
 					Type:     schema.TypeList,
 					MaxItems: 1,
 					Optional: true,
-					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"enabled": {

--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -88,6 +88,7 @@ func schemaKubernetesAddOnProfiles() *schema.Schema {
 					Type:     schema.TypeList,
 					MaxItems: 1,
 					Optional: true,
+					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"enabled": {

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1106,7 +1106,11 @@ resource "azurerm_kubernetes_cluster" "test" {
 func (KubernetesClusterResource) diskEncryptionConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -9,7 +9,7 @@ import (
 
 	privateDnsValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/validate"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/azurerm/internal/services/containers/kubernetes_cluster_validate.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_validate.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers/client"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -7,7 +7,7 @@ import (
 	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers/validate"
 
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice/CHANGELOG.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice/CHANGELOG.md
@@ -1,5 +1,0 @@
-Generated from https://github.com/Azure/azure-rest-api-specs/tree/b08824e05817297a4b2874d8db5e6fc8c29349c9//specification/containerservice/resource-manager/readme.md tag: `package-2020-12`
-
-Code generator @microsoft.azure/autorest.go@2.1.175
-
-

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/CHANGELOG.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/CHANGELOG.md
@@ -1,0 +1,5 @@
+Generated from https://github.com/Azure/azure-rest-api-specs/tree/80e4e1b77162711ca1123042f50db03ffbf1bb40/specification/containerservice/resource-manager/readme.md tag: `package-2021-02`
+
+Code generator @microsoft.azure/autorest.go@2.1.175
+
+

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/agentpools.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/agentpools.go
@@ -100,7 +100,7 @@ func (client AgentPoolsClient) CreateOrUpdatePreparer(ctx context.Context, resou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -215,7 +215,7 @@ func (client AgentPoolsClient) DeletePreparer(ctx context.Context, resourceGroup
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -324,7 +324,7 @@ func (client AgentPoolsClient) GetPreparer(ctx context.Context, resourceGroupNam
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -410,7 +410,7 @@ func (client AgentPoolsClient) GetAvailableAgentPoolVersionsPreparer(ctx context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -499,7 +499,7 @@ func (client AgentPoolsClient) GetUpgradeProfilePreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -591,7 +591,7 @@ func (client AgentPoolsClient) ListPreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -709,7 +709,7 @@ func (client AgentPoolsClient) UpgradeNodeImageVersionPreparer(ctx context.Conte
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/client.go
@@ -1,4 +1,4 @@
-// Package containerservice implements the Azure ARM Containerservice service API version 2020-12-01.
+// Package containerservice implements the Azure ARM Containerservice service API version 2021-02-01.
 //
 // The Container Service Client.
 package containerservice

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/enums.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/enums.go
@@ -125,11 +125,13 @@ type KubeletDiskType string
 const (
 	// OS ...
 	OS KubeletDiskType = "OS"
+	// Temporary ...
+	Temporary KubeletDiskType = "Temporary"
 )
 
 // PossibleKubeletDiskTypeValues returns an array of possible values for the KubeletDiskType const type.
 func PossibleKubeletDiskTypeValues() []KubeletDiskType {
-	return []KubeletDiskType{OS}
+	return []KubeletDiskType{OS, Temporary}
 }
 
 // LicenseType enumerates the values for license type.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/maintenanceconfigurations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/maintenanceconfigurations.go
@@ -101,7 +101,7 @@ func (client MaintenanceConfigurationsClient) CreateOrUpdatePreparer(ctx context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -192,7 +192,7 @@ func (client MaintenanceConfigurationsClient) DeletePreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -279,7 +279,7 @@ func (client MaintenanceConfigurationsClient) GetPreparer(ctx context.Context, r
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -371,7 +371,7 @@ func (client MaintenanceConfigurationsClient) ListByManagedClusterPreparer(ctx c
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/managedclusters.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/managedclusters.go
@@ -131,7 +131,7 @@ func (client ManagedClustersClient) CreateOrUpdatePreparer(ctx context.Context, 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -244,7 +244,7 @@ func (client ManagedClustersClient) DeletePreparer(ctx context.Context, resource
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -351,7 +351,7 @@ func (client ManagedClustersClient) GetPreparer(ctx context.Context, resourceGro
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -444,7 +444,7 @@ func (client ManagedClustersClient) GetAccessProfilePreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -531,7 +531,7 @@ func (client ManagedClustersClient) GetUpgradeProfilePreparer(ctx context.Contex
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -608,7 +608,7 @@ func (client ManagedClustersClient) ListPreparer(ctx context.Context) (*http.Req
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -731,7 +731,7 @@ func (client ManagedClustersClient) ListByResourceGroupPreparer(ctx context.Cont
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -855,7 +855,7 @@ func (client ManagedClustersClient) ListClusterAdminCredentialsPreparer(ctx cont
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -942,7 +942,7 @@ func (client ManagedClustersClient) ListClusterMonitoringUserCredentialsPreparer
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1029,7 +1029,7 @@ func (client ManagedClustersClient) ListClusterUserCredentialsPreparer(ctx conte
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1109,7 +1109,7 @@ func (client ManagedClustersClient) ResetAADProfilePreparer(ctx context.Context,
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1214,7 +1214,7 @@ func (client ManagedClustersClient) ResetServicePrincipalProfilePreparer(ctx con
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1316,7 +1316,7 @@ func (client ManagedClustersClient) RotateClusterCertificatesPreparer(ctx contex
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1416,7 +1416,7 @@ func (client ManagedClustersClient) StartPreparer(ctx context.Context, resourceG
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1516,7 +1516,7 @@ func (client ManagedClustersClient) StopPreparer(ctx context.Context, resourceGr
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1617,7 +1617,7 @@ func (client ManagedClustersClient) UpdateTagsPreparer(ctx context.Context, reso
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/models.go
@@ -29,7 +29,7 @@ import (
 )
 
 // The package's fully qualified name.
-const fqdn = "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice"
+const fqdn = "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice"
 
 // AccessProfile profile for enabling a user to access a managed cluster.
 type AccessProfile struct {
@@ -1131,7 +1131,7 @@ type ManagedClusterAgentPoolProfile struct {
 	OsDiskSizeGB *int32 `json:"osDiskSizeGB,omitempty"`
 	// OsDiskType - OS disk type to be used for machines in a given agent pool. Allowed values are 'Ephemeral' and 'Managed'. Defaults to 'Managed'. May not be changed after creation. Possible values include: 'Managed', 'Ephemeral'
 	OsDiskType OSDiskType `json:"osDiskType,omitempty"`
-	// KubeletDiskType - KubeletDiskType determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. Currently allows one value, OS, resulting in Kubelet using the OS disk for data. Possible values include: 'OS'
+	// KubeletDiskType - KubeletDiskType determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. Currently allows one value, OS, resulting in Kubelet using the OS disk for data. Possible values include: 'OS', 'Temporary'
 	KubeletDiskType KubeletDiskType `json:"kubeletDiskType,omitempty"`
 	// VnetSubnetID - VNet SubnetID specifies the VNet's subnet identifier for nodes and maybe pods
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
@@ -1165,6 +1165,8 @@ type ManagedClusterAgentPoolProfile struct {
 	AvailabilityZones *[]string `json:"availabilityZones,omitempty"`
 	// EnableNodePublicIP - Enable public IP for nodes
 	EnableNodePublicIP *bool `json:"enableNodePublicIP,omitempty"`
+	// NodePublicIPPrefixID - Public IP Prefix ID. VM nodes use IPs assigned from this Public IP Prefix.
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 	// ScaleSetPriority - ScaleSetPriority to be used to specify virtual machine scale set priority. Default to regular. Possible values include: 'Spot', 'Regular'
 	ScaleSetPriority ScaleSetPriority `json:"scaleSetPriority,omitempty"`
 	// ScaleSetEvictionPolicy - ScaleSetEvictionPolicy to be used to specify eviction policy for Spot virtual machine scale set. Default to Delete. Possible values include: 'Delete', 'Deallocate'
@@ -1247,6 +1249,9 @@ func (mcapp ManagedClusterAgentPoolProfile) MarshalJSON() ([]byte, error) {
 	if mcapp.EnableNodePublicIP != nil {
 		objectMap["enableNodePublicIP"] = mcapp.EnableNodePublicIP
 	}
+	if mcapp.NodePublicIPPrefixID != nil {
+		objectMap["nodePublicIPPrefixID"] = mcapp.NodePublicIPPrefixID
+	}
 	if mcapp.ScaleSetPriority != "" {
 		objectMap["scaleSetPriority"] = mcapp.ScaleSetPriority
 	}
@@ -1290,7 +1295,7 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	OsDiskSizeGB *int32 `json:"osDiskSizeGB,omitempty"`
 	// OsDiskType - OS disk type to be used for machines in a given agent pool. Allowed values are 'Ephemeral' and 'Managed'. Defaults to 'Managed'. May not be changed after creation. Possible values include: 'Managed', 'Ephemeral'
 	OsDiskType OSDiskType `json:"osDiskType,omitempty"`
-	// KubeletDiskType - KubeletDiskType determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. Currently allows one value, OS, resulting in Kubelet using the OS disk for data. Possible values include: 'OS'
+	// KubeletDiskType - KubeletDiskType determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. Currently allows one value, OS, resulting in Kubelet using the OS disk for data. Possible values include: 'OS', 'Temporary'
 	KubeletDiskType KubeletDiskType `json:"kubeletDiskType,omitempty"`
 	// VnetSubnetID - VNet SubnetID specifies the VNet's subnet identifier for nodes and maybe pods
 	VnetSubnetID *string `json:"vnetSubnetID,omitempty"`
@@ -1324,6 +1329,8 @@ type ManagedClusterAgentPoolProfileProperties struct {
 	AvailabilityZones *[]string `json:"availabilityZones,omitempty"`
 	// EnableNodePublicIP - Enable public IP for nodes
 	EnableNodePublicIP *bool `json:"enableNodePublicIP,omitempty"`
+	// NodePublicIPPrefixID - Public IP Prefix ID. VM nodes use IPs assigned from this Public IP Prefix.
+	NodePublicIPPrefixID *string `json:"nodePublicIPPrefixID,omitempty"`
 	// ScaleSetPriority - ScaleSetPriority to be used to specify virtual machine scale set priority. Default to regular. Possible values include: 'Spot', 'Regular'
 	ScaleSetPriority ScaleSetPriority `json:"scaleSetPriority,omitempty"`
 	// ScaleSetEvictionPolicy - ScaleSetEvictionPolicy to be used to specify eviction policy for Spot virtual machine scale set. Default to Delete. Possible values include: 'Delete', 'Deallocate'
@@ -1402,6 +1409,9 @@ func (mcappp ManagedClusterAgentPoolProfileProperties) MarshalJSON() ([]byte, er
 	}
 	if mcappp.EnableNodePublicIP != nil {
 		objectMap["enableNodePublicIP"] = mcappp.EnableNodePublicIP
+	}
+	if mcappp.NodePublicIPPrefixID != nil {
+		objectMap["nodePublicIPPrefixID"] = mcappp.NodePublicIPPrefixID
 	}
 	if mcappp.ScaleSetPriority != "" {
 		objectMap["scaleSetPriority"] = mcappp.ScaleSetPriority
@@ -1747,6 +1757,8 @@ func (mcpie ManagedClusterPodIdentityException) MarshalJSON() ([]byte, error) {
 type ManagedClusterPodIdentityProfile struct {
 	// Enabled - Whether the pod identity addon is enabled.
 	Enabled *bool `json:"enabled,omitempty"`
+	// AllowNetworkPluginKubenet - Customer consent for enabling AAD pod identity addon in cluster using Kubenet network plugin.
+	AllowNetworkPluginKubenet *bool `json:"allowNetworkPluginKubenet,omitempty"`
 	// UserAssignedIdentities - User assigned pod identity settings.
 	UserAssignedIdentities *[]ManagedClusterPodIdentity `json:"userAssignedIdentities,omitempty"`
 	// UserAssignedIdentityExceptions - User assigned pod identity exception settings.
@@ -1791,10 +1803,14 @@ type ManagedClusterProperties struct {
 	KubernetesVersion *string `json:"kubernetesVersion,omitempty"`
 	// DNSPrefix - DNS prefix specified when creating the managed cluster.
 	DNSPrefix *string `json:"dnsPrefix,omitempty"`
+	// FqdnSubdomain - FQDN subdomain specified when creating private cluster with custom private dns zone.
+	FqdnSubdomain *string `json:"fqdnSubdomain,omitempty"`
 	// Fqdn - READ-ONLY; FQDN for the master pool.
 	Fqdn *string `json:"fqdn,omitempty"`
 	// PrivateFQDN - READ-ONLY; FQDN of private cluster.
 	PrivateFQDN *string `json:"privateFQDN,omitempty"`
+	// AzurePortalFQDN - READ-ONLY; FQDN for the master pool which used by proxy config.
+	AzurePortalFQDN *string `json:"azurePortalFQDN,omitempty"`
 	// AgentPoolProfiles - Properties of the agent pool.
 	AgentPoolProfiles *[]ManagedClusterAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
 	// LinuxProfile - Profile for Linux VMs in the container service cluster.
@@ -1837,6 +1853,9 @@ func (mcp ManagedClusterProperties) MarshalJSON() ([]byte, error) {
 	}
 	if mcp.DNSPrefix != nil {
 		objectMap["dnsPrefix"] = mcp.DNSPrefix
+	}
+	if mcp.FqdnSubdomain != nil {
+		objectMap["fqdnSubdomain"] = mcp.FqdnSubdomain
 	}
 	if mcp.AgentPoolProfiles != nil {
 		objectMap["agentPoolProfiles"] = mcp.AgentPoolProfiles

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/operations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/operations.go
@@ -77,7 +77,7 @@ func (client OperationsClient) List(ctx context.Context) (result OperationListRe
 
 // ListPreparer prepares the List request.
 func (client OperationsClient) ListPreparer(ctx context.Context) (*http.Request, error) {
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/privateendpointconnections.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/privateendpointconnections.go
@@ -93,7 +93,7 @@ func (client PrivateEndpointConnectionsClient) DeletePreparer(ctx context.Contex
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -202,7 +202,7 @@ func (client PrivateEndpointConnectionsClient) GetPreparer(ctx context.Context, 
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -289,7 +289,7 @@ func (client PrivateEndpointConnectionsClient) ListPreparer(ctx context.Context,
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -381,7 +381,7 @@ func (client PrivateEndpointConnectionsClient) UpdatePreparer(ctx context.Contex
 		"subscriptionId":                autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/privatelinkresources.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/privatelinkresources.go
@@ -99,7 +99,7 @@ func (client PrivateLinkResourcesClient) ListPreparer(ctx context.Context, resou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/resolveprivatelinkserviceid.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/resolveprivatelinkserviceid.go
@@ -99,7 +99,7 @@ func (client ResolvePrivateLinkServiceIDClient) POSTPreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2020-12-01"
+	const APIVersion = "2021-02-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + Version() + " containerservice/2020-12-01"
+	return "Azure-SDK-For-Go/" + Version() + " containerservice/2021-02-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2019-06-01-preview/templatespecs/CHANGELOG.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2019-06-01-preview/templatespecs/CHANGELOG.md
@@ -1,5 +1,5 @@
 Generated from https://github.com/Azure/azure-rest-api-specs/tree/b08824e05817297a4b2874d8db5e6fc8c29349c9//specification/resources/resource-manager/readme.md tag: `package-templatespecs-2019-06-preview`
 
-Code generator @microsoft.azure/autorest.go@2.1.171
+Code generator @microsoft.azure/autorest.go@2.1.175
 
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,7 @@ github.com/Azure/azure-sdk-for-go/services/cognitiveservices/mgmt/2017-04-18/cog
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute
 github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2019-12-01/containerinstance
 github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-08-01/containerservice
-github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-12-01/containerservice
+github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-02-01/containerservice
 github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-10-01/costmanagement
 github.com/Azure/azure-sdk-for-go/services/databoxedge/mgmt/2019-08-01/databoxedge
 github.com/Azure/azure-sdk-for-go/services/databricks/mgmt/2018-04-01/databricks


### PR DESCRIPTION
this PR contains changes:
1. fix aks test case
1.1 for acctest `TestAccKubernetesCluster_diskEncryption`, it fails because purging key vault key failed. since using `azurerm_disk_encryption_set` needs to enable `purge_protection`, the fix way is to not purge key vault key when delete
2. upgrade api version to 2021-02-01