### PR TITLE
`azurerm_site_recovery_fabric` - Fixes error in checking for existing resource

### DIFF
--- a/azurerm/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/azurerm/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -65,7 +65,7 @@ func resourceSiteRecoveryFabricCreate(d *schema.ResourceData, meta interface{}) 
 		existing, err := client.Get(ctx, name)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) || !utils.ResponseWasBadRequest(existing.Response) {
+			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequest(existing.Response) {
 				return fmt.Errorf("Error checking for presence of existing site recovery fabric %s (vault %s): %+v", name, vaultName, err)
 			}
 		}


### PR DESCRIPTION
Fixes #11019 and the currently failing acceptance test TestAccSiteRecoveryFabric_basic