### PR TITLE
`azurerm_hpc_cache` - support for `tags`

### DIFF
--- a/azurerm/internal/services/hpccache/hpc_cache_resource.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+
 	"github.com/Azure/azure-sdk-for-go/services/storagecache/mgmt/2021-03-01/storagecache"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -206,6 +208,8 @@ func resourceHPCCache() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+			"tags": tags.Schema(),
 		},
 	}
 }
@@ -277,6 +281,7 @@ func resourceHPCCacheCreateOrUpdate(d *schema.ResourceData, meta interface{}) er
 		Sku: &storagecache.CacheSku{
 			Name: utils.String(skuName),
 		},
+		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, cache)
@@ -362,7 +367,7 @@ func resourceHPCCacheRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("sku_name", sku.Name)
 	}
 
-	return nil
+	return tags.FlattenAndSet(d, resp.Tags)
 }
 
 func resourceHPCCacheDelete(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
@@ -238,6 +238,9 @@ resource "azurerm_hpc_cache" "test" {
   cache_size_in_gb    = 3072
   subnet_id           = azurerm_subnet.test.id
   sku_name            = "Standard_2G"
+  tags = {
+    environment = "Production"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/azurerm/internal/services/hpccache/hpc_cache_resource_test.go
@@ -213,6 +213,30 @@ func TestAccHPCCache_defaultAccessPolicy(t *testing.T) {
 	})
 }
 
+func TestAccHPCCache_updateTags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
+	r := HPCCacheResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_addresses.#").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateTags(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("mount_addresses.#").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (HPCCacheResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.CacheID(state.ID)
 	if err != nil {
@@ -240,6 +264,24 @@ resource "azurerm_hpc_cache" "test" {
   sku_name            = "Standard_2G"
   tags = {
     environment = "Production"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HPCCacheResource) updateTags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+  tags = {
+    environment = "Test"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -71,7 +71,9 @@ The following arguments are supported:
 * `ntp_server` - (Optional) The NTP server IP Address or FQDN for the HPC Cache. Defaults to `time.windows.com`.
 
 * `dns` - (Optional) A `dns` block as defined below.
-  
+
+* `tags` - (Optional) A mapping of tags to assign to the HPC Cache.
+
 ---
 
 An `access_rule` block contains the following:


### PR DESCRIPTION
Fix #8117

## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=2h ./azurerm/internal/services/hpccache -run=TestAccHPCCache_updateTags
2021/04/09 10:30:17 [DEBUG] not using binary driver name, it's no longer needed
2021/04/09 10:30:17 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccHPCCache_updateTags
=== PAUSE TestAccHPCCache_updateTags
=== CONT  TestAccHPCCache_updateTags
--- PASS: TestAccHPCCache_updateTags (1483.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hpccache    1483.759s
```