### PR TITLE
`azurerm_hpc_cache` - support for `ntp_server` and `dns`

### DIFF
--- a/azurerm/internal/services/hpccache/hpc_cache_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource.go
@@ -533,7 +533,6 @@ func flattenStorageCacheNetworkSettings(settings *storagecache.CacheNetworkSetti
 				"search_domain": searchDomain,
 			},
 		}
-
 	}
 	return
 }

--- a/azurerm/internal/services/hpccache/hpc_cache_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource.go
@@ -93,7 +93,7 @@ func resourceHPCCache() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"dns_setting": {
+			"dns": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -333,8 +333,8 @@ func resourceHPCCacheRead(d *schema.ResourceData, meta interface{}) error {
 		mtu, ntpServer, dnsSetting := flattenStorageCacheNetworkSettings(props.NetworkSettings)
 		d.Set("mtu", mtu)
 		d.Set("ntp_server", ntpServer)
-		if err := d.Set("dns_setting", dnsSetting); err != nil {
-			return fmt.Errorf("setting `dns_setting`: %v", err)
+		if err := d.Set("dns", dnsSetting); err != nil {
+			return fmt.Errorf("setting `dns`: %v", err)
 		}
 
 		if securitySettings := props.SecuritySettings; securitySettings != nil {
@@ -495,7 +495,7 @@ func expandStorageCacheNetworkSettings(d *schema.ResourceData) *storagecache.Cac
 		NtpServer: utils.String(d.Get("ntp_server").(string)),
 	}
 
-	if dnsSetting, ok := d.GetOk("dns_setting"); ok {
+	if dnsSetting, ok := d.GetOk("dns"); ok {
 		dnsSetting := dnsSetting.([]interface{})[0].(map[string]interface{})
 		out.DNSServers = utils.ExpandStringSlice(dnsSetting["servers"].([]interface{}))
 		searchDomain := dnsSetting["search_domain"].(string)

--- a/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
@@ -375,7 +375,7 @@ resource "azurerm_hpc_cache" "test" {
   cache_size_in_gb    = 3072
   subnet_id           = azurerm_subnet.test.id
   sku_name            = "Standard_2G"
-  dns_setting {
+  dns {
     servers       = ["8.8.8.8"]
     search_domain = "foo.com"
   }

--- a/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
@@ -65,6 +65,68 @@ func TestAccHPCCache_mtu(t *testing.T) {
 	})
 }
 
+func TestAccHPCCache_ntpServer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
+	r := HPCCacheResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ntpServer(data, "time.microsoft.com"),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_addresses.#").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_addresses.#").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccHPCCache_dnsSetting(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
+	r := HPCCacheResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.dnsSetting(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_addresses.#").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_addresses.#").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccHPCCache_rootSquashDeprecated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
 	r := HPCCacheResource{}
@@ -281,6 +343,41 @@ resource "azurerm_hpc_cache" "test" {
       access = "no"
       filter = "10.0.0.1"
     }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HPCCacheResource) ntpServer(data acceptance.TestData, server string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+  ntp_server          = %q
+}
+`, r.template(data), data.RandomInteger, server)
+}
+
+func (r HPCCacheResource) dnsSetting(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+  dns_setting {
+    servers       = ["8.8.8.8"]
+    search_domain = "foo.com"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -67,6 +67,10 @@ The following arguments are supported:
 * `mtu` - (Optional) The IPv4 maximum transmission unit configured for the subnet of the HPC Cache. Possible values range from 576 - 1500. Defaults to 1500.
 
 * `default_access_policy` - (Optional) A `default_access_policy` block as defined below.
+
+* `ntp_server` - (Optional) The NTP server IP Address or FQDN for the HPC Cache. Defaults to `time.windows.com`.
+
+* `dns_setting` - (Optional) A `dns_setting` block as defined below.
   
 ---
 
@@ -95,6 +99,14 @@ An `access_rule` block contains the following:
 A `default_access_policy` block contains the following:
 
 * `access_rule` - (Required) One to three `access_rule` blocks as defined above.
+
+---
+
+A `dns_setting` block contains the following:
+
+* `servers` - (Required) A list of DNS servers for the HPC Cache. At most three IP(s) are allowed to set.
+
+* `search_domain` - (Optional) The DNS search domain for the HPC Cache.
 
 ## Attributes Reference
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 * `ntp_server` - (Optional) The NTP server IP Address or FQDN for the HPC Cache. Defaults to `time.windows.com`.
 
-* `dns_setting` - (Optional) A `dns_setting` block as defined below.
+* `dns` - (Optional) A `dns` block as defined below.
   
 ---
 
@@ -102,7 +102,7 @@ A `default_access_policy` block contains the following:
 
 ---
 
-A `dns_setting` block contains the following:
+A `dns` block contains the following:
 
 * `servers` - (Required) A list of DNS servers for the HPC Cache. At most three IP(s) are allowed to set.
 


### PR DESCRIPTION
Support `ntp_server` and `dns_setting` for `azurerm_hpc_cache`.