### PR TITLE
`azurerm_eventgrid_system_topic` - remove strict validation on `topic_type`

### DIFF
--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_resource.go
@@ -65,29 +65,10 @@ func resourceEventGridSystemTopic() *schema.Resource {
 			},
 
 			"topic_type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Microsoft.AppConfiguration.ConfigurationStores",
-					"Microsoft.Communication.CommunicationServices",
-					"Microsoft.ContainerRegistry.Registries",
-					"Microsoft.Devices.IoTHubs",
-					"Microsoft.EventGrid.Domains",
-					"Microsoft.EventGrid.Topics",
-					"Microsoft.Eventhub.Namespaces",
-					"Microsoft.KeyVault.vaults",
-					"Microsoft.MachineLearningServices.Workspaces",
-					"Microsoft.Maps.Accounts",
-					"Microsoft.Media.MediaServices",
-					"Microsoft.Resources.ResourceGroups",
-					"Microsoft.Resources.Subscriptions",
-					"Microsoft.ServiceBus.Namespaces",
-					"Microsoft.SignalRService.SignalR",
-					"Microsoft.Storage.StorageAccounts",
-					"Microsoft.Web.ServerFarms",
-					"Microsoft.Web.Sites",
-				}, false),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"metric_arm_resource_id": {


### PR DESCRIPTION
Fixes #11308

Instead of doing validation of every topic type I think this should be changed to letting API handle it as the error message is very clear. This would not require changes to any code when new topic types are released.

Error message on a system topic that is not available:
` Original Error: Code="InvalidRequest" Message="Unrecognized topic type justtesting in system topic properties."`