### PR TITLE
azurerm_kubernetes_cluster: Support for max_empty_bulk_delete in auto_scaler_profile block

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -171,7 +171,7 @@ func resourceKubernetesCluster() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
-						"max_empty_bulk_delete": {
+						"empty_bulk_delete_max": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
@@ -2095,9 +2095,9 @@ func flattenKubernetesClusterAutoScalerProfile(profile *containerservice.Managed
 		scaleDownUtilizationThreshold = *profile.ScaleDownUtilizationThreshold
 	}
 
-	maxEmptyBulkDelete := ""
+	emptyBulkDeleteMax := ""
 	if profile.MaxEmptyBulkDelete != nil {
-		maxEmptyBulkDelete = *profile.MaxEmptyBulkDelete
+		emptyBulkDeleteMax = *profile.MaxEmptyBulkDelete
 	}
 
 	scanInterval := ""
@@ -2127,7 +2127,7 @@ func flattenKubernetesClusterAutoScalerProfile(profile *containerservice.Managed
 			"scale_down_unneeded":              scaleDownUnneededTime,
 			"scale_down_unready":               scaleDownUnreadyTime,
 			"scale_down_utilization_threshold": scaleDownUtilizationThreshold,
-			"max_empty_bulk_delete":            maxEmptyBulkDelete,
+			"empty_bulk_delete_max":            emptyBulkDeleteMax,
 			"scan_interval":                    scanInterval,
 			"skip_nodes_with_local_storage":    skipNodesWithLocalStorage,
 			"skip_nodes_with_system_pods":      skipNodesWithSystemPods,
@@ -2152,7 +2152,7 @@ func expandKubernetesClusterAutoScalerProfile(input []interface{}) *containerser
 	scaleDownUnneededTime := config["scale_down_unneeded"].(string)
 	scaleDownUnreadyTime := config["scale_down_unready"].(string)
 	scaleDownUtilizationThreshold := config["scale_down_utilization_threshold"].(string)
-	maxEmptyBulkDelete := config["max_empty_bulk_delete"].(string)
+	emptyBulkDeleteMax := config["empty_bulk_delete_max"].(string)
 	scanInterval := config["scan_interval"].(string)
 	skipNodesWithLocalStorage := config["skip_nodes_with_local_storage"].(bool)
 	skipNodesWithSystemPods := config["skip_nodes_with_system_pods"].(bool)
@@ -2168,7 +2168,7 @@ func expandKubernetesClusterAutoScalerProfile(input []interface{}) *containerser
 		ScaleDownUnneededTime:         utils.String(scaleDownUnneededTime),
 		ScaleDownUnreadyTime:          utils.String(scaleDownUnreadyTime),
 		ScaleDownUtilizationThreshold: utils.String(scaleDownUtilizationThreshold),
-		MaxEmptyBulkDelete:            utils.String(maxEmptyBulkDelete),
+		MaxEmptyBulkDelete:            utils.String(emptyBulkDeleteMax),
 		ScanInterval:                  utils.String(scanInterval),
 		SkipNodesWithLocalStorage:     utils.String(strconv.FormatBool(skipNodesWithLocalStorage)),
 		SkipNodesWithSystemPods:       utils.String(strconv.FormatBool(skipNodesWithSystemPods)),

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -171,6 +171,11 @@ func resourceKubernetesCluster() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"max_empty_bulk_delete": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"skip_nodes_with_local_storage": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -2090,6 +2095,11 @@ func flattenKubernetesClusterAutoScalerProfile(profile *containerservice.Managed
 		scaleDownUtilizationThreshold = *profile.ScaleDownUtilizationThreshold
 	}
 
+	maxEmptyBulkDelete := ""
+	if profile.MaxEmptyBulkDelete != nil {
+		maxEmptyBulkDelete = *profile.MaxEmptyBulkDelete
+	}
+
 	scanInterval := ""
 	if profile.ScanInterval != nil {
 		scanInterval = *profile.ScanInterval
@@ -2117,6 +2127,7 @@ func flattenKubernetesClusterAutoScalerProfile(profile *containerservice.Managed
 			"scale_down_unneeded":              scaleDownUnneededTime,
 			"scale_down_unready":               scaleDownUnreadyTime,
 			"scale_down_utilization_threshold": scaleDownUtilizationThreshold,
+			"max_empty_bulk_delete":            maxEmptyBulkDelete,
 			"scan_interval":                    scanInterval,
 			"skip_nodes_with_local_storage":    skipNodesWithLocalStorage,
 			"skip_nodes_with_system_pods":      skipNodesWithSystemPods,
@@ -2141,6 +2152,7 @@ func expandKubernetesClusterAutoScalerProfile(input []interface{}) *containerser
 	scaleDownUnneededTime := config["scale_down_unneeded"].(string)
 	scaleDownUnreadyTime := config["scale_down_unready"].(string)
 	scaleDownUtilizationThreshold := config["scale_down_utilization_threshold"].(string)
+	maxEmptyBulkDelete := config["max_empty_bulk_delete"].(string)
 	scanInterval := config["scan_interval"].(string)
 	skipNodesWithLocalStorage := config["skip_nodes_with_local_storage"].(bool)
 	skipNodesWithSystemPods := config["skip_nodes_with_system_pods"].(bool)
@@ -2156,6 +2168,7 @@ func expandKubernetesClusterAutoScalerProfile(input []interface{}) *containerser
 		ScaleDownUnneededTime:         utils.String(scaleDownUnneededTime),
 		ScaleDownUnreadyTime:          utils.String(scaleDownUnreadyTime),
 		ScaleDownUtilizationThreshold: utils.String(scaleDownUtilizationThreshold),
+		MaxEmptyBulkDelete:            utils.String(maxEmptyBulkDelete),
 		ScanInterval:                  utils.String(scanInterval),
 		SkipNodesWithLocalStorage:     utils.String(strconv.FormatBool(skipNodesWithLocalStorage)),
 		SkipNodesWithSystemPods:       utils.String(strconv.FormatBool(skipNodesWithSystemPods)),

--- a/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -297,6 +297,7 @@ func testAccKubernetesCluster_autoScalingProfile(t *testing.T) {
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scale_down_unneeded").HasValue("15m"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scale_down_unready").HasValue("15m"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scale_down_utilization_threshold").HasValue("0.5"),
+				check.That(data.ResourceName).Key("auto_scaler_profile.0.max_empty_bulk_delete").HasValue("50"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scan_interval").HasValue("10s"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.skip_nodes_with_local_storage").HasValue("false"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.skip_nodes_with_system_pods").HasValue("false"),
@@ -558,6 +559,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     scale_down_unneeded              = "15m"
     scale_down_unready               = "15m"
     scale_down_utilization_threshold = "0.5"
+	max_empty_bulk_delete            = 50
     skip_nodes_with_local_storage    = false
     skip_nodes_with_system_pods      = false
   }

--- a/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -297,7 +297,7 @@ func testAccKubernetesCluster_autoScalingProfile(t *testing.T) {
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scale_down_unneeded").HasValue("15m"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scale_down_unready").HasValue("15m"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scale_down_utilization_threshold").HasValue("0.5"),
-				check.That(data.ResourceName).Key("auto_scaler_profile.0.max_empty_bulk_delete").HasValue("50"),
+				check.That(data.ResourceName).Key("auto_scaler_profile.0.empty_bulk_delete_max").HasValue("50"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.scan_interval").HasValue("10s"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.skip_nodes_with_local_storage").HasValue("false"),
 				check.That(data.ResourceName).Key("auto_scaler_profile.0.skip_nodes_with_system_pods").HasValue("false"),
@@ -559,7 +559,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     scale_down_unneeded              = "15m"
     scale_down_unready               = "15m"
     scale_down_utilization_threshold = "0.5"
-	max_empty_bulk_delete            = "50"
+	empty_bulk_delete_max            = "50"
     skip_nodes_with_local_storage    = false
     skip_nodes_with_system_pods      = false
   }

--- a/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -559,7 +559,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     scale_down_unneeded              = "15m"
     scale_down_unready               = "15m"
     scale_down_utilization_threshold = "0.5"
-	empty_bulk_delete_max            = "50"
+    empty_bulk_delete_max            = "50"
     skip_nodes_with_local_storage    = false
     skip_nodes_with_system_pods      = false
   }

--- a/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_scaling_resource_test.go
@@ -559,7 +559,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     scale_down_unneeded              = "15m"
     scale_down_unready               = "15m"
     scale_down_utilization_threshold = "0.5"
-	max_empty_bulk_delete            = 50
+	max_empty_bulk_delete            = "50"
     skip_nodes_with_local_storage    = false
     skip_nodes_with_system_pods      = false
   }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -241,7 +241,7 @@ A `auto_scaler_profile` block supports the following:
 
 * `scale_down_utilization_threshold` - Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Defaults to `0.5`.
 
-* `max_empty_bulk_delete` - Maximum number of empty nodes that can be deleted at the same time. Defaults to `10`.
+* `empty_bulk_delete_max` - Maximum number of empty nodes that can be deleted at the same time. Defaults to `10`.
 
 * `skip_nodes_with_local_storage` - If `true` cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. Defaults to `true`.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -241,6 +241,8 @@ A `auto_scaler_profile` block supports the following:
 
 * `scale_down_utilization_threshold` - Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Defaults to `0.5`.
 
+* `max_empty_bulk_delete` - Maximum number of empty nodes that can be deleted at the same time. Defaults to `10`.
+
 * `skip_nodes_with_local_storage` - If `true` cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. Defaults to `true`.
 
 * `skip_nodes_with_system_pods` - If `true` cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). Defaults to `true`.


### PR DESCRIPTION
This PR adds support for the `max_empty_bulk_delete` property in the `auto_scaler_profile` block for `azurerm_kubernetes_cluster`.

As per https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler#using-the-autoscaler-profile