### PR TITLE
azurerm_kusto_eventhub_data_connection: support event_system_properties

### DIFF
--- a/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -83,6 +83,16 @@ func resourceKustoEventHubDataConnection() *schema.Resource {
 				ValidateFunc: eventhubValidate.EventHubID,
 			},
 
+			"event_system_properties": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			"consumer_group": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -222,6 +232,7 @@ func resourceKustoEventHubDataConnectionRead(d *schema.ResourceData, meta interf
 			d.Set("mapping_rule_name", props.MappingRuleName)
 			d.Set("data_format", props.DataFormat)
 			d.Set("compression", props.Compression)
+			d.Set("event_system_properties", props.EventSystemProperties)
 		}
 	}
 
@@ -275,6 +286,14 @@ func expandKustoEventHubDataConnectionProperties(d *schema.ResourceData) *kusto.
 
 	if compression, ok := d.GetOk("compression"); ok {
 		eventHubConnectionProperties.Compression = kusto.Compression(compression.(string))
+	}
+
+	if eventSystemProperties, ok := d.GetOk("event_system_properties"); ok {
+		props := make([]string, 0)
+		for _, prop := range eventSystemProperties.([]interface{}) {
+			props = append(props, prop.(string))
+		}
+		eventHubConnectionProperties.EventSystemProperties = &props
 	}
 
 	return eventHubConnectionProperties

--- a/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/azurerm/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -32,6 +32,21 @@ func TestAccKustoEventHubDataConnection_basic(t *testing.T) {
 	})
 }
 
+func TestAccKustoEventHubDataConnection_eventSystemProperties(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.eventSystemProperties(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKustoEventHubDataConnection_unboundMapping1(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
 	r := KustoEventHubDataConnectionResource{}
@@ -133,6 +148,29 @@ resource "azurerm_kusto_eventhub_data_connection" "test" {
 
   mapping_rule_name = "Json_Mapping"
   data_format       = "MULTIJSON"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoEventHubDataConnectionResource) eventSystemProperties(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    = azurerm_eventhub.test.id
+  consumer_group = azurerm_eventhub_consumer_group.test.name
+
+  mapping_rule_name = "Json_Mapping"
+  data_format       = "MULTIJSON"
+  event_system_properties = [
+    "x-opt-publisher"
+  ]
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `eventhub_id` - (Required) Specifies the resource id of the EventHub this data connection will use for ingestion. Changing this forces a new resource to be created.
 
-* `event_system_properties` - (Optional) Specifies a list of system properties of the Event Hub.
+* `event_system_properties` - (Optional) Specifies a list of system properties for the Event Hub.
 
 * `consumer_group` - (Required) Specifies the EventHub consumer group this data connection will use for ingestion. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -96,6 +96,8 @@ The following arguments are supported:
 
 * `eventhub_id` - (Required) Specifies the resource id of the EventHub this data connection will use for ingestion. Changing this forces a new resource to be created.
 
+* `event_system_properties` - (Optional) Specifies a list of system properties of the Event Hub.
+
 * `consumer_group` - (Required) Specifies the EventHub consumer group this data connection will use for ingestion. Changing this forces a new resource to be created.
 
 * `table_name` - (Optional) Specifies the target table name used for the message ingestion. Table must exist before resource is created.


### PR DESCRIPTION
Fixes #10993

```
$ make acctests SERVICE='kusto' TESTARGS='-run=TestAccKustoEventHubDataConnection_eventSystemProperties' TESTTIMEOUT='600m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/kusto -run=TestAccKustoEventHubDataConnection_eventSystemProperties -timeout 600m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/17 14:33:24 [DEBUG] not using binary driver name, it's no longer needed
2021/03/17 14:33:25 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccKustoEventHubDataConnection_eventSystemProperties
=== PAUSE TestAccKustoEventHubDataConnection_eventSystemProperties
=== CONT  TestAccKustoEventHubDataConnection_eventSystemProperties
--- PASS: TestAccKustoEventHubDataConnection_eventSystemProperties (1460.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/kusto	1461.373s
```