### PR TITLE
Ignore Tags Feature block

### DIFF
--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -7,6 +7,7 @@ type UserFeatures struct {
 	Network                NetworkFeatures
 	TemplateDeployment     TemplateDeploymentFeatures
 	LogAnalyticsWorkspace  LogAnalyticsWorkspaceFeatures
+	IgnoreTags             IgnoreTagsFeatures
 }
 
 type VirtualMachineFeatures struct {
@@ -33,4 +34,9 @@ type TemplateDeploymentFeatures struct {
 
 type LogAnalyticsWorkspaceFeatures struct {
 	PermanentlyDeleteOnDestroy bool
+}
+
+type IgnoreTagsFeatures struct {
+	Keys        []string
+	KeyPrefixes []string
 }

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -99,6 +99,31 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 				},
 			},
 		},
+
+		"ignore_tags": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Configuration block with settings to ignore resource tags across all resources.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"keys": {
+						Type:        schema.TypeSet,
+						Optional:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
+						Description: "Resource tag keys to ignore across all resources.",
+					},
+					"key_prefixes": {
+						Type:        schema.TypeSet,
+						Optional:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Set:         schema.HashString,
+						Description: "Resource tag key prefixes to ignore across all resources.",
+					},
+				},
+			},
+		},
 	}
 
 	// this is a temporary hack to enable us to gradually add provider blocks to test configurations
@@ -196,6 +221,29 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			scaleSetRaw := items[0].(map[string]interface{})
 			if v, ok := scaleSetRaw["roll_instances_when_required"]; ok {
 				features.VirtualMachineScaleSet.RollInstancesWhenRequired = v.(bool)
+			}
+		}
+	}
+
+	if raw, ok := val["ignore_tags"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			keysRaw := items[0].(map[string]interface{})
+			if v, ok := keysRaw["keys"].(*schema.Set); ok {
+				t := make([]string, v.Len())
+				list := v.List()
+				for i, key := range list {
+					t[i] = key.(string)
+				}
+				features.IgnoreTags.Keys = t
+			}
+			if v, ok := keysRaw["key_prefixes"].(*schema.Set); ok {
+				t := make([]string, v.Len())
+				list := v.List()
+				for i, key := range list {
+					t[i] = key.(string)
+				}
+				features.IgnoreTags.KeyPrefixes = t
 			}
 		}
 	}

--- a/azurerm/internal/tags/flatten.go
+++ b/azurerm/internal/tags/flatten.go
@@ -2,8 +2,10 @@ package tags
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 func Flatten(tagMap map[string]*string) map[string]interface{} {
@@ -28,4 +30,23 @@ func FlattenAndSet(d *schema.ResourceData, tagMap map[string]*string) error {
 	}
 
 	return nil
+}
+
+func IgnoreTags(tagMap map[string]*string, ignored features.IgnoreTagsFeatures) map[string]*string {
+	ignoredKeys := ignored.Keys
+	ignoredKeyPrefixes := ignored.KeyPrefixes
+	for _, ignorePrefix := range ignoredKeyPrefixes {
+		for key := range tagMap {
+			if strings.HasPrefix(key, ignorePrefix) {
+				delete(tagMap, key)
+			}
+		}
+	}
+	for _, ignore := range ignoredKeys {
+		if _, ok := tagMap[ignore]; ok {
+			delete(tagMap, ignore)
+		}
+	}
+
+	return tagMap
 }


### PR DESCRIPTION
Hi !

Following the example provided by aws provider about ignore tags and requested [here ](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7034) I'm submitting this Pull Request for validation.

This is essentially a work in progress as i wanted to get review/validation from maintainers before going ahead with the process of implementing the "IgnoreTags" function in every resources/datasources.
Also I'm not an expert in Go so I thought you guys would probably have ideas/ways for improvements in my code.

WIP :  (waiting for validation of the whole process)
1. Idempotency:
The function basically compares a list of keys (and key_prefixes) with the keys of the tagMap retrieved when reading the resource. This creates an idempotency problem when a tag is at the same time in "ignore_tags" features AND defined in a resource block. thought i could maybe use the CustomizeDiff hook for warning/erroring on this.
Another might be to duplicate the "HasChange" into an "HasChangeTag" method but not sure whether it's something you guys would accept or not.
2. Tests
3. Doc 

Thanks