### PR TITLE
azurerm_log_analytics_saved_search : Fix Regex within function_parame…

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_saved_search_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_saved_search_resource.go
@@ -90,8 +90,8 @@ func resourceLogAnalyticsSavedSearch() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringMatch(
-						regexp.MustCompile(`^[a-zA-Z0-9!-_]*:[a-zA-Z0-9!_-]+=[a-zA-Z0-9!_-]+`),
-						"Log Analytics Saved Search Function Parameters must be in the following format: param-name1:type1=default_value1",
+						regexp.MustCompile(`^[a-zA-Z0-9!-_]*:[a-zA-Z0-9!_-]+=[a-zA-Z0-9!_-]+|^[a-zA-Z0-9!-_]*:[a-zA-Z0-9!_-]+`),
+						"Log Analytics Saved Search Function Parameters must be in the following format: param-name1:type1=default_value1 OR param-name1:type1 OR param-name1:string='string goes here'",
 					),
 				},
 			},


### PR DESCRIPTION
…ters validation

The regex requirement in the given resource works for integers, as given in the example in the original PR, however it does not for strings. If a string has a default value supplied it must be in quotes (i.e in powershell New-AzOperationalInsightsSavedSearch, it would be -FunctionParameter "ID:string='g'"). While you can still make a successful apply doing var:string=abc, it will break when using the function as it is essentially going to run (e.g) | where Computer contains abc. abc does not exist. It needs to be "abc" if you where doing a query in LA (just an example). 

Example Error:
![image](https://user-images.githubusercontent.com/29356754/114877057-d8d0a480-9df6-11eb-96cf-445f5eec14f9.png)


I have changed two things about the regex, one is to allow single quotes after the ='s if a user wants to set a default string, I have also put an OR so its optional to just not have any default values at all, which are both valid options using powershell / raw api. 

One option is just to get rid of this regex check completely and give responsibility to the user rather than having an extensive regex check, it seems this is more just so the users knows how to use the resource.

@mbfrahry

#8253