### PR TITLE
azurerm_api_management: fix panic when given empty `hostname_configuration`

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -941,6 +941,9 @@ func expandAzureRmApiManagementHostnameConfigurations(d *schema.ResourceData) *[
 	hostnameVs := vs.([]interface{})
 
 	for _, hostnameRawVal := range hostnameVs {
+		if hostnameRawVal == nil {
+			continue
+		}
 		hostnameV := hostnameRawVal.(map[string]interface{})
 
 		managementVs := hostnameV["management"].([]interface{})

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -372,6 +372,7 @@ func resourceApiManagementService() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: apiManagementResourceHostnameSchema(),
 							},
+							AtLeastOneOf: []string{"hostname_configuration.0.management", "hostname_configuration.0.portal", "hostname_configuration.0.developer_portal", "hostname_configuration.0.proxy", "hostname_configuration.0.scm"},
 						},
 						"portal": {
 							Type:     schema.TypeList,
@@ -379,6 +380,7 @@ func resourceApiManagementService() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: apiManagementResourceHostnameSchema(),
 							},
+							AtLeastOneOf: []string{"hostname_configuration.0.management", "hostname_configuration.0.portal", "hostname_configuration.0.developer_portal", "hostname_configuration.0.proxy", "hostname_configuration.0.scm"},
 						},
 						"developer_portal": {
 							Type:     schema.TypeList,
@@ -386,6 +388,7 @@ func resourceApiManagementService() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: apiManagementResourceHostnameSchema(),
 							},
+							AtLeastOneOf: []string{"hostname_configuration.0.management", "hostname_configuration.0.portal", "hostname_configuration.0.developer_portal", "hostname_configuration.0.proxy", "hostname_configuration.0.scm"},
 						},
 						"proxy": {
 							Type:     schema.TypeList,
@@ -393,6 +396,7 @@ func resourceApiManagementService() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: apiManagementResourceHostnameProxySchema(),
 							},
+							AtLeastOneOf: []string{"hostname_configuration.0.management", "hostname_configuration.0.portal", "hostname_configuration.0.developer_portal", "hostname_configuration.0.proxy", "hostname_configuration.0.scm"},
 						},
 						"scm": {
 							Type:     schema.TypeList,
@@ -400,6 +404,7 @@ func resourceApiManagementService() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: apiManagementResourceHostnameSchema(),
 							},
+							AtLeastOneOf: []string{"hostname_configuration.0.management", "hostname_configuration.0.portal", "hostname_configuration.0.developer_portal", "hostname_configuration.0.proxy", "hostname_configuration.0.scm"},
 						},
 					},
 				},
@@ -941,9 +946,7 @@ func expandAzureRmApiManagementHostnameConfigurations(d *schema.ResourceData) *[
 	hostnameVs := vs.([]interface{})
 
 	for _, hostnameRawVal := range hostnameVs {
-		if hostnameRawVal == nil {
-			continue
-		}
+		// hostnameRawVal is guaranteed to be non-nil as there is AtLeastOneOf constraint on its containing properties.
 		hostnameV := hostnameRawVal.(map[string]interface{})
 
 		managementVs := hostnameV["management"].([]interface{})


### PR DESCRIPTION
Fixes #11422 

The panic happens with following configuration:

```hcl
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name = "apimgmtcrash"
  location = "eastus2"
}

resource "azurerm_api_management" "apimtest" {
  name                = "apimgmtcrash"
  location            = azurerm_resource_group.test.location
  resource_group_name = azurerm_resource_group.test.name
  publisher_name      = "Terraform"
  publisher_email     = "foo@bar.com"
  sku_name            = "Developer_1"
  identity {
    type = "SystemAssigned"
  }
  hostname_configuration {} # THIS LINE CAUSES PANIC
}
```

Note that this PR only avoids the panic, whilst it will cause diff in next plan:

```bash
  ~ resource "azurerm_api_management" "apimtest" {
        id                        = "/subscriptions/xxx/resourceGroups/apimgmtcrash/providers/Microsoft.ApiManagement/service/apimgmtcrash"
        name                      = "apimgmtcrash"
        tags                      = {}
        # (16 unchanged attributes hidden)

      + hostname_configuration {
        }
```
