### PR TITLE
docs: adding a heads up about the breaking api change rolling out 2021-04-09

### DIFF
--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 A CDN Endpoint is the entity within a CDN Profile containing configuration information regarding caching behaviours and origins. The CDN Endpoint is exposed using the URL format <endpointname>.azureedge.net.
 
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April which may cause issues with the CDN/FrontDoor resources. [More information is available in this Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a CDN Profile to create a collection of CDN Endpoints.
 
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April which may cause issues with the CDN/FrontDoor resources. [More information is available in this Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -17,6 +17,8 @@ Below are some of the key scenarios that Azure Front Door Service addresses:
 * Use Front Door to improve application performance with SSL offload and routing requests to the fastest available application backend.
 * Use Front Door for application layer security and DDoS protection for your application.
 
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April which may cause issues with the CDN/FrontDoor resources. [More information is available in this Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -16,6 +16,8 @@ Manages the Custom Https Configuration for an Azure Front Door Frontend Endpoint
 
 -> **NOTE:** UPCOMING BREAKING CHANGE: In order to address the ordering issue we have changed the design on how to retrieve existing sub resources such as frontend endpoints. Existing design will be deprecated and will result in an incorrect configuration. Please refer to the updated documentation below for more information.
 
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April which may cause issues with the CDN/FrontDoor resources. [More information is available in this Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+
 ```hcl
 resource "azurerm_resource_group" "example" {
   name     = "FrontDoorExampleResourceGroup"

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages an Azure Front Door Web Application Firewall Policy instance.
 
+!> **Be Aware:** Azure is rolling out a breaking change on Friday 9th April which may cause issues with the CDN/FrontDoor resources. [More information is available in this Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) - however unfortunately this may necessitate a breaking change to the CDN and FrontDoor resources, more information will be posted [in the Github issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/11231) as the necessary changes are identified.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
More details are in #11231, although it's hard for us to do much about this ahead of time unfortunately due to the inability to test these changes (and confirm which breaking changes are necessary), as such giving some notice this is happening is the most helpful thing we can do at the moment.