### PR TITLE
`azurerm_hpc_cache_nfs_target` - support of more `usage_model` enums

### DIFF
--- a/azurerm/internal/services/hpccache/hpc_cache_nfs_target_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_nfs_target_resource.go
@@ -101,8 +101,12 @@ func resourceHPCCacheNFSTarget() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"READ_HEAVY_INFREQ",
+					"READ_HEAVY_CHECK_180",
 					"WRITE_WORKLOAD_15",
 					"WRITE_AROUND",
+					"WRITE_WORKLOAD_CHECK_30",
+					"WRITE_WORKLOAD_CHECK_60",
+					"WRITE_WORKLOAD_CLOUDWS",
 				}, false),
 			},
 		},

--- a/azurerm/internal/services/hpccache/hpc_cache_nfs_target_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_nfs_target_resource.go
@@ -96,6 +96,8 @@ func resourceHPCCacheNFSTarget() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			// TODO: use SDK enums once following issue is addressed
+			// https://github.com/Azure/azure-rest-api-specs/issues/13839
 			"usage_model": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/website/docs/r/hpc_cache_nfs_target.html.markdown
+++ b/website/docs/r/hpc_cache_nfs_target.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
 
 * `target_host_name` - (Required) The IP address or fully qualified domain name (FQDN) of the HPC Cache NFS target. Changing this forces a new resource to be created.
 
-* `usage_model` - (Required) The type of usage of the HPC Cache NFS Target.
+* `usage_model` - (Required) The type of usage of the HPC Cache NFS Target. Possible values are: `READ_HEAVY_INFREQ`, `READ_HEAVY_CHECK_180`, `WRITE_WORKLOAD_15`, `WRITE_AROUND`, `WRITE_WORKLOAD_CHECK_30`, `WRITE_WORKLOAD_CHECK_60` and `WRITE_WORKLOAD_CLOUDWS`.
 
 * `namespace_junction` - (Required) Can be specified multiple times to define multiple `namespace_junction`. Each `namespace_juntion` block supports fields documented below.
 


### PR DESCRIPTION
`azurerm_hpc_cache_nfs_target` - support of more `usage_model` enums