### PR TITLE
Make KeyVault work in Private Networks

### DIFF
--- a/azurerm/internal/features/defaults.go
+++ b/azurerm/internal/features/defaults.go
@@ -4,6 +4,7 @@ func Default() UserFeatures {
 	return UserFeatures{
 		// NOTE: ensure all nested objects are fully populated
 		KeyVault: KeyVaultFeatures{
+			ValidateKeyVaultEndpoint:    true,
 			PurgeSoftDeleteOnDestroy:    true,
 			RecoverSoftDeletedKeyVaults: true,
 		},

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -19,6 +19,7 @@ type VirtualMachineScaleSetFeatures struct {
 }
 
 type KeyVaultFeatures struct {
+	ValidateKeyVaultEndpoint    bool
 	PurgeSoftDeleteOnDestroy    bool
 	RecoverSoftDeletedKeyVaults bool
 }


### PR DESCRIPTION
Currently, if you disable public network access when a keyvault is created (with the intent of setting up a private dns endpoint) you put it in a state that terraform cannot proceed from. This is caused by it waiting for the actual http url to become available. This pattern is a contrast to other resources which separate out accessing (and controlling) the data plane of the provisioned resource from executing actions against azures control plane. 

The proposed solution adds a flag that tells terraform to skip checking for liveness of the vault url, and only check for contacts if they are actually used in the resource or said flag is not activated. 

The (arguably more correct) alternative would be to separate key vault contacts out into it's own resource.