### PR TITLE
*_template_deployment: Fix #8840 Missing parameters error when updating

### DIFF
--- a/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
@@ -190,13 +190,11 @@ func resourceGroupTemplateDeploymentResourceUpdate(d *schema.ResourceData, meta 
 		deployment.Properties.Mode = resources.DeploymentMode(d.Get("deployment_mode").(string))
 	}
 
-	if d.HasChange("parameters_content") {
-		parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
-		if err != nil {
-			return fmt.Errorf("expanding `parameters_content`: %+v", err)
-		}
-		deployment.Properties.Parameters = parameters
+	parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
+	if err != nil {
+		return fmt.Errorf("expanding `parameters_content`: %+v", err)
 	}
+	deployment.Properties.Parameters = parameters
 
 	if d.HasChange("template_content") {
 		templateContents, err := expandTemplateDeploymentBody(d.Get("template_content").(string))

--- a/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
@@ -190,15 +190,11 @@ func resourceGroupTemplateDeploymentResourceUpdate(d *schema.ResourceData, meta 
 		deployment.Properties.Mode = resources.DeploymentMode(d.Get("deployment_mode").(string))
 	}
 
-	if d.HasChange("parameters_content") {
-		parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
-		if err != nil {
-			return fmt.Errorf("expanding `parameters_content`: %+v", err)
-		}
-		deployment.Properties.Parameters = parameters
-	} else {
-		deployment.Properties.Parameters = template.Properties.Parameters
+	parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
+	if err != nil {
+		return fmt.Errorf("expanding `parameters_content`: %+v", err)
 	}
+	deployment.Properties.Parameters = parameters
 
 	if d.HasChange("template_content") {
 		templateContents, err := expandTemplateDeploymentBody(d.Get("template_content").(string))

--- a/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
@@ -190,11 +190,15 @@ func resourceGroupTemplateDeploymentResourceUpdate(d *schema.ResourceData, meta 
 		deployment.Properties.Mode = resources.DeploymentMode(d.Get("deployment_mode").(string))
 	}
 
-	parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
-	if err != nil {
-		return fmt.Errorf("expanding `parameters_content`: %+v", err)
+	if d.HasChange("parameters_content") {
+		parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
+		if err != nil {
+			return fmt.Errorf("expanding `parameters_content`: %+v", err)
+		}
+		deployment.Properties.Parameters = parameters
+	} else {
+		deployment.Properties.Parameters = template.Properties.Parameters
 	}
-	deployment.Properties.Parameters = parameters
 
 	if d.HasChange("template_content") {
 		templateContents, err := expandTemplateDeploymentBody(d.Get("template_content").(string))

--- a/azurerm/internal/services/resource/resource_group_template_deployment_resource_test.go
+++ b/azurerm/internal/services/resource/resource_group_template_deployment_resource_test.go
@@ -78,7 +78,7 @@ func TestAccResourceGroupTemplateDeployment_singleItemIncorrectCasing(t *testing
 	})
 }
 
-func TestAccResourceGroupTemplateDeployment_singleItemSameParams(t *testing.T) {
+func TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_resource_group_template_deployment", "test")
 	r := ResourceGroupTemplateDeploymentResource{}
 
@@ -91,8 +91,8 @@ func TestAccResourceGroupTemplateDeployment_singleItemSameParams(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-      // Update the ARM template to trigger update on resource BUT don't vary the parameter value
-      // Validates fix for bug #8840
+			// Update the ARM template to trigger update on resource BUT don't vary the parameter value
+			// Validates fix for bug #8840
 			Config: r.singleItemWithParameterConfigAndVariable(data, "forceupdatetemplate", "first"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/azurerm/internal/services/resource/subscription_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/subscription_template_deployment_resource.go
@@ -178,13 +178,11 @@ func subscriptionTemplateDeploymentResourceUpdate(d *schema.ResourceData, meta i
 		deployment.Properties.DebugSetting = expandTemplateDeploymentDebugSetting(d.Get("debug_level").(string))
 	}
 
-	if d.HasChange("parameters_content") {
-		parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
-		if err != nil {
-			return fmt.Errorf("expanding `parameters_content`: %+v", err)
-		}
-		deployment.Properties.Parameters = parameters
+	parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
+	if err != nil {
+		return fmt.Errorf("expanding `parameters_content`: %+v", err)
 	}
+	deployment.Properties.Parameters = parameters
 
 	if d.HasChange("template_content") {
 		templateContents, err := expandTemplateDeploymentBody(d.Get("template_content").(string))

--- a/azurerm/internal/services/resource/subscription_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/subscription_template_deployment_resource.go
@@ -178,15 +178,11 @@ func subscriptionTemplateDeploymentResourceUpdate(d *schema.ResourceData, meta i
 		deployment.Properties.DebugSetting = expandTemplateDeploymentDebugSetting(d.Get("debug_level").(string))
 	}
 
-	if d.HasChange("parameters_content") {
-		parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
-		if err != nil {
-			return fmt.Errorf("expanding `parameters_content`: %+v", err)
-		}
-		deployment.Properties.Parameters = parameters
-	} else {
-		deployment.Properties.Parameters = template.Properties.Parameters
+	parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
+	if err != nil {
+		return fmt.Errorf("expanding `parameters_content`: %+v", err)
 	}
+	deployment.Properties.Parameters = parameters
 
 	if d.HasChange("template_content") {
 		templateContents, err := expandTemplateDeploymentBody(d.Get("template_content").(string))

--- a/azurerm/internal/services/resource/subscription_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/subscription_template_deployment_resource.go
@@ -178,11 +178,15 @@ func subscriptionTemplateDeploymentResourceUpdate(d *schema.ResourceData, meta i
 		deployment.Properties.DebugSetting = expandTemplateDeploymentDebugSetting(d.Get("debug_level").(string))
 	}
 
-	parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
-	if err != nil {
-		return fmt.Errorf("expanding `parameters_content`: %+v", err)
+	if d.HasChange("parameters_content") {
+		parameters, err := expandTemplateDeploymentBody(d.Get("parameters_content").(string))
+		if err != nil {
+			return fmt.Errorf("expanding `parameters_content`: %+v", err)
+		}
+		deployment.Properties.Parameters = parameters
+	} else {
+		deployment.Properties.Parameters = template.Properties.Parameters
 	}
-	deployment.Properties.Parameters = parameters
 
 	if d.HasChange("template_content") {
 		templateContents, err := expandTemplateDeploymentBody(d.Get("template_content").(string))


### PR DESCRIPTION
Fix #8840 Missing parameters error when updating.

Done:
- [x] Reproduce issue with acc test on resource_group_template_deployment resource
- [x] Fix on resource_group_template_deployment resource
- [x] Reproduce issue with acc test on subscription_template_deployment
- [x] Fix on subscription_template_deployment


Before RG:
```
=== RUN   TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== PAUSE TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== CONT  TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
    /workspaces/terraform-provider-azurerm/azurerm/internal/services/resource/testing.go:620: Step 3/4 error: Error running apply: 2021/03/17 12:12:07 [DEBUG] Using modified User-Agent: Terraform/0.12.26 HashiCorp-terraform-exec/0.10.0

        Error: validating Template Deployment "acctest" (Resource Group "acctestrg-210317121006548909"): requesting validating: resources.DeploymentsClient#Validate: Failure sending request: StatusCode=0 -- Original Error: Code="InvalidTemplate" Message="Deployment template validation failed: 'The value for the template parameter 'someParam' at line '1' and column '173' is not provided. Please see https://aka.ms/resource-manager-parameter-files for usage details.'." AdditionalInfo=[{"info":{"lineNumber":1,"linePosition":173,"path":"properties.template.parameters.someParam"},"type":"TemplateViolation"}]

          on config064461449/terraform_plugin_test.tf line 11, in resource "azurerm_resource_group_template_deployment" "test":
          11: resource "azurerm_resource_group_template_deployment" "test" {


--- FAIL: TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams (192.75s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource	192.809s
```
After RG:
```
=== RUN   TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== PAUSE TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== CONT  TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
--- PASS: TestAccResourceGroupTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams (270.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource	270.830s

```

Before Sub:
```
=== RUN   TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== PAUSE TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== CONT  TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
    /workspaces/terraform-provider-azurerm/azurerm/internal/services/resource/testing.go:620: Step 3/4 error: Error running apply: 2021/03/17 12:25:06 [DEBUG] Using modified User-Agent: Terraform/0.12.26 HashiCorp-terraform-exec/0.10.0

        Error: validating Subscription Template Deployment "acctestsubdeploy-210317122308153114": requesting validating: resources.DeploymentsClient#ValidateAtSubscriptionScope: Failure sending request: StatusCode=0 -- Original Error: Code="InvalidTemplate" Message="Deployment template validation failed: 'The value for the template parameter 'someParam' at line '1' and column '197' is not provided. Please see https://aka.ms/resource-manager-parameter-files for usage details.'." AdditionalInfo=[{"info":{"lineNumber":1,"linePosition":197,"path":"properties.template.parameters.someParam"},"type":"TemplateViolation"}]

          on config059206512/terraform_plugin_test.tf line 6, in resource "azurerm_subscription_template_deployment" "test":
           6: resource "azurerm_subscription_template_deployment" "test" {
```

After Sub:

```
=== RUN   TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== PAUSE TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
=== CONT  TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams
--- PASS: TestAccSubscriptionTemplateDeployment_singleItemUpdateTemplateWithUnchangedParams (225.59s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource	225.638s

```