### PR TITLE
fix(docs): d/shared_image_version: description error in the gallery_name

### DIFF
--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `image_name` - The name of the Shared Image in which this Version exists.
 
-* `gallery_name` - The name of the Shared Image in which the Shared Image exists.
+* `gallery_name` - The name of the Shared Image Gallery in which the Shared Image exists.
 
 * `resource_group_name` - The name of the Resource Group in which the Shared Image Gallery exists.
 


### PR DESCRIPTION
Fixes an error in the documentation. `The name of the Shared Image **Gallery** in which the Shared Image exists.`  instead of `The name of the Shared Image in which the Shared Image exists.`