### PR TITLE
resources: removing some unnecessary state functions on computed fields

### DIFF
--- a/azurerm/internal/services/resource/management_group_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/management_group_template_deployment_resource.go
@@ -99,9 +99,8 @@ func managementGroupTemplateDeploymentResource() *schema.Resource {
 
 			// Computed
 			"output_content": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				StateFunc: utils.NormalizeJson,
+				Type:     schema.TypeString,
+				Computed: true,
 				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
 				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
 			},

--- a/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/resource_group_template_deployment_resource.go
@@ -99,9 +99,8 @@ func resourceGroupTemplateDeploymentResource() *schema.Resource {
 
 			// Computed
 			"output_content": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				StateFunc: utils.NormalizeJson,
+				Type:     schema.TypeString,
+				Computed: true,
 				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
 				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
 			},

--- a/azurerm/internal/services/resource/subscription_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/subscription_template_deployment_resource.go
@@ -90,9 +90,8 @@ func subscriptionTemplateDeploymentResource() *schema.Resource {
 
 			// Computed
 			"output_content": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				StateFunc: utils.NormalizeJson,
+				Type:     schema.TypeString,
+				Computed: true,
 				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
 				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
 			},

--- a/azurerm/internal/services/resource/template_spec_version_data_source.go
+++ b/azurerm/internal/services/resource/template_spec_version_data_source.go
@@ -41,9 +41,8 @@ func dataSourceTemplateSpecVersion() *schema.Resource {
 			},
 
 			"template_body": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				StateFunc: utils.NormalizeJson,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"tags": tags.SchemaDataSource(),

--- a/azurerm/internal/services/resource/tenant_template_deployment_resource.go
+++ b/azurerm/internal/services/resource/tenant_template_deployment_resource.go
@@ -90,9 +90,8 @@ func tenantTemplateDeploymentResource() *schema.Resource {
 
 			// Computed
 			"output_content": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				StateFunc: utils.NormalizeJson,
+				Type:     schema.TypeString,
+				Computed: true,
 				// NOTE:  outputs can be strings, ints, objects etc - whilst using a nested object was considered
 				// parsing the JSON using `jsondecode` allows the users to interact with/map objects as required
 			},


### PR DESCRIPTION
Plugin SDKv2 highlights these can be removed, since they're superflurous:

```
* resource azurerm_tenant_template_deployment: output_content: StateFunc is
extraneous, value should just be changed before setting on computed-only field
* resource azurerm_subscription_template_deployment: output_content:
StateFunc is extraneous, value should just be changed before setting on
computed-only field
* resource azurerm_resource_group_template_deployment: output_content:
StateFunc is extraneous, value should just be changed before setting on
computed-only field
* resource azurerm_management_group_template_deployment: output_content:
StateFunc is extraneous, value should just be changed before setting on
computed-only field
* data source azurerm_template_spec_version: template_body: StateFunc is
extraneous, value should just be changed before setting on computed-only field
```