### PR TITLE
add data source for service bus topic and service bus queue

### DIFF
--- a/azurerm/internal/services/servicebus/registration.go
+++ b/azurerm/internal/services/servicebus/registration.go
@@ -27,6 +27,8 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 		"azurerm_servicebus_topic_authorization_rule":     dataSourceServiceBusTopicAuthorizationRule(),
 		"azurerm_servicebus_queue_authorization_rule":     dataSourceServiceBusQueueAuthorizationRule(),
 		"azurerm_servicebus_subscription":                 dataSourceServiceBusSubscription(),
+		"azurerm_servicebus_topic":                        dataSourceServiceBusTopic(),
+		"azurerm_servicebus_queue":                        dataSourceServiceBusQueue(),
 	}
 }
 

--- a/azurerm/internal/services/servicebus/servicebus_queue_data_source.go
+++ b/azurerm/internal/services/servicebus/servicebus_queue_data_source.go
@@ -1,0 +1,178 @@
+package servicebus
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/servicebus/mgmt/2017-04-01/servicebus"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/parse"
+	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceServiceBusQueue() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceServiceBusQueueRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azValidate.QueueName(),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"namespace_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azValidate.NamespaceName,
+			},
+
+			"auto_delete_on_idle": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"dead_lettering_on_message_expiration": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"default_message_ttl": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"duplicate_detection_history_time_window": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"enable_batched_operations": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"enable_express": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"enable_partitioning": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"forward_dead_lettered_messages_to": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"forward_to": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"lock_duration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"max_delivery_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"max_size_in_megabytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"requires_duplicate_detection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"requires_session": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceServiceBusQueueRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ServiceBus.QueuesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	id := parse.NewQueueID(subscriptionId, resourceGroup, namespaceName, name)
+
+	resp, err := client.Get(ctx, resourceGroup, namespaceName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Service Bus Queue %q was not found in Resource Group %q Namespace %q", name, resourceGroup, namespaceName)
+		}
+		return fmt.Errorf("Error making Read request on Azure Service Bus Queue %q in Resource Group %q Namespace %q: %v", name, resourceGroup, namespaceName, err)
+	}
+
+	d.SetId(id.ID())
+
+	if props := resp.SBQueueProperties; props != nil {
+		d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)
+		d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
+		d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
+		d.Set("duplicate_detection_history_time_window", props.DuplicateDetectionHistoryTimeWindow)
+		d.Set("enable_batched_operations", props.EnableBatchedOperations)
+		d.Set("enable_express", props.EnableExpress)
+		d.Set("enable_partitioning", props.EnablePartitioning)
+		d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
+		d.Set("forward_to", props.ForwardTo)
+		d.Set("lock_duration", props.LockDuration)
+		d.Set("max_delivery_count", props.MaxDeliveryCount)
+		d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
+		d.Set("requires_session", props.RequiresSession)
+		d.Set("status", props.Status)
+
+		if apiMaxSizeInMegabytes := props.MaxSizeInMegabytes; apiMaxSizeInMegabytes != nil {
+			maxSizeInMegabytes := int(*apiMaxSizeInMegabytes)
+
+			// If the queue is NOT in a premium namespace (ie. it is Basic or Standard) and partitioning is enabled
+			// then the max size returned by the API will be 16 times greater than the value set.
+			if *props.EnablePartitioning {
+				namespacesClient := meta.(*clients.Client).ServiceBus.NamespacesClient
+				namespace, err := namespacesClient.Get(ctx, resourceGroup, namespaceName)
+				if err != nil {
+					return err
+				}
+
+				if namespace.Sku.Name != servicebus.Premium {
+					const partitionCount = 16
+					maxSizeInMegabytes = int(*apiMaxSizeInMegabytes / partitionCount)
+				}
+			}
+
+			d.Set("max_size_in_megabytes", maxSizeInMegabytes)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/servicebus/servicebus_queue_data_source_test.go
+++ b/azurerm/internal/services/servicebus/servicebus_queue_data_source_test.go
@@ -1,0 +1,52 @@
+package servicebus_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type ServiceBusQueueDataSource struct {
+}
+
+func TestAccDataSourceServiceBusQueue_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_servicebus_queue", "test")
+	r := ServiceBusQueueDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("auto_delete_on_idle").Exists(),
+				check.That(data.ResourceName).Key("dead_lettering_on_message_expiration").Exists(),
+				check.That(data.ResourceName).Key("default_message_ttl").Exists(),
+				check.That(data.ResourceName).Key("duplicate_detection_history_time_window").Exists(),
+				check.That(data.ResourceName).Key("enable_batched_operations").Exists(),
+				check.That(data.ResourceName).Key("enable_express").Exists(),
+				check.That(data.ResourceName).Key("enable_partitioning").Exists(),
+				check.That(data.ResourceName).Key("lock_duration").Exists(),
+				check.That(data.ResourceName).Key("max_delivery_count").Exists(),
+				check.That(data.ResourceName).Key("max_size_in_megabytes").Exists(),
+				check.That(data.ResourceName).Key("requires_duplicate_detection").Exists(),
+				check.That(data.ResourceName).Key("requires_session").Exists(),
+				check.That(data.ResourceName).Key("status").Exists(),
+			),
+		},
+	})
+}
+
+func (ServiceBusQueueDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_servicebus_queue" "test" {
+  name                = azurerm_servicebus_queue.test.name
+  namespace_name      = azurerm_servicebus_queue.test.namespace_name
+  resource_group_name = azurerm_servicebus_queue.test.resource_group_name
+}
+`, ServiceBusQueueResource{}.basic(data))
+}

--- a/azurerm/internal/services/servicebus/servicebus_topic_data_source.go
+++ b/azurerm/internal/services/servicebus/servicebus_topic_data_source.go
@@ -1,0 +1,152 @@
+package servicebus
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/servicebus/mgmt/2017-04-01/servicebus"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/parse"
+	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceServiceBusTopic() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceServiceBusTopicRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azValidate.TopicName(),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"namespace_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azValidate.NamespaceName,
+			},
+
+			"auto_delete_on_idle": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_message_ttl": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"duplicate_detection_history_time_window": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"enable_batched_operations": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"enable_express": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"enable_partitioning": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"max_size_in_megabytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"requires_duplicate_detection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"support_ordering": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceServiceBusTopicRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ServiceBus.TopicsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	id := parse.NewTopicID(subscriptionId, resourceGroup, namespaceName, name)
+
+	resp, err := client.Get(ctx, resourceGroup, namespaceName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Service Bus Topic %q was not found in Resource Group %q Namespace %q", name, resourceGroup, namespaceName)
+		}
+		return fmt.Errorf("Error making Read request on Azure Service Bus Topic %q in Resource Group %q Namespace %q: %v", name, resourceGroup, namespaceName, err)
+	}
+
+	d.SetId(id.ID())
+
+	if props := resp.SBTopicProperties; props != nil {
+		d.Set("status", string(props.Status))
+		d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)
+		d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
+
+		if window := props.DuplicateDetectionHistoryTimeWindow; window != nil && *window != "" {
+			d.Set("duplicate_detection_history_time_window", window)
+		}
+
+		d.Set("enable_batched_operations", props.EnableBatchedOperations)
+		d.Set("enable_express", props.EnableExpress)
+		d.Set("enable_partitioning", props.EnablePartitioning)
+		d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
+		d.Set("support_ordering", props.SupportOrdering)
+
+		if maxSizeMB := props.MaxSizeInMegabytes; maxSizeMB != nil {
+			maxSize := int(*props.MaxSizeInMegabytes)
+
+			// if the topic is in a premium namespace and partitioning is enabled then the
+			// max size returned by the API will be 16 times greater than the value set
+			if partitioning := props.EnablePartitioning; partitioning != nil && *partitioning {
+				namespacesClient := meta.(*clients.Client).ServiceBus.NamespacesClient
+				namespace, err := namespacesClient.Get(ctx, resourceGroup, namespaceName)
+				if err != nil {
+					return err
+				}
+
+				if namespace.Sku.Name != servicebus.Premium {
+					const partitionCount = 16
+					maxSize = int(*props.MaxSizeInMegabytes / partitionCount)
+				}
+			}
+
+			d.Set("max_size_in_megabytes", maxSize)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/servicebus/servicebus_topic_data_source_test.go
+++ b/azurerm/internal/services/servicebus/servicebus_topic_data_source_test.go
@@ -1,0 +1,49 @@
+package servicebus_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type ServiceBusTopicDataSource struct {
+}
+
+func TestAccDataSourceServiceBusTopic_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_servicebus_topic", "test")
+	r := ServiceBusTopicDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("auto_delete_on_idle").Exists(),
+				check.That(data.ResourceName).Key("default_message_ttl").Exists(),
+				check.That(data.ResourceName).Key("duplicate_detection_history_time_window").Exists(),
+				check.That(data.ResourceName).Key("enable_batched_operations").Exists(),
+				check.That(data.ResourceName).Key("enable_express").Exists(),
+				check.That(data.ResourceName).Key("enable_partitioning").Exists(),
+				check.That(data.ResourceName).Key("max_size_in_megabytes").Exists(),
+				check.That(data.ResourceName).Key("requires_duplicate_detection").Exists(),
+				check.That(data.ResourceName).Key("status").Exists(),
+				check.That(data.ResourceName).Key("support_ordering").Exists(),
+			),
+		},
+	})
+}
+
+func (ServiceBusTopicDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_servicebus_topic" "test" {
+  name                = azurerm_servicebus_topic.test.name
+  namespace_name      = azurerm_servicebus_topic.test.namespace_name
+  resource_group_name = azurerm_servicebus_topic.test.resource_group_name
+}
+`, ServiceBusTopicResource{}.basic(data))
+}

--- a/website/docs/d/servicebus_queue.html.markdown
+++ b/website/docs/d/servicebus_queue.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_servicebus_queue"
+description: |-
+  Gets information about an existing Service Bus Queue.
+---
+
+# Data Source: azurerm_servicebus_queue
+
+Use this data source to access information about an existing Service Bus Queue.
+
+## Example Usage
+
+```hcl
+data "azurerm_servicebus_queue" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+  namespace_name      = "existing"
+}
+
+output "id" {
+  value = data.azurerm_servicebus_queue.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Service Bus Queue.
+
+* `namespace_name` - (Required) The name of the ServiceBus Namespace.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Service Bus Queue exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Service Bus Queue.
+
+* `auto_delete_on_idle` - The ISO 8601 timespan duration of the idle interval after which the Queue is automatically deleted, minimum of 5 minutes.
+
+* `dead_lettering_on_message_expiration` - Boolean flag which controls whether the Queue has dead letter support when a message expires.
+
+* `default_message_ttl` - The ISO 8601 timespan duration of the TTL of messages sent to this queue. This is the default value used when TTL is not set on a message itself.
+
+* `duplicate_detection_history_time_window` - The ISO 8601 timespan duration during which duplicates can be detected.
+
+* `enable_batched_operations` - Boolean flag which controls whether server-side batched operations are enabled.
+
+* `enable_express` - Boolean flag which controls whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage.
+
+* `enable_partitioning` - Boolean flag which controls whether to enable the queue to be partitioned across multiple message brokers. 
+
+* `forward_dead_lettered_messages_to` - The name of a Queue or Topic to automatically forward dead lettered messages to.
+
+* `forward_to` - The name of a Queue or Topic to automatically forward messages to. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-auto-forwarding) for more information.
+
+* `lock_duration` - The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers.
+
+* `max_delivery_count` - Integer value which controls when a message is automatically dead lettered.
+
+* `max_size_in_megabytes` - Integer value which controls the size of memory allocated for the queue. For supported values see the "Queue or topic size" section of [Service Bus Quotas](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).
+
+* `requires_duplicate_detection` - Boolean flag which controls whether the Queue requires duplicate detection.
+
+* `requires_session` - Boolean flag which controls whether the Queue requires sessions. This will allow ordered handling of unbounded sequences of related messages. With sessions enabled a queue can guarantee first-in-first-out delivery of messages.
+
+* `status` -  The status of the Queue. Possible values are `Active`, `Creating`, `Deleting`, `Disabled`, `ReceiveDisabled`, `Renaming`, `SendDisabled`, `Unknown`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Service Bus Queue.

--- a/website/docs/d/servicebus_topic.html.markdown
+++ b/website/docs/d/servicebus_topic.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_servicebus_topic"
+description: |-
+  Gets information about an existing Service Bus Topic.
+---
+
+# Data Source: azurerm_servicebus_topic
+
+Use this data source to access information about an existing Service Bus Topic.
+
+## Example Usage
+
+```hcl
+data "azurerm_servicebus_topic" "example" {
+  name                = "existing"
+  resource_group_name = "existing"
+  namespace_name      = "existing"
+}
+
+output "id" {
+  value = data.azurerm_servicebus_topic.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Service Bus Topic.
+
+* `namespace_name` - (Required) The name of the Service Bus Namespace.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Service Bus Topic exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Service Bus Topic.
+
+* `auto_delete_on_idle` - The ISO 8601 timespan duration of the idle interval after which the Topic is automatically deleted, minimum of 5 minutes.
+
+* `default_message_ttl` - The ISO 8601 timespan duration of TTL of messages sent to this topic if no TTL value is set on the message itself.
+
+* `duplicate_detection_history_time_window` - The ISO 8601 timespan duration during which duplicates can be detected. 
+
+* `enable_batched_operations` - Boolean flag which controls if server-side batched operations are enabled.
+
+* `enable_express` - Boolean flag which controls whether Express Entities are enabled. An express topic holds a message in memory temporarily before writing it to persistent storage.
+
+* `enable_partitioning` - Boolean flag which controls whether to enable the topic to be partitioned across multiple message brokers.
+
+* `max_size_in_megabytes` - Integer value which controls the size of memory allocated for the topic. For supported values see the "Queue/topic size" section of [this document](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).
+
+* `requires_duplicate_detection` - Boolean flag which controls whether the Topic requires duplicate detection. 
+
+* `status` - The Status of the Service Bus Topic. Acceptable values are Active or Disabled.
+
+* `support_ordering` - Boolean flag which controls whether the Topic supports ordering.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Service Bus Topic.


### PR DESCRIPTION
To address issue https://github.com/terraform-providers/terraform-provider-azurerm/issues/10845

Below paste the run pass result for the added test cases

```
=== RUN   TestAccDataSourceServiceBusTopic_basic
=== PAUSE TestAccDataSourceServiceBusTopic_basic
=== CONT  TestAccDataSourceServiceBusTopic_basic
--- PASS: TestAccDataSourceServiceBusTopic_basic (263.58s)
PASS

=== RUN   TestAccDataSourceServiceBusQueue_basic
=== PAUSE TestAccDataSourceServiceBusQueue_basic
=== CONT  TestAccDataSourceServiceBusQueue_basic
--- PASS: TestAccDataSourceServiceBusQueue_basic (271.11s)
PASS

```