### PR TITLE
`azurerm_key_vault_key` - added `versionless_id` to data source

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_key_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_data_source.go
@@ -57,6 +57,11 @@ func dataSourceKeyVaultKey() *schema.Resource {
 				Computed: true,
 			},
 
+			"versionless_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"n": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -106,6 +111,7 @@ func dataSourceKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(id)
 	d.Set("key_vault_id", keyVaultId.ID())
+	d.Set("versionless_id", parsedId.VersionlessID())
 
 	if key := resp.Key; key != nil {
 		d.Set("key_type", string(key.Kty))


### PR DESCRIPTION
Fixes #11339

Attribute documentation was already there so I think implementation was just missed for the data source.