### PR TITLE
fix kubernates cluster acc tests

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -434,21 +434,21 @@ func testAccKubernetesClusterNodePool_nodeLabels(t *testing.T) {
 		{
 			Config: r.nodeLabelsConfig(data, labels1),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("node_labels.#").HasValue("1"),
+				check.That(data.ResourceName).Key("node_labels.%").HasValue("1"),
 				check.That(data.ResourceName).Key("node_labels.key").HasValue("value"),
 			),
 		},
 		{
 			Config: r.nodeLabelsConfig(data, labels2),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("node_labels.#").HasValue("1"),
+				check.That(data.ResourceName).Key("node_labels.%").HasValue("1"),
 				check.That(data.ResourceName).Key("node_labels.key2").HasValue("value2"),
 			),
 		},
 		{
 			Config: r.nodeLabelsConfig(data, labels3),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("node_labels.#").HasValue("0"),
+				check.That(data.ResourceName).Key("node_labels.%").HasValue("0"),
 			),
 		},
 	})
@@ -1591,7 +1591,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   windows_profile {
     admin_username = "azureuser"
-    admin_password = "P@55W0rd1234!"
+    admin_password = "P@55W0rd1234!h@2h1C0rP"
   }
 
   network_profile {


### PR DESCRIPTION
The fixed test are listed as following
```

=== RUN   TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled
=== PAUSE TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled
=== CONT  TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinuxDisabled (711.06s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileAciConnectorLinux
=== PAUSE TestAccKubernetesCluster_addonProfileAciConnectorLinux
=== CONT  TestAccKubernetesCluster_addonProfileAciConnectorLinux
--- PASS: TestAccKubernetesCluster_addonProfileAciConnectorLinux (987.80s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileAzurePolicy
=== PAUSE TestAccKubernetesCluster_addonProfileAzurePolicy
=== CONT  TestAccKubernetesCluster_addonProfileAzurePolicy
--- PASS: TestAccKubernetesCluster_addonProfileAzurePolicy (1214.04s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileOMS
=== PAUSE TestAccKubernetesCluster_addonProfileOMS
=== CONT  TestAccKubernetesCluster_addonProfileOMS
--- PASS: TestAccKubernetesCluster_addonProfileOMS (805.21s)
PASS

=== RUN   TestAccKubernetesCluster_addonProfileOMSToggle
=== PAUSE TestAccKubernetesCluster_addonProfileOMSToggle
=== CONT  TestAccKubernetesCluster_addonProfileOMSToggle
--- PASS: TestAccKubernetesCluster_addonProfileOMSToggle (1774.62s)
PASS


=== RUN   TestAccDataSourceKubernetesCluster_addOnProfileAzurePolicy
=== PAUSE TestAccDataSourceKubernetesCluster_addOnProfileAzurePolicy
=== CONT  TestAccDataSourceKubernetesCluster_addOnProfileAzurePolicy
--- PASS: TestAccDataSourceKubernetesCluster_addOnProfileAzurePolicy (925.07s)
PASS

=== RUN   TestAccDataSourceKubernetesCluster_addOnProfileOMS
=== PAUSE TestAccDataSourceKubernetesCluster_addOnProfileOMS
=== CONT  TestAccDataSourceKubernetesCluster_addOnProfileOMS
--- PASS: TestAccDataSourceKubernetesCluster_addOnProfileOMS (951.25s)
PASS

=== RUN   TestAccKubernetesClusterNodePool_windowsAndLinux
=== PAUSE TestAccKubernetesClusterNodePool_windowsAndLinux
=== CONT  TestAccKubernetesClusterNodePool_windowsAndLinux
--- PASS: TestAccKubernetesClusterNodePool_windowsAndLinux (1084.91s)
PASS

=== RUN   TestAccKubernetesClusterNodePool_windows
=== PAUSE TestAccKubernetesClusterNodePool_windows
=== CONT  TestAccKubernetesClusterNodePool_windows
--- PASS: TestAccKubernetesClusterNodePool_windows (1172.49s)
PASS

=== RUN   TestAccKubernetesClusterNodePool_nodeLabels
=== PAUSE TestAccKubernetesClusterNodePool_nodeLabels
=== CONT  TestAccKubernetesClusterNodePool_nodeLabels
--- PASS: TestAccKubernetesClusterNodePool_nodeLabels (1823.93s)
PASS

```