### PR TITLE
`azurerm_app_service` and `azurerm_function_app` - Fix broken `ip_restrictions` and `scm_ip_restrictions` updates 

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -845,18 +845,8 @@ func schemaAppServiceIpRestriction() *schema.Schema {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
-				"subnet_id": {
-					// TODO - Remove in 3.0
-					Type:         schema.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					Deprecated:   "This field has been deprecated in favour of `virtual_network_subnet_id` and will be removed in a future version of the provider",
-				},
-
 				"virtual_network_subnet_id": {
 					Type:         schema.TypeString,
-					Computed:     true, // TODO Remove `Computed` in 3.0
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
@@ -899,27 +889,27 @@ func schemaAppServiceDataSourceIpRestriction() *schema.Schema {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+
 				"service_tag": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"subnet_id": {
-					// TODO - Remove in 3.0
-					Type:     schema.TypeString,
-					Computed: true,
-				},
+
 				"virtual_network_subnet_id": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+
 				"name": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
+
 				"priority": {
 					Type:     schema.TypeInt,
 					Computed: true,
 				},
+
 				"action": {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -1814,7 +1804,6 @@ func flattenAppServiceIpRestriction(input *[]web.IPSecurityRestriction) []interf
 			subnetId = *subnetIdRaw
 		}
 		restriction["virtual_network_subnet_id"] = subnetId
-		restriction["subnet_id"] = subnetId
 
 		name := ""
 		if nameRaw := v.Name; nameRaw != nil {
@@ -1902,10 +1891,6 @@ func expandAppServiceIpRestriction(input interface{}) ([]web.IPSecurityRestricti
 
 		ipAddress := restriction["ip_address"].(string)
 		vNetSubnetID := ""
-
-		if subnetID, ok := restriction["subnet_id"]; ok && subnetID != "" {
-			vNetSubnetID = subnetID.(string)
-		}
 
 		if subnetID, ok := restriction["virtual_network_subnet_id"]; ok && subnetID != "" {
 			vNetSubnetID = subnetID.(string)

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1809,22 +1809,30 @@ func flattenAppServiceIpRestriction(input *[]web.IPSecurityRestriction) []interf
 			}
 		}
 
-		if subnetId := v.VnetSubnetResourceID; subnetId != nil {
-			restriction["virtual_network_subnet_id"] = subnetId
-			restriction["subnet_id"] = subnetId
+		subnetId := ""
+		if subnetIdRaw := v.VnetSubnetResourceID; subnetIdRaw != nil {
+			subnetId = *subnetIdRaw
 		}
+		restriction["virtual_network_subnet_id"] = subnetId
+		restriction["subnet_id"] = subnetId
 
-		if name := v.Name; name != nil {
-			restriction["name"] = *name
+		name := ""
+		if nameRaw := v.Name; nameRaw != nil {
+			name = *nameRaw
 		}
+		restriction["name"] = name
 
-		if priority := v.Priority; priority != nil {
-			restriction["priority"] = *priority
+		priority := 0
+		if priorityRaw := v.Priority; priorityRaw != nil {
+			priority = int(*priorityRaw)
 		}
+		restriction["priority"] = priority
 
-		if action := v.Action; action != nil {
-			restriction["action"] = *action
+		action := ""
+		if actionRaw := v.Action; actionRaw != nil {
+			action = *actionRaw
 		}
+		restriction["action"] = action
 
 		restrictions = append(restrictions, restriction)
 	}
@@ -1895,11 +1903,11 @@ func expandAppServiceIpRestriction(input interface{}) ([]web.IPSecurityRestricti
 		ipAddress := restriction["ip_address"].(string)
 		vNetSubnetID := ""
 
-		if subnetID, ok := restriction["subnet_id"]; ok {
+		if subnetID, ok := restriction["subnet_id"]; ok && subnetID != "" {
 			vNetSubnetID = subnetID.(string)
 		}
 
-		if subnetID, ok := restriction["virtual_network_subnet_id"]; ok {
+		if subnetID, ok := restriction["virtual_network_subnet_id"]; ok && subnetID != "" {
 			vNetSubnetID = subnetID.(string)
 		}
 

--- a/azurerm/internal/services/web/app_service_resource.go
+++ b/azurerm/internal/services/web/app_service_resource.go
@@ -315,7 +315,7 @@ func resourceAppServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	read, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving App Service %q (Resource Group %q): %s", name, resourceGroup, err)
+		return fmt.Errorf("retrieving App Service %q (Resource Group %q): %s", name, resourceGroup, err)
 	}
 
 	if read.ID == nil || *read.ID == "" {
@@ -333,7 +333,7 @@ func resourceAppServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, err := client.UpdateAuthSettings(ctx, resourceGroup, name, auth); err != nil {
-		return fmt.Errorf("Error updating auth settings for App Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("updating auth settings for App Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	logsConfig := expandAppServiceLogs(d.Get("logs"))
@@ -344,13 +344,13 @@ func resourceAppServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if _, err := client.UpdateDiagnosticLogsConfig(ctx, resourceGroup, name, logs); err != nil {
-		return fmt.Errorf("Error updating diagnostic logs config for App Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("updating diagnostic logs config for App Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	backupRaw := d.Get("backup").([]interface{})
 	if backup := expandAppServiceBackup(backupRaw); backup != nil {
 		if _, err = client.UpdateBackupConfiguration(ctx, resourceGroup, name, *backup); err != nil {
-			return fmt.Errorf("Error updating Backup Settings for App Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+			return fmt.Errorf("updating Backup Settings for App Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
 
@@ -376,7 +376,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
 	if err != nil {
-		return fmt.Errorf("Error expanding `site_config` for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+		return fmt.Errorf("expanding `site_config` for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
 	}
 
 	siteEnvelope := web.Site{
@@ -410,7 +410,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		// update the main configuration
 		siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
 		if err != nil {
-			return fmt.Errorf("Error expanding `site_config` for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+			return fmt.Errorf("expanding `site_config` for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
 		}
 		siteConfigResource := web.SiteConfigResource{
 			SiteConfig: siteConfig,
@@ -423,7 +423,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.CreateOrUpdateConfiguration(ctx, id.ResourceGroup, id.SiteName, siteConfigResource); err != nil {
-			return fmt.Errorf("Error updating Configuration for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Configuration for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -457,7 +457,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.UpdateAuthSettings(ctx, id.ResourceGroup, id.SiteName, authSettings); err != nil {
-			return fmt.Errorf("Error updating Authentication Settings for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Authentication Settings for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -465,11 +465,11 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		backupRaw := d.Get("backup").([]interface{})
 		if backup := expandAppServiceBackup(backupRaw); backup != nil {
 			if _, err = client.UpdateBackupConfiguration(ctx, id.ResourceGroup, id.SiteName, *backup); err != nil {
-				return fmt.Errorf("Error updating Backup Settings for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+				return fmt.Errorf("updating Backup Settings for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
 			}
 		} else {
 			if _, err = client.DeleteBackupConfiguration(ctx, id.ResourceGroup, id.SiteName); err != nil {
-				return fmt.Errorf("Error removing Backup Settings for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
+				return fmt.Errorf("removing Backup Settings for App Service %q (Resource Group %q): %s", id.SiteName, id.ResourceGroup, err)
 			}
 		}
 	}
@@ -485,7 +485,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.Update(ctx, id.ResourceGroup, id.SiteName, sitePatchResource); err != nil {
-			return fmt.Errorf("Error updating App Service ARR Affinity setting %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating App Service ARR Affinity setting %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -498,7 +498,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.UpdateApplicationSettings(ctx, id.ResourceGroup, id.SiteName, settings); err != nil {
-			return fmt.Errorf("Error updating Application Settings for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Application Settings for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -516,7 +516,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.UpdateDiagnosticLogsConfig(ctx, id.ResourceGroup, id.SiteName, logsResource); err != nil {
-			return fmt.Errorf("Error updating Diagnostics Logs for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Diagnostics Logs for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -528,7 +528,7 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.UpdateAzureStorageAccounts(ctx, id.ResourceGroup, id.SiteName, properties); err != nil {
-			return fmt.Errorf("Error updating Storage Accounts for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Storage Accounts for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -540,14 +540,14 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if _, err := client.UpdateConnectionStrings(ctx, id.ResourceGroup, id.SiteName, properties); err != nil {
-			return fmt.Errorf("Error updating Connection Strings for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Connection Strings for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
 	if d.HasChange("identity") {
 		site, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
 		if err != nil {
-			return fmt.Errorf("Error getting configuration for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("getting configuration for App Service %q: %+v", id.SiteName, err)
 		}
 
 		appServiceIdentityRaw := d.Get("identity").([]interface{})
@@ -556,11 +556,11 @@ func resourceAppServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, site)
 		if err != nil {
-			return fmt.Errorf("Error updating Managed Service Identity for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Managed Service Identity for App Service %q: %+v", id.SiteName, err)
 		}
 
 		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error updating Managed Service Identity for App Service %q: %+v", id.SiteName, err)
+			return fmt.Errorf("updating Managed Service Identity for App Service %q: %+v", id.SiteName, err)
 		}
 	}
 
@@ -584,7 +584,7 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service %q: %+v", id.SiteName, err)
 	}
 
 	configResp, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)
@@ -594,24 +594,24 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service Configuration %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service Configuration %q: %+v", id.SiteName, err)
 	}
 
 	authResp, err := client.GetAuthSettings(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the AuthSettings for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving the AuthSettings for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
 
 	backupResp, err := client.GetBackupConfiguration(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(backupResp.Response) {
-			return fmt.Errorf("Error retrieving the BackupConfiguration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
+			return fmt.Errorf("retrieving the BackupConfiguration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 		}
 	}
 
 	logsResp, err := client.GetDiagnosticLogsConfiguration(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the DiagnosticsLogsConfiguration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving the DiagnosticsLogsConfiguration for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
 
 	appSettingsResp, err := client.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
@@ -621,22 +621,22 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service AppSettings %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service AppSettings %q: %+v", id.SiteName, err)
 	}
 
 	storageAccountsResp, err := client.ListAzureStorageAccounts(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service Storage Accounts %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service Storage Accounts %q: %+v", id.SiteName, err)
 	}
 
 	connectionStringsResp, err := client.ListConnectionStrings(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service ConnectionStrings %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service ConnectionStrings %q: %+v", id.SiteName, err)
 	}
 
 	scmResp, err := client.GetSourceControl(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service Source Control %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service Source Control %q: %+v", id.SiteName, err)
 	}
 
 	siteCredFuture, err := client.ListPublishingCredentials(ctx, id.ResourceGroup, id.SiteName)
@@ -649,7 +649,7 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	siteCredResp, err := siteCredFuture.Result(*client)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service Site Credential %q: %+v", id.SiteName, err)
+		return fmt.Errorf("making Read request on AzureRM App Service Site Credential %q: %+v", id.SiteName, err)
 	}
 
 	d.Set("name", id.SiteName)
@@ -685,19 +685,19 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 	delete(appSettings, "WEBSITE_HTTPLOGGING_RETENTION_DAYS")
 
 	if err := d.Set("app_settings", appSettings); err != nil {
-		return fmt.Errorf("Error setting `app_settings`: %s", err)
+		return fmt.Errorf("setting `app_settings`: %s", err)
 	}
 
 	if err := d.Set("backup", flattenAppServiceBackup(backupResp.BackupRequestProperties)); err != nil {
-		return fmt.Errorf("Error setting `backup`: %s", err)
+		return fmt.Errorf("setting `backup`: %s", err)
 	}
 
 	if err := d.Set("storage_account", flattenAppServiceStorageAccounts(storageAccountsResp.Properties)); err != nil {
-		return fmt.Errorf("Error setting `storage_account`: %s", err)
+		return fmt.Errorf("setting `storage_account`: %s", err)
 	}
 
 	if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
-		return fmt.Errorf("Error setting `connection_string`: %s", err)
+		return fmt.Errorf("setting `connection_string`: %s", err)
 	}
 
 	siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
@@ -707,22 +707,22 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	authSettings := flattenAppServiceAuthSettings(authResp.SiteAuthSettingsProperties)
 	if err := d.Set("auth_settings", authSettings); err != nil {
-		return fmt.Errorf("Error setting `auth_settings`: %s", err)
+		return fmt.Errorf("setting `auth_settings`: %s", err)
 	}
 
 	logs := flattenAppServiceLogs(logsResp.SiteLogsConfigProperties)
 	if err := d.Set("logs", logs); err != nil {
-		return fmt.Errorf("Error setting `logs`: %s", err)
+		return fmt.Errorf("setting `logs`: %s", err)
 	}
 
 	scm := flattenAppServiceSourceControl(scmResp.SiteSourceControlProperties)
 	if err := d.Set("source_control", scm); err != nil {
-		return fmt.Errorf("Error setting `source_control`: %s", err)
+		return fmt.Errorf("setting `source_control`: %s", err)
 	}
 
 	siteCred := flattenAppServiceSiteCredential(siteCredResp.UserProperties)
 	if err := d.Set("site_credential", siteCred); err != nil {
-		return fmt.Errorf("Error setting `site_credential`: %s", err)
+		return fmt.Errorf("setting `site_credential`: %s", err)
 	}
 
 	identity, err := flattenAppServiceIdentity(resp.Identity)
@@ -730,7 +730,7 @@ func resourceAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 	if err := d.Set("identity", identity); err != nil {
-		return fmt.Errorf("Error setting `identity`: %s", err)
+		return fmt.Errorf("setting `identity`: %s", err)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -543,6 +543,38 @@ func TestAccAppService_oneVNetSubnetIpRestriction(t *testing.T) {
 	})
 }
 
+func TestAccAppService_multipleVNetSubnetIpRestrictionUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	r := AppServiceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.oneVNetSubnetIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.multipleVNetSubnetIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.oneVNetSubnetIpRestriction(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppService_zeroedIpRestriction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
@@ -2883,11 +2915,72 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-      virtual_network_subnet_id = azurerm_subnet.test.id
+      subnet_id = azurerm_subnet.test.id
     }
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r AppServiceResource) multipleVNetSubnetIpRestriction(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "acctestsubnet%d-2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.3.0/24"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  site_config {
+    ip_restriction {
+      subnet_id = azurerm_subnet.test.id
+    }
+    ip_restriction {
+      subnet_id = azurerm_subnet.test2.id
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r AppServiceResource) manyIpRestrictions(data acceptance.TestData) string {

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -575,6 +575,38 @@ func TestAccAppService_multipleVNetSubnetIpRestrictionUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAppService_mixedIpRestrictionUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
+	r := AppServiceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.mixedIpRestrictions(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("4"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.mixedIpRestrictionsUpdate(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.mixedIpRestrictions(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.ip_restriction.#").HasValue("4"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppService_zeroedIpRestriction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
@@ -2977,6 +3009,138 @@ resource "azurerm_app_service" "test" {
     }
     ip_restriction {
       subnet_id = azurerm_subnet.test2.id
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r AppServiceResource) mixedIpRestrictions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "acctestsubnet%d-2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.3.0/24"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  site_config {
+    ip_restriction {
+      virtual_network_subnet_id = azurerm_subnet.test.id
+    }
+
+    ip_restriction {
+      virtual_network_subnet_id = azurerm_subnet.test2.id
+    }
+
+    ip_restriction {
+      ip_address = "30.30.0.0/16"
+    }
+
+    ip_restriction {
+      ip_address = "192.168.1.2/24"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r AppServiceResource) mixedIpRestrictionsUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "acctestsubnet%d-2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.3.0/24"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+
+  site_config {
+    ip_restriction {
+      virtual_network_subnet_id = azurerm_subnet.test.id
+    }
+
+    ip_restriction {
+      ip_address = "30.30.0.0/16"
     }
   }
 }

--- a/azurerm/internal/services/web/app_service_resource_test.go
+++ b/azurerm/internal/services/web/app_service_resource_test.go
@@ -2947,7 +2947,7 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-      subnet_id = azurerm_subnet.test.id
+      virtual_network_subnet_id = azurerm_subnet.test.id
     }
   }
 }
@@ -3005,10 +3005,10 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     ip_restriction {
-      subnet_id = azurerm_subnet.test.id
+      virtual_network_subnet_id = azurerm_subnet.test.id
     }
     ip_restriction {
-      subnet_id = azurerm_subnet.test2.id
+      virtual_network_subnet_id = azurerm_subnet.test2.id
     }
   }
 }


### PR DESCRIPTION
The `subnet_id` property, deprecated in provider version 2.23.0, has been removed to resolve a bug in updating IP Restrictions and SCM IP Restrictions created by that deprecation. The property name `virtual_network_subnet_id` is a direct replacement.

Closes #8768 
Supersedes #10843 

Affects:
`azurerm_app_service`
`azurerm_function_app`
Data Source: `azurerm_app_service`
Data Source: `azurerm_function_app`
