### PR TITLE
Update `azurerm_machine_learning_workspace` - deprecate the enterprise sku because it has been deprecated by Azure

### DIFF
--- a/azurerm/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -23,6 +23,14 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+type WorkspaceSku string
+
+const (
+	Basic WorkspaceSku = "Basic"
+	// TODO -- remove Enterprise in 3.0 which has been deprecated here: https://docs.microsoft.com/en-us/azure/machine-learning/concept-workspace#what-happened-to-enterprise-edition
+	Enterprise WorkspaceSku = "Enterprise"
+)
+
 func resourceMachineLearningWorkspace() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceMachineLearningWorkspaceCreate,
@@ -138,8 +146,9 @@ func resourceMachineLearningWorkspace() *schema.Resource {
 				Optional: true,
 				Default:  "Basic",
 				ValidateFunc: validation.StringInSlice([]string{
-					"Basic",
-					"Enterprise",
+					string(Basic),
+					// TODO -- remove Enterprise in 3.0 which has been deprecated here: https://docs.microsoft.com/en-us/azure/machine-learning/concept-workspace#what-happened-to-enterprise-edition
+					string(Enterprise),
 				}, true),
 			},
 

--- a/azurerm/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -220,7 +220,7 @@ resource "azurerm_machine_learning_workspace" "test" {
   key_vault_id            = azurerm_key_vault.test.id
   storage_account_id      = azurerm_storage_account.test.id
   container_registry_id   = azurerm_container_registry.test.id
-  sku_name                = "Enterprise"
+  sku_name                = "Basic"
   high_business_impact    = true
 
   identity {

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 * `high_business_impact` - (Optional) Flag to signal High Business Impact (HBI) data in the workspace and reduce diagnostic data collected by the service
 
-* `sku_name` - (Optional) SKU/edition of the Machine Learning Workspace, possible values are `Basic` for a basic workspace or `Enterprise` for a feature rich workspace. Defaults to `Basic`.
+* `sku_name` - (Optional) SKU/edition of the Machine Learning Workspace, possible values are `Basic`. Defaults to `Basic`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/9987

Deprecation note: https://docs.microsoft.com/en-us/azure/machine-learning/concept-workspace#what-happened-to-enterprise-edition