### PR TITLE
Update `azurerm_dedicated_host_group` - support automatic placement

### DIFF
--- a/azurerm/internal/services/compute/dedicated_host_group_data_source.go
+++ b/azurerm/internal/services/compute/dedicated_host_group_data_source.go
@@ -40,6 +40,11 @@ func dataSourceDedicatedHostGroup() *schema.Resource {
 				Computed: true,
 			},
 
+			"automatic_placement_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"zones": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -82,6 +87,8 @@ func dataSourceDedicatedHostGroupRead(d *schema.ResourceData, meta interface{}) 
 			platformFaultDomainCount = int(*props.PlatformFaultDomainCount)
 		}
 		d.Set("platform_fault_domain_count", platformFaultDomainCount)
+
+		d.Set("automatic_placement_enabled", props.SupportAutomaticPlacement)
 	}
 
 	d.Set("zones", utils.FlattenStringSlice(resp.Zones))

--- a/azurerm/internal/services/compute/dedicated_host_group_data_source_test.go
+++ b/azurerm/internal/services/compute/dedicated_host_group_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceDedicatedHostGroup_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("zones.#").HasValue("1"),
 				check.That(data.ResourceName).Key("zones.0").HasValue("1"),
 				check.That(data.ResourceName).Key("platform_fault_domain_count").HasValue("2"),
+				check.That(data.ResourceName).Key("automatic_placement_enabled").HasValue("false"),
 			),
 		},
 	})

--- a/azurerm/internal/services/compute/dedicated_host_group_resource.go
+++ b/azurerm/internal/services/compute/dedicated_host_group_resource.go
@@ -59,6 +59,13 @@ func resourceDedicatedHostGroup() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 3),
 			},
 
+			"automatic_placement_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
 			// Currently only one endpoint is allowed.
 			// we'll leave this open to enhancement when they add multiple zones support.
 			"zones": azure.SchemaSingleZone(),
@@ -101,6 +108,10 @@ func resourceDedicatedHostGroupCreate(d *schema.ResourceData, meta interface{}) 
 	}
 	if zones, ok := d.GetOk("zones"); ok {
 		parameters.Zones = utils.ExpandStringSlice(zones.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("automatic_placement_enabled"); ok {
+		parameters.DedicatedHostGroupProperties.SupportAutomaticPlacement = utils.Bool(v.(bool))
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, resourceGroupName, name, parameters); err != nil {
@@ -152,6 +163,8 @@ func resourceDedicatedHostGroupRead(d *schema.ResourceData, meta interface{}) er
 			platformFaultDomainCount = int(*props.PlatformFaultDomainCount)
 		}
 		d.Set("platform_fault_domain_count", platformFaultDomainCount)
+
+		d.Set("automatic_placement_enabled", props.SupportAutomaticPlacement)
 	}
 	d.Set("zones", utils.FlattenStringSlice(resp.Zones))
 

--- a/website/docs/d/dedicated_host_group.html.markdown
+++ b/website/docs/d/dedicated_host_group.html.markdown
@@ -42,6 +42,8 @@ The following attributes are exported:
 
 * `platform_fault_domain_count` - The number of fault domains that the Dedicated Host Group spans.
 
+* `automatic_placement_enabled` - Whether virtual machines or virtual machine scale sets be placed automatically on this Dedicated Host Group.
+
 * `zones` - The Availability Zones in which this Dedicated Host Group is located.
 
 * `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/r/dedicated_host_group.html.markdown
+++ b/website/docs/r/dedicated_host_group.html.markdown
@@ -38,6 +38,8 @@ The following arguments are supported:
 
 * `platform_fault_domain_count` - (Required) The number of fault domains that the Dedicated Host Group spans. Changing this forces a new resource to be created.
 
+* `automatic_placement_enabled` - (Optional) Would virtual machines or virtual machine scale sets be placed automatically on this Dedicated Host Group? Defaults to `false`. Changing this forces a new resource to be created.
+
 * `zones` - (Optional) A list of Availability Zones in which the Dedicated Host Group should be located. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
This PR adds the `automatic_placement_enabled` attribute for `azurerm_dedicated_host_group`, which gives the ability of VMs and VMSSs to directly scales depending a dedicated host group instead of a specific dedicated host.

I will open another PR for VM and VMSS to support dedicated host group after this PR merges.