### PR TITLE
azurerm_kubernetes_cluster: Allow for any identity type if `private_dns_zone_id` is `None`

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -866,8 +866,10 @@ func resourceKubernetesClusterCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if v, ok := d.GetOk("private_dns_zone_id"); ok {
-		if (parameters.Identity == nil && !servicePrincipalSet) || (v.(string) != "System" && (!servicePrincipalSet && parameters.Identity.Type != containerservice.ResourceIdentityTypeUserAssigned)) {
-			return fmt.Errorf("a user assigned identity or a service principal must be used when using a custom private dns zone")
+		if v.(string) != "None" {
+			if (parameters.Identity == nil && !servicePrincipalSet) || (v.(string) != "System" && (!servicePrincipalSet && parameters.Identity.Type != containerservice.ResourceIdentityTypeUserAssigned)) {
+				return fmt.Errorf("a user assigned identity or a service principal must be used when using a custom private dns zone hosted in Azure")
+			}
 		}
 		apiAccessProfile.PrivateDNSZone = utils.String(v.(string))
 	}

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -867,7 +867,9 @@ func resourceKubernetesClusterCreate(d *schema.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("private_dns_zone_id"); ok {
 		if v.(string) != "None" {
-			if (parameters.Identity == nil && !servicePrincipalSet) || (v.(string) != "System" && (!servicePrincipalSet && parameters.Identity.Type != containerservice.ResourceIdentityTypeUserAssigned)) {
+			usingAServicePrincipal := parameters.Identity == nil && !servicePrincipalSet
+			hasAUserIdentity := !servicePrincipalSet && parameters.Identity.Type != containerservice.ResourceIdentityTypeUserAssigned
+			if usingAServicePrincipal || (v.(string) != "System" && hasAUserIdentity) {
 				return fmt.Errorf("a user assigned identity or a service principal must be used when using a custom private dns zone hosted in Azure")
 			}
 		}


### PR DESCRIPTION
`None` use-case for `private_dns_zone_id` still has no acceptance tests, since it's not trivial to implement, as it implies some "on-prem" DNS that's pre-configured.

Winging this one thus.

Fixes #10952