### PR TITLE
fix acctest for azurerm_app_service_slot

### DIFF
--- a/azurerm/internal/services/web/app_service_slot_resource_test.go
+++ b/azurerm/internal/services/web/app_service_slot_resource_test.go
@@ -159,26 +159,16 @@ func TestAccAppServiceSlot_connectionStrings(t *testing.T) {
 			Config: r.connectionStrings(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("connection_string.3173438943.name").HasValue("First"),
-				check.That(data.ResourceName).Key("connection_string.3173438943.value").HasValue("first-connection-string"),
-				check.That(data.ResourceName).Key("connection_string.3173438943.type").HasValue("Custom"),
-				check.That(data.ResourceName).Key("connection_string.2442860602.name").HasValue("Second"),
-				check.That(data.ResourceName).Key("connection_string.2442860602.value").HasValue("some-postgresql-connection-string"),
-				check.That(data.ResourceName).Key("connection_string.2442860602.type").HasValue("PostgreSQL"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.connectionStringsUpdated(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("connection_string.3173438943.name").HasValue("First"),
-				check.That(data.ResourceName).Key("connection_string.3173438943.value").HasValue("first-connection-string"),
-				check.That(data.ResourceName).Key("connection_string.3173438943.type").HasValue("Custom"),
-				check.That(data.ResourceName).Key("connection_string.2442860602.name").HasValue("Second"),
-				check.That(data.ResourceName).Key("connection_string.2442860602.value").HasValue("some-postgresql-connection-string"),
-				check.That(data.ResourceName).Key("connection_string.2442860602.type").HasValue("PostgreSQL"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
## Test Result

```bash
💤 TF_ACC=1 go test ./azurerm/internal/services/web -v -run="TestAccAppServiceSlot_connectionStrings" -timeout=1h
2021/04/12 13:08:23 [DEBUG] not using binary driver name, it's no longer needed
2021/04/12 13:08:25 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccAppServiceSlot_connectionStrings
=== PAUSE TestAccAppServiceSlot_connectionStrings
=== CONT  TestAccAppServiceSlot_connectionStrings
--- PASS: TestAccAppServiceSlot_connectionStrings (422.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web 424.410s
```