### PR TITLE
Documentation update for `monitor_scheduled_query_rules_alert`

### DIFF
--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 
 ---
 
-* `action` supports the following:
+`action` supports the following:
 
 * `action_group` - (Required) List of action group reference resource IDs.
 * `custom_webhook_payload` - (Optional) Custom payload to be sent for all webhook payloads in alerting action.


### PR DESCRIPTION
The `action` block should be started with the name of the block, the `action` block name should not be part of the bullets because it is the name of the block.