### PR TITLE
azurerm_iothub - change `filter_rule` from TypeSet to TypeList

### DIFF
--- a/azurerm/internal/services/iothub/iothub_resource.go
+++ b/azurerm/internal/services/iothub/iothub_resource.go
@@ -424,7 +424,7 @@ func resourceIotHub() *schema.Resource {
 			},
 
 			"ip_filter_rule": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -1286,7 +1286,7 @@ func validateIoTHubFileNameFormat(v interface{}, k string) (warnings []string, e
 }
 
 func expandIPFilterRules(d *schema.ResourceData) *[]devices.IPFilterRule {
-	ipFilterRuleList := d.Get("ip_filter_rule").(*schema.Set).List()
+	ipFilterRuleList := d.Get("ip_filter_rule").([]interface{})
 	if len(ipFilterRuleList) == 0 {
 		return nil
 	}

--- a/azurerm/internal/services/iothub/iothub_resource_test.go
+++ b/azurerm/internal/services/iothub/iothub_resource_test.go
@@ -44,6 +44,13 @@ func TestAccIotHub_ipFilterRules(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.ipFilterRulesUpdate(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -356,6 +363,70 @@ resource "azurerm_iothub" "test" {
   ip_filter_rule {
     name    = "test"
     ip_mask = "10.0.0.0/31"
+    action  = "Accept"
+  }
+
+  ip_filter_rule {
+    name    = "test2"
+    ip_mask = "10.0.2.0/31"
+    action  = "Accept"
+  }
+
+  ip_filter_rule {
+    name    = "test3"
+    ip_mask = "10.0.3.0/31"
+    action  = "Accept"
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (IotHubResource) ipFilterRulesUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  ip_filter_rule {
+    name    = "test4"
+    ip_mask = "10.0.4.0/31"
+    action  = "Accept"
+  }
+
+  ip_filter_rule {
+    name    = "test"
+    ip_mask = "10.0.0.0/31"
+    action  = "Accept"
+  }
+
+  ip_filter_rule {
+    name    = "test3"
+    ip_mask = "10.0.3.0/31"
+    action  = "Accept"
+  }
+
+  ip_filter_rule {
+    name    = "test5"
+    ip_mask = "10.0.5.0/31"
     action  = "Accept"
   }
 


### PR DESCRIPTION
This is to reserve the order of the rules as defined in the TF config.

Fixes: #10341 