### PR TITLE
`azurerm_spring_cloud_custom_domain`: `thumbprint` is required when specifying `certificate_name`

### DIFF
--- a/azurerm/internal/services/springcloud/spring_cloud_custom_domain_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_custom_domain_resource.go
@@ -62,6 +62,7 @@ func resourceSpringCloudCustomDomain() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"certificate_name"},
 			},
 		},
 	}

--- a/azurerm/internal/services/springcloud/spring_cloud_custom_domain_resource.go
+++ b/azurerm/internal/services/springcloud/spring_cloud_custom_domain_resource.go
@@ -55,6 +55,7 @@ func resourceSpringCloudCustomDomain() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+				RequiredWith: []string{"thumbprint"},
 			},
 
 			"thumbprint": {

--- a/website/docs/r/spring_cloud_custom_domain.html.markdown
+++ b/website/docs/r/spring_cloud_custom_domain.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `spring_cloud_app_id` - (Required) Specifies the resource ID of the Spring Cloud Application. Changing this forces a new resource to be created.
 
-* `certificate_name` - (Optional) Specifies the name of the Spring Cloud Certificate that binds to the Spring Cloud Custom Domain.
+* `certificate_name` - (Optional) Specifies the name of the Spring Cloud Certificate that binds to the Spring Cloud Custom Domain. Required when `thumbprint` is specified
 
 * `thumbprint` - (Optional) Specifies the thumbprint of the Spring Cloud Certificate that binds to the Spring Cloud Custom Domain. Required when `certificate_name` is specified. Changing this forces a new resource to be created.
 

--- a/website/docs/r/spring_cloud_custom_domain.html.markdown
+++ b/website/docs/r/spring_cloud_custom_domain.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `certificate_name` - (Optional) Specifies the name of the Spring Cloud Certificate that binds to the Spring Cloud Custom Domain.
 
-* `thumbprint` - (Optional) Specifies the thumbprint of the Spring Cloud Certificate that binds to the Spring Cloud Custom Domain. Changing this forces a new resource to be created.
+* `thumbprint` - (Optional) Specifies the thumbprint of the Spring Cloud Certificate that binds to the Spring Cloud Custom Domain. Required when `certificate_name` is specified. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
`azurerm_spring_cloud_custom_domain`: `thumbprint` is required when specifying `certificate_name`