### PR TITLE
Fix markdown heading not rendering

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a virtual machine scale set.
 
-## Disclaimers
+## Disclaimers
 
 -> **Note:** The `azurerm_virtual_machine_scale_set` resource has been superseded by the [`azurerm_linux_virtual_machine_scale_set`](linux_virtual_machine_scale_set.html) and [`azurerm_windows_virtual_machine_scale_set`](windows_virtual_machine_scale_set.html) resources. The existing `azurerm_virtual_machine_scale_set` resource will continue to be available throughout the 2.x releases however is in a feature-frozen state to maintain compatibility - new functionality will instead be added to the `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources.
 


### PR DESCRIPTION
The heading was not rendering in the Terraform registry doc. It looks like that the space between `##` and `Disclaimers` was not a space.