### PR TITLE
Fix for azurerm_resource_group_template_deployment example

### DIFF
--- a/website/docs/r/resource_group_template_deployment.html.markdown
+++ b/website/docs/r/resource_group_template_deployment.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_resource_group_template_deployment" "example" {
         {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2020-05-01",
-            "name": "[variables("vnetName")]",
+            "name": "[parameters("vnetName")]",
             "location": "[resourceGroup().location]",
             "properties": {
                 "addressSpace": {

--- a/website/docs/r/resource_group_template_deployment.html.markdown
+++ b/website/docs/r/resource_group_template_deployment.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_resource_group_template_deployment" "example" {
         {
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2020-05-01",
-            "name": "[parameters("vnetName")]",
+            "name": "[parameters('vnetName')]",
             "location": "[resourceGroup().location]",
             "properties": {
                 "addressSpace": {


### PR DESCRIPTION
Documentation makes reference to a non-existent variable, when it should be a parameter