### PR TITLE
refactor: renaming a few fields to avoid conflicts with the Plugin SDK script

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -341,16 +341,16 @@ func expandTableSchemaClusterKeys(input []interface{}) *[]documentdb.ClusterKey 
 	return &keys
 }
 
-func flattenTableSchema(schema *documentdb.CassandraSchema) []interface{} {
+func flattenTableSchema(input *documentdb.CassandraSchema) []interface{} {
 	results := make([]interface{}, 0)
-	if schema == nil {
+	if input == nil {
 		return results
 	}
 
 	result := make(map[string]interface{})
-	result["column"] = flattenTableSchemaColumns(schema.Columns)
-	result["partition_key"] = flattenTableSchemaPartitionKeys(schema.PartitionKeys)
-	result["cluster_key"] = flattenTableSchemaClusterKeys(schema.ClusterKeys)
+	result["column"] = flattenTableSchemaColumns(input.Columns)
+	result["partition_key"] = flattenTableSchemaPartitionKeys(input.PartitionKeys)
+	result["cluster_key"] = flattenTableSchemaClusterKeys(input.ClusterKeys)
 
 	results = append(results, result)
 	return results

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource.go
@@ -198,8 +198,8 @@ func resourceCosmosDbSQLStoredProcedureRead(d *schema.ResourceData, meta interfa
 	d.Set("name", id.StoredProcedureName)
 
 	if props := resp.SQLStoredProcedureGetProperties; props != nil {
-		if resource := props.Resource; resource != nil {
-			d.Set("body", resource.Body)
+		if props.Resource != nil {
+			d.Set("body", props.Resource.Body)
 		}
 	}
 

--- a/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_gen2_environment_resource.go
+++ b/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_gen2_environment_resource.go
@@ -171,16 +171,16 @@ func resourceIoTTimeSeriesInsightsGen2EnvironmentCreateUpdate(d *schema.Resource
 		return fmt.Errorf("retrieving IoT Time Series Insights Gen2 Environment %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	resource, ok := resp.Value.AsGen2EnvironmentResource()
+	read, ok := resp.Value.AsGen2EnvironmentResource()
 	if !ok {
 		return fmt.Errorf("resource was not IoT Time Series Insights Gen2 Environment %q (Resource Group %q)", name, resourceGroup)
 	}
 
-	if resource.ID == nil || *resource.ID == "" {
+	if read.ID == nil || *read.ID == "" {
 		return fmt.Errorf("cannot read IoT Time Series Insights Gen2 Environment %q (Resource Group %q) ID", name, resourceGroup)
 	}
 
-	d.SetId(*resource.ID)
+	d.SetId(*read.ID)
 
 	return resourceIoTTimeSeriesInsightsGen2EnvironmentRead(d, meta)
 }

--- a/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_standard_environment_resource.go
+++ b/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_standard_environment_resource.go
@@ -178,16 +178,16 @@ func resourceIoTTimeSeriesInsightsStandardEnvironmentCreateUpdate(d *schema.Reso
 		return fmt.Errorf("retrieving IoT Time Series Insights Standard Environment %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	resource, ok := resp.Value.AsGen1EnvironmentResource()
+	read, ok := resp.Value.AsGen1EnvironmentResource()
 	if !ok {
 		return fmt.Errorf("resource was not a standard IoT Time Series Insights Standard Environment %q (Resource Group %q)", name, resourceGroup)
 	}
 
-	if resource.ID == nil || *resource.ID == "" {
+	if read.ID == nil || *read.ID == "" {
 		return fmt.Errorf("cannot read IoT Time Series Insights Standard Environment %q (Resource Group %q) ID", name, resourceGroup)
 	}
 
-	d.SetId(*resource.ID)
+	d.SetId(*read.ID)
 
 	return resourceIoTTimeSeriesInsightsStandardEnvironmentRead(d, meta)
 }

--- a/azurerm/internal/services/keyvault/client/helpers.go
+++ b/azurerm/internal/services/keyvault/client/helpers.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
-	resource "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/client"
+	resourcesClient "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource/client"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -89,7 +89,7 @@ func (c *Client) Exists(ctx context.Context, keyVaultId parse.VaultId) (bool, er
 	return true, nil
 }
 
-func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *resource.Client, keyVaultBaseUrl string) (*string, error) {
+func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *resourcesClient.Client, keyVaultBaseUrl string) (*string, error) {
 	keyVaultName, err := c.parseNameFromBaseUrl(keyVaultBaseUrl)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/network/vpn_gateway_connection_resource.go
+++ b/azurerm/internal/services/network/vpn_gateway_connection_resource.go
@@ -625,10 +625,10 @@ func flattenVpnGatewayConnectionRoutingConfiguration(input *network.RoutingConfi
 
 	propagatedRouteTables := []interface{}{}
 	if input.PropagatedRouteTables != nil && input.PropagatedRouteTables.Ids != nil {
-		for _, subresource := range *input.PropagatedRouteTables.Ids {
+		for _, routeTableId := range *input.PropagatedRouteTables.Ids {
 			id := ""
-			if subresource.ID != nil {
-				id = *subresource.ID
+			if routeTableId.ID != nil {
+				id = *routeTableId.ID
 			}
 			propagatedRouteTables = append(propagatedRouteTables, id)
 		}


### PR DESCRIPTION
Whilst we could make the (simple) Plugin SDK script complex and handle all of these scenarios, it's considerably easier to rename these fields and avoid conflicts