### PR TITLE
UserAssignedIdentityID - Parsing error message

### DIFF
--- a/azurerm/internal/services/msi/parse/user_assigned_identity.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity.go
@@ -77,7 +77,7 @@ func UserAssignedIdentityID(input string) (*UserAssignedIdentityId, error) {
 func UserAssignedIdentityIDInsensitively(input string) (*UserAssignedIdentityId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot parse User Assigned Identity ID: %q", input)
 	}
 
 	resourceId := UserAssignedIdentityId{

--- a/azurerm/internal/services/msi/parse/user_assigned_identity.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity.go
@@ -41,7 +41,7 @@ func (id UserAssignedIdentityId) ID() string {
 func UserAssignedIdentityID(input string) (*UserAssignedIdentityId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to parse User Assigned Identity ID: %q", input)
 	}
 
 	resourceId := UserAssignedIdentityId{

--- a/azurerm/internal/services/msi/parse/user_assigned_identity.go
+++ b/azurerm/internal/services/msi/parse/user_assigned_identity.go
@@ -41,7 +41,7 @@ func (id UserAssignedIdentityId) ID() string {
 func UserAssignedIdentityID(input string) (*UserAssignedIdentityId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse User Assigned Identity ID: %q", input)
+		return nil, fmt.Errorf("cannot parse User Assigned Identity ID: %q", input)
 	}
 
 	resourceId := UserAssignedIdentityId{


### PR DESCRIPTION
Making error message clearer when inputting wrong formatted user assigned identity id.

From this: `Cannot parse Azure ID: parse "6cf8cc26-e532-4519-893b-1902258efdb5": invalid URI for request`
To this: `cannot parse User Assigned Identity ID: "6cf8cc26-e532-4519-893b-1902258efdb5"`