### PR TITLE
`azurerm_storage_account` - support for versioning and change feed

### DIFF
--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -1577,7 +1577,9 @@ func expandBlobPropertiesCors(input []interface{}) *storage.CorsRules {
 }
 
 func expandBlobPropertiesChangeFeed(input []interface{}) *storage.ChangeFeed {
-	changeFeed := storage.ChangeFeed{}
+	changeFeed := storage.ChangeFeed{
+		Enabled: utils.Bool(false),
+	}
 
 	if len(input) == 0 {
 		return &changeFeed
@@ -1819,7 +1821,6 @@ func flattenBlobProperties(input storage.BlobServiceProperties) []interface{} {
 	serviceProps["delete_retention_policy"] = flattenedDeletePolicy
 	serviceProps["container_delete_retention_policy"] = flattenedContainerDeletePolicy
 	serviceProps["change_feed"] = flattenedChangeFeed
-
 	if versioningEnabled := input.BlobServicePropertiesProperties.IsVersioningEnabled; versioningEnabled != nil {
 		serviceProps["versioning_enabled"] = versioningEnabled
 	}

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -533,6 +533,9 @@ func TestAccStorageAccount_blobProperties(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("blob_properties.0.cors_rule.#").HasValue("1"),
 				check.That(data.ResourceName).Key("blob_properties.0.delete_retention_policy.0.days").HasValue("300"),
+				check.That(data.ResourceName).Key("blob_properties.0.container_delete_retention_policy.0.days").HasValue("300"),
+				check.That(data.ResourceName).Key("blob_properties.0.versioning_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("blob_properties.0.change_feed.0.enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -542,6 +545,9 @@ func TestAccStorageAccount_blobProperties(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("blob_properties.0.cors_rule.#").HasValue("2"),
 				check.That(data.ResourceName).Key("blob_properties.0.delete_retention_policy.0.days").HasValue("7"),
+				check.That(data.ResourceName).Key("blob_properties.0.container_delete_retention_policy.0.days").HasValue("7"),
+				check.That(data.ResourceName).Key("blob_properties.0.versioning_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("blob_properties.0.change_feed.0.enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -1539,9 +1545,14 @@ resource "azurerm_storage_account" "test" {
     }
 
     container_delete_retention_policy {
-      days = 7
+      days = 300
     }
 
+    change_feed {
+      enabled = true
+    }
+
+    versioning_enabled = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
@@ -1587,6 +1598,12 @@ resource "azurerm_storage_account" "test" {
     }
 
     container_delete_retention_policy {
+    }
+
+    versioning_enabled = false
+
+    change_feed {
+      enabled = false
     }
   }
 }

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -139,6 +139,10 @@ A `blob_properties` block supports the following:
 
 * `container_delete_retention_policy` - (Optional) A `container_delete_retention_policy` block as defined below.
 
+* `change_feed` - (Optional) A `change_feed` block as defined below.
+
+* `versioning_enabled` - (Optional) Is Blob Versioning Enabled?
+
 ---
 
 A `cors_rule` block supports the following:
@@ -172,6 +176,16 @@ A `delete_retention_policy` block supports the following:
 A `container_delete_retention_policy` block supports the following:
 
 * `days` - (Optional) Specifies the number of days that the container should be retained, between `1` and `365` days. Defaults to `7`.
+
+---
+
+A `change_feed` block supports the following:
+
+~> **NOTE:** `change_feed` can only be enabled when the `account_kind` is set to `StorageV2` or `BlobStorage`.
+
+* `enabled` - (Required) Is Change Feed Enabled?
+
+~> **NOTE:** At this time, [setting retention policy for change feed is not possible](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-change-feed?tabs=azure-portal#conditions-and-known-issues).
 
 ---
 


### PR DESCRIPTION
Fixes #8268

Enables support for both blob versioning and change feed on storage accounts.
The reason I am using a different schema for `change_feed` compared to blob_retention_policy (i.e. Enabled is set when Days is set) is that the retention policy for change feed is not [functioning in the current released version](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-change-feed?tabs=azure-portal#conditions-and-known-issues). 
It seems to be a feature that is coming so I choose to do `change_feed` by TypeList to make it easier to enable support for retention policy later on.

If you don't agree with my decision we can change it to a single `change_feed_enabled` instead.