### PR TITLE
`azurerm_monitor_diagnostic_setting` - Support dynamic block from unprovisioned data source for `log`/`metric`

### DIFF
--- a/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -108,7 +108,6 @@ func resourceMonitorDiagnosticSetting() *schema.Resource {
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
 						},
 
 						"retention_policy": {
@@ -147,7 +146,6 @@ func resourceMonitorDiagnosticSetting() *schema.Resource {
 						"enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
 						},
 
 						"retention_policy": {
@@ -523,35 +521,40 @@ func flattenMonitorDiagnosticMetrics(input *[]insights.MetricSettings) []interfa
 	}
 
 	for _, v := range *input {
-		output := make(map[string]interface{})
-
+		var category string
 		if v.Category != nil {
-			output["category"] = *v.Category
+			category = *v.Category
 		}
 
+		var enabled bool
 		if v.Enabled != nil {
-			output["enabled"] = *v.Enabled
+			enabled = *v.Enabled
 		}
 
 		policies := make([]interface{}, 0)
 
 		if inputPolicy := v.RetentionPolicy; inputPolicy != nil {
-			outputPolicy := make(map[string]interface{})
-
+			var days int
 			if inputPolicy.Days != nil {
-				outputPolicy["days"] = int(*inputPolicy.Days)
+				days = int(*inputPolicy.Days)
 			}
 
+			var enabled bool
 			if inputPolicy.Enabled != nil {
-				outputPolicy["enabled"] = *inputPolicy.Enabled
+				enabled = *inputPolicy.Enabled
 			}
 
-			policies = append(policies, outputPolicy)
+			policies = append(policies, map[string]interface{}{
+				"days":    days,
+				"enabled": enabled,
+			})
 		}
 
-		output["retention_policy"] = policies
-
-		results = append(results, output)
+		results = append(results, map[string]interface{}{
+			"category":         category,
+			"enabled":          enabled,
+			"retention_policy": policies,
+		})
 	}
 
 	return results

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -101,7 +101,7 @@ A `log` block supports the following:
 
 * `retention_policy` - (Optional) A `retention_policy` block as defined below.
 
-* `enabled` - (Optional) Is this Diagnostic Log enabled? Defaults to `true`.
+* `enabled` - (Optional) Is this Diagnostic Log enabled? Defaults to `false`.
 
 ---
 
@@ -113,7 +113,7 @@ A `metric` block supports the following:
 
 * `retention_policy` - (Optional) A `retention_policy` block as defined below.
 
-* `enabled` - (Optional) Is this Diagnostic Metric enabled? Defaults to `true`.
+* `enabled` - (Optional) Is this Diagnostic Metric enabled? Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
This PR mainly remove the default value for `log`/`metirc`'s `enabled` (which is apparently a breaking change), in order to allow dynamic block which based on some unprovisioned data source, e.g. `azurerm_monitor_diagnostic_categories` whose `resource_id` set to some to-be-provisioned resource.

Due to hashicorp/terraform#28340, currently all we can do is to *not alter the block data during planning if compatibility with the dynamic feature was desired*. In this case, we shall not set the default value.

Fixes #9923, #6254