### PR TITLE
`azurerm_eventgrid_data_connection`: add support for `table_name`, `mapping_rule_name` and `data_format`

### DIFF
--- a/website/docs/r/kusto_eventgrid_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventgrid_data_connection.html.markdown
@@ -120,7 +120,15 @@ The following arguments are supported:
   Values are `Microsoft.Storage.BlobCreated` and `Microsoft.Storage.BlobRenamed`. Defaults
   to `Microsoft.Storage.BlobCreated`.
 
+* `data_format` - (Optional) Specifies the data format of the EventHub messages. Allowed values: `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSV` and `TXT`
+
+* `mapping_rule_name` - (Optional) Specifies the mapping rule used for the message ingestion. Mapping rule must exist before resource is created.
+
+* `table_name` - (Optional) Specifies the target table name used for the message ingestion. Table must exist before resource is created.
+
 * `skip_first_record` - (Optional) is the first record of every file ignored? Defaults to `false`.
+
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
`azurerm_eventgrid_data_connection`: add support for `table_name`, `mapping_rule_name` and `data_format`

```
$ make acctests SERVICE='kusto' TESTARGS='-run=TestAccKustoEventGridDataConnection_mappingRule' TESTTIMEOUT='600m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/kusto -run=TestAccKustoEventGridDataConnection_mappingRule -timeout 600m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/03/30 16:20:12 [DEBUG] not using binary driver name, it's no longer needed
2021/03/30 16:20:12 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccKustoEventGridDataConnection_mappingRule
=== PAUSE TestAccKustoEventGridDataConnection_mappingRule
=== CONT  TestAccKustoEventGridDataConnection_mappingRule
--- PASS: TestAccKustoEventGridDataConnection_mappingRule (1647.62s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/kusto	1648.919s
```

Fixes #10977