### PR TITLE
azurerm_databricks_workspace - allow for workspace names up to 64 characters

### DIFF
--- a/azurerm/internal/services/databricks/databricks_workspace_resource.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource.go
@@ -383,10 +383,12 @@ func ValidateDatabricksWorkspaceName(i interface{}, k string) (warnings []string
 		errors = append(errors, fmt.Errorf("%q must be at least 3 characters: %q", k, v))
 	}
 
-	// 3) The value must have a length of at most 30.
-	// NOTE: Restricted name to 30 characters because that is the restriction in Azure Portal even though the API supports 64 characters
-	if len(v) > 30 {
-		errors = append(errors, fmt.Errorf("%q must be no more than 30 characters: %q", k, v))
+	// 3) The value must have a length of at most 64
+	// NOTE: Portal limits name to 30 characters but API allows up to 64. In order to facilitate imports of workspaces
+	// created through API, use the higher limit. Note that once the workspace is created, the portal handles workspace
+	// names >30 characters just fine
+	if len(v) > 64 {
+		errors = append(errors, fmt.Errorf("%q must be no more than 64 characters: %q", k, v))
 	}
 
 	// 4) Only alphanumeric characters, underscores, and hyphens are allowed.

--- a/azurerm/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource_test.go
@@ -23,7 +23,7 @@ type DatabricksWorkspaceResource struct {
 func TestAzureRMDatabrickWorkspaceName(t *testing.T) {
 	const errEmpty = "cannot be an empty string"
 	const errMinLen = "must be at least 3 characters"
-	const errMaxLen = "must be no more than 30 characters"
+	const errMaxLen = "must be no more than 64 characters"
 	const errAllowList = "can contain only alphanumeric characters, underscores, and hyphens"
 
 	cases := []struct {
@@ -42,7 +42,7 @@ func TestAzureRMDatabrickWorkspaceName(t *testing.T) {
 		},
 		{
 			Name:  "Maximum character length",
-			Input: "012345678901234567890123456789", // 30 chars
+			Input: "0123456789012345678901234567890123456789012345678901234567890123", // 64 chars
 		},
 
 		// Simple negative cases:
@@ -58,7 +58,7 @@ func TestAzureRMDatabrickWorkspaceName(t *testing.T) {
 		},
 		{
 			Name:           "Above maximum character length",
-			Input:          "0123456789012345678901234567890", // 31 chars
+			Input:          "01234567890123456789012345678901234567890123456789012345678901234", // 31 chars
 			ExpectedErrors: []string{errMaxLen},
 		},
 		{
@@ -75,7 +75,7 @@ func TestAzureRMDatabrickWorkspaceName(t *testing.T) {
 		},
 		{
 			Name:           "Too long and non-allowed char",
-			Input:          "012345678901234567890123456789ß",
+			Input:          "0123456789012345678901234567890123456789012345678901234567890123ß",
 			ExpectedErrors: []string{errMaxLen, errAllowList},
 		},
 	}


### PR DESCRIPTION
Limiting workspace names to 30 characters because of the validation rules enforced by the UI prevents importing workspaces that were previously created through the API (which allows up to 64 characters). This change increases the limit to 64. Note that workspace names >30 characters work fine in the portal. I believe this change is backwards compatible.

Note that I had some trouble running the unit tests due to the `runGraduallyDeprecatedFunctions` checks. Being completely unfamiliar with golang, I didn't feel comfortable making the suggested changes (which had nothing to do with my change) so I am hoping someone here can look at that.