### PR TITLE
`azurerm_container_registry` - deprecated `classic` `sku` and `storage_account_id`

### DIFF
--- a/azurerm/internal/services/containers/container_registry_data_source.go
+++ b/azurerm/internal/services/containers/container_registry_data_source.go
@@ -56,11 +56,6 @@ func dataSourceContainerRegistry() *schema.Resource {
 				Computed: true,
 			},
 
-			"storage_account_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -94,10 +89,6 @@ func dataSourceContainerRegistryRead(d *schema.ResourceData, meta interface{}) e
 
 	if sku := resp.Sku; sku != nil {
 		d.Set("sku", string(sku.Tier))
-	}
-
-	if account := resp.StorageAccount; account != nil {
-		d.Set("storage_account_id", account.ID)
 	}
 
 	if *resp.AdminUserEnabled {

--- a/website/docs/d/container_registry.markdown
+++ b/website/docs/d/container_registry.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 * `sku` - The SKU of this Container Registry, such as `Basic`.
 
-* `storage_account_id` - The ID of the Storage Account used for this Container Registry. This is only returned for `Classic` SKU's.
-
 * `tags` - A map of tags assigned to the Container Registry.
 
 ## Timeouts

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -44,8 +44,6 @@ The following arguments are supported:
 
 * `admin_enabled` - (Optional) Specifies whether the admin user is enabled. Defaults to `false`.
 
-* `storage_account_id` - (Required for `Classic` Sku - Forbidden otherwise) The ID of a Storage Account which must be located in the same Azure Region as the Container Registry.  Changing this forces a new resource to be created.
-
 * `sku` - (Optional) The SKU name of the container registry. Possible values are  `Basic`, `Standard` and `Premium`. `Classic` (which was previously `Basic`) is supported only for existing resources.
 
 ~> **NOTE:** The `Classic` SKU is Deprecated and will no longer be available for new resources from the end of March 2019.

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -44,9 +44,7 @@ The following arguments are supported:
 
 * `admin_enabled` - (Optional) Specifies whether the admin user is enabled. Defaults to `false`.
 
-* `sku` - (Optional) The SKU name of the container registry. Possible values are  `Basic`, `Standard` and `Premium`. `Classic` (which was previously `Basic`) is supported only for existing resources.
-
-~> **NOTE:** The `Classic` SKU is Deprecated and will no longer be available for new resources from the end of March 2019.
+* `sku` - (Optional) The SKU name of the container registry. Possible values are  `Basic`, `Standard` and `Premium`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
The `classic` sku is deprecated by service. The
[document](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-skus) even doesn't show it up. Meanwhile, the service reject this sku for (at least) `PUT` request, (at least) since 2017-10-01 (used by provider v2.0.0).

Since `storage_account_id` is used together with `classic` sku, this proeprty is also useless. Furthermore, this property has been removed in [Swagger](https://github.com/Azure/azure-rest-api-specs/pull/13001).

Besides, confirmed with ACR team that all the classic instances should have been migrated today. So it should be safe to deprecate this sku.