### PR TITLE
"azurerm_spring_cloud_service" - supports property `sample_rate`

### DIFF
--- a/azurerm/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_service_resource.go
@@ -206,6 +206,13 @@ func resourceSpringCloudService() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+
+						"sample_rate": {
+							Type:         schema.TypeFloat,
+							Optional:     true,
+							Default:      10,
+							ValidateFunc: validation.FloatBetween(0, 100),
+						},
 					},
 				},
 			},
@@ -605,6 +612,7 @@ func expandSpringCloudTrace(input []interface{}) *appplatform.MonitoringSettingP
 	return &appplatform.MonitoringSettingProperties{
 		TraceEnabled:                  utils.Bool(true),
 		AppInsightsInstrumentationKey: utils.String(v["instrumentation_key"].(string)),
+		AppInsightsSamplingRate:       utils.Float(v["sample_rate"].(float64)),
 	}
 }
 
@@ -814,11 +822,15 @@ func flattenSpringCloudTrace(input *appplatform.MonitoringSettingProperties) []i
 
 	enabled := false
 	instrumentationKey := ""
+	samplingRate := 0.0
 	if input.TraceEnabled != nil {
 		enabled = *input.TraceEnabled
 	}
 	if input.AppInsightsInstrumentationKey != nil {
 		instrumentationKey = *input.AppInsightsInstrumentationKey
+	}
+	if input.AppInsightsSamplingRate != nil {
+		samplingRate = *input.AppInsightsSamplingRate
 	}
 
 	if !enabled {
@@ -828,6 +840,7 @@ func flattenSpringCloudTrace(input *appplatform.MonitoringSettingProperties) []i
 	return []interface{}{
 		map[string]interface{}{
 			"instrumentation_key": instrumentationKey,
+			"sample_rate":         samplingRate,
 		},
 	}
 }

--- a/azurerm/internal/services/springcloud/spring_cloud_service_resource_test.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_service_resource_test.go
@@ -222,6 +222,7 @@ resource "azurerm_spring_cloud_service" "test" {
 
   trace {
     instrumentation_key = azurerm_application_insights.test.instrumentation_key
+    sample_rate         = 20
   }
 
   tags = {

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -43,6 +43,7 @@ resource "azurerm_spring_cloud_service" "example" {
 
   trace {
     instrumentation_key = azurerm_application_insights.example.instrumentation_key
+    sample_rate         = 10.0
   }
 
   tags = {
@@ -146,6 +147,8 @@ The `ssh_auth` block supports the following:
 The `trace` block supports the following:
 
 * `instrumentation_key` - (Required) The Instrumentation Key used for Application Insights.
+
+* `sample_rate` - (Optional) The sampling rate of Application Insights Agent. Must be between `0.0` and `100.0`. Defaults to `10.0`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
supports property `sample_rate`.

if not set this property, the default value from backend is 10.0.

![image](https://user-images.githubusercontent.com/2786738/112430688-72b5ac00-8d79-11eb-8750-9f1214307500.png)
