### PR TITLE
`azurerm_media_service_account` - `storage_authentication_type` correctly accepts both `ManagedIdentity` and `System`

### DIFF
--- a/azurerm/internal/services/media/media_services_account_resource.go
+++ b/azurerm/internal/services/media/media_services_account_resource.go
@@ -109,8 +109,8 @@ func resourceMediaServicesAccount() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(media.ManagedIdentityTypeSystemAssigned),
-					string(media.ManagedIdentityTypeSystemAssigned),
+					string(media.StorageAuthenticationSystem),
+					string(media.StorageAuthenticationManagedIdentity),
 				}, true),
 			},
 


### PR DESCRIPTION
fixes #11213 