### PR TITLE
scripts/gradually-deprecated: exiting with the right status code

### DIFF
--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -17,6 +17,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
+          fetch-depth: 0
           go-version: '1.16.0'
-      - run: git fetch origin --unshallow
       - run: ./scripts/run-gradually-deprecated.sh

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -1,0 +1,22 @@
+---
+name: Check for new usages of deprecated functionality
+on:
+  pull_request:
+    types: ['opened', 'synchronize']
+    paths:
+      - '**.go'
+      - 'vendor/**'
+      - '.github/workflows/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.0'
+      - run: git fetch origin --unshallow
+      - run: ./scripts/run-gradually-deprecated.sh

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -5,8 +5,6 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '**.go'
-      - 'vendor/**'
-      - '.github/workflows/**'
 
 jobs:
   test:
@@ -15,8 +13,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.0'

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -15,8 +15,9 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          fetch-depth: 0
           go-version: '1.16.0'
       - run: ./scripts/run-gradually-deprecated.sh

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -20,5 +20,5 @@ jobs:
           go-version: '1.16.0'
       - run: bash scripts/gogetcookie.sh
       - run: make test
-          env:
-            GITHUB_ACTIONS_STAGE: "UNIT_TESTS"
+        env:
+          GITHUB_ACTIONS_STAGE: "UNIT_TESTS"

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -20,3 +20,5 @@ jobs:
           go-version: '1.16.0'
       - run: bash scripts/gogetcookie.sh
       - run: make test
+          env:
+            GITHUB_ACTIONS_STAGE: "UNIT_TESTS"

--- a/azurerm/internal/services/advisor/advisor_recommendations_data_source.go
+++ b/azurerm/internal/services/advisor/advisor_recommendations_data_source.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+
 	"github.com/Azure/azure-sdk-for-go/services/advisor/mgmt/2020-01-01/advisor"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -128,6 +130,9 @@ func dataSourceAdvisorRecommendationsRead(d *schema.ResourceData, meta interface
 	if err := d.Set("recommendations", flattenAzureRmAdvisorRecommendations(recommends)); err != nil {
 		return fmt.Errorf("setting `recommendations`: %+v", err)
 	}
+
+	nameeee := utils.String("bob")
+	d.SetId(*nameeee)
 
 	d.SetId(fmt.Sprintf("avdisor/recommendations/%s", time.Now().UTC().String()))
 

--- a/azurerm/internal/services/advisor/advisor_recommendations_data_source.go
+++ b/azurerm/internal/services/advisor/advisor_recommendations_data_source.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-
 	"github.com/Azure/azure-sdk-for-go/services/advisor/mgmt/2020-01-01/advisor"
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -130,9 +128,6 @@ func dataSourceAdvisorRecommendationsRead(d *schema.ResourceData, meta interface
 	if err := d.Set("recommendations", flattenAzureRmAdvisorRecommendations(recommends)); err != nil {
 		return fmt.Errorf("setting `recommendations`: %+v", err)
 	}
-
-	nameeee := utils.String("bob")
-	d.SetId(*nameeee)
 
 	d.SetId(fmt.Sprintf("avdisor/recommendations/%s", time.Now().UTC().String()))
 

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -2,9 +2,9 @@
 
 function runGraduallyDeprecatedFunctions {
   echo "==> Checking for use of gradually deprecated functions..."
-  
+
   # require resources to be imported is now hard-coded on - but only checking for additions
-  result=$(git diff master | grep + | grep -R "features\.ShouldResourcesBeImported")
+  result=$(git diff origin/master | grep + | grep -R "features\.ShouldResourcesBeImported")
   if [ "$result" != "" ];
   then
     echo "The Feature Flag for 'ShouldResourcesBeImported' will be deprecated in the future"
@@ -18,7 +18,7 @@ function runGraduallyDeprecatedFunctions {
   fi
 
   # using Resource ID Formatters/Parsers
-  result=$(git diff master | grep + | grep -R "d\.SetId(\*")
+  result=$(git diff origin/master | grep + | grep -R "d\.SetId(\*")
   if [ "$result" != "" ];
   then
     echo "Due to the Azure API returning the Resource ID's inconsistently - Terraform"

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -4,7 +4,7 @@ function runGraduallyDeprecatedFunctions {
   echo "==> Checking for use of gradually deprecated functions..."
   
   # require resources to be imported is now hard-coded on - but only checking for additions
-  result=$(git diff origin/master | grep + | grep -R "features\.ShouldResourcesBeImported")
+  result=$(git diff master | grep + | grep -R "features\.ShouldResourcesBeImported")
   if [ "$result" != "" ];
   then
     echo "The Feature Flag for 'ShouldResourcesBeImported' will be deprecated in the future"
@@ -14,10 +14,11 @@ function runGraduallyDeprecatedFunctions {
     echo ""
     echo "In the future this function will be marked as Deprecated - however it's not for"
     echo "the moment to not conflict with open Pull Requests."
+    echo 1
   fi
 
   # using Resource ID Formatters/Parsers
-  result=$(git diff origin/master | grep + | grep -R "d\.SetId(\*")
+  result=$(git diff master | grep + | grep -R "d\.SetId(\*")
   if [ "$result" != "" ];
   then
     echo "Due to the Azure API returning the Resource ID's inconsistently - Terraform"
@@ -53,6 +54,7 @@ function runGraduallyDeprecatedFunctions {
     echo "New Resources should be using Resource ID Formatters/Parsers by default"
     echo "however existing (unmodified) resources can continue to use the Azure ID"
     echo "for the moment - but over time these will be switched across."
+    echo 1
   fi
 }
 
@@ -67,7 +69,7 @@ function runDeprecatedFunctions {
     echo "Please remove the references to 'd.SetId("") from the Data Sources listed below"
     echo "and raise an error instead:"
     echo ""
-    echo $result
+    echo 1
   fi
 }
 

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -14,7 +14,7 @@ function runGraduallyDeprecatedFunctions {
     echo ""
     echo "In the future this function will be marked as Deprecated - however it's not for"
     echo "the moment to not conflict with open Pull Requests."
-    echo 1
+    exit 1
   fi
 
   # using Resource ID Formatters/Parsers
@@ -54,7 +54,7 @@ function runGraduallyDeprecatedFunctions {
     echo "New Resources should be using Resource ID Formatters/Parsers by default"
     echo "however existing (unmodified) resources can continue to use the Azure ID"
     echo "for the moment - but over time these will be switched across."
-    echo 1
+    exit 1
   fi
 }
 
@@ -69,7 +69,7 @@ function runDeprecatedFunctions {
     echo "Please remove the references to 'd.SetId("") from the Data Sources listed below"
     echo "and raise an error instead:"
     echo ""
-    echo 1
+    exit 1
   fi
 }
 

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -4,7 +4,7 @@ function runGraduallyDeprecatedFunctions {
   echo "==> Checking for use of gradually deprecated functions..."
 
   # require resources to be imported is now hard-coded on - but only checking for additions
-  result=$(git diff origin/master | grep + | grep -R "features\.ShouldResourcesBeImported")
+  result=$(git diff master | grep + | grep -R "features\.ShouldResourcesBeImported")
   if [ "$result" != "" ];
   then
     echo "The Feature Flag for 'ShouldResourcesBeImported' will be deprecated in the future"
@@ -18,7 +18,7 @@ function runGraduallyDeprecatedFunctions {
   fi
 
   # using Resource ID Formatters/Parsers
-  result=$(git diff origin/master | grep + | grep -R "d\.SetId(\*")
+  result=$(git diff master | grep + | grep -R "d\.SetId(\*")
   if [ "$result" != "" ];
   then
     echo "Due to the Azure API returning the Resource ID's inconsistently - Terraform"

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -18,7 +18,7 @@ function runGraduallyDeprecatedFunctions {
   fi
 
   # using Resource ID Formatters/Parsers
-  result=$(git diff master | grep + | grep -R "d\.SetId(\*")
+  result=$(git diff master | grep + | grep -R "d\.SetId(\\*")
   if [ "$result" != "" ];
   then
     echo "Due to the Azure API returning the Resource ID's inconsistently - Terraform"
@@ -74,6 +74,13 @@ function runDeprecatedFunctions {
 }
 
 function main {
+  if [ "$GITHUB_ACTIONS_STAGE" == "UNIT_TESTS" ];
+  then
+    echo "Skipping - the Gradually Deprecated check is separate in Github Actions"
+    echo "so this can be skipped as a part of the build process."
+    exit 0
+  fi
+
   runGraduallyDeprecatedFunctions
   runDeprecatedFunctions
 }


### PR DESCRIPTION
Whilst the Azure API's _should_ be consistent insofar as they're supposed to follow Postel's Law (in that they're lossy in what they accept but strict in what they send) - in practice this isn't the case. To work around this we're moving towards using the (generated) Terraform-maintained ID Formatters/Parsers across the provider - ultimately allowing us to remove casing issues within the Azure API (which cause consistency issues within Terraform Core).

As such this PR adds a new "gradually deprecated" check to look for usages of `d.SetID(*` (as in `d.SetId(*resp.ID)`) in new changes, meaning that new PR's going forward will be using ID Formatters - back porting the ID Formatters to existing resources is a separate/longer job, but this prevents new resources from using the Azure Resource ID in the response.