### PR TITLE
r/iotcentral_application: fixing the state migration

### DIFF
--- a/azurerm/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/azurerm/internal/services/iotcentral/iotcentral_application_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+
 	"github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -11,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iotcentral/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iotcentral/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iotcentral/validate"
@@ -26,9 +29,10 @@ func resourceIotCentralApplication() *schema.Resource {
 		Update: resourceIotCentralAppUpdate,
 		Delete: resourceIotCentralAppDelete,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.ApplicationID(id)
+			return err
+		}),
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
@@ -93,31 +97,32 @@ func resourceIotCentralApplication() *schema.Resource {
 func resourceIotCentralAppCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).IoTCentral.AppsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
+	id := parse.NewApplicationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("Error checking for presence of existing IoT Central Application  %q (Resource Group %q): %+v", name, resourceGroup, err)
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
 
-	if existing.ID != nil && *existing.ID != "" {
-		return tf.ImportAsExistsError("azurerm_iotcentral_application", *existing.ID)
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_iotcentral_application", id.ID())
 	}
 
 	resp, err := client.CheckNameAvailability(ctx, iotcentral.OperationInputs{
 		Name: utils.String(name),
 	})
 	if err != nil {
-		return fmt.Errorf("Error happened on check name availability. %q (Group Name %q). Error:  %+v", name, resourceGroup, err)
+		return fmt.Errorf("checking if the name %q was globally available:  %+v", id.IoTAppName, err)
 	}
 	if !*resp.NameAvailable {
-		return fmt.Errorf("Resource name not available. name: %s, Reason:  %q, Message  %q", name, *resp.Reason, *resp.Message)
+		return fmt.Errorf("the name %q cannot be used. Reason: %q Message: %q", name, *resp.Reason, *resp.Message)
 	}
 
 	displayName := d.Get("display_name").(string)
@@ -141,32 +146,22 @@ func resourceIotCentralAppCreate(d *schema.ResourceData, meta interface{}) error
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, app)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IoTAppName, app)
 	if err != nil {
-		return fmt.Errorf("Error creating Iot Central Application.  %v", err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for creating IoT Central Application %q (Resource Group %q):  %+v", name, resourceGroup, err)
+		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
-	response, err := client.Get(ctx, resourceGroup, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving IoT Central Application %q (Resource Group %q):  %+v", name, resourceGroup, err)
-	}
-
-	if response.ID == nil || *response.ID == "" {
-		return fmt.Errorf("Error creating IoT Central Application %q (Resource Group %q):  %+v", name, resourceGroup, err)
-	}
-	resourceId := parse.NewApplicationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	d.SetId(resourceId.ID())
+	d.SetId(id.ID())
 	return resourceIotCentralAppRead(d, meta)
 }
 
 func resourceIotCentralAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).IoTCentral.AppsClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.ApplicationID(d.Id())
@@ -191,24 +186,13 @@ func resourceIotCentralAppUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 	future, err := client.Update(ctx, id.ResourceGroup, id.IoTAppName, appPatch)
 	if err != nil {
-		return fmt.Errorf("Error update Iot Central Application %q (Resource Group %q).  %+v", id.IoTAppName, id.ResourceGroup, err)
+		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for the completion of update Iot Central Application %q (Resource Group %q):  %+v", id.IoTAppName, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for the update of %s: %+v", *id, err)
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.IoTAppName)
-	if err != nil {
-		return fmt.Errorf("Error retrieving IoT Central Application %q (Resource Group %q):  %+v", id.IoTAppName, id.ResourceGroup, err)
-	}
-
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("Cannot read IoT Central Application %q (Resource Group %q):  %+v", id.IoTAppName, id.ResourceGroup, err)
-	}
-
-	resourceId := parse.NewApplicationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	d.SetId(resourceId.ID())
 	return resourceIotCentralAppRead(d, meta)
 }
 
@@ -228,17 +212,15 @@ func resourceIotCentralAppRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error retrieving IoT Central Application %q (Resource Group %q):  %+v", id.IoTAppName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", resp.Name)
+	d.Set("name", id.IoTAppName)
 	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
 
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
 	if err := d.Set("sku", resp.Sku.Name); err != nil {
-		return fmt.Errorf("Error setting `sku`:  %+v", err)
+		return fmt.Errorf("setting `sku`: %+v", err)
 	}
 
 	if props := resp.AppProperties; props != nil {
@@ -262,12 +244,13 @@ func resourceIotCentralAppDelete(d *schema.ResourceData, meta interface{}) error
 	resp, err := client.Delete(ctx, id.ResourceGroup, id.IoTAppName)
 	if err != nil {
 		if !response.WasNotFound(resp.Response()) {
-			return fmt.Errorf("Error delete Iot Central Application %q (Resource Group %q).  %+v", id.IoTAppName, id.ResourceGroup, err)
+			return fmt.Errorf("deleting %s: %+v", *id, err)
 		}
 	}
 
 	if err := resp.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error delete Iot Central Application %q Resource Group %q).  %+v", id.IoTAppName, id.ResourceGroup, err)
+		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 	}
+
 	return nil
 }

--- a/azurerm/internal/services/iotcentral/iotcentral_application_resource_test.go
+++ b/azurerm/internal/services/iotcentral/iotcentral_application_resource_test.go
@@ -61,6 +61,7 @@ func TestAccIoTCentralApplication_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.update(data),
 			Check: resource.ComposeTestCheckFunc(
@@ -73,7 +74,7 @@ func TestAccIoTCentralApplication_update(t *testing.T) {
 	})
 }
 
-func TestAccIoTCentralApplication_requiresImportErrorStep(t *testing.T) {
+func TestAccIoTCentralApplication_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_iotcentral_application", "test")
 	r := IoTCentralApplicationResource{}
 
@@ -84,10 +85,7 @@ func TestAccIoTCentralApplication_requiresImportErrorStep(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		{
-			Config:      r.requiresImport(data),
-			ExpectError: acceptance.RequiresImportError("azurerm_iotcentral_application"),
-		},
+		data.RequiresImportErrorStep(r.requiresImport),
 	})
 }
 
@@ -99,7 +97,7 @@ func (IoTCentralApplicationResource) Exists(ctx context.Context, clients *client
 
 	resp, err := clients.IoTCentral.AppsClient.Get(ctx, id.ResourceGroup, id.IoTAppName)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Analysis Services Server %q (resource group: %q): %+v", id.IoTAppName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
 	return utils.Bool(resp.AppProperties != nil), nil
@@ -120,7 +118,7 @@ resource "azurerm_iotcentral_application" "test" {
   name                = "acctest-iotcentralapp-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sub_domain          = "acctest-iotcentralapp-%[1]d"
+  sub_domain          = "subdomain-%[1]d"
   sku                 = "ST1"
 }
 `, data.RandomInteger, data.Locations.Primary)
@@ -133,23 +131,23 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[2]d"
-  location = "%[1]s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_iotcentral_application" "test" {
-  name                = "acctest-iotcentralapp-%[2]d"
+  name                = "acctest-iotcentralapp-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sub_domain          = "acctest-iotcentralapp-%[2]d"
-  display_name        = "acctest-iotcentralapp-%[2]d"
+  sub_domain          = "subdomain-%[1]d"
+  display_name        = "some-display-name"
   sku                 = "ST1"
   template            = "iotc-pnp-preview@1.0.0"
   tags = {
     ENV = "Test"
   }
 }
-`, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (IoTCentralApplicationResource) update(data acceptance.TestData) string {
@@ -159,35 +157,36 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[2]d"
-  location = "%[1]s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_iotcentral_application" "test" {
-  name                = "acctest-iotcentralapp-%[2]d"
+  name                = "acctest-iotcentralapp-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sub_domain          = "acctest-iotcentralapp-%[2]d"
-  display_name        = "acctest-iotcentralapp-%[2]d"
+  sub_domain          = "subdomain-%[1]d"
+  display_name        = "some-display-name"
   sku                 = "ST1"
   tags = {
     ENV = "Test"
   }
 }
-`, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
-func (IoTCentralApplicationResource) requiresImport(data acceptance.TestData) string {
-	template := IoTCentralApplicationResource{}.basic(data)
+func (r IoTCentralApplicationResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
+
 resource "azurerm_iotcentral_application" "import" {
   name                = azurerm_iotcentral_application.test.name
   resource_group_name = azurerm_iotcentral_application.test.resource_group_name
   location            = azurerm_iotcentral_application.test.location
   sub_domain          = azurerm_iotcentral_application.test.sub_domain
   display_name        = azurerm_iotcentral_application.test.display_name
-  sku                 = "ST1"
+  sku                 = azurerm_iotcentral_application.test.sku
 }
 `, template)
 }

--- a/azurerm/internal/services/iotcentral/migration/iotcentral_application_V0_to_V1.go
+++ b/azurerm/internal/services/iotcentral/migration/iotcentral_application_V0_to_V1.go
@@ -72,7 +72,7 @@ func iotCentralApplicationV0Schema() *schema.Resource {
 
 func iotCentralApplicationUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	oldId := rawState["id"].(string)
-	id, err := parse.ApplicationID(oldId)
+	id, err := parse.ApplicationIDInsensitively(oldId)
 	if err != nil {
 		return rawState, err
 	}

--- a/azurerm/internal/services/iotcentral/parse/application.go
+++ b/azurerm/internal/services/iotcentral/parse/application.go
@@ -33,7 +33,7 @@ func (id ApplicationId) String() string {
 }
 
 func (id ApplicationId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.IoTCentral/IoTApps/%s"
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.IoTCentral/ioTApps/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.IoTAppName)
 }
 
@@ -57,7 +57,7 @@ func ApplicationID(input string) (*ApplicationId, error) {
 		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
 	}
 
-	if resourceId.IoTAppName, err = id.PopSegment("IoTApps"); err != nil {
+	if resourceId.IoTAppName, err = id.PopSegment("ioTApps"); err != nil {
 		return nil, err
 	}
 
@@ -93,15 +93,15 @@ func ApplicationIDInsensitively(input string) (*ApplicationId, error) {
 		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
 	}
 
-	// find the correct casing for the 'IoTApps' segment
-	IoTAppsKey := "IoTApps"
+	// find the correct casing for the 'ioTApps' segment
+	ioTAppsKey := "ioTApps"
 	for key := range id.Path {
-		if strings.EqualFold(key, IoTAppsKey) {
-			IoTAppsKey = key
+		if strings.EqualFold(key, ioTAppsKey) {
+			ioTAppsKey = key
 			break
 		}
 	}
-	if resourceId.IoTAppName, err = id.PopSegment(IoTAppsKey); err != nil {
+	if resourceId.IoTAppName, err = id.PopSegment(ioTAppsKey); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/iotcentral/parse/application.go
+++ b/azurerm/internal/services/iotcentral/parse/application.go
@@ -67,3 +67,47 @@ func ApplicationID(input string) (*ApplicationId, error) {
 
 	return &resourceId, nil
 }
+
+// ApplicationIDInsensitively parses an Application ID into an ApplicationId struct, insensitively
+// This should only be used to parse an ID for rewriting, the ApplicationID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func ApplicationIDInsensitively(input string) (*ApplicationId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ApplicationId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'IoTApps' segment
+	IoTAppsKey := "IoTApps"
+	for key := range id.Path {
+		if strings.EqualFold(key, IoTAppsKey) {
+			IoTAppsKey = key
+			break
+		}
+	}
+	if resourceId.IoTAppName, err = id.PopSegment(IoTAppsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/iotcentral/parse/application_test.go
+++ b/azurerm/internal/services/iotcentral/parse/application_test.go
@@ -12,7 +12,7 @@ var _ resourceid.Formatter = ApplicationId{}
 
 func TestApplicationIDFormatter(t *testing.T) {
 	actual := NewApplicationID("12345678-1234-9876-4563-123456789012", "resGroup1", "app1").ID()
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1"
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/app1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -63,13 +63,13 @@ func TestApplicationID(t *testing.T) {
 
 		{
 			// missing value for IoTAppName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/app1",
 			Expected: &ApplicationId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
@@ -156,13 +156,13 @@ func TestApplicationIDInsensitively(t *testing.T) {
 
 		{
 			// missing value for IoTAppName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/app1",
 			Expected: &ApplicationId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",

--- a/azurerm/internal/services/iotcentral/parse/application_test.go
+++ b/azurerm/internal/services/iotcentral/parse/application_test.go
@@ -110,3 +110,120 @@ func TestApplicationID(t *testing.T) {
 		}
 	}
 }
+
+func TestApplicationIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ApplicationId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing IoTAppName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/",
+			Error: true,
+		},
+
+		{
+			// missing value for IoTAppName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1",
+			Expected: &ApplicationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				IoTAppName:     "app1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/iotapps/app1",
+			Expected: &ApplicationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				IoTAppName:     "app1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IOTAPPS/app1",
+			Expected: &ApplicationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				IoTAppName:     "app1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTaPpS/app1",
+			Expected: &ApplicationId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				IoTAppName:     "app1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ApplicationIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.IoTAppName != v.Expected.IoTAppName {
+			t.Fatalf("Expected %q but got %q for IoTAppName", v.Expected.IoTAppName, actual.IoTAppName)
+		}
+	}
+}

--- a/azurerm/internal/services/iotcentral/resourceids.go
+++ b/azurerm/internal/services/iotcentral/resourceids.go
@@ -1,3 +1,3 @@
 package iotcentral
 
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Application -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1 -rewrite=true
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Application -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/app1 -rewrite=true

--- a/azurerm/internal/services/iotcentral/resourceids.go
+++ b/azurerm/internal/services/iotcentral/resourceids.go
@@ -1,3 +1,3 @@
 package iotcentral
 
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Application -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Application -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1 -rewrite=true

--- a/azurerm/internal/services/iotcentral/validate/application_id_test.go
+++ b/azurerm/internal/services/iotcentral/validate/application_id_test.go
@@ -48,13 +48,13 @@ func TestApplicationID(t *testing.T) {
 
 		{
 			// missing value for IoTAppName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/IoTApps/app1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.IoTCentral/ioTApps/app1",
 			Valid: true,
 		},
 

--- a/website/docs/r/iotcentral_application.html.markdown
+++ b/website/docs/r/iotcentral_application.html.markdown
@@ -74,5 +74,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 The IoT Central Application can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_iotcentral_application.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.IoTCentral/IoTApps/app1
+terraform import azurerm_iotcentral_application.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.IoTCentral/ioTApps/app1
 ```


### PR DESCRIPTION
This PR fixes a couple of issues spotted after the merge of #10947, where the state migration won't work for older resources.

As such this PR generates and uses an insensitive parser within the state migration, which fixes this for newer and older resources - ultimately making these consistent casing wise.

Tests pass:

```
--- PASS: TestAccIoTCentralApplication_complete (146.32s)
--- PASS: TestAccIoTCentralApplication_basic (147.81s)
--- PASS: TestAccIoTCentralApplication_requiresImport (162.67s)
--- PASS: TestAccIoTCentralApplication_update (208.53s)
PASS
```