### PR TITLE
`azurerm_app_service_slot` - fix crash bug when given empty `http_logs`

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1394,9 +1394,12 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 		appLogsConfigs := v.([]interface{})
 
 		for _, config := range appLogsConfigs {
-			appLogsConfig := config.(map[string]interface{})
-
 			logs.ApplicationLogs = &web.ApplicationLogsConfig{}
+
+			if config == nil {
+				continue
+			}
+			appLogsConfig := config.(map[string]interface{})
 
 			if v, ok := appLogsConfig["file_system_level"]; ok {
 				logs.ApplicationLogs.FileSystem = &web.FileSystemApplicationLogsConfig{

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1424,9 +1424,12 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 		httpLogsConfigs := v.([]interface{})
 
 		for _, config := range httpLogsConfigs {
-			httpLogsConfig := config.(map[string]interface{})
-
 			logs.HTTPLogs = &web.HTTPLogsConfig{}
+
+			if config == nil {
+				continue
+			}
+			httpLogsConfig := config.(map[string]interface{})
 
 			if v, ok := httpLogsConfig["file_system"]; ok {
 				fileSystemConfigs := v.([]interface{})


### PR DESCRIPTION
This fixes a provider crash when the `http_logs` block is empty for the app service slot (and likely the parent app service):
```hcl
  logs {
    http_logs {
    }
  }
```

IIRC, that configuration is currently the only way to disable the app service HTTP logs. 