### PR TITLE
Fix typo issue

### DIFF
--- a/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
+++ b/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
@@ -73,7 +73,7 @@ resource "azurerm_app_service_virtual_network_swift_connection" "example" {
 
 ## Example Usage (with Function App)
 ```hcl
-esource "azurerm_resource_group" "example" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }


### PR DESCRIPTION
The letter 'r' is missing in the word "resource" on the "app_service_virtual_network_swift_connection" documentation