### PR TITLE
Fix TC for Virtual Hub IP

### DIFF
--- a/azurerm/internal/services/network/virtual_hub_bgp_connection_resource_test.go
+++ b/azurerm/internal/services/network/virtual_hub_bgp_connection_resource_test.go
@@ -92,7 +92,7 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctest-Subnet-%d"
+  name                 = "RouteServerSubnet"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefix       = "10.5.1.0/24"
@@ -106,7 +106,7 @@ resource "azurerm_virtual_hub_ip" "test" {
   public_ip_address_id         = azurerm_public_ip.test.id
   subnet_id                    = azurerm_subnet.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r VirtualHubBGPConnectionResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/network/virtual_hub_ip_resource_test.go
+++ b/azurerm/internal/services/network/virtual_hub_ip_resource_test.go
@@ -173,10 +173,10 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctest-subnet-%d"
+  name                 = "RouteServerSubnet"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefix       = "10.5.1.0/24"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/virtual_hub_bgp_connection.html.markdown
+++ b/website/docs/r/virtual_hub_bgp_connection.html.markdown
@@ -40,7 +40,7 @@ resource "azurerm_virtual_network" "example" {
 }
 
 resource "azurerm_subnet" "example" {
-  name                 = "example-subnet"
+  name                 = "RouteServerSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefix       = "10.5.1.0/24"

--- a/website/docs/r/virtual_hub_ip.html.markdown
+++ b/website/docs/r/virtual_hub_ip.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_virtual_network" "example" {
 }
 
 resource "azurerm_subnet" "example" {
-  name                 = "example-subnet"
+  name                 = "RouteServerSubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefix       = "10.5.1.0/24"


### PR DESCRIPTION
After confirmed with service team, they made a change to support only subnet with name RouteServerSubnet. It's a permanent change. So we have to update test cases accordingly.

--- PASS: TestAccVirtualHubIP_basic (1439.71s)
--- PASS: TestAccVirtualHubIP_complete (1457.31s)
--- PASS: TestAccVirtualHubIP_requiresImport (1485.83s)
--- PASS: TestAccVirtualHubIP_update (1594.56s)

--- PASS: TestAccVirtualHubBgpConnection_requiresImport (1519.32s)
--- PASS: TestAccVirtualHubBgpConnection_basic (1569.73s)