### PR TITLE
azurerm_storage_account: add support for NFSv3 protocol

### DIFF
--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -157,6 +157,13 @@ func resourceStorageAccount() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"is_nfsv3_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
 			"allow_blob_public_access": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -660,6 +667,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 	enableHTTPSTrafficOnly := d.Get("enable_https_traffic_only").(bool)
 	minimumTLSVersion := d.Get("min_tls_version").(string)
 	isHnsEnabled := d.Get("is_hns_enabled").(bool)
+	isNFSv3Enabled := d.Get("is_nfsv3_enabled").(bool)
 	allowBlobPublicAccess := d.Get("allow_blob_public_access").(bool)
 
 	accountTier := d.Get("account_tier").(string)
@@ -677,6 +685,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 			EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly,
 			NetworkRuleSet:         expandStorageAccountNetworkRules(d),
 			IsHnsEnabled:           &isHnsEnabled,
+			EnableNfsV3:            &isNFSv3Enabled,
 		},
 	}
 
@@ -721,6 +730,20 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 		parameters.AccountPropertiesCreateParameters.AccessTier = storage.AccessTier(accessTier.(string))
 	} else if isHnsEnabled && accountKind != string(storage.BlockBlobStorage) {
 		return fmt.Errorf("`is_hns_enabled` can only be used with account kinds `StorageV2`, `BlobStorage` and `BlockBlobStorage`")
+	}
+
+	// NFSv3 is supported for standard general-purpose v2 storage accounts and for premium block blob storage accounts.
+	// (https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to#step-5-create-and-configure-a-storage-account)
+	if isNFSv3Enabled &&
+		!((accountTier == string(storage.Premium) && accountKind == string(storage.BlockBlobStorage)) ||
+			(accountTier == string(storage.Standard) && accountKind == string(storage.StorageV2))) {
+		return fmt.Errorf("`is_nfsv3_enabled` can only be used with account tier `Standard` and account kind `StorageV2`, or account tier `Premium` and account kind `BlockBlobStorage`")
+	}
+	if isNFSv3Enabled && enableHTTPSTrafficOnly {
+		return fmt.Errorf("`is_nfsv3_enabled` can only be used when `enable_https_traffic_only` is `false`")
+	}
+	if isNFSv3Enabled && !isHnsEnabled {
+		return fmt.Errorf("`is_nfsv3_enabled` can only be used when `is_hns_enabled` is `true`")
 	}
 
 	// AccountTier must be Premium for FileStorage
@@ -1151,6 +1174,7 @@ func resourceStorageAccountRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("access_tier", props.AccessTier)
 		d.Set("enable_https_traffic_only", props.EnableHTTPSTrafficOnly)
 		d.Set("is_hns_enabled", props.IsHnsEnabled)
+		d.Set("is_nfsv3_enabled", props.EnableNfsV3)
 		d.Set("allow_blob_public_access", props.AllowBlobPublicAccess)
 		// For all Clouds except Public and USGovernmentCloud, "min_tls_version" is not returned from Azure so always persist the default values for "min_tls_version".
 		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7812

--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -157,7 +157,7 @@ func resourceStorageAccount() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"is_nfsv3_enabled": {
+			"nfsv3_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -667,7 +667,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 	enableHTTPSTrafficOnly := d.Get("enable_https_traffic_only").(bool)
 	minimumTLSVersion := d.Get("min_tls_version").(string)
 	isHnsEnabled := d.Get("is_hns_enabled").(bool)
-	isNFSv3Enabled := d.Get("is_nfsv3_enabled").(bool)
+	nfsV3Enabled := d.Get("nfsv3_enabled").(bool)
 	allowBlobPublicAccess := d.Get("allow_blob_public_access").(bool)
 
 	accountTier := d.Get("account_tier").(string)
@@ -685,7 +685,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 			EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly,
 			NetworkRuleSet:         expandStorageAccountNetworkRules(d),
 			IsHnsEnabled:           &isHnsEnabled,
-			EnableNfsV3:            &isNFSv3Enabled,
+			EnableNfsV3:            &nfsV3Enabled,
 		},
 	}
 
@@ -734,16 +734,16 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// NFSv3 is supported for standard general-purpose v2 storage accounts and for premium block blob storage accounts.
 	// (https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to#step-5-create-and-configure-a-storage-account)
-	if isNFSv3Enabled &&
+	if nfsV3Enabled &&
 		!((accountTier == string(storage.Premium) && accountKind == string(storage.BlockBlobStorage)) ||
 			(accountTier == string(storage.Standard) && accountKind == string(storage.StorageV2))) {
-		return fmt.Errorf("`is_nfsv3_enabled` can only be used with account tier `Standard` and account kind `StorageV2`, or account tier `Premium` and account kind `BlockBlobStorage`")
+		return fmt.Errorf("`nfsv3_enabled` can only be used with account tier `Standard` and account kind `StorageV2`, or account tier `Premium` and account kind `BlockBlobStorage`")
 	}
-	if isNFSv3Enabled && enableHTTPSTrafficOnly {
-		return fmt.Errorf("`is_nfsv3_enabled` can only be used when `enable_https_traffic_only` is `false`")
+	if nfsV3Enabled && enableHTTPSTrafficOnly {
+		return fmt.Errorf("`nfsv3_enabled` can only be used when `enable_https_traffic_only` is `false`")
 	}
-	if isNFSv3Enabled && !isHnsEnabled {
-		return fmt.Errorf("`is_nfsv3_enabled` can only be used when `is_hns_enabled` is `true`")
+	if nfsV3Enabled && !isHnsEnabled {
+		return fmt.Errorf("`nfsv3_enabled` can only be used when `is_hns_enabled` is `true`")
 	}
 
 	// AccountTier must be Premium for FileStorage
@@ -1174,7 +1174,7 @@ func resourceStorageAccountRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("access_tier", props.AccessTier)
 		d.Set("enable_https_traffic_only", props.EnableHTTPSTrafficOnly)
 		d.Set("is_hns_enabled", props.IsHnsEnabled)
-		d.Set("is_nfsv3_enabled", props.EnableNfsV3)
+		d.Set("nfsv3_enabled", props.EnableNfsV3)
 		d.Set("allow_blob_public_access", props.AllowBlobPublicAccess)
 		// For all Clouds except Public and USGovernmentCloud, "min_tls_version" is not returned from Azure so always persist the default values for "min_tls_version".
 		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7812

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -1116,7 +1116,7 @@ resource "azurerm_storage_account" "test" {
   account_kind              = "BlockBlobStorage"
   account_replication_type  = "LRS"
   is_hns_enabled            = true
-  is_nfsv3_enabled          = true
+  nfsv3_enabled             = true
   enable_https_traffic_only = false
   network_rules {
     default_action             = "Deny"

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -109,6 +109,10 @@ The following arguments are supported:
 
 -> **NOTE:** This can only be `true` when `account_tier` is `Standard` or when `account_tier` is `Premium` *and* `account_kind` is `BlockBlobStorage` 
 
+* `is_nfsv3_enabled` - (Optional) Is NFSv3 protocol enabled? Changing this forces a new resource to be created. Defaults to `false`.
+
+-> **NOTE:** This can only be `true` when `account_tier` is `Standard` and `account_kind` is `StorageV2`, or `account_tier` is `Premium` and `account_kind` is `BlockBlobStorage`. Additionally, the `is_hns_enabled` is `true`, and `enable_https_traffic_only` is `false`.
+
 * `custom_domain` - (Optional) A `custom_domain` block as documented below.
 
 * `identity` - (Optional) A `identity` block as defined below.

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -109,7 +109,7 @@ The following arguments are supported:
 
 -> **NOTE:** This can only be `true` when `account_tier` is `Standard` or when `account_tier` is `Premium` *and* `account_kind` is `BlockBlobStorage` 
 
-* `is_nfsv3_enabled` - (Optional) Is NFSv3 protocol enabled? Changing this forces a new resource to be created. Defaults to `false`.
+* `nfsv3_enabled` - (Optional) Is NFSv3 protocol enabled? Changing this forces a new resource to be created. Defaults to `false`.
 
 -> **NOTE:** This can only be `true` when `account_tier` is `Standard` and `account_kind` is `StorageV2`, or `account_tier` is `Premium` and `account_kind` is `BlockBlobStorage`. Additionally, the `is_hns_enabled` is `true`, and `enable_https_traffic_only` is `false`.
 


### PR DESCRIPTION
`azurerm_storage_account` add supports for NFSv3.

The [subscription has to register for feature `AllowNFSV3`](https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to#step-1-register-the-nfs-30-protocol-feature-with-your-subscription) in order to use this functionality.

Fixes: #11373 

Document reference:

- https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to
- https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support

## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=2h ./azurerm/internal/services/storage -run="TestAccStorageAccount_isNFSv3Enabled"
2021/04/20 14:21:27 [DEBUG] not using binary driver name, it's no longer needed
2021/04/20 14:21:27 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccStorageAccount_isNFSv3Enabled
=== PAUSE TestAccStorageAccount_isNFSv3Enabled
=== CONT  TestAccStorageAccount_isNFSv3Enabled
--- PASS: TestAccStorageAccount_isNFSv3Enabled (259.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage     259.301s
```