### PR TITLE
Stop force recreate on Key Vault Certificate tags

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -351,7 +351,7 @@ func resourceKeyVaultCertificate() *schema.Resource {
 				Computed: true,
 			},
 
-			"tags": tags.ForceNewSchema(),
+			"tags": tags.Schema(),
 		},
 	}
 }


### PR DESCRIPTION
Changing Key Vault Certificate tags should not trigger a recreate of resource.