### PR TITLE
`azurerm_mssql_database ` - error when secondary database uses `max_size_gb`

### DIFF
--- a/azurerm/internal/services/mssql/mssql_database_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource.go
@@ -396,7 +396,7 @@ func resourceMsSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("max_size_gb"); ok {
-		if createMode == string(sql.CreateModeOnlineSecondary) || createMode == string(sql.Secondary) {
+		if d.HasChange("max_size_gb") && (createMode == string(sql.CreateModeOnlineSecondary) || createMode == string(sql.Secondary)) {
 			return fmt.Errorf("it is not possible to change maximum size nor advised to configure maximum size on SQL Database %q (Resource Group %q, Server %q) in secondary create mode", name, serverId.ResourceGroup, serverId.Name)
 		}
 		params.DatabaseProperties.MaxSizeBytes = utils.Int64(int64(v.(int) * 1073741824))

--- a/azurerm/internal/services/mssql/mssql_database_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource.go
@@ -397,7 +397,7 @@ func resourceMsSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("max_size_gb"); ok {
 		if createMode == string(sql.CreateModeOnlineSecondary) || createMode == string(sql.Secondary) {
-			log.Printf("[WARN] it is not possible to change maximum size nor advised to configure maximum size on SQL Database %q (Resource Group %q, Server %q) in secondary create mode", name, serverId.ResourceGroup, serverId.Name)
+			return fmt.Errorf("it is not possible to change maximum size nor advised to configure maximum size on SQL Database %q (Resource Group %q, Server %q) in secondary create mode", name, serverId.ResourceGroup, serverId.Name)
 		}
 		params.DatabaseProperties.MaxSizeBytes = utils.Int64(int64(v.(int) * 1073741824))
 	}

--- a/azurerm/internal/services/mssql/mssql_database_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource.go
@@ -397,7 +397,7 @@ func resourceMsSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("max_size_gb"); ok {
 		if createMode == string(sql.CreateModeOnlineSecondary) || createMode == string(sql.Secondary) {
-			return fmt.Errorf("it is not possible to change maximum size nor advised to configure maximum size on SQL Database %q (Resource Group %q, Server %q) in secondary create mode", name, serverId.ResourceGroup, serverId.Name)
+			log.Printf("[WARN] it is not possible to change maximum size nor advised to configure maximum size on SQL Database %q (Resource Group %q, Server %q) in secondary create mode", name, serverId.ResourceGroup, serverId.Name)
 		}
 		params.DatabaseProperties.MaxSizeBytes = utils.Int64(int64(v.(int) * 1073741824))
 	}

--- a/azurerm/internal/services/mssql/mssql_database_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource.go
@@ -396,10 +396,14 @@ func resourceMsSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if v, ok := d.GetOk("max_size_gb"); ok {
+		// `max_size_gb` is Computed, so has a value after the first run
+		if createMode != string(sql.CreateModeOnlineSecondary) && createMode != string(sql.Secondary) {
+			params.DatabaseProperties.MaxSizeBytes = utils.Int64(int64(v.(int) * 1073741824))
+		}
+		// `max_size_gb` only has change if it is configured
 		if d.HasChange("max_size_gb") && (createMode == string(sql.CreateModeOnlineSecondary) || createMode == string(sql.Secondary)) {
 			return fmt.Errorf("it is not possible to change maximum size nor advised to configure maximum size on SQL Database %q (Resource Group %q, Server %q) in secondary create mode", name, serverId.ResourceGroup, serverId.Name)
 		}
-		params.DatabaseProperties.MaxSizeBytes = utils.Int64(int64(v.(int) * 1073741824))
 	}
 
 	readScale := sql.DatabaseReadScaleDisabled

--- a/azurerm/internal/services/mssql/mssql_database_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource_test.go
@@ -272,6 +272,41 @@ func TestAccMsSqlDatabase_createSecondaryMode(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlDatabase_scaleReplicaSetWithFailovergroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "secondary")
+	r := MsSqlDatabaseResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.scaleReplicaSetWithFailovergroup(data, "GP_Gen5_2", 5),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("collation").HasValue("SQL_AltDiction_CP850_CI_AI"),
+				check.That(data.ResourceName).Key("license_type").HasValue("BasePrice"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
+			),
+		},
+		{
+			Config: r.scaleReplicaSetWithFailovergroup(data, "GP_Gen5_8", 25),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("collation").HasValue("SQL_AltDiction_CP850_CI_AI"),
+				check.That(data.ResourceName).Key("license_type").HasValue("BasePrice"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_8"),
+			),
+		},
+		{
+			Config: r.scaleReplicaSetWithFailovergroup(data, "GP_Gen5_2", 5),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("collation").HasValue("SQL_AltDiction_CP850_CI_AI"),
+				check.That(data.ResourceName).Key("license_type").HasValue("BasePrice"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
+			),
+		},
+	})
+}
+
 func TestAccMsSqlDatabase_createRestoreMode(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 	r := MsSqlDatabaseResource{}
@@ -879,6 +914,64 @@ resource "azurerm_mssql_database" "secondary" {
 
 }
 `, r.complete(data), data.RandomInteger, data.Locations.Secondary)
+}
+
+func (r MsSqlDatabaseResource) scaleReplicaSetWithFailovergroup(data acceptance.TestData, sku string, size int) string {
+	return fmt.Sprintf(`
+	%[1]s
+
+resource "azurerm_mssql_database" "test" {
+  name         = "acctest-db-%[2]d"
+  server_id    = azurerm_sql_server.test.id
+  collation    = "SQL_AltDiction_CP850_CI_AI"
+  license_type = "BasePrice"
+  max_size_gb  = %[5]d
+  sample_name  = "AdventureWorksLT"
+  sku_name     = "%[4]s"
+
+  tags = {
+    ENV = "Test"
+  }
+}
+
+resource "azurerm_resource_group" "second" {
+  name     = "acctestRG-mssql2-%[2]d"
+  location = "%[3]s"
+}
+
+resource "azurerm_sql_server" "second" {
+  name                         = "acctest-sqlserver2-%[2]d"
+  resource_group_name          = azurerm_resource_group.second.name
+  location                     = azurerm_resource_group.second.location
+  version                      = "12.0"
+  administrator_login          = "mradministrator"
+  administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_mssql_database" "secondary" {
+  name                        = "acctest-db-%[2]d"
+  server_id                   = azurerm_sql_server.second.id
+  create_mode                 = "Secondary"
+  creation_source_database_id = azurerm_mssql_database.test.id
+  sku_name                    = "%[4]s"
+}
+
+resource "azurerm_sql_failover_group" "failover_group" {
+  depends_on          = [azurerm_mssql_database.test, azurerm_mssql_database.secondary]
+  name                = "acctest-fog-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  server_name         = azurerm_sql_server.test.name
+  databases           = [azurerm_mssql_database.test.id]
+  partner_servers {
+    id = azurerm_sql_server.second.id
+  }
+
+  read_write_endpoint_failover_policy {
+    mode          = "Automatic"
+    grace_minutes = 5
+  }
+}
+`, r.template(data), data.RandomInteger, data.Locations.Secondary, sku, size)
 }
 
 func (MsSqlDatabaseResource) createRestoreMode(data acceptance.TestData) string {

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -96,9 +96,7 @@ The following arguments are supported:
 
 * `long_term_retention_policy` - (Optional) A `long_term_retention_policy` block as defined below.
 
-* `max_size_gb` - (Optional) The max size of the database in gigabytes.
-
-~> **Note:** This value should not be configured when the `create_mode` is `Secondary` or `OnlineSecondary`, as the sizing of the primary is then used as per [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-sql/database/single-database-scale#geo-replicated-database).
+* `max_size_gb` - (Optional) The max size of the database in gigabytes. This value should not be configured when the `create_mode` is `Secondary` or `OnlineSecondary`, as the sizing of the primary is then used as per [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-sql/database/single-database-scale#geo-replicated-database).
 
 * `min_capacity` - (Optional) Minimal capacity that database will always have allocated, if not paused. This property is only settable for General Purpose Serverless databases.
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -96,7 +96,9 @@ The following arguments are supported:
 
 * `long_term_retention_policy` - (Optional) A `long_term_retention_policy` block as defined below.
 
-* `max_size_gb` - (Optional) The max size of the database in gigabytes. This value should not be configured when the `create_mode` is `Secondary` or `OnlineSecondary`, as the sizing of the primary is then used as per [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-sql/database/single-database-scale#geo-replicated-database).
+* `max_size_gb` - (Optional) The max size of the database in gigabytes.
+
+~> **Note:** This value should not be configured when the `create_mode` is `Secondary` or `OnlineSecondary`, as the sizing of the primary is then used as per [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-sql/database/single-database-scale#geo-replicated-database).
 
 * `min_capacity` - (Optional) Minimal capacity that database will always have allocated, if not paused. This property is only settable for General Purpose Serverless databases.
 


### PR DESCRIPTION
@katbyte I introduced a bug in #11286 :(

Because `max_size_gb` is `Computed`, `GetOk("max_size_gb")` is not empty in a second run. I added `HasChange("max_size_gb")` as an extra check before I throw an error to fix it.