### PR TITLE
feat: add has_root_access to netapp vol export rules

### DIFF
--- a/azurerm/internal/services/netapp/netapp_volume_resource.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource.go
@@ -189,6 +189,11 @@ func resourceNetAppVolume() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+
+						"has_root_access": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -733,6 +738,7 @@ func expandNetAppVolumeExportPolicyRule(input []interface{}) *netapp.VolumePrope
 
 			unixReadOnly := v["unix_read_only"].(bool)
 			unixReadWrite := v["unix_read_write"].(bool)
+			hasRootAccess := v["has_root_access"].(bool)
 
 			result := netapp.ExportPolicyRule{
 				AllowedClients: utils.String(allowedClients),
@@ -742,6 +748,7 @@ func expandNetAppVolumeExportPolicyRule(input []interface{}) *netapp.VolumePrope
 				RuleIndex:      utils.Int32(ruleIndex),
 				UnixReadOnly:   utils.Bool(unixReadOnly),
 				UnixReadWrite:  utils.Bool(unixReadWrite),
+				HasRootAccess:  utils.Bool(hasRootAccess),
 			}
 
 			results = append(results, result)
@@ -827,12 +834,17 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 		if v := item.UnixReadWrite; v != nil {
 			unixReadWrite = *v
 		}
+		hasRootAccess := false
+		if v := item.HasRootAccess; v != nil {
+			hasRootAccess = *v
+		}
 
 		results = append(results, map[string]interface{}{
 			"rule_index":        ruleIndex,
 			"allowed_clients":   utils.FlattenStringSlice(&allowedClients),
 			"unix_read_only":    unixReadOnly,
 			"unix_read_write":   unixReadWrite,
+			"has_root_access":   hasRootAccess,
 			"protocols_enabled": utils.FlattenStringSlice(&protocolsEnabled),
 			// TODO: Remove in next major version
 			"cifs_enabled":  cifsEnabled,

--- a/azurerm/internal/services/netapp/netapp_volume_resource.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource.go
@@ -190,7 +190,7 @@ func resourceNetAppVolume() *schema.Resource {
 							Optional: true,
 						},
 
-						"has_root_access": {
+						"root_access_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},

--- a/azurerm/internal/services/netapp/netapp_volume_resource.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource.go
@@ -835,7 +835,7 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 			unixReadWrite = *v
 		}
 		rootAccessEnabled := false
-		if v := item.RootAccessEnabled; v != nil {
+		if v := item.HasRootAccess; v != nil {
 			rootAccessEnabled = *v
 		}
 

--- a/azurerm/internal/services/netapp/netapp_volume_resource.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource.go
@@ -738,7 +738,7 @@ func expandNetAppVolumeExportPolicyRule(input []interface{}) *netapp.VolumePrope
 
 			unixReadOnly := v["unix_read_only"].(bool)
 			unixReadWrite := v["unix_read_write"].(bool)
-			hasRootAccess := v["has_root_access"].(bool)
+			rootAccessEnabled := v["root_access_enabled"].(bool)
 
 			result := netapp.ExportPolicyRule{
 				AllowedClients: utils.String(allowedClients),
@@ -748,7 +748,7 @@ func expandNetAppVolumeExportPolicyRule(input []interface{}) *netapp.VolumePrope
 				RuleIndex:      utils.Int32(ruleIndex),
 				UnixReadOnly:   utils.Bool(unixReadOnly),
 				UnixReadWrite:  utils.Bool(unixReadWrite),
-				HasRootAccess:  utils.Bool(hasRootAccess),
+				HasRootAccess:  utils.Bool(rootAccessEnabled),
 			}
 
 			results = append(results, result)
@@ -834,18 +834,18 @@ func flattenNetAppVolumeExportPolicyRule(input *netapp.VolumePropertiesExportPol
 		if v := item.UnixReadWrite; v != nil {
 			unixReadWrite = *v
 		}
-		hasRootAccess := false
-		if v := item.HasRootAccess; v != nil {
-			hasRootAccess = *v
+		rootAccessEnabled := false
+		if v := item.RootAccessEnabled; v != nil {
+			rootAccessEnabled = *v
 		}
 
 		results = append(results, map[string]interface{}{
-			"rule_index":        ruleIndex,
-			"allowed_clients":   utils.FlattenStringSlice(&allowedClients),
-			"unix_read_only":    unixReadOnly,
-			"unix_read_write":   unixReadWrite,
-			"has_root_access":   hasRootAccess,
-			"protocols_enabled": utils.FlattenStringSlice(&protocolsEnabled),
+			"rule_index":          ruleIndex,
+			"allowed_clients":     utils.FlattenStringSlice(&allowedClients),
+			"unix_read_only":      unixReadOnly,
+			"unix_read_write":     unixReadWrite,
+			"root_access_enabled": rootAccessEnabled,
+			"protocols_enabled":   utils.FlattenStringSlice(&protocolsEnabled),
 			// TODO: Remove in next major version
 			"cifs_enabled":  cifsEnabled,
 			"nfsv3_enabled": nfsv3Enabled,

--- a/azurerm/internal/services/netapp/netapp_volume_resource_test.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource_test.go
@@ -524,7 +524,7 @@ resource "azurerm_netapp_volume" "test" {
     protocols_enabled = ["NFSv3"]
     unix_read_only    = false
     unix_read_write   = true
-    has_root_access   = true
+    root_access_enabled   = true
   }
 
   tags = {

--- a/azurerm/internal/services/netapp/netapp_volume_resource_test.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource_test.go
@@ -519,12 +519,12 @@ resource "azurerm_netapp_volume" "test" {
   storage_quota_in_gb = 101
 
   export_policy_rule {
-    rule_index        = 1
-    allowed_clients   = ["1.2.4.0/24", "1.3.4.0"]
-    protocols_enabled = ["NFSv3"]
-    unix_read_only    = false
-    unix_read_write   = true
-    root_access_enabled   = true
+    rule_index          = 1
+    allowed_clients     = ["1.2.4.0/24", "1.3.4.0"]
+    protocols_enabled   = ["NFSv3"]
+    unix_read_only      = false
+    unix_read_write     = true
+    root_access_enabled = true
   }
 
   tags = {

--- a/azurerm/internal/services/netapp/netapp_volume_resource_test.go
+++ b/azurerm/internal/services/netapp/netapp_volume_resource_test.go
@@ -524,6 +524,7 @@ resource "azurerm_netapp_volume" "test" {
     protocols_enabled = ["NFSv3"]
     unix_read_only    = false
     unix_read_write   = true
+    has_root_access   = true
   }
 
   tags = {

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -140,6 +140,8 @@ An `export_policy_rule` block supports the following:
 
 * `unix_read_write` - (Optional) Is the file system on unix read and write?
 
+* `allow_root_access` - (Optional) Has root access to the volume?
+
 ---
 
 An `data_protection_replication` is used when enabling the Cross-Region Replication (CRR) data protection option by deploying two Azure NetApp Files Volumes, one to be a primary volume and the other one will be the secondary, the secondary will have this block and will reference the primary volume, each volume must be in a supported [region pair](https://docs.microsoft.com/en-us/azure/azure-netapp-files/cross-region-replication-introduction#supported-region-pairs) and it supports the following:

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -140,7 +140,7 @@ An `export_policy_rule` block supports the following:
 
 * `unix_read_write` - (Optional) Is the file system on unix read and write?
 
-* `allow_root_access` - (Optional) Has root access to the volume?
+* `allow_root_access` - (Optional) Is root access permitted to this volume?
 
 ---
 


### PR DESCRIPTION
This adds the ability to set `has_root_access` on `export_policies`.