### PR TITLE
Docs: fix missing scope argument for azurerm_lighthouse_definition resource

### DIFF
--- a/website/docs/r/lighthouse_definition.html.markdown
+++ b/website/docs/r/lighthouse_definition.html.markdown
@@ -22,6 +22,7 @@ resource "azurerm_lighthouse_definition" "example" {
   name               = "Sample definition"
   description        = "This is a lighthouse definition created via Terraform"
   managing_tenant_id = "00000000-0000-0000-0000-000000000000"
+  scope              = "/subscriptions/00000000-0000-0000-0000-000000000000"
 
   authorization {
     principal_id           = "00000000-0000-0000-0000-000000000000"
@@ -40,6 +41,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the Lighthouse Definition.
 
 * `managing_tenant_id` - (Required) The ID of the managing tenant.
+
+* `scope` - (Required) The ID of the managed subscription.
 
 * `description` - (Optional) A description of the Lighthouse Definition.
 


### PR DESCRIPTION
Adding documentation for `scope` argument of the `azurerm_lighthouse_definition` resource.