### PR TITLE
Remove obsolete reference to virtual_network_name.

### DIFF
--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -230,8 +230,6 @@ The following arguments are supported:
 
 ~> **Note:** Deployment Slots are not supported in the `Free`, `Shared`, or `Basic` App Service Plans.
 
-* `virtual_network_name` - (Optional) The name of the Virtual Network which this App Service Slot should be attached to.
-
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
 
 * `auto_swap_slot_name` - (Optional) The name of the slot to automatically swap to during deployment


### PR DESCRIPTION
As far as I can tell, this argument was removed from app_service_slot when it was removed from app_service and function_app, but the docs were not updated.