### PR TITLE
d/dns_zone: not setting the resource id until after we've looked it up

### DIFF
--- a/azurerm/internal/services/dns/dns_zone_data_source.go
+++ b/azurerm/internal/services/dns/dns_zone_data_source.go
@@ -66,8 +66,6 @@ func dataSourceDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	resourceId := parse.NewDnsZoneID(subscriptionId, resourceGroup, name)
-
 	var (
 		resp dns.Zone
 		err  error
@@ -94,10 +92,7 @@ func dataSourceDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 		resp = *zone
 	}
 
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("failed reading ID for DNS Zone %q (Resource Group %q)", name, resourceGroup)
-	}
-
+	resourceId := parse.NewDnsZoneID(subscriptionId, resourceGroup, name)
 	d.SetId(resourceId.ID())
 
 	d.Set("name", name)


### PR DESCRIPTION
This data source is a special case where the Resource Group name can either be specified or looked up, so we need to set the ID once we're sure we've got the Resource Group, else the segment will be empty in the Resource ID.

Fixes #11220