### PR TITLE
Update `azurerm_(linux|windows)_virtual_machine_scale_set` - Fix #8454

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -939,7 +939,14 @@ func resourceLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta interf
 		d.Set("max_bid_price", maxBidPrice)
 
 		d.Set("eviction_policy", string(profile.EvictionPolicy))
-		d.Set("priority", string(profile.Priority))
+
+		// the service just return empty when this is not assigned when provisioned
+		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
+		priority := compute.Regular
+		if profile.Priority != "" {
+			priority = profile.Priority
+		}
+		d.Set("priority", priority)
 
 		if storageProfile := profile.StorageProfile; storageProfile != nil {
 			if err := d.Set("os_disk", FlattenVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -987,7 +987,14 @@ func resourceWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta inte
 
 		d.Set("eviction_policy", string(profile.EvictionPolicy))
 		d.Set("license_type", profile.LicenseType)
-		d.Set("priority", string(profile.Priority))
+
+		// the service just return empty when this is not assigned when provisioned
+		// See discussion on https://github.com/Azure/azure-rest-api-specs/issues/10971
+		priority := compute.Regular
+		if profile.Priority != "" {
+			priority = profile.Priority
+		}
+		d.Set("priority", priority)
 
 		if storageProfile := profile.StorageProfile; storageProfile != nil {
 			if err := d.Set("os_disk", FlattenVirtualMachineScaleSetOSDisk(storageProfile.OsDisk)); err != nil {


### PR DESCRIPTION
Partially fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/8454

We could do this work around because the service team has confirmed that the default value when absence of this attribute is `Regular` (details [here](https://github.com/Azure/azure-rest-api-specs/issues/10971))

And the service cannot return anything when a property is not set in the request, they call this principal as "PUT-GET consistency". 
In some circumstances, this helps - sometimes absence of a property means it was automatically assigned to a value chosen by Azure, and in this way, we will not be getting any diff, which is convenient. They usually will provide another operation to query the actual value of this. An example for this behaviour is the "managed boot diagnostics" [here](https://github.com/terraform-providers/terraform-provider-azurerm/pull/8917)