### PR TITLE
azurerm_local_network_gateway -  mark address_space argument optional

### DIFF
--- a/azurerm/internal/services/network/local_network_gateway_resource.go
+++ b/azurerm/internal/services/network/local_network_gateway_resource.go
@@ -57,7 +57,7 @@ func resourceLocalNetworkGateway() *schema.Resource {
 
 			"address_space": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/azurerm/internal/services/network/local_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/local_network_gateway_resource_test.go
@@ -182,6 +182,13 @@ func TestAccLocalNetworkGateway_updateAddressSpace(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
+			Config: r.noneAddressSpace(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.multipleAddressSpace(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -365,6 +372,26 @@ resource "azurerm_local_network_gateway" "test" {
     bgp_peering_address = "10.104.1.1"
     peer_weight         = 15
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (LocalNetworkGatewayResource) noneAddressSpace(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-%d"
+  location = "%s"
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  gateway_address     = "127.0.0.1"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 * `location` - (Required) The location/region where the local network gateway is
     created. Changing this forces a new resource to be created.
 
-* `address_space` - (Required) The list of string CIDRs representing the
+* `address_space` - (Optional) The list of string CIDRs representing the
     address spaces the gateway exposes.
 
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below containing the


### PR DESCRIPTION
To address issue https://github.com/terraform-providers/terraform-provider-azurerm/issues/10891

Below paste the run pass result for the test cases

```
=== RUN   TestAccLocalNetworkGateway_updateAddressSpace
=== PAUSE TestAccLocalNetworkGateway_updateAddressSpace
=== CONT  TestAccLocalNetworkGateway_updateAddressSpace
--- PASS: TestAccLocalNetworkGateway_updateAddressSpace (371.85s)
PASS

```

According to https://docs.microsoft.com/en-us/azure/templates/microsoft.network/localnetworkgateways?tabs=json, address_space argument is not required.