### PR TITLE
"azurerm_kubernetes_cluster" and "azurerm_kubernetes_cluster_node_pool" supports "kubelet_config", "linux_os_config"

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -417,7 +417,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	if linuxOSConfig := d.Get("linux_os_config").([]interface{}); len(linuxOSConfig) > 0 {
 		if osType != string(containerservice.Linux) {
-			return fmt.Errorf("`linux_os_config` could only be configured when `os_type` is set to `linux`")
+			return fmt.Errorf("`linux_os_config` can only be configured when `os_type` is set to `linux`")
 		}
 		linuxOSConfig, err := expandAgentPoolLinuxOSConfig(linuxOSConfig)
 		if err != nil {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -107,6 +107,10 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				}, false),
 			},
 
+			"kubelet_config": schemaNodePoolKubeletConfig(),
+
+			"linux_os_config": schemaNodePoolLinuxOSConfig(),
+
 			"max_count": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
@@ -407,6 +411,21 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("`max_count` and `min_count` must be set to `null` when enable_auto_scaling is set to `false`")
 	}
 
+	if kubeletConfig := d.Get("kubelet_config").([]interface{}); len(kubeletConfig) > 0 {
+		profile.KubeletConfig = expandAgentPoolKubeletConfig(kubeletConfig)
+	}
+
+	if linuxOSConfig := d.Get("linux_os_config").([]interface{}); len(linuxOSConfig) > 0 {
+		if osType != string(containerservice.Linux) {
+			return fmt.Errorf("`linux_os_config` could only be configured when `os_type` is set to `linux`")
+		}
+		linuxOSConfig, err := expandAgentPoolLinuxOSConfig(linuxOSConfig)
+		if err != nil {
+			return err
+		}
+		profile.LinuxOSConfig = linuxOSConfig
+	}
+
 	parameters := containerservice.AgentPool{
 		Name:                                     &name,
 		ManagedClusterAgentPoolProfileProperties: &profile,
@@ -634,6 +653,18 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 			evictionPolicy = string(props.ScaleSetEvictionPolicy)
 		}
 		d.Set("eviction_policy", evictionPolicy)
+
+		if err := d.Set("kubelet_config", flattenAgentPoolKubeletConfig(props.KubeletConfig)); err != nil {
+			return fmt.Errorf("setting `kubelet_config`: %+v", err)
+		}
+
+		linuxOSConfig, err := flattenAgentPoolLinuxOSConfig(props.LinuxOSConfig)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("linux_os_config", linuxOSConfig); err != nil {
+			return fmt.Errorf("setting `linux_os_config`: %+v", err)
+		}
 
 		maxCount := 0
 		if props.MaxCount != nil {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -416,7 +416,7 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if linuxOSConfig := d.Get("linux_os_config").([]interface{}); len(linuxOSConfig) > 0 {
-		if osType != string(containerservice.Linux) {
+		if osType != string(containerservice.OSTypeLinux) {
 			return fmt.Errorf("`linux_os_config` can only be configured when `os_type` is set to `linux`")
 		}
 		linuxOSConfig, err := expandAgentPoolLinuxOSConfig(linuxOSConfig)

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -24,6 +24,7 @@ var kubernetesNodePoolTests = map[string]func(t *testing.T){
 	"autoScaleUpdate":                testAccKubernetesClusterNodePool_autoScaleUpdate,
 	"availabilityZones":              testAccKubernetesClusterNodePool_availabilityZones,
 	"errorForAvailabilitySet":        testAccKubernetesClusterNodePool_errorForAvailabilitySet,
+	"kubeletAndLinuxOSConfig":        testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig,
 	"multiplePools":                  testAccKubernetesClusterNodePool_multiplePools,
 	"manualScale":                    testAccKubernetesClusterNodePool_manualScale,
 	"manualScaleMultiplePools":       testAccKubernetesClusterNodePool_manualScaleMultiplePools,
@@ -158,6 +159,26 @@ func testAccKubernetesClusterNodePool_errorForAvailabilitySet(t *testing.T) {
 			Config:      r.availabilitySetConfig(data),
 			ExpectError: regexp.MustCompile("must be a VirtualMachineScaleSet to attach multiple node pools"),
 		},
+	})
+}
+
+func TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig(t)
+}
+
+func testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.kubeletAndLinuxOSConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -932,6 +953,94 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
   vm_size               = "Standard_DS2_v2"
   node_count            = 1
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (KubernetesClusterNodePoolResource) kubeletAndLinuxOSConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+
+  kubelet_config {
+    cpu_manager_policy        = "static"
+    cpu_cfs_quota_enabled     = true
+    cpu_cfs_quota_period      = "10ms"
+    image_gc_high_threshold   = 90
+    image_gc_low_threshold    = 70
+    topology_manager_policy   = "best-effort"
+    allowed_unsafe_sysctls    = ["kernel.msg*", "net.core.somaxconn"]
+    container_log_max_size_mb = 100
+    container_log_max_line    = 100000
+    pod_max_pid               = 12345
+  }
+
+  linux_os_config {
+    transparent_huge_page_enabled = "always"
+    transparent_huge_page_defrag  = "always"
+    swap_file_size_mb             = 300
+
+    sysctl_config {
+      fs_aio_max_nr                      = 65536
+      fs_file_max                        = 100000
+      fs_inotify_max_user_watches        = 1000000
+      fs_nr_open                         = 1000000
+      kernel_threads_max                 = 200000
+      net_core_netdev_max_backlog        = 1800
+      net_core_optmem_max                = 30000
+      net_core_rmem_max                  = 300000
+      net_core_rmem_default              = 300000
+      net_core_somaxconn                 = 5000
+      net_core_wmem_default              = 300000
+      net_core_wmem_max                  = 300000
+      net_ipv4_ip_local_port_range_min   = 32768
+      net_ipv4_ip_local_port_range_max   = 60000
+      net_ipv4_neigh_default_gc_thresh1  = 128
+      net_ipv4_neigh_default_gc_thresh2  = 512
+      net_ipv4_neigh_default_gc_thresh3  = 1024
+      net_ipv4_tcp_fin_timeout           = 60
+      net_ipv4_tcp_keepalive_probes      = 9
+      net_ipv4_tcp_keepalive_time        = 6000
+      net_ipv4_tcp_max_syn_backlog       = 2048
+      net_ipv4_tcp_max_tw_buckets        = 100000
+      net_ipv4_tcp_tw_reuse              = true
+      net_ipv4_tcp_keepalive_intvl       = 70
+      net_netfilter_nf_conntrack_buckets = 65536
+      net_netfilter_nf_conntrack_max     = 200000
+      vm_max_map_count                   = 65536
+      vm_swappiness                      = 45
+      vm_vfs_cache_pressure              = 80
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -172,10 +172,10 @@ func testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.kubeletAndLinuxOSConfig(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -192,10 +192,10 @@ func testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial(t *testing.
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.kubeletAndLinuxOSConfigPartial(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1034,7 +1034,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
       fs_aio_max_nr                      = 65536
       fs_file_max                        = 100000
       fs_inotify_max_user_watches        = 1000000
-      fs_nr_open                         = 1000000
+      fs_nr_open                         = 1048576
       kernel_threads_max                 = 200000
       net_core_netdev_max_backlog        = 1800
       net_core_optmem_max                = 30000

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1101,18 +1101,18 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
 
   kubelet_config {
-    cpu_manager_policy        = "static"
-    cpu_cfs_quota_enabled     = true
-    cpu_cfs_quota_period      = "10ms"
+    cpu_manager_policy    = "static"
+    cpu_cfs_quota_enabled = true
+    cpu_cfs_quota_period  = "10ms"
   }
 
   linux_os_config {
     transparent_huge_page_enabled = "always"
 
     sysctl_config {
-      fs_aio_max_nr                      = 65536
-      fs_file_max                        = 100000
-      fs_inotify_max_user_watches        = 1000000
+      fs_aio_max_nr               = 65536
+      fs_file_max                 = 100000
+      fs_inotify_max_user_watches = 1000000
     }
   }
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -859,7 +859,7 @@ resource "azurerm_kubernetes_cluster" "test" {
         fs_aio_max_nr                      = 65536
         fs_file_max                        = 100000
         fs_inotify_max_user_watches        = 1000000
-        fs_nr_open                         = 1000000
+        fs_nr_open                         = 1048576
         kernel_threads_max                 = 200000
         net_core_netdev_max_backlog        = 1800
         net_core_optmem_max                = 30000

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -918,18 +918,18 @@ resource "azurerm_kubernetes_cluster" "test" {
     node_count = 1
     vm_size    = "Standard_DS2_v2"
     kubelet_config {
-      cpu_manager_policy        = "static"
-      cpu_cfs_quota_enabled     = true
-      cpu_cfs_quota_period      = "10ms"
+      cpu_manager_policy    = "static"
+      cpu_cfs_quota_enabled = true
+      cpu_cfs_quota_period  = "10ms"
     }
 
     linux_os_config {
       transparent_huge_page_enabled = "always"
 
       sysctl_config {
-        fs_aio_max_nr                      = 65536
-        fs_file_max                        = 100000
-        fs_inotify_max_user_watches        = 1000000
+        fs_aio_max_nr               = 65536
+        fs_file_max                 = 100000
+        fs_inotify_max_user_watches = 1000000
       }
     }
   }

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -14,6 +14,7 @@ var kubernetesOtherTests = map[string]func(t *testing.T){
 	"basicVMSS":                         testAccKubernetesCluster_basicVMSS,
 	"requiresImport":                    testAccKubernetesCluster_requiresImport,
 	"criticalAddonsTaint":               testAccKubernetesCluster_criticalAddonsTaint,
+	"kubeletAndLinuxOSConfig":           testAccKubernetesCluster_kubeletAndLinuxOSConfig,
 	"linuxProfile":                      testAccKubernetesCluster_linuxProfile,
 	"nodeLabels":                        testAccKubernetesCluster_nodeLabels,
 	"nodeResourceGroup":                 testAccKubernetesCluster_nodeResourceGroup,
@@ -165,6 +166,26 @@ func testAccKubernetesCluster_criticalAddonsTaint(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_node_pool.0.only_critical_addons_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_kubeletAndLinuxOSConfig(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_kubeletAndLinuxOSConfig(t)
+}
+
+func testAccKubernetesCluster_kubeletAndLinuxOSConfig(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.kubeletAndLinuxOSConfig(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -765,6 +786,86 @@ resource "azurerm_kubernetes_cluster" "test" {
     type                         = "AvailabilitySet"
     vm_size                      = "Standard_DS2_v2"
     only_critical_addons_enabled = true
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (KubernetesClusterResource) kubeletAndLinuxOSConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+    kubelet_config {
+      cpu_manager_policy        = "static"
+      cpu_cfs_quota_enabled     = true
+      cpu_cfs_quota_period      = "10ms"
+      image_gc_high_threshold   = 90
+      image_gc_low_threshold    = 70
+      topology_manager_policy   = "best-effort"
+      allowed_unsafe_sysctls    = ["kernel.msg*", "net.core.somaxconn"]
+      container_log_max_size_mb = 100
+      container_log_max_line    = 100000
+      pod_max_pid               = 12345
+    }
+
+    linux_os_config {
+      transparent_huge_page_enabled = "always"
+      transparent_huge_page_defrag  = "always"
+      swap_file_size_mb             = 300
+
+      sysctl_config {
+        fs_aio_max_nr                      = 65536
+        fs_file_max                        = 100000
+        fs_inotify_max_user_watches        = 1000000
+        fs_nr_open                         = 1000000
+        kernel_threads_max                 = 200000
+        net_core_netdev_max_backlog        = 1800
+        net_core_optmem_max                = 30000
+        net_core_rmem_max                  = 300000
+        net_core_rmem_default              = 300000
+        net_core_somaxconn                 = 5000
+        net_core_wmem_default              = 300000
+        net_core_wmem_max                  = 300000
+        net_ipv4_ip_local_port_range_min   = 32768
+        net_ipv4_ip_local_port_range_max   = 60000
+        net_ipv4_neigh_default_gc_thresh1  = 128
+        net_ipv4_neigh_default_gc_thresh2  = 512
+        net_ipv4_neigh_default_gc_thresh3  = 1024
+        net_ipv4_tcp_fin_timeout           = 60
+        net_ipv4_tcp_keepalive_probes      = 9
+        net_ipv4_tcp_keepalive_time        = 6000
+        net_ipv4_tcp_max_syn_backlog       = 2048
+        net_ipv4_tcp_max_tw_buckets        = 100000
+        net_ipv4_tcp_tw_reuse              = true
+        net_ipv4_tcp_keepalive_intvl       = 70
+        net_netfilter_nf_conntrack_buckets = 65536
+        net_netfilter_nf_conntrack_max     = 200000
+        vm_max_map_count                   = 65536
+        vm_swappiness                      = 45
+        vm_vfs_cache_pressure              = 80
+      }
+    }
   }
 
   identity {

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -182,10 +182,10 @@ func testAccKubernetesCluster_kubeletAndLinuxOSConfig(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.kubeletAndLinuxOSConfig(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -202,10 +202,10 @@ func testAccKubernetesCluster_kubeletAndLinuxOSConfigPartial(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.kubeletAndLinuxOSConfigPartial(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -2,6 +2,8 @@ package containers
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-03-01/containerservice"
@@ -73,6 +75,10 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					Optional: true,
 					ForceNew: true,
 				},
+
+				"kubelet_config": schemaNodePoolKubeletConfig(),
+
+				"linux_os_config": schemaNodePoolLinuxOSConfig(),
 
 				"max_count": {
 					Type:     pluginsdk.TypeInt,
@@ -179,6 +185,352 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 	}
 }
 
+func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"cpu_manager_policy": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"none",
+						"static",
+					}, false),
+				},
+
+				"cpu_cfs_quota_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+
+				"cpu_cfs_quota_period": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+
+				"image_gc_high_threshold": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(0, 100),
+				},
+
+				"image_gc_low_threshold": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(0, 100),
+				},
+
+				"topology_manager_policy": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"none",
+						"best-effort",
+						"restricted",
+						"single-numa-node",
+					}, false),
+				},
+
+				"allowed_unsafe_sysctls": {
+					Type:     pluginsdk.TypeSet,
+					Optional: true,
+					ForceNew: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"container_log_max_size_mb": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					ForceNew: true,
+				},
+
+				"container_log_max_line": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(2),
+				},
+
+				"pod_max_pid": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					ForceNew: true,
+				},
+			},
+		},
+	}
+}
+
+func schemaNodePoolLinuxOSConfig() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"sysctl_config": schemaNodePoolSysctlConfig(),
+
+				"transparent_huge_page_enabled": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"always",
+						"madvise",
+						"never",
+					}, false),
+				},
+
+				"transparent_huge_page_defrag": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"always",
+						"defer",
+						"defer+madvise",
+						"madvise",
+						"never",
+					}, false),
+				},
+
+				"swap_file_size_mb": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+					ForceNew: true,
+				},
+			},
+		},
+	}
+}
+
+func schemaNodePoolSysctlConfig() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"fs_aio_max_nr": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(65536, 6553500),
+				},
+
+				"fs_file_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(8192, 12000500),
+				},
+
+				"fs_inotify_max_user_watches": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(781250, 2097152),
+				},
+
+				"fs_nr_open": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(8192, 20000500),
+				},
+
+				"kernel_threads_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(20, 513785),
+				},
+
+				"net_core_netdev_max_backlog": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1000, 3240000),
+				},
+
+				"net_core_optmem_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(20480, 4194304),
+				},
+
+				"net_core_rmem_default": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(212992, 134217728),
+				},
+
+				"net_core_rmem_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(212992, 134217728),
+				},
+
+				"net_core_somaxconn": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(4096, 3240000),
+				},
+
+				"net_core_wmem_default": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(212992, 134217728),
+				},
+
+				"net_core_wmem_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(212992, 134217728),
+				},
+
+				"net_ipv4_ip_local_port_range_min": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1024, 60999),
+				},
+
+				"net_ipv4_ip_local_port_range_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1024, 60999),
+				},
+
+				"net_ipv4_neigh_default_gc_thresh1": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(128, 80000),
+				},
+
+				"net_ipv4_neigh_default_gc_thresh2": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(512, 90000),
+				},
+
+				"net_ipv4_neigh_default_gc_thresh3": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1024, 100000),
+				},
+
+				"net_ipv4_tcp_fin_timeout": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(5, 120),
+				},
+
+				"net_ipv4_tcp_keepalive_intvl": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(10, 75),
+				},
+
+				"net_ipv4_tcp_keepalive_probes": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(1, 15),
+				},
+
+				"net_ipv4_tcp_keepalive_time": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(30, 432000),
+				},
+
+				"net_ipv4_tcp_max_syn_backlog": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(128, 3240000),
+				},
+
+				"net_ipv4_tcp_max_tw_buckets": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(8000, 1440000),
+				},
+
+				"net_ipv4_tcp_tw_reuse": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+
+				"net_netfilter_nf_conntrack_buckets": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(65536, 147456),
+				},
+
+				"net_netfilter_nf_conntrack_max": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(131072, 589824),
+				},
+
+				"vm_max_map_count": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(65530, 262144),
+				},
+
+				"vm_swappiness": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(0, 100),
+				},
+
+				"vm_vfs_cache_pressure": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntBetween(0, 100),
+				},
+			},
+		},
+	}
+}
+
 func ConvertDefaultNodePoolToAgentPool(input *[]containerservice.ManagedClusterAgentPoolProfile) containerservice.AgentPool {
 	defaultCluster := (*input)[0]
 	return containerservice.AgentPool{
@@ -189,6 +541,8 @@ func ConvertDefaultNodePoolToAgentPool(input *[]containerservice.ManagedClusterA
 			OsDiskSizeGB:              defaultCluster.OsDiskSizeGB,
 			OsDiskType:                defaultCluster.OsDiskType,
 			VnetSubnetID:              defaultCluster.VnetSubnetID,
+			KubeletConfig:             defaultCluster.KubeletConfig,
+			LinuxOSConfig:             defaultCluster.LinuxOSConfig,
 			MaxPods:                   defaultCluster.MaxPods,
 			OsType:                    defaultCluster.OsType,
 			MaxCount:                  defaultCluster.MaxCount,
@@ -345,9 +699,160 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]containerservice.Manag
 		return nil, fmt.Errorf("`max_count`(%d) and `min_count`(%d) must be set to `null` when `enable_auto_scaling` is set to `false`", maxCount, minCount)
 	}
 
+	if kubeletConfig := raw["kubelet_config"].([]interface{}); len(kubeletConfig) > 0 {
+		profile.KubeletConfig = expandAgentPoolKubeletConfig(kubeletConfig)
+	}
+
+	if linuxOSConfig := raw["linux_os_config"].([]interface{}); len(linuxOSConfig) > 0 {
+		linuxOSConfig, err := expandAgentPoolLinuxOSConfig(linuxOSConfig)
+		if err != nil {
+			return nil, err
+		}
+		profile.LinuxOSConfig = linuxOSConfig
+	}
+
 	return &[]containerservice.ManagedClusterAgentPoolProfile{
 		profile,
 	}, nil
+}
+
+func expandAgentPoolKubeletConfig(input []interface{}) *containerservice.KubeletConfig {
+	if len(input) == 0 {
+		return nil
+	}
+
+	config := input[0].(map[string]interface{})
+	return &containerservice.KubeletConfig{
+		CPUManagerPolicy:      utils.String(config["cpu_manager_policy"].(string)),
+		CPUCfsQuota:           utils.Bool(config["cpu_cfs_quota_enabled"].(bool)),
+		CPUCfsQuotaPeriod:     utils.String(config["cpu_cfs_quota_period"].(string)),
+		ImageGcHighThreshold:  utils.Int32(int32(config["image_gc_high_threshold"].(int))),
+		ImageGcLowThreshold:   utils.Int32(int32(config["image_gc_low_threshold"].(int))),
+		TopologyManagerPolicy: utils.String(config["topology_manager_policy"].(string)),
+		AllowedUnsafeSysctls:  utils.ExpandStringSlice(config["allowed_unsafe_sysctls"].(*pluginsdk.Set).List()),
+		// must be false, otherwise the backend will report error: CustomKubeletConfig.FailSwapOn must be set to false to enable swap file on nodes.
+		FailSwapOn:            utils.Bool(false),
+		ContainerLogMaxSizeMB: utils.Int32(int32(config["container_log_max_size_mb"].(int))),
+		ContainerLogMaxFiles:  utils.Int32(int32(config["container_log_max_line"].(int))),
+		PodMaxPids:            utils.Int32(int32(config["pod_max_pid"].(int))),
+	}
+}
+
+func expandAgentPoolLinuxOSConfig(input []interface{}) (*containerservice.LinuxOSConfig, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	v := input[0].(map[string]interface{})
+	sysctlConfig, err := expandAgentPoolSysctlConfig(v["sysctl_config"].([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+	return &containerservice.LinuxOSConfig{
+		Sysctls:                    sysctlConfig,
+		TransparentHugePageEnabled: utils.String(v["transparent_huge_page_enabled"].(string)),
+		TransparentHugePageDefrag:  utils.String(v["transparent_huge_page_defrag"].(string)),
+		SwapFileSizeMB:             utils.Int32(int32(v["swap_file_size_mb"].(int))),
+	}, nil
+}
+
+func expandAgentPoolSysctlConfig(input []interface{}) (*containerservice.SysctlConfig, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	raw := input[0].(map[string]interface{})
+	result := &containerservice.SysctlConfig{
+		NetIpv4TCPTwReuse: utils.Bool(raw["net_ipv4_tcp_tw_reuse"].(bool)),
+	}
+	if v := raw["net_core_somaxconn"].(int); v != 0 {
+		result.NetCoreSomaxconn = utils.Int32(int32(v))
+	}
+	if v := raw["net_core_netdev_max_backlog"].(int); v != 0 {
+		result.NetCoreNetdevMaxBacklog = utils.Int32(int32(v))
+	}
+	if v := raw["net_core_rmem_default"].(int); v != 0 {
+		result.NetCoreRmemDefault = utils.Int32(int32(v))
+	}
+	if v := raw["net_core_rmem_max"].(int); v != 0 {
+		result.NetCoreRmemMax = utils.Int32(int32(v))
+	}
+	if v := raw["net_core_wmem_default"].(int); v != 0 {
+		result.NetCoreWmemDefault = utils.Int32(int32(v))
+	}
+	if v := raw["net_core_wmem_max"].(int); v != 0 {
+		result.NetCoreWmemMax = utils.Int32(int32(v))
+	}
+	if v := raw["net_core_optmem_max"].(int); v != 0 {
+		result.NetCoreOptmemMax = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_tcp_max_syn_backlog"].(int); v != 0 {
+		result.NetIpv4TCPMaxSynBacklog = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_tcp_max_tw_buckets"].(int); v != 0 {
+		result.NetIpv4TCPMaxTwBuckets = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_tcp_fin_timeout"].(int); v != 0 {
+		result.NetIpv4TCPFinTimeout = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_tcp_keepalive_time"].(int); v != 0 {
+		result.NetIpv4TCPKeepaliveTime = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_tcp_keepalive_probes"].(int); v != 0 {
+		result.NetIpv4TCPKeepaliveProbes = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_tcp_keepalive_intvl"].(int); v != 0 {
+		result.NetIpv4TcpkeepaliveIntvl = utils.Int32(int32(v))
+	}
+	netIpv4IPLocalPortRangeMin := raw["net_ipv4_ip_local_port_range_min"].(int)
+	netIpv4IPLocalPortRangeMax := raw["net_ipv4_ip_local_port_range_max"].(int)
+	if (netIpv4IPLocalPortRangeMin != 0 && netIpv4IPLocalPortRangeMax == 0) || (netIpv4IPLocalPortRangeMin == 0 && netIpv4IPLocalPortRangeMax != 0) {
+		return nil, fmt.Errorf("`net_ipv4_ip_local_port_range_min` and `net_ipv4_ip_local_port_range_max` should both be set or unset")
+	}
+	if netIpv4IPLocalPortRangeMin > netIpv4IPLocalPortRangeMax {
+		return nil, fmt.Errorf("`net_ipv4_ip_local_port_range_min` should be no larger than `net_ipv4_ip_local_port_range_max`")
+	}
+	if netIpv4IPLocalPortRangeMin != 0 && netIpv4IPLocalPortRangeMax != 0 {
+		result.NetIpv4IPLocalPortRange = utils.String(fmt.Sprintf("%d %d", netIpv4IPLocalPortRangeMin, netIpv4IPLocalPortRangeMax))
+	}
+	if v := raw["net_ipv4_neigh_default_gc_thresh1"].(int); v != 0 {
+		result.NetIpv4NeighDefaultGcThresh1 = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_neigh_default_gc_thresh2"].(int); v != 0 {
+		result.NetIpv4NeighDefaultGcThresh2 = utils.Int32(int32(v))
+	}
+	if v := raw["net_ipv4_neigh_default_gc_thresh3"].(int); v != 0 {
+		result.NetIpv4NeighDefaultGcThresh3 = utils.Int32(int32(v))
+	}
+	if v := raw["net_netfilter_nf_conntrack_max"].(int); v != 0 {
+		result.NetNetfilterNfConntrackMax = utils.Int32(int32(v))
+	}
+	if v := raw["net_netfilter_nf_conntrack_buckets"].(int); v != 0 {
+		result.NetNetfilterNfConntrackBuckets = utils.Int32(int32(v))
+	}
+	if v := raw["fs_aio_max_nr"].(int); v != 0 {
+		result.FsAioMaxNr = utils.Int32(int32(v))
+	}
+	if v := raw["fs_inotify_max_user_watches"].(int); v != 0 {
+		result.FsInotifyMaxUserWatches = utils.Int32(int32(v))
+	}
+	if v := raw["fs_file_max"].(int); v != 0 {
+		result.FsFileMax = utils.Int32(int32(v))
+	}
+	if v := raw["fs_nr_open"].(int); v != 0 {
+		result.FsNrOpen = utils.Int32(int32(v))
+	}
+	if v := raw["kernel_threads_max"].(int); v != 0 {
+		result.KernelThreadsMax = utils.Int32(int32(v))
+	}
+	if v := raw["vm_max_map_count"].(int); v != 0 {
+		result.VMMaxMapCount = utils.Int32(int32(v))
+	}
+	if v := raw["vm_swappiness"].(int); v != 0 {
+		result.VMSwappiness = utils.Int32(int32(v))
+	}
+	if v := raw["vm_vfs_cache_pressure"].(int); v != 0 {
+		result.VMVfsCachePressure = utils.Int32(int32(v))
+	}
+	return result, nil
 }
 
 func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolProfile, d *pluginsdk.ResourceData) (*[]interface{}, error) {
@@ -458,7 +963,10 @@ func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolPro
 	}
 
 	upgradeSettings := flattenUpgradeSettings(agentPool.UpgradeSettings)
-
+	linuxOSConfig, err := flattenAgentPoolLinuxOSConfig(agentPool.LinuxOSConfig)
+	if err != nil {
+		return nil, err
+	}
 	return &[]interface{}{
 		map[string]interface{}{
 			"availability_zones":           availabilityZones,
@@ -483,6 +991,256 @@ func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolPro
 			"upgrade_settings":             upgradeSettings,
 			"vnet_subnet_id":               vnetSubnetId,
 			"only_critical_addons_enabled": criticalAddonsEnabled,
+			"kubelet_config":               flattenAgentPoolKubeletConfig(agentPool.KubeletConfig),
+			"linux_os_config":              linuxOSConfig,
+		},
+	}, nil
+}
+
+func flattenAgentPoolKubeletConfig(input *containerservice.KubeletConfig) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	var cpuManagerPolicy, cpuCfsQuotaPeriod, topologyManagerPolicy string
+	var cpuCfsQuotaEnabled bool
+	var imageGcHighThreshold, imageGcLowThreshold, containerLogMaxSizeMB, containerLogMaxLines, podMaxPids int
+
+	if input.CPUManagerPolicy != nil {
+		cpuManagerPolicy = *input.CPUManagerPolicy
+	}
+	if input.CPUCfsQuota != nil {
+		cpuCfsQuotaEnabled = *input.CPUCfsQuota
+	}
+	if input.CPUCfsQuotaPeriod != nil {
+		cpuCfsQuotaPeriod = *input.CPUCfsQuotaPeriod
+	}
+	if input.ImageGcHighThreshold != nil {
+		imageGcHighThreshold = int(*input.ImageGcHighThreshold)
+	}
+	if input.ImageGcLowThreshold != nil {
+		imageGcLowThreshold = int(*input.ImageGcLowThreshold)
+	}
+	if input.TopologyManagerPolicy != nil {
+		topologyManagerPolicy = *input.TopologyManagerPolicy
+	}
+	if input.ContainerLogMaxSizeMB != nil {
+		containerLogMaxSizeMB = int(*input.ContainerLogMaxSizeMB)
+	}
+	if input.ContainerLogMaxFiles != nil {
+		containerLogMaxLines = int(*input.ContainerLogMaxFiles)
+	}
+	if input.PodMaxPids != nil {
+		podMaxPids = int(*input.PodMaxPids)
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"cpu_manager_policy":        cpuManagerPolicy,
+			"cpu_cfs_quota_enabled":     cpuCfsQuotaEnabled,
+			"cpu_cfs_quota_period":      cpuCfsQuotaPeriod,
+			"image_gc_high_threshold":   imageGcHighThreshold,
+			"image_gc_low_threshold":    imageGcLowThreshold,
+			"topology_manager_policy":   topologyManagerPolicy,
+			"allowed_unsafe_sysctls":    utils.FlattenStringSlice(input.AllowedUnsafeSysctls),
+			"container_log_max_size_mb": containerLogMaxSizeMB,
+			"container_log_max_line":    containerLogMaxLines,
+			"pod_max_pid":               podMaxPids,
+		},
+	}
+}
+
+func flattenAgentPoolLinuxOSConfig(input *containerservice.LinuxOSConfig) ([]interface{}, error) {
+	if input == nil {
+		return make([]interface{}, 0), nil
+	}
+
+	var swapFileSizeMB int32
+	if input.SwapFileSizeMB != nil {
+		swapFileSizeMB = *input.SwapFileSizeMB
+	}
+	var transparentHugePageDefrag string
+	if input.TransparentHugePageDefrag != nil {
+		transparentHugePageDefrag = *input.TransparentHugePageDefrag
+	}
+	var transparentHugePageEnabled string
+	if input.TransparentHugePageEnabled != nil {
+		transparentHugePageEnabled = *input.TransparentHugePageEnabled
+	}
+	sysctlConfig, err := flattenAgentPoolSysctlConfig(input.Sysctls)
+	if err != nil {
+		return nil, err
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"swap_file_size_mb":             swapFileSizeMB,
+			"sysctl_config":                 sysctlConfig,
+			"transparent_huge_page_defrag":  transparentHugePageDefrag,
+			"transparent_huge_page_enabled": transparentHugePageEnabled,
+		},
+	}, nil
+}
+
+func flattenAgentPoolSysctlConfig(input *containerservice.SysctlConfig) ([]interface{}, error) {
+	if input == nil {
+		return make([]interface{}, 0), nil
+	}
+
+	var fsAioMaxNr int32
+	if input.FsAioMaxNr != nil {
+		fsAioMaxNr = *input.FsAioMaxNr
+	}
+	var fsFileMax int32
+	if input.FsFileMax != nil {
+		fsFileMax = *input.FsFileMax
+	}
+	var fsInotifyMaxUserWatches int32
+	if input.FsInotifyMaxUserWatches != nil {
+		fsInotifyMaxUserWatches = *input.FsInotifyMaxUserWatches
+	}
+	var fsNrOpen int32
+	if input.FsNrOpen != nil {
+		fsNrOpen = *input.FsNrOpen
+	}
+	var kernelThreadsMax int32
+	if input.KernelThreadsMax != nil {
+		kernelThreadsMax = *input.KernelThreadsMax
+	}
+	var netCoreNetdevMaxBacklog int32
+	if input.NetCoreNetdevMaxBacklog != nil {
+		netCoreNetdevMaxBacklog = *input.NetCoreNetdevMaxBacklog
+	}
+	var netCoreOptmemMax int32
+	if input.NetCoreOptmemMax != nil {
+		netCoreOptmemMax = *input.NetCoreOptmemMax
+	}
+	var netCoreRmemDefault int32
+	if input.NetCoreRmemDefault != nil {
+		netCoreRmemDefault = *input.NetCoreRmemDefault
+	}
+	var netCoreRmemMax int32
+	if input.NetCoreRmemMax != nil {
+		netCoreRmemMax = *input.NetCoreRmemMax
+	}
+	var netCoreSomaxconn int32
+	if input.NetCoreSomaxconn != nil {
+		netCoreSomaxconn = *input.NetCoreSomaxconn
+	}
+	var netCoreWmemDefault int32
+	if input.NetCoreWmemDefault != nil {
+		netCoreWmemDefault = *input.NetCoreWmemDefault
+	}
+	var netCoreWmemMax int32
+	if input.NetCoreWmemMax != nil {
+		netCoreWmemMax = *input.NetCoreWmemMax
+	}
+	var netIpv4IpLocalPortRangeMin, netIpv4IpLocalPortRangeMax int
+	if input.NetIpv4IPLocalPortRange != nil {
+		arr := regexp.MustCompile("[ \t]+").Split(*input.NetIpv4IPLocalPortRange, -1)
+		if len(arr) != 2 {
+			return nil, fmt.Errorf("parsing `NetIpv4IPLocalPortRange` %s", *input.NetIpv4IPLocalPortRange)
+		}
+		var err error
+		netIpv4IpLocalPortRangeMin, err = strconv.Atoi(arr[0])
+		if err != nil {
+			return nil, err
+		}
+		netIpv4IpLocalPortRangeMax, err = strconv.Atoi(arr[1])
+		if err != nil {
+			return nil, err
+		}
+	}
+	var netIpv4NeighDefaultGcThresh1 int32
+	if input.NetIpv4NeighDefaultGcThresh1 != nil {
+		netIpv4NeighDefaultGcThresh1 = *input.NetIpv4NeighDefaultGcThresh1
+	}
+	var netIpv4NeighDefaultGcThresh2 int32
+	if input.NetIpv4NeighDefaultGcThresh2 != nil {
+		netIpv4NeighDefaultGcThresh2 = *input.NetIpv4NeighDefaultGcThresh2
+	}
+	var netIpv4NeighDefaultGcThresh3 int32
+	if input.NetIpv4NeighDefaultGcThresh3 != nil {
+		netIpv4NeighDefaultGcThresh3 = *input.NetIpv4NeighDefaultGcThresh3
+	}
+	var netIpv4TcpFinTimeout int32
+	if input.NetIpv4TCPFinTimeout != nil {
+		netIpv4TcpFinTimeout = *input.NetIpv4TCPFinTimeout
+	}
+	var netIpv4TcpkeepaliveIntvl int32
+	if input.NetIpv4TcpkeepaliveIntvl != nil {
+		netIpv4TcpkeepaliveIntvl = *input.NetIpv4TcpkeepaliveIntvl
+	}
+	var netIpv4TcpKeepaliveProbes int32
+	if input.NetIpv4TCPKeepaliveProbes != nil {
+		netIpv4TcpKeepaliveProbes = *input.NetIpv4TCPKeepaliveProbes
+	}
+	var netIpv4TcpKeepaliveTime int32
+	if input.NetIpv4TCPKeepaliveTime != nil {
+		netIpv4TcpKeepaliveTime = *input.NetIpv4TCPKeepaliveTime
+	}
+	var netIpv4TcpMaxSynBacklog int32
+	if input.NetIpv4TCPMaxSynBacklog != nil {
+		netIpv4TcpMaxSynBacklog = *input.NetIpv4TCPMaxSynBacklog
+	}
+	var netIpv4TcpMaxTwBuckets int32
+	if input.NetIpv4TCPMaxTwBuckets != nil {
+		netIpv4TcpMaxTwBuckets = *input.NetIpv4TCPMaxTwBuckets
+	}
+	var netIpv4TcpTwReuse bool
+	if input.NetIpv4TCPTwReuse != nil {
+		netIpv4TcpTwReuse = *input.NetIpv4TCPTwReuse
+	}
+	var netNetfilterNfConntrackBuckets int32
+	if input.NetNetfilterNfConntrackBuckets != nil {
+		netNetfilterNfConntrackBuckets = *input.NetNetfilterNfConntrackBuckets
+	}
+	var netNetfilterNfConntrackMax int32
+	if input.NetNetfilterNfConntrackMax != nil {
+		netNetfilterNfConntrackMax = *input.NetNetfilterNfConntrackMax
+	}
+	var vmMaxMapCount int32
+	if input.VMMaxMapCount != nil {
+		vmMaxMapCount = *input.VMMaxMapCount
+	}
+	var vmSwappiness int32
+	if input.VMSwappiness != nil {
+		vmSwappiness = *input.VMSwappiness
+	}
+	var vmVfsCachePressure int32
+	if input.VMVfsCachePressure != nil {
+		vmVfsCachePressure = *input.VMVfsCachePressure
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"fs_aio_max_nr":                      fsAioMaxNr,
+			"fs_file_max":                        fsFileMax,
+			"fs_inotify_max_user_watches":        fsInotifyMaxUserWatches,
+			"fs_nr_open":                         fsNrOpen,
+			"kernel_threads_max":                 kernelThreadsMax,
+			"net_core_netdev_max_backlog":        netCoreNetdevMaxBacklog,
+			"net_core_optmem_max":                netCoreOptmemMax,
+			"net_core_rmem_default":              netCoreRmemDefault,
+			"net_core_rmem_max":                  netCoreRmemMax,
+			"net_core_somaxconn":                 netCoreSomaxconn,
+			"net_core_wmem_default":              netCoreWmemDefault,
+			"net_core_wmem_max":                  netCoreWmemMax,
+			"net_ipv4_ip_local_port_range_min":   netIpv4IpLocalPortRangeMin,
+			"net_ipv4_ip_local_port_range_max":   netIpv4IpLocalPortRangeMax,
+			"net_ipv4_neigh_default_gc_thresh1":  netIpv4NeighDefaultGcThresh1,
+			"net_ipv4_neigh_default_gc_thresh2":  netIpv4NeighDefaultGcThresh2,
+			"net_ipv4_neigh_default_gc_thresh3":  netIpv4NeighDefaultGcThresh3,
+			"net_ipv4_tcp_fin_timeout":           netIpv4TcpFinTimeout,
+			"net_ipv4_tcp_keepalive_intvl":       netIpv4TcpkeepaliveIntvl,
+			"net_ipv4_tcp_keepalive_probes":      netIpv4TcpKeepaliveProbes,
+			"net_ipv4_tcp_keepalive_time":        netIpv4TcpKeepaliveTime,
+			"net_ipv4_tcp_max_syn_backlog":       netIpv4TcpMaxSynBacklog,
+			"net_ipv4_tcp_max_tw_buckets":        netIpv4TcpMaxTwBuckets,
+			"net_ipv4_tcp_tw_reuse":              netIpv4TcpTwReuse,
+			"net_netfilter_nf_conntrack_buckets": netNetfilterNfConntrackBuckets,
+			"net_netfilter_nf_conntrack_max":     netNetfilterNfConntrackMax,
+			"vm_max_map_count":                   vmMaxMapCount,
+			"vm_swappiness":                      vmSwappiness,
+			"vm_vfs_cache_pressure":              vmVfsCachePressure,
 		},
 	}, nil
 }

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -717,7 +717,7 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]containerservice.Manag
 }
 
 func expandAgentPoolKubeletConfig(input []interface{}) *containerservice.KubeletConfig {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 
@@ -758,7 +758,7 @@ func expandAgentPoolKubeletConfig(input []interface{}) *containerservice.Kubelet
 }
 
 func expandAgentPoolLinuxOSConfig(input []interface{}) (*containerservice.LinuxOSConfig, error) {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil, nil
 	}
 	raw := input[0].(map[string]interface{})
@@ -783,7 +783,7 @@ func expandAgentPoolLinuxOSConfig(input []interface{}) (*containerservice.LinuxO
 }
 
 func expandAgentPoolSysctlConfig(input []interface{}) (*containerservice.SysctlConfig, error) {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil, nil
 	}
 	raw := input[0].(map[string]interface{})

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -378,7 +378,7 @@ A `kubelet_config` block supports the following:
 
 * `container_log_max_line` - (Optional) Specifies the maximum number of container log files that can be present for a container. must be at least 2. Changing this forces a new resource to be created.
 
-* `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10Mi) of container log file before it is rotated. Changing this forces a new resource to be created.
+* `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10MB) of container log file before it is rotated. Changing this forces a new resource to be created.
 
 * `cpu_cfs_quota_enabled` - (Optional) Is CPU CFS quota enforcement for containers enabled? Changing this forces a new resource to be created.
 
@@ -386,9 +386,9 @@ A `kubelet_config` block supports the following:
 
 * `cpu_manager_policy` - (Optional) Specifies the CPU Manager policy to use. Possible values are `none` and `static`, Changing this forces a new resource to be created.
 
-* `image_gc_high_threshold` - (Optional) Specifies the percent of disk usage after which image garbage collection is always run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+* `image_gc_high_threshold` - (Optional) Specifies the percent of disk usage above which image garbage collection is always run. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
-* `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage before which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+* `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage lower than which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
 * `pod_max_pid` - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.
 
@@ -420,7 +420,7 @@ A `linux_os_config` block supports the following:
 
 * `sysctl_config` - (Optional) A `sysctl_config` block as defined below. Changing this forces a new resource to be created.
 
-* `transparent_huge_page_defrag` - (Optional) Specifies the Transparent Huge Page defrag configuration. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. Changing this forces a new resource to be created.
+* `transparent_huge_page_defrag` - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. Changing this forces a new resource to be created.
 
 * `transparent_huge_page_enabled` - (Optional) Specifies the Transparent Huge Page enabled configuration. Possible values are `always`, `madvise` and `never`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -540,6 +540,8 @@ A `ssh_key` block supports the following:
 
 A `sysctl_config` block supports the following:
 
+~> For more information, please refer to [Linux Kernel Doc](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/index.html).
+
 * `fs_aio_max_nr` - (Optional) The sysctl setting fs.aio-max-nr. Must be between `65536` and `6553500`. Changing this forces a new resource to be created.
 
 * `fs_file_max` - (Optional) The sysctl setting fs.file-max. Must be between `8192` and `12000500`. Changing this forces a new resource to be created.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -309,6 +309,10 @@ A `default_node_pool` block supports the following:
 
 * `enable_node_public_ip` - (Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to `false`. Changing this forces a new resource to be created.
 
+* `kubelet_config` - (Optional) A `kubelet_config` block as defined below.
+
+* `linux_os_config` - (Optional) A `linux_os_config` block as defined below.
+
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 
 * `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.
@@ -368,6 +372,30 @@ An `identity` block supports the following:
 
 ---
 
+A `kubelet_config` block supports the following:
+
+* `allowed_unsafe_sysctls` - (Optional) Specifies the allow list of unsafe sysctls command or patterns (ending in `*`). Changing this forces a new resource to be created.
+
+* `container_log_max_line` - (Optional) Specifies the maximum number of container log files that can be present for a container. must be at least 2. Changing this forces a new resource to be created.
+
+* `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10Mi) of container log file before it is rotated. Changing this forces a new resource to be created.
+
+* `cpu_cfs_quota_enabled` - (Optional) Is CPU CFS quota enforcement for containers enabled? Changing this forces a new resource to be created.
+
+* `cpu_cfs_quota_period` - (Optional) Specifies the CPU CFS quota period value. Changing this forces a new resource to be created.
+
+* `cpu_manager_policy` - (Optional) Specifies the CPU Manager policy to use. Possible values are `none` and `static`, Changing this forces a new resource to be created.
+
+* `image_gc_high_threshold` - (Optional) Specifies the percent of disk usage after which image garbage collection is always run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+* `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage before which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+* `pod_max_pid` - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.
+
+* `topology_manager_policy` - (Optional) Specifies the Topology Manager policy to use. Possible values are `none`, `best-effort`, `restricted` or `single-numa-node`. Changing this forces a new resource to be created.
+
+---
+
 The `kubelet_identity` block supports the following:
 
 * `client_id` - (Required) The Client ID of the user-defined Managed Identity to be assigned to the Kubelets. If not specified a Managed Identity is created automatically.
@@ -377,11 +405,24 @@ The `kubelet_identity` block supports the following:
 * `user_assigned_identity_id` - (Required) The ID of the User Assigned Identity assigned to the Kubelets. If not specified a Managed Identity is created automatically. 
 
 -> **NOTE:** The functionality to bring your own `kubelet_identity` is in Public Preview, and therefore has some limitations - please [see the Azure documentation for more information](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#limitations-2). It requires a BYO Cluster Identity  `identity.0.user_assigned_identity_id`) to be specified.
+
 ---
 
 A `kube_dashboard` block supports the following:
 
 * `enabled` - (Required) Is the Kubernetes Dashboard enabled?
+
+---
+
+A `linux_os_config` block supports the following:
+
+* `swap_file_size_mb` - (Optional) Specifies the size of swap file on each node in MB. Changing this forces a new resource to be created.
+
+* `sysctl_config` - (Optional) A `sysctl_config` block as defined below. Changing this forces a new resource to be created.
+
+* `transparent_huge_page_defrag` - (Optional) Specifies the Transparent Huge Page defrag configuration. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. Changing this forces a new resource to be created.
+
+* `transparent_huge_page_enabled` - (Optional) Specifies the Transparent Huge Page enabled configuration. Possible values are `always`, `madvise` and `never`. Changing this forces a new resource to be created.
 
 ---
 
@@ -494,6 +535,68 @@ A `service_principal` block supports the following:
 A `ssh_key` block supports the following:
 
 * `key_data` - (Required) The Public SSH Key used to access the cluster. Changing this forces a new resource to be created.
+
+---
+
+A `sysctl_config` block supports the following:
+
+* `fs_aio_max_nr` - (Optional) The sysctl setting fs.aio-max-nr. Must be between `65536` and `6553500`. Changing this forces a new resource to be created.
+
+* `fs_file_max` - (Optional) The sysctl setting fs.file-max. Must be between `8192` and `12000500`. Changing this forces a new resource to be created.
+
+* `fs_inotify_max_user_watches` - (Optional) The sysctl setting fs.inotify.max_user_watches. Must be between `781250` and `2097152`. Changing this forces a new resource to be created.
+
+* `fs_nr_open` - (Optional) The sysctl setting fs.nr_open. Must be between `8192` and `20000500`. Changing this forces a new resource to be created.
+
+* `kernel_threads_max` - (Optional) The sysctl setting kernel.threads-max. Must be between `20` and `513785`. Changing this forces a new resource to be created.
+
+* `net_core_netdev_max_backlog` - (Optional) The sysctl setting net.core.netdev_max_backlog. Must be between `1000` and `3240000`. Changing this forces a new resource to be created.
+
+* `net_core_optmem_max` - (Optional) The sysctl setting net.core.optmem_max. Must be between `20480` and `4194304`. Changing this forces a new resource to be created.
+
+* `net_core_rmem_default` - (Optional) The sysctl setting net.core.rmem_default. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_core_rmem_max` - (Optional) The sysctl setting net.core.rmem_max. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_core_somaxconn` - (Optional) The sysctl setting net.core.somaxconn. Must be between `4096` and `3240000`. Changing this forces a new resource to be created.
+
+* `net_core_wmem_default` - (Optional) The sysctl setting net.core.wmem_default. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_core_wmem_max` - (Optional) The sysctl setting net.core.wmem_max. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_ipv4_ip_local_port_range_max` - (Optional) The sysctl setting net.ipv4.ip_local_port_range max value. Must be between `1024` and `60999`. Changing this forces a new resource to be created.
+
+* `net_ipv4_ip_local_port_range_min` - (Optional) The sysctl setting net.ipv4.ip_local_port_range min value. Must be between `1024` and `60999`. Changing this forces a new resource to be created.
+
+* `net_ipv4_neigh_default_gc_thresh1` - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh1. Must be between `128` and `80000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_neigh_default_gc_thresh2` - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh2. Must be between `512` and `90000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_neigh_default_gc_thresh3` - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh3. Must be between `1024` and `100000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_fin_timeout` - (Optional) The sysctl setting net.ipv4.tcp_fin_timeout. Must be between `5` and `120`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_keepalive_intvl` - (Optional) The sysctl setting net.ipv4.tcp_keepalive_intvl. Must be between `10` and `75`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_keepalive_probes` - (Optional) The sysctl setting net.ipv4.tcp_keepalive_probes. Must be between `1` and `15`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_keepalive_time` - (Optional) The sysctl setting net.ipv4.tcp_keepalive_time. Must be between `30` and `432000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_max_syn_backlog` - (Optional) The sysctl setting net.ipv4.tcp_max_syn_backlog. Must be between `128` and `3240000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_max_tw_buckets` - (Optional) The sysctl setting net.ipv4.tcp_max_tw_buckets. Must be between `8000` and `1440000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_tw_reuse` - (Optional) The sysctl setting net.ipv4.tcp_tw_reuse. Changing this forces a new resource to be created.
+
+* `net_netfilter_nf_conntrack_buckets` - (Optional) The sysctl setting net.netfilter.nf_conntrack_buckets. Must be between `65536` and `147456`. Changing this forces a new resource to be created.
+
+* `net_netfilter_nf_conntrack_max` - (Optional) The sysctl setting net.netfilter.nf_conntrack_max. Must be between `131072` and `589824`. Changing this forces a new resource to be created.
+
+* `vm_max_map_count` - (Optional) The sysctl setting vm.max_map_count. Must be between `65530` and `262144`. Changing this forces a new resource to be created.
+
+* `vm_swappiness` - (Optional) The sysctl setting vm.swappiness. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+* `vm_vfs_cache_pressure` - (Optional) The sysctl setting vm.vfs_cache_pressure. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -157,7 +157,7 @@ A `kubelet_config` block supports the following:
 
 * `container_log_max_line` - (Optional) Specifies the maximum number of container log files that can be present for a container. must be at least 2. Changing this forces a new resource to be created.
 
-* `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10Mi) of container log file before it is rotated. Changing this forces a new resource to be created.
+* `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10MB) of container log file before it is rotated. Changing this forces a new resource to be created.
 
 * `cpu_cfs_quota_enabled` - (Optional) Is CPU CFS quota enforcement for containers enabled? Changing this forces a new resource to be created.
 
@@ -165,9 +165,9 @@ A `kubelet_config` block supports the following:
 
 * `cpu_manager_policy` - (Optional) Specifies the CPU Manager policy to use. Possible values are `none` and `static`, Changing this forces a new resource to be created.
 
-* `image_gc_high_threshold` - (Optional) Specifies the percent of disk usage after which image garbage collection is always run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+* `image_gc_high_threshold` - (Optional) Specifies the percent of disk usage above which image garbage collection is always run. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
-* `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage before which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+* `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage lower than which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
 * `pod_max_pids` - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.
 
@@ -181,7 +181,7 @@ A `linux_os_config` block supports the following:
 
 * `sysctl_config` - (Optional) A `sysctl_config` block as defined below. Changing this forces a new resource to be created.
 
-* `transparent_huge_page_defrag` - (Optional) Specifies the Transparent Huge Page defrag configuration. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. Changing this forces a new resource to be created.
+* `transparent_huge_page_defrag` - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. Changing this forces a new resource to be created.
 
 * `transparent_huge_page_enabled` - (Optional) Specifies the Transparent Huge Page enabled configuration. Possible values are `always`, `madvise` and `never`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -85,6 +85,10 @@ The following arguments are supported:
 
 -> **Note:** An Eviction Policy can only be configured when `priority` is set to `Spot`.
 
+* `kubelet_config` - (Optional) A `kubelet_config` block as defined below.
+
+* `linux_os_config` - (Optional) A `linux_os_config` block as defined below.
+
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 
 * `mode` - (Optional) Should this Node Pool be used for System or User resources? Possible values are `System` and `User`. Defaults to `User`.
@@ -144,6 +148,104 @@ If `enable_auto_scaling` is set to `true`, then the following fields can also be
 If `enable_auto_scaling` is set to `false`, then the following fields can also be configured:
 
 * `node_count` - (Required) The number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000`.
+
+---
+
+A `kubelet_config` block supports the following:
+
+* `allowed_unsafe_sysctls` - (Optional) Specifies the allow list of unsafe sysctls command or patterns (ending in `*`). Changing this forces a new resource to be created.
+
+* `container_log_max_line` - (Optional) Specifies the maximum number of container log files that can be present for a container. must be at least 2. Changing this forces a new resource to be created.
+
+* `container_log_max_size_mb` - (Optional) Specifies the maximum size (e.g. 10Mi) of container log file before it is rotated. Changing this forces a new resource to be created.
+
+* `cpu_cfs_quota_enabled` - (Optional) Is CPU CFS quota enforcement for containers enabled? Changing this forces a new resource to be created.
+
+* `cpu_cfs_quota_period` - (Optional) Specifies the CPU CFS quota period value. Changing this forces a new resource to be created.
+
+* `cpu_manager_policy` - (Optional) Specifies the CPU Manager policy to use. Possible values are `none` and `static`, Changing this forces a new resource to be created.
+
+* `image_gc_high_threshold` - (Optional) Specifies the percent of disk usage after which image garbage collection is always run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+* `image_gc_low_threshold` - (Optional) Specifies the percent of disk usage before which image garbage collection is never run. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+* `pod_max_pids` - (Optional) Specifies the maximum number of processes per pod. Changing this forces a new resource to be created.
+
+* `topology_manager_policy` - (Optional) Specifies the Topology Manager policy to use. Possible values are `none`, `best-effort`, `restricted` or `single-numa-node`. Changing this forces a new resource to be created.
+
+---
+
+A `linux_os_config` block supports the following:
+
+* `swap_file_size_mb` - (Optional) Specifies the size of swap file on each node in MB. Changing this forces a new resource to be created.
+
+* `sysctl_config` - (Optional) A `sysctl_config` block as defined below. Changing this forces a new resource to be created.
+
+* `transparent_huge_page_defrag` - (Optional) Specifies the Transparent Huge Page defrag configuration. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. Changing this forces a new resource to be created.
+
+* `transparent_huge_page_enabled` - (Optional) Specifies the Transparent Huge Page enabled configuration. Possible values are `always`, `madvise` and `never`. Changing this forces a new resource to be created.
+
+---
+
+A `sysctl_config` block supports the following:
+
+* `fs_aio_max_nr` - (Optional) The sysctl setting fs.aio-max-nr. Must be between `65536` and `6553500`. Changing this forces a new resource to be created.
+
+* `fs_file_max` - (Optional) The sysctl setting fs.file-max. Must be between `8192` and `12000500`. Changing this forces a new resource to be created.
+
+* `fs_inotify_max_user_watches` - (Optional) The sysctl setting fs.inotify.max_user_watches. Must be between `781250` and `2097152`. Changing this forces a new resource to be created.
+
+* `fs_nr_open` - (Optional) The sysctl setting fs.nr_open. Must be between `8192` and `20000500`. Changing this forces a new resource to be created.
+
+* `kernel_threads_max` - (Optional) The sysctl setting kernel.threads-max. Must be between `20` and `513785`. Changing this forces a new resource to be created.
+
+* `net_core_netdev_max_backlog` - (Optional) The sysctl setting net.core.netdev_max_backlog. Must be between `1000` and `3240000`. Changing this forces a new resource to be created.
+
+* `net_core_optmem_max` - (Optional) The sysctl setting net.core.optmem_max. Must be between `20480` and `4194304`. Changing this forces a new resource to be created.
+
+* `net_core_rmem_default` - (Optional) The sysctl setting net.core.rmem_default. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_core_rmem_max` - (Optional) The sysctl setting net.core.rmem_max. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_core_somaxconn` - (Optional) The sysctl setting net.core.somaxconn. Must be between `4096` and `3240000`. Changing this forces a new resource to be created.
+
+* `net_core_wmem_default` - (Optional) The sysctl setting net.core.wmem_default. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_core_wmem_max` - (Optional) The sysctl setting net.core.wmem_max. Must be between `212992` and `134217728`. Changing this forces a new resource to be created.
+
+* `net_ipv4_ip_local_port_range_max` - (Optional) The sysctl setting net.ipv4.ip_local_port_range max value. Must be between `1024` and `60999`. Changing this forces a new resource to be created.
+
+* `net_ipv4_ip_local_port_range_min` - (Optional) The sysctl setting net.ipv4.ip_local_port_range min value. Must be between `1024` and `60999`. Changing this forces a new resource to be created.
+
+* `net_ipv4_neigh_default_gc_thresh1` - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh1. Must be between `128` and `80000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_neigh_default_gc_thresh2` - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh2. Must be between `512` and `90000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_neigh_default_gc_thresh3` - (Optional) The sysctl setting net.ipv4.neigh.default.gc_thresh3. Must be between `1024` and `100000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_fin_timeout` - (Optional) The sysctl setting net.ipv4.tcp_fin_timeout. Must be between `5` and `120`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_keepalive_intvl` - (Optional) The sysctl setting net.ipv4.tcp_keepalive_intvl. Must be between `10` and `75`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_keepalive_probes` - (Optional) The sysctl setting net.ipv4.tcp_keepalive_probes. Must be between `1` and `15`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_keepalive_time` - (Optional) The sysctl setting net.ipv4.tcp_keepalive_time. Must be between `30` and `432000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_max_syn_backlog` - (Optional) The sysctl setting net.ipv4.tcp_max_syn_backlog. Must be between `128` and `3240000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_max_tw_buckets` - (Optional) The sysctl setting net.ipv4.tcp_max_tw_buckets. Must be between `8000` and `1440000`. Changing this forces a new resource to be created.
+
+* `net_ipv4_tcp_tw_reuse` - (Optional) Is sysctl setting net.ipv4.tcp_tw_reuse enabled? Changing this forces a new resource to be created.
+
+* `net_netfilter_nf_conntrack_buckets` - (Optional) The sysctl setting net.netfilter.nf_conntrack_buckets. Must be between `65536` and `147456`. Changing this forces a new resource to be created.
+
+* `net_netfilter_nf_conntrack_max` - (Optional) The sysctl setting net.netfilter.nf_conntrack_max. Must be between `131072` and `589824`. Changing this forces a new resource to be created.
+
+* `vm_max_map_count` - (Optional) The sysctl setting vm.max_map_count. Must be between `65530` and `262144`. Changing this forces a new resource to be created.
+
+* `vm_swappiness` - (Optional) The sysctl setting vm.swappiness. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+* `vm_vfs_cache_pressure` - (Optional) The sysctl setting vm.vfs_cache_pressure. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -189,6 +189,8 @@ A `linux_os_config` block supports the following:
 
 A `sysctl_config` block supports the following:
 
+~> For more information, please refer to [Linux Kernel Doc](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/index.html).
+
 * `fs_aio_max_nr` - (Optional) The sysctl setting fs.aio-max-nr. Must be between `65536` and `6553500`. Changing this forces a new resource to be created.
 
 * `fs_file_max` - (Optional) The sysctl setting fs.file-max. Must be between `8192` and `12000500`. Changing this forces a new resource to be created.


### PR DESCRIPTION
two new blocks in node pool: `kubelet_config`  and `linux_os_config`

`linux_os_config` contains a sub block "sysctl_config", which could set the the kernel parameters, could refer to https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/

this two blocks are forcenew fields, if we try to update it, the rest api will report error code: `CustomKubeletConfigOrCustomLinuxOSConfigCanNotBeChanged`. 

![image](https://user-images.githubusercontent.com/2786738/112598477-95af9100-8e49-11eb-93d0-cac5de8b1f7c.png)
