### PR TITLE
`azurerm_function_app`: Support for "client_cert_mode" and "client_cert_enabled" for Function Apps

### DIFF
--- a/azurerm/internal/services/web/function_app_data_source.go
+++ b/azurerm/internal/services/web/function_app_data_source.go
@@ -221,14 +221,6 @@ func dataSourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
 
-		if clientCertEnabled := props.ClientCertEnabled; clientCertEnabled != nil {
-			if *clientCertEnabled {
-				d.Set("client_cert_mode", props.ClientCertMode)
-			} else {
-				d.Set("client_cert_mode", "Ignore")
-			}
-		}
-
 		clientCertMode := ""
 		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {
 			clientCertMode = string(props.ClientCertMode)

--- a/azurerm/internal/services/web/function_app_data_source.go
+++ b/azurerm/internal/services/web/function_app_data_source.go
@@ -88,6 +88,11 @@ func dataSourceFunctionApp() *schema.Resource {
 				Computed: true,
 			},
 
+			"client_cert_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"outbound_ip_addresses": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -212,6 +217,7 @@ func dataSourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("enabled", props.Enabled)
 		d.Set("default_hostname", props.DefaultHostName)
+		d.Set("client_cert_enabled", props.ClientCertEnabled)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)

--- a/azurerm/internal/services/web/function_app_data_source.go
+++ b/azurerm/internal/services/web/function_app_data_source.go
@@ -217,10 +217,17 @@ func dataSourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("enabled", props.Enabled)
 		d.Set("default_hostname", props.DefaultHostName)
-		d.Set("client_cert_enabled", props.ClientCertEnabled)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
+
+		if clientCertEnabled := props.ClientCertEnabled; clientCertEnabled != nil {
+			if *clientCertEnabled {
+				d.Set("client_cert_mode", props.ClientCertMode)
+			} else {
+				d.Set("client_cert_mode", "Ignore")
+			}
+		}
 	}
 
 	osType := ""

--- a/azurerm/internal/services/web/function_app_data_source.go
+++ b/azurerm/internal/services/web/function_app_data_source.go
@@ -88,8 +88,8 @@ func dataSourceFunctionApp() *schema.Resource {
 				Computed: true,
 			},
 
-			"client_cert_enabled": {
-				Type:     schema.TypeBool,
+			"client_cert_mode": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 

--- a/azurerm/internal/services/web/function_app_data_source.go
+++ b/azurerm/internal/services/web/function_app_data_source.go
@@ -227,7 +227,11 @@ func dataSourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 			} else {
 				d.Set("client_cert_mode", "Ignore")
 			}
+		clientCertMode := ""
+		if props.ClientCertMode != nil {
+			clientCertMode = props.ClientCertMode
 		}
+		d.Set("client_cert_mode", clientCertMode)
 	}
 
 	osType := ""

--- a/azurerm/internal/services/web/function_app_data_source.go
+++ b/azurerm/internal/services/web/function_app_data_source.go
@@ -227,9 +227,11 @@ func dataSourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 			} else {
 				d.Set("client_cert_mode", "Ignore")
 			}
+		}
+
 		clientCertMode := ""
-		if props.ClientCertMode != nil {
-			clientCertMode = props.ClientCertMode
+		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {
+			clientCertMode = string(props.ClientCertMode)
 		}
 		d.Set("client_cert_mode", clientCertMode)
 	}

--- a/azurerm/internal/services/web/function_app_data_source_test.go
+++ b/azurerm/internal/services/web/function_app_data_source_test.go
@@ -88,9 +88,21 @@ func TestAccFunctionAppDataSource_clientCertMode(t *testing.T) {
 
 	data.DataSourceTest(t, []resource.TestStep{
 		{
+			Config: FunctionAppDataSource{}.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue(""),
+			),
+		},
+		{
 			Config: FunctionAppDataSource{}.certClientMode(data, "Optional"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Optional"),
+			),
+		},
+		{
+			Config: FunctionAppDataSource{}.certClientMode(data, "Required"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Required"),
 			),
 		},
 	})

--- a/azurerm/internal/services/web/function_app_data_source_test.go
+++ b/azurerm/internal/services/web/function_app_data_source_test.go
@@ -83,6 +83,19 @@ func TestAccFunctionAppDataSource_siteConfig(t *testing.T) {
 	})
 }
 
+func TestAccFunctionAppDataSource_clientCertMode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: FunctionAppDataSource{}.certClientMode(data, "Optional"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Optional"),
+			),
+		},
+	})
+}
+
 func (d FunctionAppDataSource) basic(data acceptance.TestData) string {
 	template := FunctionAppResource{}.basic(data)
 	return fmt.Sprintf(`
@@ -141,4 +154,16 @@ data "azurerm_function_app" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, config)
+}
+
+func (d FunctionAppDataSource) certClientMode(data acceptance.TestData, modeValue string) string {
+	template := FunctionAppResource{}.clientCertMode(data, modeValue)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_function_app" "test" {
+  name                = azurerm_function_app.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
 }

--- a/azurerm/internal/services/web/function_app_resource.go
+++ b/azurerm/internal/services/web/function_app_resource.go
@@ -115,6 +115,12 @@ func resourceFunctionApp() *schema.Resource {
 				Computed: true,
 			},
 
+			"client_cert_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"daily_memory_time_quota": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -287,6 +293,7 @@ func resourceFunctionAppCreate(d *schema.ResourceData, meta interface{}) error {
 	appServicePlanID := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	clientAffinityEnabled := d.Get("client_affinity_enabled").(bool)
+	clientCertEnabled := d.Get("client_cert_enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
 	dailyMemoryTimeQuota := d.Get("daily_memory_time_quota").(int)
 	t := d.Get("tags").(map[string]interface{})
@@ -315,6 +322,7 @@ func resourceFunctionAppCreate(d *schema.ResourceData, meta interface{}) error {
 			ServerFarmID:          utils.String(appServicePlanID),
 			Enabled:               utils.Bool(enabled),
 			ClientAffinityEnabled: utils.Bool(clientAffinityEnabled),
+			ClientCertEnabled:     utils.Bool(clientCertEnabled),
 			HTTPSOnly:             utils.Bool(httpsOnly),
 			DailyMemoryTimeQuota:  utils.Int32(int32(dailyMemoryTimeQuota)),
 			SiteConfig:            &siteConfig,
@@ -399,6 +407,7 @@ func resourceFunctionAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	appServicePlanID := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	clientAffinityEnabled := d.Get("client_affinity_enabled").(bool)
+	clientCertEnabled := d.Get("client_cert_enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
 	dailyMemoryTimeQuota := d.Get("daily_memory_time_quota").(int)
 	t := d.Get("tags").(map[string]interface{})
@@ -428,6 +437,7 @@ func resourceFunctionAppUpdate(d *schema.ResourceData, meta interface{}) error {
 			ServerFarmID:          utils.String(appServicePlanID),
 			Enabled:               utils.Bool(enabled),
 			ClientAffinityEnabled: utils.Bool(clientAffinityEnabled),
+			ClientCertEnabled:     utils.Bool(clientCertEnabled),
 			HTTPSOnly:             utils.Bool(httpsOnly),
 			DailyMemoryTimeQuota:  utils.Int32(int32(dailyMemoryTimeQuota)),
 			SiteConfig:            &siteConfig,
@@ -610,6 +620,7 @@ func resourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
+		d.Set("client_cert_enabled", props.ClientCertEnabled)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
 	}
 

--- a/azurerm/internal/services/web/function_app_resource.go
+++ b/azurerm/internal/services/web/function_app_resource.go
@@ -297,7 +297,7 @@ func resourceFunctionAppCreate(d *schema.ResourceData, meta interface{}) error {
 	enabled := d.Get("enabled").(bool)
 	clientAffinityEnabled := d.Get("client_affinity_enabled").(bool)
 	clientCertMode := d.Get("client_cert_mode").(string)
-	clientCertEnabled := clientCertMode != "Ignore"
+	clientCertEnabled := clientCertMode != ""
 	httpsOnly := d.Get("https_only").(bool)
 	dailyMemoryTimeQuota := d.Get("daily_memory_time_quota").(int)
 	t := d.Get("tags").(map[string]interface{})
@@ -453,7 +453,7 @@ func resourceFunctionAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		},
 	}
 
-	if clientCertEnabled {
+	if clientCertMode != "" {
 		siteEnvelope.SiteProperties.ClientCertMode = web.ClientCertMode(clientCertMode)
 	}
 
@@ -636,8 +636,8 @@ func resourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
 
 		clientCertMode := ""
-		if props.ClientCertEnabled != nil {
-			clientCertMode = *props.ClientCertMode
+		if props.ClientCertEnabled != nil && *props.ClientCertEnabled {
+			clientCertMode = string(props.ClientCertMode)
 		}
 		d.Set("client_cert_mode", clientCertMode)
 	}

--- a/azurerm/internal/services/web/function_app_resource.go
+++ b/azurerm/internal/services/web/function_app_resource.go
@@ -121,9 +121,7 @@ func resourceFunctionApp() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"Required",
 					"Optional",
-					"Ignore",
 				}, false),
-				Default: "Ignore",
 			},
 
 			"daily_memory_time_quota": {
@@ -335,7 +333,7 @@ func resourceFunctionAppCreate(d *schema.ResourceData, meta interface{}) error {
 		},
 	}
 
-	if clientCertEnabled {
+	if clientCertMode != "" {
 		siteEnvelope.SiteProperties.ClientCertMode = web.ClientCertMode(clientCertMode)
 	}
 
@@ -418,7 +416,7 @@ func resourceFunctionAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	enabled := d.Get("enabled").(bool)
 	clientAffinityEnabled := d.Get("client_affinity_enabled").(bool)
 	clientCertMode := d.Get("client_cert_mode").(string)
-	clientCertEnabled := clientCertMode != "Ignore"
+	clientCertEnabled := clientCertMode != ""
 	httpsOnly := d.Get("https_only").(bool)
 	dailyMemoryTimeQuota := d.Get("daily_memory_time_quota").(int)
 	t := d.Get("tags").(map[string]interface{})
@@ -637,13 +635,11 @@ func resourceFunctionAppRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("custom_domain_verification_id", props.CustomDomainVerificationID)
 
-		if clientCertEnabled := props.ClientCertEnabled; clientCertEnabled != nil {
-			if *clientCertEnabled {
-				d.Set("client_cert_mode", props.ClientCertMode)
-			} else {
-				d.Set("client_cert_mode", "Ignore")
-			}
+		clientCertMode := ""
+		if props.ClientCertEnabled != nil {
+			clientCertMode = *props.ClientCertMode
 		}
+		d.Set("client_cert_mode", clientCertMode)
 	}
 
 	appSettings := flattenAppServiceAppSettings(appSettingsResp.Properties)

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -910,7 +910,7 @@ func TestAccFunctionApp_clientCertMode(t *testing.T) {
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Ignore"),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue(""),
 			),
 		},
 		{
@@ -928,10 +928,10 @@ func TestAccFunctionApp_clientCertMode(t *testing.T) {
 			),
 		},
 		{
-			Config: r.clientCertMode(data, "Ignore"),
+			Config: r.basic(),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Ignore"),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue(""),
 			),
 		},
 		data.ImportStep(),

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -928,7 +928,7 @@ func TestAccFunctionApp_clientCertMode(t *testing.T) {
 			),
 		},
 		{
-			Config: r.basic(),
+			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("client_cert_mode").HasValue(""),

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -901,6 +901,29 @@ func TestAccFunctionApp_scm(t *testing.T) {
 	})
 }
 
+func TestAccFunctionAppDataSource_clientCertEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
+	r := FunctionAppResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.clientCertEnabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("client_cert_enabled").HasValue("true"),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("client_cert_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r FunctionAppResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.FunctionAppID(state.ID)
 	if err != nil {
@@ -2941,6 +2964,48 @@ resource "azurerm_function_app" "test" {
     scm_type                  = "LocalGit"
     use_32_bit_worker_process = false
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r FunctionAppResource) clientCertEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                       = "acctest-%[1]d-func"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  app_service_plan_id        = azurerm_app_service_plan.test.id
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+  client_cert_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/web/function_app_resource_test.go
+++ b/azurerm/internal/services/web/function_app_resource_test.go
@@ -901,23 +901,37 @@ func TestAccFunctionApp_scm(t *testing.T) {
 	})
 }
 
-func TestAccFunctionAppDataSource_clientCertEnabled(t *testing.T) {
+func TestAccFunctionApp_clientCertMode(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.clientCertEnabled(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_cert_enabled").HasValue("true"),
-			),
-		},
-		{
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("client_cert_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Ignore"),
+			),
+		},
+		{
+			Config: r.clientCertMode(data, "Required"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Required"),
+			),
+		},
+		{
+			Config: r.clientCertMode(data, "Optional"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Optional"),
+			),
+		},
+		{
+			Config: r.clientCertMode(data, "Ignore"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("client_cert_mode").HasValue("Ignore"),
 			),
 		},
 		data.ImportStep(),
@@ -2968,7 +2982,7 @@ resource "azurerm_function_app" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r FunctionAppResource) clientCertEnabled(data acceptance.TestData) string {
+func (r FunctionAppResource) clientCertMode(data acceptance.TestData, modeValue string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -3005,7 +3019,7 @@ resource "azurerm_function_app" "test" {
   app_service_plan_id        = azurerm_app_service_plan.test.id
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
-  client_cert_enabled = true
+  client_cert_mode           = "%[4]s"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, modeValue)
 }

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -50,7 +50,7 @@ The following attributes are exported:
 
 * `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.
 
-`client_cert_enabled` - Is the Function App client certificates enabled for incoming requests?
+* `client_cert_mode` - The mode of the Function App's client certificates requirement for incoming requests.
 
 * `os_type` - A string indicating the Operating System type for this function app.
 

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -50,6 +50,8 @@ The following attributes are exported:
 
 * `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.
 
+`client_cert_enabled` - Is the Function App client certificates enabled for incoming requests?
+
 * `os_type` - A string indicating the Operating System type for this function app.
 
 ~> **NOTE:** This value will be `linux` for Linux Derivatives, or an empty string for Windows. 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -146,7 +146,7 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance?
 
-* `client_cert_enabled` - (Optional) Should the Function App enable client certificates for incoming requests? Defaults to `false`.
+* `client_cert_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are "Required", "Optional", and "Ignore". Defaults to "Ignore".
 
 * `daily_memory_time_quota` - (Optional) The amount of memory in gigabyte-seconds that your application is allowed to consume per day. Setting this value only affects function apps under the consumption plan. Defaults to `0`.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -146,6 +146,8 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance?
 
+* `client_cert_enabled` - (Optional) Should the Function App enable client certificates for incoming requests? Defaults to `false`.
+
 * `daily_memory_time_quota` - (Optional) The amount of memory in gigabyte-seconds that your application is allowed to consume per day. Setting this value only affects function apps under the consumption plan. Defaults to `0`.
 
 * `enabled` - (Optional) Is the Function App enabled?

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -146,7 +146,7 @@ The following arguments are supported:
 
 * `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance?
 
-* `client_cert_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are "Required", "Optional", and "Ignore". Defaults to "Ignore".
+* `client_cert_mode` - (Optional) The mode of the Function App's client certificates requirement for incoming requests. Possible values are `Required` and `Optional`.
 
 * `daily_memory_time_quota` - (Optional) The amount of memory in gigabyte-seconds that your application is allowed to consume per day. Setting this value only affects function apps under the consumption plan. Defaults to `0`.
 


### PR DESCRIPTION
PR closes #5006

Changes:
* Implements `client_cert_mode` that takes in one of three possible values: "Required", "Optional", "Ignore"
  * Depending on the value, it will properly set the values of `client_cert_enabled` and `client_cert_mode` on the ARM client

TestResult:
```
❯ go test -timeout 30m -run ^TestAccFunctionApp_clientCertMode$ github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web -v
2021/03/30 15:31:30 [DEBUG] not using binary driver name, it's no longer needed
2021/03/30 15:31:30 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccFunctionApp_clientCertMode
=== PAUSE TestAccFunctionApp_clientCertMode
=== CONT  TestAccFunctionApp_clientCertMode
--- PASS: TestAccFunctionApp_clientCertMode (284.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web 284.133s
```

