### PR TITLE
Update link to ADF IR SSIS page

### DIFF
--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Azure Data Factory Managed Integration Runtime.
 
-~> **NOTE:** The `azurerm_data_factory_integration_runtime_managed` resource has been superseded by the [`azurerm_data_factory_integration_runtime_azure_ssis`](data_factory_integration_runtime_azure_ssis.html) resource. The existing `azurerm_data_factory_integration_runtime_managed` resource will be deprecated (but still available) in version 3.0 of the AzureRM Terraform Provider - we recommend using the `azurerm_data_factory_integration_runtime_azure_ssis` resource for new deployments.
+~> **NOTE:** The `azurerm_data_factory_integration_runtime_managed` resource has been superseded by the [`azurerm_data_factory_integration_runtime_azure_ssis`](data_factory_integration_runtime_azure_ssis.html) resource. The existing `azurerm_data_factory_integration_runtime_managed` resource will be deprecated (but still available) in version 3.0 of the AzureRM Terraform Provider - we recommend using the [`azurerm_data_factory_integration_runtime_azure_ssis`](data_factory_integration_runtime_azure_ssis.html) resource for new deployments.
 
 ## Example Usage
 

--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Azure Data Factory Managed Integration Runtime.
 
-~> **NOTE:** The `azurerm_data_factory_integration_runtime_managed` resource has been superseded by the [`azurerm_data_factory_integration_runtime_azure_ssis`](resource_group_template_deployment.html) resource. The existing `azurerm_data_factory_integration_runtime_managed` resource will be deprecated (but still available) in version 3.0 of the AzureRM Terraform Provider - we recommend using the `azurerm_data_factory_integration_runtime_azure_ssis` resource for new deployments.
+~> **NOTE:** The `azurerm_data_factory_integration_runtime_managed` resource has been superseded by the [`azurerm_data_factory_integration_runtime_azure_ssis`](data_factory_integration_runtime_azure_ssis.html) resource. The existing `azurerm_data_factory_integration_runtime_managed` resource will be deprecated (but still available) in version 3.0 of the AzureRM Terraform Provider - we recommend using the `azurerm_data_factory_integration_runtime_azure_ssis` resource for new deployments.
 
 ## Example Usage
 


### PR DESCRIPTION
The link to azurerm_data_factory_integration_runtime_azure_ssis was
 previously pointing to
 azurerm_resource_group_template_deployment.html instead of
 data_factory_integration_runtime_azure_ssis.html