### PR TITLE
New Resource: `azurerm_management_group_subscription_association`

### DIFF
--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -24,6 +24,7 @@ func (td TestData) DataSourceTest(t *testing.T, steps []resource.TestStep) {
 	td.runAcceptanceTest(t, testCase)
 }
 
+// lintignore:AT001
 func (td TestData) DataSourceTestInSequence(t *testing.T, steps []resource.TestStep) {
 	// DataSources don't need a check destroy - however since this is a wrapper function
 	// and not matching the ignore pattern `XXX_data_source_test.go`, this needs to be explicitly opted out

--- a/azurerm/internal/services/managementgroup/management_group_resource.go
+++ b/azurerm/internal/services/managementgroup/management_group_resource.go
@@ -79,6 +79,7 @@ func resourceManagementGroup() *schema.Resource {
 			"subscription_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.IsUUID,

--- a/azurerm/internal/services/managementgroup/management_group_resource_test.go
+++ b/azurerm/internal/services/managementgroup/management_group_resource_test.go
@@ -173,7 +173,7 @@ func TestAccManagementGroup_withSubscriptions(t *testing.T) {
 			),
 		},
 		{
-			Config: r.basic(),
+			Config: r.removeSubscriptions(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("subscription_ids.#").HasValue("0"),
@@ -282,4 +282,16 @@ resource "azurerm_management_group" "test" {
   ]
 }
 `, subscriptionID)
+}
+
+func (r ManagementGroupResource) removeSubscriptions() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_management_group" "test" {
+  subscription_ids = []
+}
+`
 }

--- a/azurerm/internal/services/managementgroup/parse/management_group.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group.go
@@ -10,6 +10,17 @@ type ManagementGroupId struct {
 	Name string
 }
 
+func NewManagementGroupId(input string) ManagementGroupId {
+	return ManagementGroupId{
+		Name: input,
+	}
+}
+
+func (r ManagementGroupId) ID() string {
+	managementGroupIdFmt := "/providers/Microsoft.Management/managementGroups/%s"
+	return fmt.Sprintf(managementGroupIdFmt, r.Name)
+}
+
 func ManagementGroupID(input string) (*ManagementGroupId, error) {
 	regex := regexp.MustCompile(`^/providers/[Mm]icrosoft\.[Mm]anagement/[Mm]anagement[Gg]roups/`)
 	if !regex.MatchString(input) {

--- a/azurerm/internal/services/managementgroup/parse/management_group.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group.go
@@ -10,17 +10,6 @@ type ManagementGroupId struct {
 	Name string
 }
 
-func NewManagementGroupId(input string) ManagementGroupId {
-	return ManagementGroupId{
-		Name: input,
-	}
-}
-
-func (r ManagementGroupId) ID() string {
-	managementGroupIdFmt := "/providers/Microsoft.Management/managementGroups/%s"
-	return fmt.Sprintf(managementGroupIdFmt, r.Name)
-}
-
 func ManagementGroupID(input string) (*ManagementGroupId, error) {
 	regex := regexp.MustCompile(`^/providers/[Mm]icrosoft\.[Mm]anagement/[Mm]anagement[Gg]roups/`)
 	if !regex.MatchString(input) {
@@ -55,6 +44,6 @@ func NewManagementGroupId(managementGroupName string) ManagementGroupId {
 }
 
 func (r ManagementGroupId) ID() string {
-	managemntGroupIdFmt := "/providers/Microsoft.Management/managementGroups/%s"
-	return fmt.Sprintf(managemntGroupIdFmt, r.Name)
+	managementGroupIdFmt := "/providers/Microsoft.Management/managementGroups/%s"
+	return fmt.Sprintf(managementGroupIdFmt, r.Name)
 }

--- a/azurerm/internal/services/managementgroup/parse/management_group_subscription_association.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group_subscription_association.go
@@ -19,6 +19,11 @@ func NewManagementGroupSubscriptionAssociationID(managementGroupName string, sub
 	}
 }
 
+func (r ManagementGroupSubscriptionAssociationId) ID() string {
+	managementGroupSubscriptionAssociationFmt := "/managementGroup/%s/subscription/%s"
+	return fmt.Sprintf(managementGroupSubscriptionAssociationFmt, r.ManagementGroup, r.SubscriptionId)
+}
+
 func ManagementGroupSubscriptionAssociationID(input string) (*ManagementGroupSubscriptionAssociationId, error) {
 	id, err := azure.ParseAzureResourceIDWithoutSubscription(input)
 	if err != nil {

--- a/azurerm/internal/services/managementgroup/parse/management_group_subscription_association.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group_subscription_association.go
@@ -1,0 +1,45 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ManagementGroupSubscriptionAssociationId struct {
+	ManagementGroup string
+	SubscriptionId  string
+}
+
+func NewManagementGroupSubscriptionAssociationID(managementGroupName string, subscriptionId string) ManagementGroupSubscriptionAssociationId {
+	return ManagementGroupSubscriptionAssociationId{
+		ManagementGroup: managementGroupName,
+		SubscriptionId:  subscriptionId,
+	}
+}
+
+func ManagementGroupSubscriptionAssociationID(input string) (*ManagementGroupSubscriptionAssociationId, error) {
+	id, err := azure.ParseAzureResourceIDWithoutSubscription(input)
+	if err != nil {
+		return nil, err
+	}
+
+	managementGroup, err := id.PopSegment("managementGroup")
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptionId, err := id.PopSegment("subscription")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := uuid.ParseUUID(subscriptionId); err != nil {
+		return nil, fmt.Errorf("expected subscription ID to be UUID, got %q", subscriptionId)
+	}
+
+	return &ManagementGroupSubscriptionAssociationId{
+		ManagementGroup: managementGroup,
+		SubscriptionId:  subscriptionId,
+	}, nil
+}

--- a/azurerm/internal/services/managementgroup/parse/management_group_subscription_association_test.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group_subscription_association_test.go
@@ -15,6 +15,31 @@ func TestManagementGroupSubscriptionAssociationID(t *testing.T) {
 			Error: true,
 		},
 		{
+			Name:  "Missing Subscription",
+			Input: "/managementGroup/MyManagementGroup",
+			Error: true,
+		},
+		{
+			Name:  "Missing Subscription Id",
+			Input: "/managementGroup/MyManagementGroup/subscription/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Management Group",
+			Input: "/subscription/12345678-1234-1234-1234-123456789012",
+			Error: true,
+		},
+		{
+			Name:  "Missing Management Group Name",
+			Input: "/managementGroup/subscription/12345678-1234-1234-1234-123456789012",
+			Error: true,
+		},
+		{
+			Name:  "Wrong Case",
+			Input: "/MANAGEMENTGROUP/MyManagementGroup/SUBSCRIPTION/12345678-1234-1234-1234-123456789012",
+			Error: true,
+		},
+		{
 			Name:  "Valid",
 			Input: "/managementGroup/MyManagementGroup/subscription/12345678-1234-1234-1234-123456789012",
 			Expected: &ManagementGroupSubscriptionAssociationId{

--- a/azurerm/internal/services/managementgroup/parse/management_group_subscription_association_test.go
+++ b/azurerm/internal/services/managementgroup/parse/management_group_subscription_association_test.go
@@ -1,0 +1,47 @@
+package parse
+
+import "testing"
+
+func TestManagementGroupSubscriptionAssociationID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Error    bool
+		Expected *ManagementGroupSubscriptionAssociationId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "Valid",
+			Input: "/managementGroup/MyManagementGroup/subscription/12345678-1234-1234-1234-123456789012",
+			Expected: &ManagementGroupSubscriptionAssociationId{
+				ManagementGroup: "MyManagementGroup",
+				SubscriptionId:  "12345678-1234-1234-1234-123456789012",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ManagementGroupSubscriptionAssociationID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.ManagementGroup != v.Expected.ManagementGroup {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.ManagementGroup, actual.ManagementGroup)
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+	}
+}

--- a/azurerm/internal/services/managementgroup/registration.go
+++ b/azurerm/internal/services/managementgroup/registration.go
@@ -28,6 +28,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_management_group": resourceManagementGroup(),
+		"azurerm_management_group":                          resourceManagementGroup(),
+		"azurerm_management_group_subscription_association": resourceManagementGroupSubscriptionAssociation(),
 	}
 }

--- a/azurerm/internal/services/managementgroup/subscription_association_resource.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource.go
@@ -2,14 +2,20 @@ package managementgroup
 
 import (
 	"fmt"
+	"log"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
+	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/managementgroups"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/validate"
+	subscriptionParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/subscription/parse"
 	subscriptionValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/subscription/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 )
 
@@ -25,7 +31,10 @@ func resourceManagementGroupSubscriptionAssociation() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		Importer: nil, // TODO
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.ManagementGroupSubscriptionAssociationID(id)
+			return err
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"management_group_id": {
@@ -55,9 +64,12 @@ func resourceManagementGroupSubscriptionAssociationCreate(d *schema.ResourceData
 		return err
 	}
 
-	subscriptionId := d.Get("subscription_id").(string)
+	subscriptionId, err := subscriptionParse.SubscriptionID(d.Get("subscription_id").(string))
+	if err != nil {
+		return err
+	}
 
-	_, err = client.Create(ctx, managementGroupId.Name, subscriptionId, "")
+	_, err = client.Create(ctx, managementGroupId.Name, subscriptionId.SubscriptionID, "")
 	if err != nil {
 		return fmt.Errorf("creating Management Group Subscription Association between %q and %q: %+v", managementGroupId.Name, subscriptionId, err)
 	}
@@ -68,9 +80,62 @@ func resourceManagementGroupSubscriptionAssociationCreate(d *schema.ResourceData
 }
 
 func resourceManagementGroupSubscriptionAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	// There is no "read" function on the appropriate client so we need to check if the Subscription is in the Management Group subscription list
+	client := meta.(*clients.Client).ManagementGroups.GroupsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ManagementGroupSubscriptionAssociationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	managementGroup, err := client.Get(ctx, id.ManagementGroup, "", utils.Bool(false), "", "")
+	found := false
+	if props := managementGroup.Properties; props != nil {
+		if props.Children == nil {
+			return fmt.Errorf("could not read properties for Management Group %q", id.ManagementGroup)
+		}
+		for _, v := range *props.Children {
+			if v.Type == managementgroups.Type1Subscriptions {
+				if v.Name != nil && *v.Name == id.SubscriptionId {
+					found = true
+				}
+			}
+		}
+
+		if !found {
+			log.Printf("[INFO] Subscription %q not found in Management group %q, removing from state", id.SubscriptionId, id.ManagementGroup)
+			d.SetId("")
+			return nil
+		}
+
+		managementGroupId := parse.NewManagementGroupId(id.ManagementGroup)
+		d.Set("management_group_id", managementGroupId.ID())
+		subscriptionId := subscriptionParse.NewSubscriptionId(id.SubscriptionId)
+		d.Set("subscription_id", subscriptionId.ID())
+
+	}
+
 	return nil
 }
 
 func resourceManagementGroupSubscriptionAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ManagementGroups.SubscriptionClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ManagementGroupSubscriptionAssociationID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Delete(ctx, id.ManagementGroup, id.SubscriptionId, "")
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("deleting Management Group Subscription Association between Management Group %q and Subscription %q: %+v", id.ManagementGroup, id.SubscriptionId, err)
+		}
+	}
+
 	return nil
 }

--- a/azurerm/internal/services/managementgroup/subscription_association_resource.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource.go
@@ -5,13 +5,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/managementgroups"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/validate"
@@ -19,6 +15,7 @@ import (
 	subscriptionValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/subscription/validate"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceManagementGroupSubscriptionAssociation() *schema.Resource {

--- a/azurerm/internal/services/managementgroup/subscription_association_resource.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource.go
@@ -1,0 +1,76 @@
+package managementgroup
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/validate"
+	subscriptionValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/subscription/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+)
+
+func resourceManagementGroupSubscriptionAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceManagementGroupSubscriptionAssociationCreate,
+		Read:   resourceManagementGroupSubscriptionAssociationRead,
+		Delete: resourceManagementGroupSubscriptionAssociationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Importer: nil, // TODO
+
+		Schema: map[string]*schema.Schema{
+			"management_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.ManagementGroupID,
+			},
+
+			"subscription_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: subscriptionValidate.SubscriptionID,
+			},
+		},
+	}
+}
+
+func resourceManagementGroupSubscriptionAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ManagementGroups.SubscriptionClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	managementGroupId, err := parse.ManagementGroupID(d.Get("management_group_id").(string))
+	if err != nil {
+		return err
+	}
+
+	subscriptionId := d.Get("subscription_id").(string)
+
+	_, err = client.Create(ctx, managementGroupId.Name, subscriptionId, "")
+	if err != nil {
+		return fmt.Errorf("creating Management Group Subscription Association between %q and %q: %+v", managementGroupId.Name, subscriptionId, err)
+	}
+
+	d.SetId(fmt.Sprintf("/managementGroup/%s/subscription/%s", managementGroupId.Name, subscriptionId))
+
+	return nil
+}
+
+func resourceManagementGroupSubscriptionAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceManagementGroupSubscriptionAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/azurerm/internal/services/managementgroup/subscription_association_resource.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource.go
@@ -91,8 +91,7 @@ func resourceManagementGroupSubscriptionAssociationCreate(d *schema.ResourceData
 		}
 	}
 
-	_, err = client.Create(ctx, id.ManagementGroup, id.SubscriptionId, "")
-	if err != nil {
+	if _, err := client.Create(ctx, id.ManagementGroup, id.SubscriptionId, ""); err != nil {
 		return fmt.Errorf("creating Management Group Subscription Association between %q and %q: %+v", managementGroupId.Name, subscriptionId, err)
 	}
 

--- a/azurerm/internal/services/managementgroup/subscription_association_resource.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource.go
@@ -112,6 +112,9 @@ func resourceManagementGroupSubscriptionAssociationRead(d *schema.ResourceData, 
 	}
 
 	managementGroup, err := client.Get(ctx, id.ManagementGroup, "children", utils.Bool(false), "", "")
+	if err != nil {
+		return fmt.Errorf("reading Management Group %q for Subscription Associations: %+v", id.ManagementGroup, err)
+	}
 	found := false
 	if props := managementGroup.Properties; props != nil {
 		if props.Children == nil {

--- a/azurerm/internal/services/managementgroup/subscription_association_resource_test.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource_test.go
@@ -33,7 +33,7 @@ func TestAccManagementGroupSubscriptionAssociation_basic(t *testing.T) {
 	})
 }
 
-func TestAddManagementGroupSubscriptionAssociation_requiresImport(t *testing.T) {
+func TestAccManagementGroupSubscriptionAssociation_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_management_group_subscription_association", "test")
 
 	r := ManagementGroupSubscriptionAssociation{}
@@ -82,7 +82,7 @@ resource "azurerm_management_group_subscription_association" "import" {
 `, r.basic())
 }
 
-func (m ManagementGroupSubscriptionAssociation) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (r ManagementGroupSubscriptionAssociation) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.ManagementGroupSubscriptionAssociationID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/managementgroup/subscription_association_resource_test.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource_test.go
@@ -1,0 +1,7 @@
+package managementgroup_test
+
+import "testing"
+
+func TestAccManagementGroupSubscriptionAssociation_basic(t *testing.T) {
+
+}

--- a/azurerm/internal/services/managementgroup/subscription_association_resource_test.go
+++ b/azurerm/internal/services/managementgroup/subscription_association_resource_test.go
@@ -1,7 +1,108 @@
 package managementgroup_test
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/managementgroups"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/managementgroup/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type ManagementGroupSubscriptionAssociation struct{}
 
 func TestAccManagementGroupSubscriptionAssociation_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_subscription_association", "test")
 
+	r := ManagementGroupSubscriptionAssociation{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAddManagementGroupSubscriptionAssociation_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_management_group_subscription_association", "test")
+
+	r := ManagementGroupSubscriptionAssociation{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r ManagementGroupSubscriptionAssociation) basic() string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_subscription" "test" {
+  subscription_id = %q
+}
+
+resource "azurerm_management_group" "test" {
+}
+
+resource "azurerm_management_group_subscription_association" "test" {
+  management_group_id = azurerm_management_group.test.id
+  subscription_id     = data.azurerm_subscription.test.id
+}
+
+`, os.Getenv("ARM_SUBSCRIPTION_ID_ALT"))
+}
+
+func (r ManagementGroupSubscriptionAssociation) requiresImport(_ acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_group_subscription_association" "import" {
+  management_group_id = azurerm_management_group_subscription_association.test.management_group_id
+  subscription_id     = azurerm_management_group_subscription_association.test.subscription_id
+}
+
+`, r.basic())
+}
+
+func (m ManagementGroupSubscriptionAssociation) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.ManagementGroupSubscriptionAssociationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ManagementGroups.GroupsClient.Get(ctx, id.ManagementGroup, "children", utils.Bool(false), "", "no-cache")
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Management Group to check for Subscription Association: %+v", err)
+	}
+
+	if resp.Properties == nil || resp.Properties.Children == nil {
+		return utils.Bool(false), nil
+	}
+
+	present := false
+	for _, v := range *resp.Children {
+		if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && *v.Name == id.SubscriptionId {
+			present = true
+		}
+	}
+
+	return utils.Bool(present), nil
 }

--- a/azurerm/internal/services/subscription/parse/subscription.go
+++ b/azurerm/internal/services/subscription/parse/subscription.go
@@ -1,0 +1,37 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type SubscriptionId struct {
+	SubscriptionID string
+}
+
+// NewSubscriptionId returns a SubscriptionId object for the given Subscription UUID
+func NewSubscriptionId(uuid string) SubscriptionId {
+	return SubscriptionId{
+		SubscriptionID: uuid,
+	}
+}
+
+func (id SubscriptionId) ID() string {
+	return fmt.Sprintf("/subscriptions/%s", id.SubscriptionID)
+}
+
+// SubscriptionID returns a SubscriptionId pointer for a valid input string.
+// This string can be either a UUID, or an Azure Resource ID in the form
+// `/subscriptions/{SubscriptionID}`
+func SubscriptionID(input string) (*SubscriptionId, error) {
+	id, err := uuid.Parse(strings.TrimPrefix(input, "/subscriptions/"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &SubscriptionId{
+		SubscriptionID: id.String(),
+	}, err
+}

--- a/azurerm/internal/services/subscription/parse/subscription_test.go
+++ b/azurerm/internal/services/subscription/parse/subscription_test.go
@@ -1,0 +1,67 @@
+package parse
+
+import "testing"
+
+func TestSubscriptionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *SubscriptionId
+	}{
+		{
+			// Empty
+			Input: "",
+			Error: true,
+		},
+		{
+			// missing ID
+			Input: "/subscriptions/",
+			Error: true,
+		},
+		{
+			// Invalid Resource ID UUID portion
+			Input: "/subscriptions/abcdefgh-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			// Invalid UUID
+			Input: "abcdefgh-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			// Valid Resource ID
+			Input: "/subscriptions/12345678-1234-5678-9012-123456789012",
+			Expected: &SubscriptionId{
+				SubscriptionID: "12345678-1234-5678-9012-123456789012",
+			},
+		},
+		{
+			// Valid UUID
+			Input: "12345678-1234-5678-9012-123456789012",
+			Expected: &SubscriptionId{
+				SubscriptionID: "12345678-1234-5678-9012-123456789012",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := SubscriptionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("expected a value, but got an error: %+v", err)
+		}
+
+		if v.Error {
+			t.Fatal("expected an error but did not get one")
+		}
+
+		if actual.SubscriptionID != v.Expected.SubscriptionID {
+			t.Fatalf("expected %q but got %q for SubscriptionId", v.Expected.SubscriptionID, actual.SubscriptionID)
+		}
+	}
+}

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Management Group.
 
+!> **Note:** Configuring `subscription_ids` is not supported when using the `azurerm_management_group_subscription_association` resource, results will be unpredictable.
+
 ## Example Usage
 
 ```hcl
@@ -48,6 +50,8 @@ The following arguments are supported:
 * `parent_management_group_id` - (Optional) The ID of the Parent Management Group. Changing this forces a new resource to be created.
 
 * `subscription_ids` - (Optional) A list of Subscription GUIDs which should be assigned to the Management Group.
+
+~> **Note:** To clear all Subscriptions from the Management Group set `subscription_ids` to an empty list
 
 ## Attributes Reference
 

--- a/website/docs/r/management_group_subscription_association.html.markdown
+++ b/website/docs/r/management_group_subscription_association.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_management_group_subscription_association"
+description: |-
+  Manages a Management Group Subscription Association.
+---
+
+# azurerm_management_group_subscription_association
+
+Manages a Management Group Subscription Association.
+
+!> **Note:** When using this resource, configuring `subscription_ids` on the `azurerm_management_group` resource is not supported.
+
+## Example Usage
+
+```hcl
+data "azurerm_management_group" "example" {
+  name = "exampleManagementGroup"
+}
+
+data "azurerm_subscription" "example" {
+  subscription_id = "12345678-1234-1234-1234-123456789012"
+}
+
+resource "azurerm_management_group_subscription_association" "example" {
+  management_group_id = data.azurerm_management_group.example.id
+  subscription_id     = data.azurerm_subscription.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `management_group_id` - (Required) The ID of the Management Group to associate the Subscription with. Changing this forces a new Management to be created.
+
+* `subscription_id` - (Required) The ID of the Subscription to be associated with the Management Group. Changing this forces a new Management to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Management Group Subscription Association.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 5 minutes) Used when creating the Management.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Management.
+* `delete` - (Defaults to 5 minutes) Used when deleting the Management.
+
+## Import
+
+Managements can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_management_group_subscription_association.example /managementGroup/MyManagementGroup/subscription/12345678-1234-1234-1234-123456789012
+```


### PR DESCRIPTION
closes #10912 
closes #3555

Breaking Change Notes:
The introduction of the `azurerm_management_group_subscription_association` creates a breaking change in the use of `azurerm_management_group`. It is now required to explicitly set an empty list to remove all `subscription_ids`, where previously simply omitting this value would remove all Subscriptions from the Management group. Setting `subscription_ids` on `azurerm_management_group` is not supported when using `azurerm_management_group_subscription_association`.
