### PR TITLE
migrations: switching to use the plugin-sdk wrapper

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_version_set_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_version_set_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/migration"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
@@ -37,9 +39,9 @@ func resourceApiManagementApiVersionSet() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.ApiVersionSetV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ApiVersionSetV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"name": schemaz.SchemaApiManagementChildName(),

--- a/azurerm/internal/services/apimanagement/api_management_property_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_property_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/migration"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
@@ -41,9 +43,9 @@ func resourceApiManagementProperty() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.ApiPropertyV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ApiPropertyV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"name": schemaz.SchemaApiManagementChildName(),

--- a/azurerm/internal/services/apimanagement/migration/api_version_set.go
+++ b/azurerm/internal/services/apimanagement/migration/api_version_set.go
@@ -1,76 +1,76 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func ApiVersionSetV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    apiVersionSetSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: apiVersionSetUpgradeV0ToV1,
-		Version: 0,
-	}
+var _ pluginsdk.StateUpgrade = ApiVersionSetV0ToV1{}
+
+type ApiVersionSetV0ToV1 struct {
 }
 
-func apiVersionSetSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (ApiVersionSetV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"api_management_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"api_management_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"display_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"display_name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"versioning_scheme": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"versioning_scheme": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"version_header_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"version_header_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"version_query_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"version_query_name": {
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 	}
 }
 
-func apiVersionSetUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "/api-version-set/", "/apiVersionSets/", 1)
+func (ApiVersionSetV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "/api-version-set/", "/apiVersionSets/", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/apimanagement/migration/property.go
+++ b/azurerm/internal/services/apimanagement/migration/property.go
@@ -1,75 +1,74 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func ApiPropertyV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    apiPropertySchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: apiPropertyUpgradeV0ToV1,
-		Version: 0,
-	}
+var _ pluginsdk.StateUpgrade = ApiPropertyV0ToV1{}
+
+type ApiPropertyV0ToV1 struct {
 }
 
-func apiPropertySchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (ApiPropertyV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"api_management_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"api_management_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"display_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"display_name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"value": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"value": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"secret": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
+		"secret": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 
-			"tags": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func apiPropertyUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "/properties/", "/namedValues/", 1)
+func (ApiPropertyV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "/properties/", "/namedValues/", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/authorization/migration/role_definition_migration.go
+++ b/azurerm/internal/services/authorization/migration/role_definition_migration.go
@@ -1,112 +1,111 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func RoleDefinitionV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    roleDefinitionSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: roleDefinitionUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = RoleDefinitionV0ToV1{}
 
-func roleDefinitionSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"role_definition_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
+type RoleDefinitionV0ToV1 struct{}
 
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+func (RoleDefinitionV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"role_definition_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
 
-			"scope": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"scope": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"permissions": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"actions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"permissions": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"actions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"not_actions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+					},
+					"not_actions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"data_actions": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Set: schema.HashString,
+					},
+					"data_actions": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"not_data_actions": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Set: schema.HashString,
+						Set: schema.HashString,
+					},
+					"not_data_actions": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
+						Set: schema.HashString,
 					},
 				},
 			},
+		},
 
-			"assignable_scopes": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"assignable_scopes": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func roleDefinitionUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+func (RoleDefinitionV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Println("[DEBUG] Migrating ID from v0 to v1 format")
 
-	oldID := rawState["id"].(string)
-	if oldID == "" {
-		return nil, fmt.Errorf("failed to migrate state: old ID empty")
+		oldID := rawState["id"].(string)
+		if oldID == "" {
+			return nil, fmt.Errorf("failed to migrate state: old ID empty")
+		}
+		scope := rawState["scope"].(string)
+		if scope == "" {
+			return nil, fmt.Errorf("failed to migrate state: scope missing")
+		}
+
+		newID := fmt.Sprintf("%s|%s", oldID, scope)
+
+		rawState["id"] = newID
+
+		return rawState, nil
 	}
-	scope := rawState["scope"].(string)
-	if scope == "" {
-		return nil, fmt.Errorf("failed to migrate state: scope missing")
-	}
-
-	newID := fmt.Sprintf("%s|%s", oldID, scope)
-
-	rawState["id"] = newID
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/authorization/migration/role_definition_migration_test.go
+++ b/azurerm/internal/services/authorization/migration/role_definition_migration_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestRoleDefinitionMigrateState(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		newID, _ := roleDefinitionUpgradeV0ToV1(tc.InputAttributes, nil)
+		newID, _ := RoleDefinitionV0ToV1{}.UpgradeFunc()(context.TODO(), tc.InputAttributes, nil)
 
 		if newID["id"].(string) != tc.ExpectedNewID {
 			t.Fatalf("ID migration failed, expected %q, got: %q", tc.ExpectedNewID, newID["id"].(string))

--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/authorization/migration"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2020-04-01-preview/authorization"
@@ -34,9 +36,9 @@ func resourceArmRoleDefinition() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.RoleDefinitionV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.RoleDefinitionV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/migration"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2019-04-15/cdn"
@@ -30,9 +32,9 @@ func resourceCdnEndpoint() *schema.Resource {
 		Delete: resourceCdnEndpointDelete,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.CdnEndpointV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CdnEndpointV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2019-04-15/cdn"
 	"github.com/hashicorp/go-azure-helpers/response"
@@ -30,9 +31,9 @@ func resourceCdnProfile() *schema.Resource {
 		Delete: resourceCdnProfileDelete,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.CdnProfileV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CdnProfileV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cdn/migration/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint.go
@@ -1,1018 +1,1017 @@
 package migration
 
 import (
+	"context"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func CdnEndpointV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    CdnEndpointV0Schema().CoreConfigSchema().ImpliedType(),
-		Upgrade: CdnEndpointUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = CdnEndpointV0ToV1{}
 
-func CdnEndpointV0Schema() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+type CdnEndpointV0ToV1 struct{}
+
+func (CdnEndpointV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"profile_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"origin_host_header": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"is_http_allowed": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"is_https_allowed": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"origin": {
+			Type:     schema.TypeSet,
+			Required: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"host_name": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"http_port": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						ForceNew: true,
+						Default:  80,
+					},
+
+					"https_port": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						ForceNew: true,
+						Default:  443,
+					},
+				},
 			},
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+		"origin_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"querystring_caching_behaviour": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "IgnoreQueryString",
+		},
+
+		"content_types_to_compress": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
+			Set: schema.HashString,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"is_compression_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"profile_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"probe_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 
-			"origin_host_header": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"is_http_allowed": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"is_https_allowed": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"origin": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-
-						"host_name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-
-						"http_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Default:  80,
-						},
-
-						"https_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Default:  443,
+		"geo_filter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"relative_path": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"action": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"country_codes": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
 					},
 				},
 			},
+		},
 
-			"origin_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		"optimization_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"querystring_caching_behaviour": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "IgnoreQueryString",
-			},
+		"host_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"content_types_to_compress": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-				Set: schema.HashString,
-			},
+		"global_delivery_rule": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cache_expiration_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"behavior": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-			"is_compression_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
-			"probe_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"geo_filter": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"relative_path": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"action": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"country_codes": {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
+								"duration": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
 							},
 						},
 					},
-				},
-			},
 
-			"optimization_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+					"cache_key_query_string_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"behavior": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-			"host_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"global_delivery_rule": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"cache_expiration_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"behavior": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"duration": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"parameters": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"cache_key_query_string_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"behavior": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"modify_request_header_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"action": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"parameters": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"value": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"modify_request_header_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"modify_response_header_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"action": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"value": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"value": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"modify_response_header_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"url_redirect_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"redirect_type": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"protocol": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "MatchRequest",
+								},
 
-									"value": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"hostname": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+
+								"path": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+
+								"query_string": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+
+								"fragment": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"url_redirect_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"redirect_type": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"protocol": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "MatchRequest",
-									},
-
-									"hostname": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-
-									"path": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-
-									"query_string": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-
-									"fragment": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+					"url_rewrite_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"source_pattern": {
+									Type:     schema.TypeString,
+									Required: true,
 								},
-							},
-						},
 
-						"url_rewrite_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"source_pattern": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"destination": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"destination": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"preserve_unmatched_path": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  true,
-									},
+								"preserve_unmatched_path": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
 								},
 							},
 						},
 					},
 				},
 			},
+		},
 
-			"delivery_rule": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"delivery_rule": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"order": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
+					"order": {
+						Type:     schema.TypeInt,
+						Required: true,
+					},
 
-						"cookies_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"selector": {
-										Type:     schema.TypeString,
-										Required: true,
+					"cookies_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"selector": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"http_version_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "Equal",
-									},
+					"http_version_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "Equal",
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
 
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"device_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "Equal",
-									},
+					"device_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "Equal",
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
 
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"post_arg_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"selector": {
-										Type:     schema.TypeString,
-										Required: true,
+					"post_arg_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"selector": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"query_string_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
+					"query_string_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"remote_address_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"remote_address_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
 
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"request_body_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
+					"request_body_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"request_header_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"selector": {
-										Type:     schema.TypeString,
-										Required: true,
+					"request_header_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"selector": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"request_method_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "Equal",
-									},
+					"request_method_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "Equal",
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
 
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"request_scheme_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "Equal",
-									},
+					"request_scheme_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "Equal",
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
 
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"request_uri_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
+					"request_uri_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"url_file_extension_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
+					"url_file_extension_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"url_file_name_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
+					"url_file_name_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"url_path_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
+					"url_path_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"negate_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"match_values": {
+									Type:     schema.TypeSet,
+									Required: true,
+									MinItems: 1,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"negate_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"match_values": {
-										Type:     schema.TypeSet,
-										Required: true,
-										MinItems: 1,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"cache_expiration_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"behavior": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"cache_expiration_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"behavior": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"duration": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"duration": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"cache_key_query_string_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"behavior": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"cache_key_query_string_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"behavior": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"parameters": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"parameters": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"modify_request_header_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"modify_request_header_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"action": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"value": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"value": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"modify_response_header_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"modify_response_header_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"action": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"value": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"value": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"url_redirect_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"redirect_type": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"url_redirect_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"redirect_type": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"protocol": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Default:  "MatchRequest",
-									},
+								"protocol": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "MatchRequest",
+								},
 
-									"hostname": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"hostname": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
 
-									"path": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"path": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
 
-									"query_string": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"query_string": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
 
-									"fragment": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"fragment": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
+					},
 
-						"url_rewrite_action": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"source_pattern": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"url_rewrite_action": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"source_pattern": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"destination": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"destination": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"preserve_unmatched_path": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  true,
-									},
+								"preserve_unmatched_path": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
 								},
 							},
 						},
 					},
 				},
 			},
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func CdnEndpointUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	// old
-	// 	/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
-	// new:
-	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
-	// summary:
-	// resourcegroups -> resourceGroups
-	oldId := rawState["id"].(string)
-	oldParsedId, err := azure.ParseAzureResourceID(oldId)
-	if err != nil {
-		return rawState, err
+func (CdnEndpointV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old
+		// 	/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
+		// new:
+		// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
+		// summary:
+		// resourcegroups -> resourceGroups
+		oldId := rawState["id"].(string)
+		oldParsedId, err := azure.ParseAzureResourceID(oldId)
+		if err != nil {
+			return rawState, err
+		}
+
+		resourceGroup := oldParsedId.ResourceGroup
+		profileName, err := oldParsedId.PopSegment("profiles")
+		if err != nil {
+			return rawState, err
+		}
+		name, err := oldParsedId.PopSegment("endpoints")
+		if err != nil {
+			return rawState, err
+		}
+
+		newId := parse.NewEndpointID(oldParsedId.SubscriptionID, resourceGroup, profileName, name)
+		newIdStr := newId.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+		rawState["id"] = newIdStr
+
+		return rawState, nil
 	}
-
-	resourceGroup := oldParsedId.ResourceGroup
-	profileName, err := oldParsedId.PopSegment("profiles")
-	if err != nil {
-		return rawState, err
-	}
-	name, err := oldParsedId.PopSegment("endpoints")
-	if err != nil {
-		return rawState, err
-	}
-
-	newId := parse.NewEndpointID(oldParsedId.SubscriptionID, resourceGroup, profileName, name)
-	newIdStr := newId.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
-
-	rawState["id"] = newIdStr
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/cdn/migration/cdn_endpoint_test.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -36,7 +37,7 @@ func TestCdnEndpointV1ToV2(t *testing.T) {
 	}
 	for _, test := range testData {
 		t.Logf("Testing %q..", test.name)
-		result, err := CdnEndpointUpgradeV0ToV1(test.input, nil)
+		result, err := CdnEndpointV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
 		if err != nil && test.expected == nil {
 			continue
 		} else {

--- a/azurerm/internal/services/cdn/migration/cdn_profile.go
+++ b/azurerm/internal/services/cdn/migration/cdn_profile.go
@@ -1,85 +1,83 @@
 package migration
 
 import (
+	"context"
 	"log"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func CdnProfileV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    cdnProfileSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: cdnProfileUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = CdnProfileV0ToV1{}
 
-func cdnProfileSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type CdnProfileV0ToV1 struct{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (CdnProfileV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"sku": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"sku": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func cdnProfileUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	// old
-	// 	/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}
-	// new:
-	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}
-	// summary:
-	// resourcegroups -> resourceGroups
-	oldId := rawState["id"].(string)
-	oldParsedId, err := azure.ParseAzureResourceID(oldId)
-	if err != nil {
-		return rawState, err
+func (CdnProfileV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old
+		// 	/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}
+		// new:
+		// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}
+		// summary:
+		// resourcegroups -> resourceGroups
+		oldId := rawState["id"].(string)
+		oldParsedId, err := azure.ParseAzureResourceID(oldId)
+		if err != nil {
+			return rawState, err
+		}
+
+		resourceGroup := oldParsedId.ResourceGroup
+		name, err := oldParsedId.PopSegment("profiles")
+		if err != nil {
+			return rawState, err
+		}
+
+		newId := parse.NewProfileID(oldParsedId.SubscriptionID, resourceGroup, name)
+		newIdStr := newId.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+		rawState["id"] = newIdStr
+
+		return rawState, nil
 	}
-
-	resourceGroup := oldParsedId.ResourceGroup
-	name, err := oldParsedId.PopSegment("profiles")
-	if err != nil {
-		return rawState, err
-	}
-
-	newId := parse.NewProfileID(oldParsedId.SubscriptionID, resourceGroup, name)
-	newIdStr := newId.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
-
-	rawState["id"] = newIdStr
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/cdn/migration/cdn_profile_test.go
+++ b/azurerm/internal/services/cdn/migration/cdn_profile_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -36,7 +37,7 @@ func TestCdnProfileV1ToV2(t *testing.T) {
 	}
 	for _, test := range testData {
 		t.Logf("Testing %q..", test.name)
-		result, err := cdnProfileUpgradeV0ToV1(test.input, nil)
+		result, err := CdnProfileV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
 		if err != nil && test.expected == nil {
 			continue
 		} else {

--- a/azurerm/internal/services/compute/migration/legacy_vmss.go
+++ b/azurerm/internal/services/compute/migration/legacy_vmss.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
@@ -15,453 +17,447 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func LegacyVMSSV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    legacyVMSSSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: legacyVMSSUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = LegacyVMSSV0ToV1{}
 
-func legacyVMSSSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+type LegacyVMSSV0ToV1 struct{}
+
+func (LegacyVMSSV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"zones": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"zones": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-
-			"identity": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
+		"identity": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"identity_ids": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"identity_ids": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"principal_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					},
+					"principal_id": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
+		},
 
-			"sku": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"sku": {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"tier": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
+					"tier": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
+					},
 
-						"capacity": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
+					"capacity": {
+						Type:     schema.TypeInt,
+						Required: true,
 					},
 				},
 			},
+		},
 
-			"license_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		"license_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 
-			"upgrade_policy_mode": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"upgrade_policy_mode": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"health_probe_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"health_probe_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"automatic_os_upgrade": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
+		"automatic_os_upgrade": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 
-			"rolling_upgrade_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"max_batch_instance_percent": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  20,
-						},
+		"rolling_upgrade_policy": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"max_batch_instance_percent": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  20,
+					},
 
-						"max_unhealthy_instance_percent": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  20,
-						},
+					"max_unhealthy_instance_percent": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  20,
+					},
 
-						"max_unhealthy_upgraded_instance_percent": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  20,
-						},
+					"max_unhealthy_upgraded_instance_percent": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  20,
+					},
 
-						"pause_time_between_batches": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "PT0S",
-						},
+					"pause_time_between_batches": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "PT0S",
 					},
 				},
 			},
+		},
 
-			"overprovision": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		"overprovision": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"single_placement_group": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-				ForceNew: true,
-			},
+		"single_placement_group": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+			ForceNew: true,
+		},
 
-			"priority": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		"priority": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 
-			"eviction_policy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		"eviction_policy": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 
-			"os_profile": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"computer_name_prefix": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
+		"os_profile": {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"computer_name_prefix": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
 
-						"admin_username": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"admin_username": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"admin_password": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-						},
+					"admin_password": {
+						Type:      schema.TypeString,
+						Optional:  true,
+						Sensitive: true,
+					},
 
-						"custom_data": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							StateFunc: userDataStateFunc,
-						},
+					"custom_data": {
+						Type:      schema.TypeString,
+						Optional:  true,
+						StateFunc: userDataStateFunc,
 					},
 				},
 			},
+		},
 
-			"os_profile_secrets": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"source_vault_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"os_profile_secrets": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"source_vault_id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"vault_certificates": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"certificate_url": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"certificate_store": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+					"vault_certificates": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"certificate_url": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"certificate_store": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
 					},
 				},
 			},
+		},
 
-			// lintignore:S018
-			"os_profile_windows_config": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"provision_vm_agent": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"enable_automatic_upgrades": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"winrm": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"protocol": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"certificate_url": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+		// lintignore:S018
+		"os_profile_windows_config": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"provision_vm_agent": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"enable_automatic_upgrades": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"winrm": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"protocol": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"certificate_url": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
-						"additional_unattend_config": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"pass": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"component": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"setting_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"content": {
-										Type:      schema.TypeString,
-										Required:  true,
-										Sensitive: true,
-									},
+					},
+					"additional_unattend_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"pass": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"component": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"setting_name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"content": {
+									Type:      schema.TypeString,
+									Required:  true,
+									Sensitive: true,
 								},
 							},
 						},
 					},
 				},
-				Set: resourceArmVirtualMachineScaleSetOsProfileWindowsConfigHash,
 			},
+			Set: resourceArmVirtualMachineScaleSetOsProfileWindowsConfigHash,
+		},
 
-			// lintignore:S018
-			"os_profile_linux_config": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"disable_password_authentication": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-							ForceNew: true,
-						},
-						"ssh_keys": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"path": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"key_data": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+		// lintignore:S018
+		"os_profile_linux_config": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"disable_password_authentication": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  false,
+						ForceNew: true,
+					},
+					"ssh_keys": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"path": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"key_data": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
 					},
 				},
-				Set: resourceArmVirtualMachineScaleSetOsProfileLinuxConfigHash,
 			},
+			Set: resourceArmVirtualMachineScaleSetOsProfileLinuxConfigHash,
+		},
 
-			"network_profile": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"network_profile": {
+			Type:     schema.TypeSet,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"primary": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
+					"primary": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
 
-						"accelerated_networking": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
+					"accelerated_networking": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 
-						"ip_forwarding": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
+					"ip_forwarding": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
 
-						"network_security_group_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+					"network_security_group_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"dns_settings": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"dns_servers": {
-										Type:     schema.TypeList,
-										Required: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+					"dns_settings": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"dns_servers": {
+									Type:     schema.TypeList,
+									Required: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
 						},
+					},
 
-						"ip_configuration": {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"name": {
-										Type:     schema.TypeString,
-										Required: true,
+					"ip_configuration": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"subnet_id": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"application_gateway_backend_address_pool_ids": {
+									Type:     schema.TypeSet,
+									Optional: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+									Set:      schema.HashString,
+								},
+
+								"application_security_group_ids": {
+									Type:     schema.TypeSet,
+									Optional: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+									Set:      schema.HashString,
+									MaxItems: 20,
+								},
 
-									"subnet_id": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"load_balancer_backend_address_pool_ids": {
+									Type:     schema.TypeSet,
+									Optional: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+									Set:      schema.HashString,
+								},
 
-									"application_gateway_backend_address_pool_ids": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-										Set:      schema.HashString,
-									},
+								"load_balancer_inbound_nat_rules_ids": {
+									Type:     schema.TypeSet,
+									Optional: true,
+									Computed: true,
+									Elem:     &schema.Schema{Type: schema.TypeString},
+									Set:      schema.HashString,
+								},
 
-									"application_security_group_ids": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-										Set:      schema.HashString,
-										MaxItems: 20,
-									},
+								"primary": {
+									Type:     schema.TypeBool,
+									Required: true,
+								},
 
-									"load_balancer_backend_address_pool_ids": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-										Set:      schema.HashString,
-									},
+								"public_ip_address_configuration": {
+									Type:     schema.TypeList,
+									Optional: true,
+									MaxItems: 1,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"name": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
 
-									"load_balancer_inbound_nat_rules_ids": {
-										Type:     schema.TypeSet,
-										Optional: true,
-										Computed: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-										Set:      schema.HashString,
-									},
+											"idle_timeout": {
+												Type:     schema.TypeInt,
+												Required: true,
+											},
 
-									"primary": {
-										Type:     schema.TypeBool,
-										Required: true,
-									},
-
-									"public_ip_address_configuration": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"name": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-
-												"idle_timeout": {
-													Type:     schema.TypeInt,
-													Required: true,
-												},
-
-												"domain_name_label": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
+											"domain_name_label": {
+												Type:     schema.TypeString,
+												Required: true,
 											},
 										},
 									},
@@ -470,253 +466,255 @@ func legacyVMSSSchemaForV0() *schema.Resource {
 						},
 					},
 				},
-				Set: resourceArmVirtualMachineScaleSetNetworkConfigurationHash,
 			},
+			Set: resourceArmVirtualMachineScaleSetNetworkConfigurationHash,
+		},
 
-			"boot_diagnostics": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
+		"boot_diagnostics": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
 
-						"storage_uri": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"storage_uri": {
+						Type:     schema.TypeString,
+						Required: true,
 					},
 				},
 			},
+		},
 
-			// lintignore:S018
-			"storage_profile_os_disk": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"image": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"vhd_containers": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-
-						"managed_disk_type": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ConflictsWith: []string{"storage_profile_os_disk.vhd_containers"},
-						},
-
-						"caching": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-
-						"os_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"create_option": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		// lintignore:S018
+		"storage_profile_os_disk": {
+			Type:     schema.TypeSet,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
 					},
-				},
-				Set: resourceArmVirtualMachineScaleSetStorageProfileOsDiskHash,
-			},
 
-			"storage_profile_data_disk": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"lun": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
+					"image": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"create_option": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"vhd_containers": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+						Set:      schema.HashString,
+					},
 
-						"caching": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
+					"managed_disk_type": {
+						Type:          schema.TypeString,
+						Optional:      true,
+						Computed:      true,
+						ConflictsWith: []string{"storage_profile_os_disk.vhd_containers"},
+					},
 
-						"disk_size_gb": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
-						},
+					"caching": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
+					},
 
-						"managed_disk_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
+					"os_type": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+
+					"create_option": {
+						Type:     schema.TypeString,
+						Required: true,
 					},
 				},
 			},
+			Set: resourceArmVirtualMachineScaleSetStorageProfileOsDiskHash,
+		},
 
-			// lintignore:S018
-			"storage_profile_image_reference": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"publisher": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"offer": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"sku": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"version": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+		"storage_profile_data_disk": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"lun": {
+						Type:     schema.TypeInt,
+						Required: true,
 					},
-				},
-				Set: resourceArmVirtualMachineScaleSetStorageProfileImageReferenceHash,
-			},
 
-			// lintignore:S018
-			"plan": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"create_option": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"publisher": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"caching": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
+					},
 
-						"product": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"disk_size_gb": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+
+					"managed_disk_type": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
 					},
 				},
 			},
+		},
 
-			"extension": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		// lintignore:S018
+		"storage_profile_image_reference": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"publisher": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"publisher": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"offer": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"type_handler_version": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"sku": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"auto_upgrade_minor_version": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-
-						"settings": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"protected_settings": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Sensitive: true,
-						},
+					"version": {
+						Type:     schema.TypeString,
+						Optional: true,
 					},
 				},
-				Set: resourceArmVirtualMachineScaleSetExtensionHash,
 			},
+			Set: resourceArmVirtualMachineScaleSetStorageProfileImageReferenceHash,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+		// lintignore:S018
+		"plan": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"publisher": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"product": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 				},
+			},
+		},
+
+		"extension": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"publisher": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"type_handler_version": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"auto_upgrade_minor_version": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+
+					"settings": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+
+					"protected_settings": {
+						Type:      schema.TypeString,
+						Optional:  true,
+						Sensitive: true,
+					},
+				},
+			},
+			Set: resourceArmVirtualMachineScaleSetExtensionHash,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func legacyVMSSUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	// @tombuildsstuff: NOTE, this state migration is essentially pointless
-	// however it existed in the legacy migration so even though this is
-	//  essentially a noop there's no reason this shouldn't be the same I guess
+func (LegacyVMSSV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// @tombuildsstuff: NOTE, this state migration is essentially pointless
+		// however it existed in the legacy migration so even though this is
+		//  essentially a noop there's no reason this shouldn't be the same I guess
 
-	client := meta.(*clients.Client).Compute.VMScaleSetClient
-	ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, 5*time.Minute)
-	defer cancel()
+		client := meta.(*clients.Client).Compute.VMScaleSetClient
+		ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, 5*time.Minute)
+		defer cancel()
 
-	resGroup := rawState["resource_group_name"].(string)
-	name := rawState["name"].(string)
+		resGroup := rawState["resource_group_name"].(string)
+		name := rawState["name"].(string)
 
-	read, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		return rawState, err
+		read, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			return rawState, err
+		}
+
+		rawState["id"] = *read.ID
+		return rawState, nil
 	}
-
-	rawState["id"] = *read.ID
-	return rawState, nil
 }
 
 func userDataStateFunc(v interface{}) string {

--- a/azurerm/internal/services/compute/migration/legacy_vmss.go
+++ b/azurerm/internal/services/compute/migration/legacy_vmss.go
@@ -701,8 +701,6 @@ func (LegacyVMSSV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		//  essentially a noop there's no reason this shouldn't be the same I guess
 
 		client := meta.(*clients.Client).Compute.VMScaleSetClient
-		ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, 5*time.Minute)
-		defer cancel()
 
 		resGroup := rawState["resource_group_name"].(string)
 		name := rawState["name"].(string)

--- a/azurerm/internal/services/compute/migration/legacy_vmss.go
+++ b/azurerm/internal/services/compute/migration/legacy_vmss.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_resource.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	validate2 "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
@@ -37,9 +39,9 @@ func resourceVirtualMachineScaleSet() *schema.Resource {
 		Delete: resourceVirtualMachineScaleSetDelete,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.LegacyVMSSV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.LegacyVMSSV0ToV1{},
+		}),
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/azurerm/internal/services/containers/container_registry_resource.go
+++ b/azurerm/internal/services/containers/container_registry_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/containerregistry/mgmt/2020-11-01-preview/containerregistry"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -31,10 +33,10 @@ func resourceContainerRegistry() *schema.Resource {
 		Delete: resourceContainerRegistryDelete,
 
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.RegistryV0ToV1(),
-			migration.RegistryV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.RegistryV0ToV1{},
+			1: migration.RegistryV1ToV2{},
+		}),
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/azurerm/internal/services/containers/migration/registry.go
+++ b/azurerm/internal/services/containers/migration/registry.go
@@ -8,139 +8,140 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func RegistryV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    registrySchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: registryUpgradeV0ToV1,
-		Version: 0,
+var _ pluginsdk.StateUpgrade = RegistryV0ToV1{}
+var _ pluginsdk.StateUpgrade = RegistryV1ToV2{}
+
+type RegistryV0ToV1 struct{}
+
+func (RegistryV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return registrySchemaForV0AndV1()
+}
+
+func (RegistryV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		rawState["sku"] = "Basic"
+		return rawState, nil
 	}
 }
 
-func RegistryV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    registrySchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: registryUpgradeV1ToV2,
-		Version: 1,
+type RegistryV1ToV2 struct{}
+
+func (RegistryV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return registrySchemaForV0AndV1()
+}
+
+func (RegistryV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// Basic's been renamed Classic to allow for "ManagedBasic" ¯\_(ツ)_/¯
+		rawState["sku"] = "Classic"
+
+		storageAccountId := ""
+		if v, ok := rawState["storage_account"]; ok {
+			raw := v.(*schema.Set).List()
+			rawVals := raw[0].(map[string]interface{})
+			storageAccountName := rawVals["name"].(string)
+
+			client := meta.(*clients.Client).Storage.AccountsClient
+			ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, time.Minute*5)
+			defer cancel()
+
+			accounts, err := client.ListComplete(ctx)
+			if err != nil {
+				return rawState, fmt.Errorf("listing storage accounts")
+			}
+
+			for accounts.NotDone() {
+				account := accounts.Value()
+				if strings.EqualFold(*account.Name, storageAccountName) {
+					storageAccountId = *account.ID
+					break
+				}
+
+				if err := accounts.NextWithContext(ctx); err != nil {
+					return rawState, fmt.Errorf("retrieving accounts: %+v", err)
+				}
+			}
+		}
+
+		if storageAccountId == "" {
+			return rawState, fmt.Errorf("unable to determine storage account ID")
+		}
+
+		return rawState, nil
 	}
 }
 
-func registrySchemaForV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func registrySchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"admin_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
+		"admin_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 
-			// lintignore:S018
-			"storage_account": {
-				Type:     schema.TypeSet,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		// lintignore:S018
+		"storage_account": {
+			Type:     schema.TypeSet,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"access_key": {
-							Type:      schema.TypeString,
-							Required:  true,
-							Sensitive: true,
-						},
+					"access_key": {
+						Type:      schema.TypeString,
+						Required:  true,
+						Sensitive: true,
 					},
 				},
 			},
+		},
 
-			"login_server": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"login_server": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"admin_username": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"admin_username": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"admin_password": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"admin_password": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
-}
-
-func registryUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	rawState["sku"] = "Basic"
-	return rawState, nil
-}
-
-func registryUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	// Basic's been renamed Classic to allow for "ManagedBasic" ¯\_(ツ)_/¯
-	rawState["sku"] = "Classic"
-
-	storageAccountId := ""
-	if v, ok := rawState["storage_account"]; ok {
-		raw := v.(*schema.Set).List()
-		rawVals := raw[0].(map[string]interface{})
-		storageAccountName := rawVals["name"].(string)
-
-		client := meta.(*clients.Client).Storage.AccountsClient
-		ctx, cancel := context.WithTimeout(meta.(*clients.Client).StopContext, time.Minute*5)
-		defer cancel()
-
-		accounts, err := client.ListComplete(ctx)
-		if err != nil {
-			return rawState, fmt.Errorf("listing storage accounts")
-		}
-
-		for accounts.NotDone() {
-			account := accounts.Value()
-			if strings.EqualFold(*account.Name, storageAccountName) {
-				storageAccountId = *account.ID
-				break
-			}
-
-			if err := accounts.NextWithContext(ctx); err != nil {
-				return rawState, fmt.Errorf("retrieving accounts: %+v", err)
-			}
-		}
-	}
-
-	if storageAccountId == "" {
-		return rawState, fmt.Errorf("unable to determine storage account ID")
-	}
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos/migration"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
@@ -32,9 +34,9 @@ func resourceCosmosDbCassandraKeyspace() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.CassandraKeyspaceV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CassandraKeyspaceV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_database_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos/migration"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
@@ -32,9 +34,9 @@ func resourceCosmosGremlinDatabase() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.GremlinDatabaseV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.GremlinDatabaseV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -33,9 +35,9 @@ func resourceCosmosDbGremlinGraph() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.GremlinGraphV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.GremlinGraphV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -32,9 +34,9 @@ func resourceCosmosDbMongoCollection() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.MongoCollectionV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.MongoCollectionV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_database_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos/migration"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
@@ -32,9 +34,9 @@ func resourceCosmosDbMongoDatabase() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.MongoDatabaseV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.MongoDatabaseV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
 	"github.com/hashicorp/go-azure-helpers/response"
@@ -33,9 +34,9 @@ func resourceCosmosDbSQLContainer() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.SqlContainerV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.SqlContainerV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -31,9 +33,9 @@ func resourceCosmosDbSQLDatabase() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.SqlDatabaseV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.SqlDatabaseV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/cosmos-db/mgmt/2020-04-01-preview/documentdb"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -31,9 +33,9 @@ func resourceCosmosDbTable() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.TableV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.TableV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/cosmos/migration/cassandra_keyspace.go
+++ b/azurerm/internal/services/cosmos/migration/cassandra_keyspace.go
@@ -1,57 +1,55 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func CassandraKeyspaceV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    cassandraKeyspaceSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: cassandraKeyspaceUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = CassandraKeyspaceV0ToV1{}
 
-func cassandraKeyspaceSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type CassandraKeyspaceV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (CassandraKeyspaceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }
 
-func cassandraKeyspaceUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/cassandra/keyspaces", "cassandraKeyspaces", 1)
+func (CassandraKeyspaceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/cassandra/keyspaces", "cassandraKeyspaces", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/gremlin_database.go
+++ b/azurerm/internal/services/cosmos/migration/gremlin_database.go
@@ -1,57 +1,55 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func GremlinDatabaseV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    gremlinDatabaseSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: gremlinDatabaseUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = GremlinDatabaseV0ToV1{}
 
-func gremlinDatabaseSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type GremlinDatabaseV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (GremlinDatabaseV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }
 
-func gremlinDatabaseUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/gremlin/databases", "gremlinDatabases", 1)
+func (GremlinDatabaseV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/gremlin/databases", "gremlinDatabases", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/gremlin_graph.go
+++ b/azurerm/internal/services/cosmos/migration/gremlin_graph.go
@@ -1,134 +1,130 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func GremlinGraphV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    gremlinGraphSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: gremlinGraphV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = GremlinGraphV0ToV1{}
 
-func gremlinGraphSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type GremlinGraphV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (GremlinGraphV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"database_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"database_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"partition_key_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
 
-			"index_policy": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"automatic": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
+		"partition_key_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"index_policy": {
+			Type:     schema.TypeList,
+			Required: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"automatic": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+
+					"indexing_mode": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"included_paths": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
+						Set: schema.HashString,
+					},
 
-						"indexing_mode": {
-							Type:     schema.TypeString,
-							Required: true,
+					"excluded_paths": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-
-						"included_paths": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Set: schema.HashString,
-						},
-
-						"excluded_paths": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Set: schema.HashString,
-						},
+						Set: schema.HashString,
 					},
 				},
 			},
+		},
 
-			"conflict_resolution_policy": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"mode": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"conflict_resolution_policy": {
+			Type:     schema.TypeList,
+			Required: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"mode": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"conflict_resolution_path": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+					"conflict_resolution_path": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"conflict_resolution_procedure": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+					"conflict_resolution_procedure": {
+						Type:     schema.TypeString,
+						Optional: true,
 					},
 				},
 			},
+		},
 
-			"unique_key": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"paths": {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+		"unique_key": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"paths": {
+						Type:     schema.TypeSet,
+						Required: true,
+						ForceNew: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
 					},
 				},
@@ -137,13 +133,15 @@ func gremlinGraphSchemaForV0() *schema.Resource {
 	}
 }
 
-func gremlinGraphV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/gremlin/databases", "gremlinDatabases", 1)
+func (GremlinGraphV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/gremlin/databases", "gremlinDatabases", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/mongo_collection.go
+++ b/azurerm/internal/services/cosmos/migration/mongo_collection.go
@@ -1,74 +1,72 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func MongoCollectionV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    mongoCollectionSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: mongoCollectionUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = MongoCollectionV0ToV1{}
 
-func mongoCollectionSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type MongoCollectionV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (MongoCollectionV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"database_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"shard_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		"database_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"default_ttl_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
+		"shard_key": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"default_ttl_seconds": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }
 
-func mongoCollectionUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/mongodb/databases", "mongodbDatabases", 1)
+func (MongoCollectionV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/mongodb/databases", "mongodbDatabases", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/mongo_database.go
+++ b/azurerm/internal/services/cosmos/migration/mongo_database.go
@@ -1,57 +1,55 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func MongoDatabaseV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    mongoDatabaseSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: mongoDatabaseUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = MongoDatabaseV0ToV1{}
 
-func mongoDatabaseSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type MongoDatabaseV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (MongoDatabaseV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }
 
-func mongoDatabaseUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/mongodb/databases", "mongodbDatabases", 1)
+func (MongoDatabaseV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/mongodb/databases", "mongodbDatabases", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/sql_container.go
+++ b/azurerm/internal/services/cosmos/migration/sql_container.go
@@ -1,78 +1,74 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func SqlContainerV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    sqlContainerSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: sqlContainerUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = SqlContainerV0ToV1{}
 
-func sqlContainerSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type SqlContainerV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (SqlContainerV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"database_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"partition_key_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		"database_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"partition_key_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 
-			"default_ttl": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
 
-			"unique_key": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"paths": {
-							Type:     schema.TypeSet,
-							Required: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+		"default_ttl": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+
+		"unique_key": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"paths": {
+						Type:     schema.TypeSet,
+						Required: true,
+						ForceNew: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
 					},
 				},
@@ -81,13 +77,15 @@ func sqlContainerSchemaForV0() *schema.Resource {
 	}
 }
 
-func sqlContainerUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/sql/databases", "sqlDatabases", 1)
+func (SqlContainerV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/sql/databases", "sqlDatabases", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/sql_database.go
+++ b/azurerm/internal/services/cosmos/migration/sql_database.go
@@ -1,57 +1,55 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func SqlDatabaseV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    sqlDatabaseSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: sqlDatabaseUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = SqlDatabaseV0ToV1{}
 
-func sqlDatabaseSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type SqlDatabaseV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (SqlDatabaseV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }
 
-func sqlDatabaseUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/sql/databases", "sqlDatabases", 1)
+func (SqlDatabaseV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/sql/databases", "sqlDatabases", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/cosmos/migration/table.go
+++ b/azurerm/internal/services/cosmos/migration/table.go
@@ -1,57 +1,55 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func TableV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    tableSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: tableUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = TableV0ToV1{}
 
-func tableSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type TableV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (TableV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"throughput": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"throughput": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
 		},
 	}
 }
 
-func tableUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "apis/table/tables", "tables", 1)
+func (TableV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "apis/table/tables", "tables", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/datafactory/data_factory_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -25,9 +27,9 @@ func resourceDataFactory() *schema.Resource {
 		Delete: resourceDataFactoryDelete,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.DataFactoryV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.DataFactoryV0ToV1{},
+		}),
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/azurerm/internal/services/datafactory/migration/data_factory.go
+++ b/azurerm/internal/services/datafactory/migration/data_factory.go
@@ -1,144 +1,142 @@
 package migration
 
 import (
+	"context"
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func DataFactoryV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    dataFactorySchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: dataFactoryUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = DataFactoryV0ToV1{}
 
-func dataFactorySchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type DataFactoryV0ToV1 struct{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (DataFactoryV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"identity": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"principal_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"identity": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"principal_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"tenant_id": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
+		},
 
-			"github_configuration": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"vsts_configuration"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"account_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"branch_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"git_url": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"repository_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"root_folder": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"github_configuration": {
+			Type:          schema.TypeList,
+			Optional:      true,
+			MaxItems:      1,
+			ConflictsWith: []string{"vsts_configuration"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"account_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"branch_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"git_url": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"repository_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"root_folder": {
+						Type:     schema.TypeString,
+						Required: true,
 					},
 				},
 			},
+		},
 
-			"vsts_configuration": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				ConflictsWith: []string{"github_configuration"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"account_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"branch_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"project_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"repository_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"root_folder": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"tenant_id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"vsts_configuration": {
+			Type:          schema.TypeList,
+			Optional:      true,
+			MaxItems:      1,
+			ConflictsWith: []string{"github_configuration"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"account_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"branch_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"project_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"repository_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"root_folder": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"tenant_id": {
+						Type:     schema.TypeString,
+						Required: true,
 					},
 				},
 			},
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func dataFactoryUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	log.Printf("[DEBUG] Updating `public_network_enabled` to %q", datafactory.PublicNetworkAccessEnabled)
+func (DataFactoryV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Printf("[DEBUG] Updating `public_network_enabled` to %q", datafactory.PublicNetworkAccessEnabled)
 
-	rawState["public_network_enabled"] = true
+		rawState["public_network_enabled"] = true
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/datalake/data_lake_store_file_resource.go
+++ b/azurerm/internal/services/datalake/data_lake_store_file_resource.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/datalake/store/2016-11-01/filesystem"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -32,9 +34,9 @@ func resourceDataLakeStoreFile() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.StoreFileV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.StoreFileV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/datalake/migration/store_file.go
+++ b/azurerm/internal/services/datalake/migration/store_file.go
@@ -1,50 +1,49 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func StoreFileV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    storeFileSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: storeFileUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = StoreFileV0ToV1{}
 
-func storeFileSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type StoreFileV0ToV1 struct{}
 
-			"remote_file_path": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (StoreFileV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"local_file_path": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"remote_file_path": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"local_file_path": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
 }
 
-func storeFileUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	client := meta.(*clients.Client).Datalake.StoreFilesClient
+func (StoreFileV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		client := meta.(*clients.Client).Datalake.StoreFilesClient
 
-	storageAccountName := rawState["account_name"].(string)
-	filePath := rawState["remote_file_path"].(string)
-	newID := fmt.Sprintf("%s.%s%s", storageAccountName, client.AdlsFileSystemDNSSuffix, filePath)
-	rawState["id"] = newID
-	return rawState, nil
+		storageAccountName := rawState["account_name"].(string)
+		filePath := rawState["remote_file_path"].(string)
+		newID := fmt.Sprintf("%s.%s%s", storageAccountName, client.AdlsFileSystemDNSSuffix, filePath)
+		rawState["id"] = newID
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/desktopvirtualization/migration/application_group_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/application_group_v0.go
@@ -1,91 +1,89 @@
 package migration
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func ApplicationGroupV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    applicationGroupSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: applicationGroupUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = ApplicationGroupV0ToV1{}
 
-func applicationGroupSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type ApplicationGroupV0ToV1 struct{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (ApplicationGroupV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"host_pool_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"type": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"friendly_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"host_pool_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"friendly_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func applicationGroupUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	id, err := parse.ApplicationGroupIDInsensitively(oldId)
-	if err != nil {
-		return nil, err
-	}
-	newId := id.ID()
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
-	rawState["id"] = newId
+func (ApplicationGroupV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		id, err := parse.ApplicationGroupIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := id.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
 
-	oldHostPoolId := rawState["host_pool_id"].(string)
-	hostPoolId, err := parse.HostPoolIDInsensitively(oldHostPoolId)
-	if err != nil {
-		return nil, err
-	}
-	newHostPoolId := hostPoolId.ID()
-	log.Printf("[DEBUG] Updating Host Pool ID from %q to %q", oldHostPoolId, newHostPoolId)
-	rawState["host_pool_id"] = newHostPoolId
+		oldHostPoolId := rawState["host_pool_id"].(string)
+		hostPoolId, err := parse.HostPoolIDInsensitively(oldHostPoolId)
+		if err != nil {
+			return nil, err
+		}
+		newHostPoolId := hostPoolId.ID()
+		log.Printf("[DEBUG] Updating Host Pool ID from %q to %q", oldHostPoolId, newHostPoolId)
+		rawState["host_pool_id"] = newHostPoolId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/desktopvirtualization/migration/workspace_application_group_association_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/workspace_application_group_association_v0.go
@@ -1,59 +1,57 @@
 package migration
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func WorkspaceApplicationGroupAssociationV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    WorkspaceApplicationGroupAssociationSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: WorkspaceApplicationGroupAssociationUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = WorkspaceApplicationGroupAssociationV0ToV1{}
 
-func WorkspaceApplicationGroupAssociationSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"workspace_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type WorkspaceApplicationGroupAssociationV0ToV1 struct{}
 
-			"application_group_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (WorkspaceApplicationGroupAssociationV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"workspace_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"application_group_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
 }
 
-func WorkspaceApplicationGroupAssociationUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
+func (WorkspaceApplicationGroupAssociationV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
 
-	id, err := parse.WorkspaceApplicationGroupAssociationIDInsensitively(oldId)
-	if err != nil {
-		return nil, err
+		id, err := parse.WorkspaceApplicationGroupAssociationIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := id.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+
+		oldApplicationGroupId := rawState["application_group_id"].(string)
+		newApplicationGroupId := id.ApplicationGroup.ID()
+		log.Printf("[DEBUG] Updating Application Group ID from %q to %q", oldApplicationGroupId, newApplicationGroupId)
+		rawState["application_group_id"] = newApplicationGroupId
+
+		oldWorkspaceId := rawState["workspace_id"].(string)
+		newWorkspaceId := id.Workspace.ID()
+		log.Printf("[DEBUG] Updating Workspace ID from %q to %q", oldWorkspaceId, newWorkspaceId)
+		rawState["workspace_id"] = newWorkspaceId
+
+		return rawState, nil
 	}
-	newId := id.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
-	rawState["id"] = newId
-
-	oldApplicationGroupId := rawState["application_group_id"].(string)
-	newApplicationGroupId := id.ApplicationGroup.ID()
-	log.Printf("[DEBUG] Updating Application Group ID from %q to %q", oldApplicationGroupId, newApplicationGroupId)
-	rawState["application_group_id"] = newApplicationGroupId
-
-	oldWorkspaceId := rawState["workspace_id"].(string)
-	newWorkspaceId := id.Workspace.ID()
-	log.Printf("[DEBUG] Updating Workspace ID from %q to %q", oldWorkspaceId, newWorkspaceId)
-	rawState["workspace_id"] = newWorkspaceId
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/desktopvirtualization/migration/workspace_v0.go
+++ b/azurerm/internal/services/desktopvirtualization/migration/workspace_v0.go
@@ -1,73 +1,72 @@
 package migration
 
 import (
+	"context"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func WorkspaceV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    workspaceSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: workspaceUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = WorkspaceV0ToV1{}
 
-func workspaceSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type WorkspaceV0ToV1 struct{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (WorkspaceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"friendly_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"friendly_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func workspaceUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
+func (WorkspaceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
 
-	id, err := parse.WorkspaceID(oldId)
-	if err != nil {
-		return nil, err
+		id, err := parse.WorkspaceID(oldId)
+		if err != nil {
+			return nil, err
+		}
+		newId := id.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+
+		return rawState, nil
 	}
-	newId := id.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
-	rawState["id"] = newId
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -6,6 +6,9 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/desktopvirtualization/mgmt/2019-12-10-preview/desktopvirtualization"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -13,7 +16,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -44,9 +46,9 @@ func resourceVirtualDesktopApplicationGroup() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.ApplicationGroupV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ApplicationGroupV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/desktopvirtualization/mgmt/2019-12-10-preview/desktopvirtualization"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -12,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -40,9 +42,9 @@ func resourceVirtualDesktopHostPool() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.HostPoolV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.HostPoolV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/desktopvirtualization/mgmt/2019-12-10-preview/desktopvirtualization"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization/validate"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -38,9 +40,9 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociation() *schema.Resour
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.WorkspaceApplicationGroupAssociationV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.WorkspaceApplicationGroupAssociationV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"workspace_id": {

--- a/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
+++ b/azurerm/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/desktopvirtualization/mgmt/2019-12-10-preview/desktopvirtualization"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -42,9 +44,9 @@ func resourceArmDesktopVirtualizationWorkspace() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.WorkspaceV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.WorkspaceV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/dns/dns_zone_resource.go
+++ b/azurerm/internal/services/dns/dns_zone_resource.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -29,9 +31,9 @@ func resourceDnsZone() *schema.Resource {
 		Delete: resourceDnsZoneDelete,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.DnsZoneV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.DnsZoneV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
+++ b/azurerm/internal/services/dns/migration/dns_zone_V0_to_V1.go
@@ -8,148 +8,144 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func DnsZoneV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Version: 0,
-		Type:    dnsZoneSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: dnsZoneUpgradeV0ToV1,
-	}
-}
+var _ pluginsdk.StateUpgrade = DnsZoneV0ToV1{}
 
-func dnsZoneSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type DnsZoneV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (DnsZoneV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"number_of_record_sets": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"max_number_of_record_sets": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
+		"number_of_record_sets": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
 
-			"name_servers": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
-			},
+		"max_number_of_record_sets": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
 
-			"soa_record": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"email": {
-							Type:     schema.TypeString,
-							Required: true,
+		"name_servers": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Set:      schema.HashString,
+		},
+
+		"soa_record": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"email": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"host_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"expire_time": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  2419200,
+					},
+
+					"minimum_ttl": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  300,
+					},
+
+					"refresh_time": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  3600,
+					},
+
+					"retry_time": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  300,
+					},
+
+					"serial_number": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  1,
+					},
+
+					"ttl": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Default:  3600,
+					},
+
+					"tags": {
+						Type:     schema.TypeMap,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
+					},
 
-						"host_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"expire_time": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  2419200,
-						},
-
-						"minimum_ttl": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  300,
-						},
-
-						"refresh_time": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  3600,
-						},
-
-						"retry_time": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  300,
-						},
-
-						"serial_number": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  1,
-						},
-
-						"ttl": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  3600,
-						},
-
-						"tags": {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-
-						"fqdn": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					"fqdn": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func dnsZoneUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	ctx := context.TODO()
-	groupsClient := meta.(*clients.Client).Resource.GroupsClient
-	oldId := rawState["id"].(string)
-	id, err := parse.DnsZoneID(oldId)
-	if err != nil {
-		return rawState, err
+func (DnsZoneV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		groupsClient := meta.(*clients.Client).Resource.GroupsClient
+		oldId := rawState["id"].(string)
+		id, err := parse.DnsZoneID(oldId)
+		if err != nil {
+			return rawState, err
+		}
+		resGroup, err := groupsClient.Get(ctx, id.ResourceGroup)
+		if err != nil {
+			return rawState, err
+		}
+		if resGroup.Name == nil {
+			return rawState, fmt.Errorf("`name` was nil for Resource Group %q", id.ResourceGroup)
+		}
+		resourceGroup := *resGroup.Name
+		name := rawState["name"].(string)
+		newId := parse.NewDnsZoneID(id.SubscriptionId, resourceGroup, name).ID()
+		log.Printf("Updating `id` from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
 	}
-	resGroup, err := groupsClient.Get(ctx, id.ResourceGroup)
-	if err != nil {
-		return rawState, err
-	}
-	if resGroup.Name == nil {
-		return rawState, fmt.Errorf("`name` was nil for Resource Group %q", id.ResourceGroup)
-	}
-	resourceGroup := *resGroup.Name
-	name := rawState["name"].(string)
-	newId := parse.NewDnsZoneID(id.SubscriptionId, resourceGroup, name).ID()
-	log.Printf("Updating `id` from %q to %q", oldId, newId)
-	rawState["id"] = newId
-	return rawState, nil
 }

--- a/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -30,10 +32,10 @@ func resourceEventHubNamespaceAuthorizationRule() *schema.Resource {
 		},
 
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.NamespaceAuthorizationRuleV0ToV1(),
-			migration.NamespaceAuthorizationRuleV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.NamespaceAuthorizationRuleV0ToV1{},
+			1: migration.NamespaceAuthorizationRuleV1ToV2{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/eventhub/migration/namespace_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/migration/namespace_authorization_rule.go
@@ -1,72 +1,76 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func NamespaceAuthorizationRuleV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    namespaceAuthorizationRuleSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: namespaceAuthorizationRuleUpgradeV0ToV1,
-		Version: 0,
+var _ pluginsdk.StateUpgrade = NamespaceAuthorizationRuleV0ToV1{}
+
+type NamespaceAuthorizationRuleV0ToV1 struct{}
+
+func (NamespaceAuthorizationRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return authorizationRuleSchemaForV0AndV1()
+}
+
+func (NamespaceAuthorizationRuleV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+
+		newId := strings.Replace(rawState["id"].(string), "/authorizationRules/", "/AuthorizationRules/", 1)
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+
+		rawState["id"] = newId
+
+		return rawState, nil
 	}
 }
 
-func NamespaceAuthorizationRuleV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    namespaceAuthorizationRuleSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: namespaceAuthorizationRuleUpgradeV1ToV2,
-		Version: 1,
+var _ pluginsdk.StateUpgrade = NamespaceAuthorizationRuleV1ToV2{}
+
+type NamespaceAuthorizationRuleV1ToV2 struct{}
+
+func (NamespaceAuthorizationRuleV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return authorizationRuleSchemaForV0AndV1()
+}
+
+func (NamespaceAuthorizationRuleV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+
+		newId := strings.Replace(rawState["id"].(string), "/AuthorizationRules/", "/authorizationRules/", 1)
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+
+		rawState["id"] = newId
+
+		return rawState, nil
 	}
 }
 
-func namespaceAuthorizationRuleSchemaForV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func authorizationRuleSchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"namespace_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"namespace_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
-}
-
-func namespaceAuthorizationRuleUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-
-	newId := strings.Replace(rawState["id"].(string), "/authorizationRules/", "/AuthorizationRules/", 1)
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
-
-	rawState["id"] = newId
-
-	return rawState, nil
-}
-
-func namespaceAuthorizationRuleUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-
-	newId := strings.Replace(rawState["id"].(string), "/AuthorizationRules/", "/authorizationRules/", 1)
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
-
-	rawState["id"] = newId
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/frontdoor/frontdoor_custom_https_configuration_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_custom_https_configuration_resource.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/frontdoor/mgmt/2020-01-01/frontdoor"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/validate"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -67,9 +69,9 @@ func resourceFrontDoorCustomHttpsConfiguration() *schema.Resource {
 		CustomizeDiff: customizeHttpsConfigurationCustomizeDiff,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.CustomHttpsConfigurationV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.CustomHttpsConfigurationV0ToV1{},
+		}),
 	}
 }
 

--- a/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -28,6 +29,11 @@ func resourceFrontDoorFirewallPolicy() *schema.Resource {
 		Read:   resourceFrontDoorFirewallPolicyRead,
 		Update: resourceFrontDoorFirewallPolicyCreateUpdate,
 		Delete: resourceFrontDoorFirewallPolicyDelete,
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.WebApplicationFirewallPolicyV0ToV1{},
+		}),
 
 		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
 			_, err := parse.WebApplicationFirewallPolicyIDInsensitively(id)
@@ -420,11 +426,6 @@ func resourceFrontDoorFirewallPolicy() *schema.Resource {
 			},
 
 			"tags": tags.Schema(),
-		},
-
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.WebApplicationFirewallPolicyV0ToV1(),
 		},
 	}
 }

--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/frontdoor/mgmt/2020-01-01/frontdoor"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -36,10 +38,10 @@ func resourceFrontDoor() *schema.Resource {
 		}),
 
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.FrontDoorUpgradeV0ToV1(),
-			migration.FrontDoorUpgradeV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.FrontDoorUpgradeV0ToV1{},
+			1: migration.FrontDoorUpgradeV1ToV2{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(6 * time.Hour),

--- a/azurerm/internal/services/frontdoor/migration/custom_https_configuration.go
+++ b/azurerm/internal/services/frontdoor/migration/custom_https_configuration.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -8,113 +9,110 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func CustomHttpsConfigurationV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    customHttpsConfigurationSchemaToV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: customHttpsConfigurationUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = CustomHttpsConfigurationV0ToV1{}
 
-func customHttpsConfigurationSchemaToV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"frontend_endpoint_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type CustomHttpsConfigurationV0ToV1 struct{}
 
-			"custom_https_provisioning_enabled": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
+func (CustomHttpsConfigurationV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"frontend_endpoint_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"custom_https_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"certificate_source": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"minimum_tls_version": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"provisioning_state": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"provisioning_substate": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"azure_key_vault_certificate_secret_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"azure_key_vault_certificate_secret_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"azure_key_vault_certificate_vault_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+		"custom_https_provisioning_enabled": {
+			Type:     schema.TypeBool,
+			Required: true,
+		},
+
+		"custom_https_configuration": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"certificate_source": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"minimum_tls_version": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"provisioning_state": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"provisioning_substate": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"azure_key_vault_certificate_secret_name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"azure_key_vault_certificate_secret_version": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"azure_key_vault_certificate_vault_id": {
+						Type:     schema.TypeString,
+						Optional: true,
 					},
 				},
 			},
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
 		},
 	}
 }
 
-func customHttpsConfigurationUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	// this was: fmt.Sprintf("%s/customHttpsConfiguration/%s", frontEndEndpointId, frontendEndpointName
-	oldId := rawState["id"].(string)
-	oldParsedId, err := azure.ParseAzureResourceID(oldId)
-	if err != nil {
-		return rawState, err
-	}
-
-	resourceGroup := oldParsedId.ResourceGroup
-	frontdoorName := ""
-	frontendEndpointName := ""
-	for key, value := range oldParsedId.Path {
-		if strings.EqualFold(key, "frontdoors") {
-			frontdoorName = value
-			continue
+func (CustomHttpsConfigurationV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// this was: fmt.Sprintf("%s/customHttpsConfiguration/%s", frontEndEndpointId, frontendEndpointName
+		oldId := rawState["id"].(string)
+		oldParsedId, err := azure.ParseAzureResourceID(oldId)
+		if err != nil {
+			return rawState, err
 		}
 
-		if strings.EqualFold(key, "frontendEndpoints") {
-			frontendEndpointName = value
-			continue
+		resourceGroup := oldParsedId.ResourceGroup
+		frontdoorName := ""
+		frontendEndpointName := ""
+		for key, value := range oldParsedId.Path {
+			if strings.EqualFold(key, "frontdoors") {
+				frontdoorName = value
+				continue
+			}
+
+			if strings.EqualFold(key, "frontendEndpoints") {
+				frontendEndpointName = value
+				continue
+			}
 		}
+
+		if frontdoorName == "" {
+			return rawState, fmt.Errorf("couldn't find the `frontdoors` segment in the old resource id %q", oldId)
+		}
+
+		if frontendEndpointName == "" {
+			return rawState, fmt.Errorf("couldn't find the `frontendEndpoints` segment in the old resource id %q", oldId)
+		}
+
+		newId := parse.NewFrontendEndpointID(oldParsedId.SubscriptionID, resourceGroup, frontdoorName, frontendEndpointName)
+		newIdStr := newId.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+		rawState["id"] = newIdStr
+
+		return rawState, nil
 	}
-
-	if frontdoorName == "" {
-		return rawState, fmt.Errorf("couldn't find the `frontdoors` segment in the old resource id %q", oldId)
-	}
-
-	if frontendEndpointName == "" {
-		return rawState, fmt.Errorf("couldn't find the `frontendEndpoints` segment in the old resource id %q", oldId)
-	}
-
-	newId := parse.NewFrontendEndpointID(oldParsedId.SubscriptionID, resourceGroup, frontdoorName, frontendEndpointName)
-	newIdStr := newId.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
-
-	rawState["id"] = newIdStr
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/frontdoor/migration/custom_https_configuration_test.go
+++ b/azurerm/internal/services/frontdoor/migration/custom_https_configuration_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -43,7 +44,7 @@ func TestCustomHttpsConfigurationV0ToV1(t *testing.T) {
 	}
 	for _, test := range testData {
 		t.Logf("Testing %q..", test.name)
-		result, err := customHttpsConfigurationUpgradeV0ToV1(test.input, nil)
+		result, err := CustomHttpsConfigurationV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
 		if err != nil && test.expected == nil {
 			continue
 		} else {

--- a/azurerm/internal/services/frontdoor/migration/frontdoor.go
+++ b/azurerm/internal/services/frontdoor/migration/frontdoor.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -8,442 +9,445 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func FrontDoorUpgradeV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    frontDoorSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: frontDoorUpgradeV0ToV1,
-		Version: 0,
+var _ pluginsdk.StateUpgrade = FrontDoorUpgradeV0ToV1{}
+
+type FrontDoorUpgradeV0ToV1 struct{}
+
+func (FrontDoorUpgradeV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return frontDoorSchemaForV0AndV1()
+}
+
+func (FrontDoorUpgradeV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// this resource was set to "schema version 1" unintentionally.. so we're adding
+		// a "fake" upgrade here to account for it
+		return rawState, nil
 	}
 }
 
-func FrontDoorUpgradeV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    frontDoorSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: frontDoorUpgradeV1ToV2,
-		Version: 1,
+var _ pluginsdk.StateUpgrade = FrontDoorUpgradeV1ToV2{}
+
+type FrontDoorUpgradeV1ToV2 struct{}
+
+func (FrontDoorUpgradeV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return frontDoorSchemaForV0AndV1()
+}
+
+func (FrontDoorUpgradeV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old
+		// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontdoors/{frontDoorName}
+		// new:
+		// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}
+		oldId := rawState["id"].(string)
+		oldParsedId, err := azure.ParseAzureResourceID(oldId)
+		if err != nil {
+			return rawState, err
+		}
+
+		resourceGroup := oldParsedId.ResourceGroup
+		frontDoorName := ""
+		for key, value := range oldParsedId.Path {
+			if strings.EqualFold(key, "frontDoors") {
+				frontDoorName = value
+				break
+			}
+		}
+
+		if frontDoorName == "" {
+			return rawState, fmt.Errorf("couldn't find the `frontDoors` segment in the old resource id %q", oldId)
+		}
+
+		newId := parse.NewFrontDoorID(oldParsedId.SubscriptionID, resourceGroup, frontDoorName)
+		newIdStr := newId.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+		rawState["id"] = newIdStr
+
+		return rawState, nil
 	}
 }
 
-func frontDoorSchemaForV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func frontDoorSchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"cname": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"cname": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"header_frontdoor_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"header_frontdoor_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"friendly_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"friendly_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"load_balancer_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"load_balancer_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"enforce_backend_pools_certificate_name_check": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
+		"enforce_backend_pools_certificate_name_check": {
+			Type:     schema.TypeBool,
+			Required: true,
+		},
 
-			"backend_pools_send_receive_timeout_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
+		"backend_pools_send_receive_timeout_seconds": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"routing_rule": {
-				Type:     schema.TypeList,
-				MaxItems: 100,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
+		"routing_rule": {
+			Type:     schema.TypeList,
+			MaxItems: 100,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"accepted_protocols": {
+						Type:     schema.TypeList,
+						Required: true,
+						MaxItems: 2,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+					},
+					"patterns_to_match": {
+						Type:     schema.TypeList,
+						Required: true,
+						MaxItems: 25,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
+					},
+					"frontend_endpoints": {
+						Type:     schema.TypeList,
+						Required: true,
+						MaxItems: 100,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"accepted_protocols": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 2,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"patterns_to_match": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 25,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"frontend_endpoints": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 100,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"redirect_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"custom_fragment": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"custom_host": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"custom_path": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"custom_query_string": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"redirect_protocol": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"redirect_type": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					},
+					"redirect_configuration": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"custom_fragment": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
-							},
-						},
-						"forwarding_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"backend_pool_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"cache_enabled": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"cache_use_dynamic_compression": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"cache_query_parameter_strip_directive": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"custom_forwarding_path": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"forwarding_protocol": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"custom_host": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"custom_path": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"custom_query_string": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"redirect_protocol": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"redirect_type": {
+									Type:     schema.TypeString,
+									Required: true,
 								},
 							},
 						},
 					},
-				},
-			},
-
-			"backend_pool_load_balancing": {
-				Type:     schema.TypeList,
-				MaxItems: 5000,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"sample_size": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"successful_samples_required": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"additional_latency_milliseconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-					},
-				},
-			},
-
-			"backend_pool_health_probe": {
-				Type:     schema.TypeList,
-				MaxItems: 5000,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"path": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"protocol": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"probe_method": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"interval_in_seconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-					},
-				},
-			},
-
-			"backend_pool": {
-				Type:     schema.TypeList,
-				MaxItems: 50,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"backend": {
-							Type:     schema.TypeList,
-							MaxItems: 100,
-							Required: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enabled": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  true,
-									},
-									"address": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"http_port": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"https_port": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-									"weight": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"priority": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"host_header": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"forwarding_configuration": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"backend_pool_name": {
+									Type:     schema.TypeString,
+									Required: true,
 								},
-							},
-						},
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"health_probe_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"load_balancing_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
-
-			"frontend_endpoint": {
-				Type:     schema.TypeList,
-				MaxItems: 100,
-				Required: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"host_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"session_affinity_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"session_affinity_ttl_seconds": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"custom_https_provisioning_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-						"web_application_firewall_policy_link_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"custom_https_configuration": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Computed: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"certificate_source": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"minimum_tls_version": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"provisioning_state": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"provisioning_substate": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"azure_key_vault_certificate_secret_name": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"azure_key_vault_certificate_secret_version": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"azure_key_vault_certificate_vault_id": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"cache_enabled": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+								"cache_use_dynamic_compression": {
+									Type:     schema.TypeBool,
+									Optional: true,
+								},
+								"cache_query_parameter_strip_directive": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"custom_forwarding_path": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"forwarding_protocol": {
+									Type:     schema.TypeString,
+									Optional: true,
 								},
 							},
 						},
 					},
-				},
-			},
-
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
 				},
 			},
 		},
+
+		"backend_pool_load_balancing": {
+			Type:     schema.TypeList,
+			MaxItems: 5000,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"sample_size": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+					"successful_samples_required": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+					"additional_latency_milliseconds": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"backend_pool_health_probe": {
+			Type:     schema.TypeList,
+			MaxItems: 5000,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"path": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"protocol": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"probe_method": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"interval_in_seconds": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+				},
+			},
+		},
+
+		"backend_pool": {
+			Type:     schema.TypeList,
+			MaxItems: 50,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"backend": {
+						Type:     schema.TypeList,
+						MaxItems: 100,
+						Required: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"enabled": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  true,
+								},
+								"address": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"http_port": {
+									Type:     schema.TypeInt,
+									Required: true,
+								},
+								"https_port": {
+									Type:     schema.TypeInt,
+									Required: true,
+								},
+								"weight": {
+									Type:     schema.TypeInt,
+									Optional: true,
+								},
+								"priority": {
+									Type:     schema.TypeInt,
+									Optional: true,
+								},
+								"host_header": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"health_probe_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"load_balancing_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"frontend_endpoint": {
+			Type:     schema.TypeList,
+			MaxItems: 100,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"host_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"session_affinity_enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"session_affinity_ttl_seconds": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+					"custom_https_provisioning_enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Computed: true,
+					},
+					"web_application_firewall_policy_link_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"custom_https_configuration": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"certificate_source": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"minimum_tls_version": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"provisioning_state": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"provisioning_substate": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+								"azure_key_vault_certificate_secret_name": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"azure_key_vault_certificate_secret_version": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"azure_key_vault_certificate_vault_id": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 	}
-}
-
-func frontDoorUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	// this resource was set to "schema version 1" unintentionally.. so we're adding
-	// a "fake" upgrade here to account for it
-	return rawState, nil
-}
-
-func frontDoorUpgradeV1ToV2(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	// old
-	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontdoors/{frontDoorName}
-	// new:
-	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoors/{frontDoorName}
-	oldId := rawState["id"].(string)
-	oldParsedId, err := azure.ParseAzureResourceID(oldId)
-	if err != nil {
-		return rawState, err
-	}
-
-	resourceGroup := oldParsedId.ResourceGroup
-	frontDoorName := ""
-	for key, value := range oldParsedId.Path {
-		if strings.EqualFold(key, "frontDoors") {
-			frontDoorName = value
-			break
-		}
-	}
-
-	if frontDoorName == "" {
-		return rawState, fmt.Errorf("couldn't find the `frontDoors` segment in the old resource id %q", oldId)
-	}
-
-	newId := parse.NewFrontDoorID(oldParsedId.SubscriptionID, resourceGroup, frontDoorName)
-	newIdStr := newId.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
-
-	rawState["id"] = newIdStr
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/frontdoor/migration/frontdoor_test.go
+++ b/azurerm/internal/services/frontdoor/migration/frontdoor_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -50,7 +51,7 @@ func TestFrontDoorV1ToV2(t *testing.T) {
 	}
 	for _, test := range testData {
 		t.Logf("Testing %q..", test.name)
-		result, err := frontDoorUpgradeV1ToV2(test.input, nil)
+		result, err := FrontDoorUpgradeV1ToV2{}.UpgradeFunc()(context.TODO(), test.input, nil)
 		if err != nil && test.expected == nil {
 			continue
 		} else {

--- a/azurerm/internal/services/frontdoor/migration/web_application_firewall_policy.go
+++ b/azurerm/internal/services/frontdoor/migration/web_application_firewall_policy.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -9,143 +10,138 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func WebApplicationFirewallPolicyV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    webApplicationFirewallPolicySchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: webApplicationFirewallPolicyUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = WebApplicationFirewallPolicyV0ToV1{}
 
-func webApplicationFirewallPolicySchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type WebApplicationFirewallPolicyV0ToV1 struct{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+func (WebApplicationFirewallPolicyV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"mode": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"redirect_url": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"mode": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"custom_block_response_status_code": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
+		"redirect_url": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-			"custom_block_response_body": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"custom_block_response_status_code": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
 
-			"custom_rule": {
-				Type:     schema.TypeList,
-				MaxItems: 100,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"custom_block_response_body": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
+		"custom_rule": {
+			Type:     schema.TypeList,
+			MaxItems: 100,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"priority": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
+					"enabled": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
 
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"priority": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
 
-						"rate_limit_duration_in_minutes": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"rate_limit_threshold": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
+					"rate_limit_duration_in_minutes": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
 
-						"action": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"rate_limit_threshold": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
 
-						"match_condition": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 100,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"match_variable": {
-										Type:     schema.TypeString,
-										Required: true,
+					"action": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+
+					"match_condition": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 100,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"match_variable": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+
+								"match_values": {
+									Type:     schema.TypeList,
+									Required: true,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
+								},
 
-									"match_values": {
-										Type:     schema.TypeList,
-										Required: true,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+								"selector": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
 
-									"selector": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
+								"negation_condition": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
 
-									"negation_condition": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
-									},
-
-									"transforms": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 5,
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
+								"transforms": {
+									Type:     schema.TypeList,
+									Optional: true,
+									MaxItems: 5,
+									Elem: &schema.Schema{
+										Type: schema.TypeString,
 									},
 								},
 							},
@@ -153,120 +149,120 @@ func webApplicationFirewallPolicySchemaForV0() *schema.Resource {
 					},
 				},
 			},
+		},
 
-			"managed_rule": {
-				Type:     schema.TypeList,
-				MaxItems: 100,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"managed_rule": {
+			Type:     schema.TypeList,
+			MaxItems: 100,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"version": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"version": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"exclusion": {
-							Type:     schema.TypeList,
-							MaxItems: 100,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"match_variable": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"operator": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"selector": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"exclusion": {
+						Type:     schema.TypeList,
+						MaxItems: 100,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"match_variable": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"operator": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"selector": {
+									Type:     schema.TypeString,
+									Required: true,
 								},
 							},
 						},
+					},
 
-						"override": {
-							Type:     schema.TypeList,
-							MaxItems: 100,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"rule_group_name": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+					"override": {
+						Type:     schema.TypeList,
+						MaxItems: 100,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"rule_group_name": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
 
-									"exclusion": {
-										Type:     schema.TypeList,
-										MaxItems: 100,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"match_variable": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"operator": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-												"selector": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
+								"exclusion": {
+									Type:     schema.TypeList,
+									MaxItems: 100,
+									Optional: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"match_variable": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
+											"operator": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
+											"selector": {
+												Type:     schema.TypeString,
+												Required: true,
 											},
 										},
 									},
+								},
 
-									"rule": {
-										Type:     schema.TypeList,
-										MaxItems: 1000,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"rule_id": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
+								"rule": {
+									Type:     schema.TypeList,
+									MaxItems: 1000,
+									Optional: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"rule_id": {
+												Type:     schema.TypeString,
+												Required: true,
+											},
 
-												"enabled": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
+											"enabled": {
+												Type:     schema.TypeBool,
+												Optional: true,
+											},
 
-												"exclusion": {
-													Type:     schema.TypeList,
-													MaxItems: 100,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"match_variable": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"operator": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
-															"selector": {
-																Type:     schema.TypeString,
-																Required: true,
-															},
+											"exclusion": {
+												Type:     schema.TypeList,
+												MaxItems: 100,
+												Optional: true,
+												Elem: &schema.Resource{
+													Schema: map[string]*schema.Schema{
+														"match_variable": {
+															Type:     schema.TypeString,
+															Required: true,
+														},
+														"operator": {
+															Type:     schema.TypeString,
+															Required: true,
+														},
+														"selector": {
+															Type:     schema.TypeString,
+															Required: true,
 														},
 													},
 												},
+											},
 
-												"action": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
+											"action": {
+												Type:     schema.TypeString,
+												Required: true,
 											},
 										},
 									},
@@ -276,50 +272,52 @@ func webApplicationFirewallPolicySchemaForV0() *schema.Resource {
 					},
 				},
 			},
-
-			"frontend_endpoint_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-
-			"tags": tags.Schema(),
 		},
+
+		"frontend_endpoint_ids": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+
+		"tags": tags.Schema(),
 	}
 }
 
-func webApplicationFirewallPolicyUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	// old
-	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/{policyName}
-	// new:
-	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/{policyName}
-	oldId := rawState["id"].(string)
-	oldParsedId, err := azure.ParseAzureResourceID(oldId)
-	if err != nil {
-		return rawState, err
-	}
-
-	resourceGroup := oldParsedId.ResourceGroup
-	policyName := ""
-	for key, value := range oldParsedId.Path {
-		if strings.EqualFold(key, "frontDoorWebApplicationFirewallPolicies") {
-			policyName = value
-			break
+func (WebApplicationFirewallPolicyV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old
+		// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/{policyName}
+		// new:
+		// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/{policyName}
+		oldId := rawState["id"].(string)
+		oldParsedId, err := azure.ParseAzureResourceID(oldId)
+		if err != nil {
+			return rawState, err
 		}
+
+		resourceGroup := oldParsedId.ResourceGroup
+		policyName := ""
+		for key, value := range oldParsedId.Path {
+			if strings.EqualFold(key, "frontDoorWebApplicationFirewallPolicies") {
+				policyName = value
+				break
+			}
+		}
+
+		if policyName == "" {
+			return rawState, fmt.Errorf("couldn't find the `frontDoorWebApplicationFirewallPolicies` segment in the old resource id %q", oldId)
+		}
+
+		newId := parse.NewWebApplicationFirewallPolicyID(oldParsedId.SubscriptionID, resourceGroup, policyName)
+		newIdStr := newId.ID()
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+		rawState["id"] = newIdStr
+
+		return rawState, nil
 	}
-
-	if policyName == "" {
-		return rawState, fmt.Errorf("couldn't find the `frontDoorWebApplicationFirewallPolicies` segment in the old resource id %q", oldId)
-	}
-
-	newId := parse.NewWebApplicationFirewallPolicyID(oldParsedId.SubscriptionID, resourceGroup, policyName)
-	newIdStr := newId.ID()
-
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
-
-	rawState["id"] = newIdStr
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/frontdoor/migration/web_application_firewall_policy_test.go
+++ b/azurerm/internal/services/frontdoor/migration/web_application_firewall_policy_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -43,7 +44,7 @@ func TestWebApplicationFirewallPolicyV0ToV1(t *testing.T) {
 	}
 	for _, test := range testData {
 		t.Logf("Testing %q..", test.name)
-		result, err := webApplicationFirewallPolicyUpgradeV0ToV1(test.input, nil)
+		result, err := WebApplicationFirewallPolicyV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
 		if err != nil && test.expected == nil {
 			continue
 		} else {

--- a/azurerm/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/azurerm/internal/services/iotcentral/iotcentral_application_resource.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 
 	"github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral"
@@ -35,9 +37,9 @@ func resourceIotCentralApplication() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.ApplicationV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ApplicationV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/iotcentral/migration/application.go
+++ b/azurerm/internal/services/iotcentral/migration/application.go
@@ -1,84 +1,83 @@
 package migration
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iotcentral/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func ApplicationV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    applicationSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: applicationUpgradeV0ToV1,
-		Version: 0,
-	}
+var _ pluginsdk.StateUpgrade = ApplicationV0ToV1{}
+
+type ApplicationV0ToV1 struct {
 }
 
-func applicationSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (ApplicationV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"sub_domain": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"sub_domain": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			"display_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		"display_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 
-			"sku": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "ST1",
-			},
+		"sku": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "ST1",
+		},
 
-			"template": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		"template": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func applicationUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	id, err := parse.ApplicationIDInsensitively(oldId)
-	if err != nil {
-		return rawState, err
-	}
+func (ApplicationV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		id, err := parse.ApplicationIDInsensitively(oldId)
+		if err != nil {
+			return rawState, err
+		}
 
-	newId := id.ID()
-	log.Printf("Updating `id` from %q to %q", oldId, newId)
-	rawState["id"] = newId
-	return rawState, nil
+		newId := id.ID()
+		log.Printf("Updating `id` from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_access_policy_resource.go
+++ b/azurerm/internal/services/iottimeseriesinsights/iot_time_series_insights_access_policy_resource.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/timeseriesinsights/mgmt/2020-05-15/timeseriesinsights"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -37,9 +39,9 @@ func resourceIoTTimeSeriesInsightsAccessPolicy() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.StandardEnvironmentAccessPolicyV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.StandardEnvironmentAccessPolicyV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/iottimeseriesinsights/migration/standard_environment.go
+++ b/azurerm/internal/services/iottimeseriesinsights/migration/standard_environment.go
@@ -1,65 +1,63 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func StandardEnvironmentAccessPolicyV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    standardEnvironmentAccessPolicySchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: standardEnvironmentAccessPolicyUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = StandardEnvironmentAccessPolicyV0ToV1{}
 
-func standardEnvironmentAccessPolicySchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type StandardEnvironmentAccessPolicyV0ToV1 struct{}
 
-			"time_series_insights_environment_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (StandardEnvironmentAccessPolicyV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"principal_object_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"time_series_insights_environment_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+		"principal_object_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"roles": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"roles": {
+			Type:     schema.TypeSet,
+			Required: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func standardEnvironmentAccessPolicyUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	log.Println("[DEBUG] Migrating ResourceType from v0 to v1 format")
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(oldId, "/accesspolicies/", "/accessPolicies/", 1)
+func (StandardEnvironmentAccessPolicyV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Println("[DEBUG] Migrating ResourceType from v0 to v1 format")
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(oldId, "/accesspolicies/", "/accessPolicies/", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	KeyVaultMgmt "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/gofrs/uuid"
@@ -52,10 +54,10 @@ func resourceKeyVault() *schema.Resource {
 		},
 
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.KeyVaultV0ToV1(),
-			migration.KeyVaultV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.KeyVaultV0ToV1{},
+			1: migration.KeyVaultV1ToV2{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/keyvault/migration/key_vault.go
+++ b/azurerm/internal/services/keyvault/migration/key_vault.go
@@ -1,360 +1,356 @@
 package migration
 
 import (
+	"context"
 	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/set"
 )
 
-func KeyVaultV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    keyVaultSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: keyVaultV0ToV1Upgrade,
-		Version: 0,
+var _ pluginsdk.StateUpgrade = KeyVaultV0ToV1{}
+
+type KeyVaultV0ToV1 struct{}
+
+func (KeyVaultV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		// TODO: dig this out
 	}
 }
 
-func KeyVaultV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    keyVaultSchemaForV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: keyVaultV1ToV2Upgrade,
-		Version: 1,
-	}
-}
+func (KeyVaultV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		inputAccessPolicies := rawState["access_policy"].([]interface{})
+		if len(inputAccessPolicies) == 0 {
+			return rawState, nil
+		}
 
-func keyVaultSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{},
-	}
-}
+		outputAccessPolicies := make([]interface{}, 0)
+		for _, accessPolicy := range inputAccessPolicies {
+			policy := accessPolicy.(map[string]interface{})
 
-func keyVaultV0ToV1Upgrade(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	inputAccessPolicies := rawState["access_policy"].([]interface{})
-	if len(inputAccessPolicies) == 0 {
+			if v, ok := policy["certificate_permissions"]; ok {
+				inputCertificatePermissions := v.([]interface{})
+				outputCertificatePermissions := make([]string, 0)
+				for _, p := range inputCertificatePermissions {
+					permission := p.(string)
+					if strings.ToLower(permission) == "all" {
+						outputCertificatePermissions = append(outputCertificatePermissions, "create")
+						outputCertificatePermissions = append(outputCertificatePermissions, "delete")
+						outputCertificatePermissions = append(outputCertificatePermissions, "deleteissuers")
+						outputCertificatePermissions = append(outputCertificatePermissions, "get")
+						outputCertificatePermissions = append(outputCertificatePermissions, "getissuers")
+						outputCertificatePermissions = append(outputCertificatePermissions, "import")
+						outputCertificatePermissions = append(outputCertificatePermissions, "list")
+						outputCertificatePermissions = append(outputCertificatePermissions, "listissuers")
+						outputCertificatePermissions = append(outputCertificatePermissions, "managecontacts")
+						outputCertificatePermissions = append(outputCertificatePermissions, "manageissuers")
+						outputCertificatePermissions = append(outputCertificatePermissions, "setissuers")
+						outputCertificatePermissions = append(outputCertificatePermissions, "update")
+						break
+					}
+				}
+
+				if len(outputCertificatePermissions) > 0 {
+					policy["certificate_permissions"] = outputCertificatePermissions
+				}
+			}
+
+			if v, ok := policy["key_permissions"]; ok {
+				inputKeyPermissions := v.([]interface{})
+				outputKeyPermissions := make([]string, 0)
+				for _, p := range inputKeyPermissions {
+					permission := p.(string)
+					if strings.ToLower(permission) == "all" {
+						outputKeyPermissions = append(outputKeyPermissions, "backup")
+						outputKeyPermissions = append(outputKeyPermissions, "create")
+						outputKeyPermissions = append(outputKeyPermissions, "decrypt")
+						outputKeyPermissions = append(outputKeyPermissions, "delete")
+						outputKeyPermissions = append(outputKeyPermissions, "encrypt")
+						outputKeyPermissions = append(outputKeyPermissions, "get")
+						outputKeyPermissions = append(outputKeyPermissions, "import")
+						outputKeyPermissions = append(outputKeyPermissions, "list")
+						outputKeyPermissions = append(outputKeyPermissions, "purge")
+						outputKeyPermissions = append(outputKeyPermissions, "recover")
+						outputKeyPermissions = append(outputKeyPermissions, "restore")
+						outputKeyPermissions = append(outputKeyPermissions, "sign")
+						outputKeyPermissions = append(outputKeyPermissions, "unwrapKey")
+						outputKeyPermissions = append(outputKeyPermissions, "update")
+						outputKeyPermissions = append(outputKeyPermissions, "verify")
+						outputKeyPermissions = append(outputKeyPermissions, "wrapKey")
+						break
+					}
+				}
+
+				if len(outputKeyPermissions) > 0 {
+					policy["key_permissions"] = outputKeyPermissions
+				}
+			}
+
+			if v, ok := policy["secret_permissions"]; ok {
+				inputSecretPermissions := v.([]interface{})
+				outputSecretPermissions := make([]string, 0)
+				for _, p := range inputSecretPermissions {
+					permission := p.(string)
+					if strings.ToLower(permission) == "all" {
+						outputSecretPermissions = append(outputSecretPermissions, "backup")
+						outputSecretPermissions = append(outputSecretPermissions, "delete")
+						outputSecretPermissions = append(outputSecretPermissions, "get")
+						outputSecretPermissions = append(outputSecretPermissions, "list")
+						outputSecretPermissions = append(outputSecretPermissions, "purge")
+						outputSecretPermissions = append(outputSecretPermissions, "recover")
+						outputSecretPermissions = append(outputSecretPermissions, "restore")
+						outputSecretPermissions = append(outputSecretPermissions, "set")
+						break
+					}
+				}
+
+				if len(outputSecretPermissions) > 0 {
+					policy["secret_permissions"] = outputSecretPermissions
+				}
+			}
+
+			outputAccessPolicies = append(outputAccessPolicies, policy)
+		}
+
+		rawState["access_policy"] = outputAccessPolicies
 		return rawState, nil
 	}
-
-	outputAccessPolicies := make([]interface{}, 0)
-	for _, accessPolicy := range inputAccessPolicies {
-		policy := accessPolicy.(map[string]interface{})
-
-		if v, ok := policy["certificate_permissions"]; ok {
-			inputCertificatePermissions := v.([]interface{})
-			outputCertificatePermissions := make([]string, 0)
-			for _, p := range inputCertificatePermissions {
-				permission := p.(string)
-				if strings.ToLower(permission) == "all" {
-					outputCertificatePermissions = append(outputCertificatePermissions, "create")
-					outputCertificatePermissions = append(outputCertificatePermissions, "delete")
-					outputCertificatePermissions = append(outputCertificatePermissions, "deleteissuers")
-					outputCertificatePermissions = append(outputCertificatePermissions, "get")
-					outputCertificatePermissions = append(outputCertificatePermissions, "getissuers")
-					outputCertificatePermissions = append(outputCertificatePermissions, "import")
-					outputCertificatePermissions = append(outputCertificatePermissions, "list")
-					outputCertificatePermissions = append(outputCertificatePermissions, "listissuers")
-					outputCertificatePermissions = append(outputCertificatePermissions, "managecontacts")
-					outputCertificatePermissions = append(outputCertificatePermissions, "manageissuers")
-					outputCertificatePermissions = append(outputCertificatePermissions, "setissuers")
-					outputCertificatePermissions = append(outputCertificatePermissions, "update")
-					break
-				}
-			}
-
-			if len(outputCertificatePermissions) > 0 {
-				policy["certificate_permissions"] = outputCertificatePermissions
-			}
-		}
-
-		if v, ok := policy["key_permissions"]; ok {
-			inputKeyPermissions := v.([]interface{})
-			outputKeyPermissions := make([]string, 0)
-			for _, p := range inputKeyPermissions {
-				permission := p.(string)
-				if strings.ToLower(permission) == "all" {
-					outputKeyPermissions = append(outputKeyPermissions, "backup")
-					outputKeyPermissions = append(outputKeyPermissions, "create")
-					outputKeyPermissions = append(outputKeyPermissions, "decrypt")
-					outputKeyPermissions = append(outputKeyPermissions, "delete")
-					outputKeyPermissions = append(outputKeyPermissions, "encrypt")
-					outputKeyPermissions = append(outputKeyPermissions, "get")
-					outputKeyPermissions = append(outputKeyPermissions, "import")
-					outputKeyPermissions = append(outputKeyPermissions, "list")
-					outputKeyPermissions = append(outputKeyPermissions, "purge")
-					outputKeyPermissions = append(outputKeyPermissions, "recover")
-					outputKeyPermissions = append(outputKeyPermissions, "restore")
-					outputKeyPermissions = append(outputKeyPermissions, "sign")
-					outputKeyPermissions = append(outputKeyPermissions, "unwrapKey")
-					outputKeyPermissions = append(outputKeyPermissions, "update")
-					outputKeyPermissions = append(outputKeyPermissions, "verify")
-					outputKeyPermissions = append(outputKeyPermissions, "wrapKey")
-					break
-				}
-			}
-
-			if len(outputKeyPermissions) > 0 {
-				policy["key_permissions"] = outputKeyPermissions
-			}
-		}
-
-		if v, ok := policy["secret_permissions"]; ok {
-			inputSecretPermissions := v.([]interface{})
-			outputSecretPermissions := make([]string, 0)
-			for _, p := range inputSecretPermissions {
-				permission := p.(string)
-				if strings.ToLower(permission) == "all" {
-					outputSecretPermissions = append(outputSecretPermissions, "backup")
-					outputSecretPermissions = append(outputSecretPermissions, "delete")
-					outputSecretPermissions = append(outputSecretPermissions, "get")
-					outputSecretPermissions = append(outputSecretPermissions, "list")
-					outputSecretPermissions = append(outputSecretPermissions, "purge")
-					outputSecretPermissions = append(outputSecretPermissions, "recover")
-					outputSecretPermissions = append(outputSecretPermissions, "restore")
-					outputSecretPermissions = append(outputSecretPermissions, "set")
-					break
-				}
-			}
-
-			if len(outputSecretPermissions) > 0 {
-				policy["secret_permissions"] = outputSecretPermissions
-			}
-		}
-
-		outputAccessPolicies = append(outputAccessPolicies, policy)
-	}
-
-	rawState["access_policy"] = outputAccessPolicies
-	return rawState, nil
 }
 
-func keyVaultSchemaForV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+var _ pluginsdk.StateUpgrade = KeyVaultV1ToV2{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type KeyVaultV1ToV2 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (KeyVaultV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"sku_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"access_policy": {
-				Type:       schema.TypeList,
-				ConfigMode: schema.SchemaConfigModeAttr,
-				Optional:   true,
-				Computed:   true,
-				MaxItems:   1024,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"tenant_id": {
-							Type:     schema.TypeString,
-							Required: true,
+		"sku_name": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+
+		"tenant_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+
+		"access_policy": {
+			Type:       schema.TypeList,
+			ConfigMode: schema.SchemaConfigModeAttr,
+			Optional:   true,
+			Computed:   true,
+			MaxItems:   1024,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"tenant_id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"object_id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"application_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"certificate_permissions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"object_id": {
-							Type:     schema.TypeString,
-							Required: true,
+					},
+					"key_permissions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"application_id": {
-							Type:     schema.TypeString,
-							Optional: true,
+					},
+					"secret_permissions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
-						"certificate_permissions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"key_permissions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"secret_permissions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						"storage_permissions": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
+					},
+					"storage_permissions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
 						},
 					},
 				},
 			},
+		},
 
-			"enabled_for_deployment": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enabled_for_deployment": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"enabled_for_disk_encryption": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enabled_for_disk_encryption": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"enabled_for_template_deployment": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enabled_for_template_deployment": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"enable_rbac_authorization": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enable_rbac_authorization": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"network_acls": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"default_action": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"bypass": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"ip_rules": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
-						"virtual_network_subnet_ids": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      set.HashStringIgnoreCase,
-						},
+		"network_acls": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"default_action": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"bypass": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"ip_rules": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+						Set:      schema.HashString,
+					},
+					"virtual_network_subnet_ids": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+						Set:      set.HashStringIgnoreCase,
 					},
 				},
 			},
+		},
 
-			"purge_protection_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"purge_protection_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"soft_delete_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
-			},
+		"soft_delete_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 
-			"soft_delete_retention_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
+		"soft_delete_retention_days": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
 
-			"contact": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"email": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"phone": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+		"contact": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"email": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"phone": {
+						Type:     schema.TypeString,
+						Optional: true,
 					},
 				},
 			},
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
+		},
 
-			// Computed
-			"vault_uri": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		// Computed
+		"vault_uri": {
+			Type:     schema.TypeString,
+			Computed: true,
 		},
 	}
 }
 
-func keyVaultV1ToV2Upgrade(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	// @tombuildsstuff: this is an int in the schema but was previously set into the
-	// state as `*int32` - so using `.(int)` causes:
-	// panic: interface conversion: interface {} is float64, not int
-	// so I guess we try both?
-	oldVal := 0
-	if v, ok := rawState["soft_delete_retention_days"]; ok {
-		if val, ok := v.(float64); ok {
-			oldVal = int(val)
+func (KeyVaultV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// @tombuildsstuff: this is an int in the schema but was previously set into the
+		// state as `*int32` - so using `.(int)` causes:
+		// panic: interface conversion: interface {} is float64, not int
+		// so I guess we try both?
+		oldVal := 0
+		if v, ok := rawState["soft_delete_retention_days"]; ok {
+			if val, ok := v.(float64); ok {
+				oldVal = int(val)
+			}
+			if val, ok := v.(int); ok {
+				oldVal = val
+			}
 		}
-		if val, ok := v.(int); ok {
-			oldVal = val
-		}
-	}
 
-	if oldVal == 0 {
-		// The Azure API force-upgraded all Key Vaults so that Soft Delete was enabled on 2020-12-15
-		// As a part of this, all Key Vaults got a default "retention days" of 90 days, however
-		// for both newly created and upgraded key vaults, this value isn't returned unless it's
-		// explicitly set by a user.
-		//
-		// As such we have to default this to a value of 90 days, which whilst assuming this default is
-		// less than ideal, unfortunately there's little choice otherwise as this isn't returned.
-		// Whilst the API Documentation doesn't show this default, it's listed here:
-		//
-		// > Once a secret, key, certificate, or key vault is deleted, it will remain recoverable
-		// > for a configurable period of 7 to 90 calendar days. If no configuration is specified
-		// > the default recovery period will be set to 90 days
-		// https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview
-		//
-		// Notably this value cannot be updated once it's initially been configured, meaning that we
-		// must not send this during creation if it's the default value, to allow users to change
-		// this value later. This also means we can't use Terraform's "ForceNew" here without breaking
-		// the one-time change.
-		//
-		// Hopefully in time this behaviour is fixed, but for now I'm not sure what else we can do.
-		//
-		// - @tombuildsstuff
-		rawState["soft_delete_retention_days"] = 90
+		if oldVal == 0 {
+			// The Azure API force-upgraded all Key Vaults so that Soft Delete was enabled on 2020-12-15
+			// As a part of this, all Key Vaults got a default "retention days" of 90 days, however
+			// for both newly created and upgraded key vaults, this value isn't returned unless it's
+			// explicitly set by a user.
+			//
+			// As such we have to default this to a value of 90 days, which whilst assuming this default is
+			// less than ideal, unfortunately there's little choice otherwise as this isn't returned.
+			// Whilst the API Documentation doesn't show this default, it's listed here:
+			//
+			// > Once a secret, key, certificate, or key vault is deleted, it will remain recoverable
+			// > for a configurable period of 7 to 90 calendar days. If no configuration is specified
+			// > the default recovery period will be set to 90 days
+			// https://docs.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview
+			//
+			// Notably this value cannot be updated once it's initially been configured, meaning that we
+			// must not send this during creation if it's the default value, to allow users to change
+			// this value later. This also means we can't use Terraform's "ForceNew" here without breaking
+			// the one-time change.
+			//
+			// Hopefully in time this behaviour is fixed, but for now I'm not sure what else we can do.
+			//
+			// - @tombuildsstuff
+			rawState["soft_delete_retention_days"] = 90
+		}
+		return rawState, nil
 	}
-	return rawState, nil
 }

--- a/azurerm/internal/services/keyvault/migration/key_vault.go
+++ b/azurerm/internal/services/keyvault/migration/key_vault.go
@@ -16,7 +16,113 @@ type KeyVaultV0ToV1 struct{}
 
 func (KeyVaultV0ToV1) Schema() map[string]*pluginsdk.Schema {
 	return map[string]*schema.Schema{
-		// TODO: dig this out
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"sku": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"vault_uri": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"tenant_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+
+		"access_policy": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MinItems: 1,
+			MaxItems: 16,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"tenant_id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"object_id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"application_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"certificate_permissions": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"key_permissions": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+					"secret_permissions": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+
+		"enabled_for_deployment": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+
+		"enabled_for_disk_encryption": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+
+		"enabled_for_template_deployment": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
 	}
 }
 

--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2020-08-01/operationalinsights"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -36,10 +38,10 @@ func resourceLogAnalyticsWorkspace() *schema.Resource {
 		}),
 
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.WorkspaceV0ToV1(),
-			migration.WorkspaceV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.WorkspaceV0ToV1{},
+			1: migration.WorkspaceV1ToV2{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/loganalytics/migration/workspace_v0_to_v1.go
+++ b/azurerm/internal/services/loganalytics/migration/workspace_v0_to_v1.go
@@ -1,113 +1,115 @@
 package migration
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func WorkspaceV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Version: 0,
-		Type:    workspaceSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: workspaceUpgradeV0ToV1,
+var _ pluginsdk.StateUpgrade = WorkspaceV0ToV1{}
+
+type WorkspaceV0ToV1 struct{}
+
+func (WorkspaceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return workspaceSchemaForV0AndV1()
+}
+
+func (WorkspaceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+
+		log.Printf("[DEBUG] Migrating IDs to correct casing for Log Analytics Workspace")
+		name := rawState["name"].(string)
+		resourceGroup := rawState["resource_group_name"].(string)
+		id := parse.NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, name)
+
+		rawState["id"] = id.ID()
+		return rawState, nil
 	}
 }
 
-func workspaceSchemaForV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func workspaceSchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"internet_ingestion_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		"internet_ingestion_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"internet_query_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
+		"internet_query_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 
-			"sku": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		"sku": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 
-			"retention_in_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
+		"retention_in_days": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
 
-			"daily_quota_gb": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				Default:  -1.0,
-			},
+		"daily_quota_gb": {
+			Type:     schema.TypeFloat,
+			Optional: true,
+			Default:  -1.0,
+		},
 
-			"workspace_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"workspace_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"portal_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"portal_url": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"primary_shared_key": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+		"primary_shared_key": {
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
 
-			"secondary_shared_key": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
+		"secondary_shared_key": {
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
-}
-
-func workspaceUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-
-	log.Printf("[DEBUG] Migrating IDs to correct casing for Log Analytics Workspace")
-	name := rawState["name"].(string)
-	resourceGroup := rawState["resource_group_name"].(string)
-	id := parse.NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, name)
-
-	rawState["id"] = id.ID()
-	return rawState, nil
 }

--- a/azurerm/internal/services/loganalytics/migration/workspace_v1_to_v2.go
+++ b/azurerm/internal/services/loganalytics/migration/workspace_v1_to_v2.go
@@ -1,31 +1,34 @@
 package migration
 
 import (
+	"context"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func WorkspaceV1ToV2() schema.StateUpgrader {
+var _ pluginsdk.StateUpgrade = WorkspaceV1ToV2{}
+
+type WorkspaceV1ToV2 struct{}
+
+func (WorkspaceV1ToV2) Schema() map[string]*pluginsdk.Schema {
 	// V1 to V2 is the same as v0 to v1 - to workaround a historical issue where `resource_group` was
 	// used in place of `resource_group_name` - ergo using the same schema is fine.
-	return schema.StateUpgrader{
-		Version: 1,
-		Type:    workspaceSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: workspaceUpgradeV1ToV2,
-	}
+	return workspaceSchemaForV0AndV1()
 }
 
-func workspaceUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+func (WorkspaceV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 
-	log.Printf("[DEBUG] Migrating IDs to correct casing for Log Analytics Workspace")
-	name := rawState["name"].(string)
-	resourceGroup := rawState["resource_group_name"].(string)
-	id := parse.NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, name)
+		log.Printf("[DEBUG] Migrating IDs to correct casing for Log Analytics Workspace")
+		name := rawState["name"].(string)
+		resourceGroup := rawState["resource_group_name"].(string)
+		id := parse.NewLogAnalyticsWorkspaceID(subscriptionId, resourceGroup, name)
 
-	rawState["id"] = id.ID()
-	return rawState, nil
+		rawState["id"] = id.ID()
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
+++ b/azurerm/internal/services/msi/migration/user_assigned_identity_V0_to_V1.go
@@ -1,69 +1,67 @@
 package migration
 
 import (
+	"context"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func UserAssignedIdentityV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Version: 0,
-		Type:    userAssignedIdentitySchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: userAssignedIdentityUpgradeV0ToV1,
-	}
-}
+var _ pluginsdk.StateUpgrade = UserAssignedIdentityV0ToV1{}
 
-func userAssignedIdentitySchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type UserAssignedIdentityV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (UserAssignedIdentityV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"principal_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"tags": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"client_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"principal_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"client_id": {
+			Type:     schema.TypeString,
+			Computed: true,
 		},
 	}
 }
 
-func userAssignedIdentityUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	id, err := parse.UserAssignedIdentityID(oldId)
-	if err != nil {
-		return rawState, err
-	}
+func (UserAssignedIdentityV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		id, err := parse.UserAssignedIdentityID(oldId)
+		if err != nil {
+			return rawState, err
+		}
 
-	newId := id.ID()
-	log.Printf("Updating `id` from %q to %q", oldId, newId)
-	rawState["id"] = newId
-	return rawState, nil
+		newId := id.ID()
+		log.Printf("Updating `id` from %q to %q", oldId, newId)
+		rawState["id"] = newId
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/msi/user_assigned_identity_resource.go
+++ b/azurerm/internal/services/msi/user_assigned_identity_resource.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/msi/mgmt/2018-11-30/msi"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -12,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -32,9 +34,9 @@ func resourceArmUserAssignedIdentity() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.UserAssignedIdentityV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.UserAssignedIdentityV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/network/migration/network_interface_application_security_group_association.go
+++ b/azurerm/internal/services/network/migration/network_interface_application_security_group_association.go
@@ -1,48 +1,46 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    networkInterfaceApplicationSecurityGroupAssociationSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: networkInterfaceApplicationSecurityGroupAssociationUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1{}
 
-func networkInterfaceApplicationSecurityGroupAssociationSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"network_interface_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1 struct{}
 
-			"application_security_group_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"network_interface_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"application_security_group_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
 }
 
-func networkInterfaceApplicationSecurityGroupAssociationUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	// after shipping support for this Resource Azure's since changed the behaviour to require that all IP Configurations
-	// are connected to the same Application Security Group
-	applicationSecurityGroupId := rawState["application_security_group_id"].(string)
-	networkInterfaceId := rawState["network_interface_id"].(string)
+func (NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// after shipping support for this Resource Azure's since changed the behaviour to require that all IP Configurations
+		// are connected to the same Application Security Group
+		applicationSecurityGroupId := rawState["application_security_group_id"].(string)
+		networkInterfaceId := rawState["network_interface_id"].(string)
 
-	oldID := rawState["id"].(string)
-	newID := fmt.Sprintf("%s|%s", networkInterfaceId, applicationSecurityGroupId)
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldID, newID)
+		oldID := rawState["id"].(string)
+		newID := fmt.Sprintf("%s|%s", networkInterfaceId, applicationSecurityGroupId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldID, newID)
 
-	rawState["id"] = newID
-	return rawState, nil
+		rawState["id"] = newID
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/network/migration/network_packet_capture.go
+++ b/azurerm/internal/services/network/migration/network_packet_capture.go
@@ -1,128 +1,124 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func NetworkPacketCaptureV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    networkPacketCaptureSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: networkPacketCaptureUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = NetworkPacketCaptureV0ToV1{}
 
-func networkPacketCaptureSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type NetworkPacketCaptureV0ToV1 struct{}
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (NetworkPacketCaptureV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"network_watcher_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"target_resource_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"network_watcher_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"maximum_bytes_per_packet": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  0,
-			},
+		"target_resource_id": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"maximum_bytes_per_session": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  1073741824,
-			},
+		"maximum_bytes_per_packet": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			ForceNew: true,
+			Default:  0,
+		},
 
-			"maximum_capture_duration": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  18000,
-			},
+		"maximum_bytes_per_session": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			ForceNew: true,
+			Default:  1073741824,
+		},
 
-			"storage_location": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"file_path": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+		"maximum_capture_duration": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			ForceNew: true,
+			Default:  18000,
+		},
 
-						"storage_account_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+		"storage_location": {
+			Type:     schema.TypeList,
+			Required: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"file_path": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"storage_path": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					"storage_account_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+
+					"storage_path": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
+		},
 
-			"filter": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"local_ip_address": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
+		"filter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"local_ip_address": {
+						Type:     schema.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
 
-						"local_port": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
+					"local_port": {
+						Type:     schema.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
 
-						"protocol": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
+					"protocol": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
 
-						"remote_ip_address": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
+					"remote_ip_address": {
+						Type:     schema.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
 
-						"remote_port": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
+					"remote_port": {
+						Type:     schema.TypeString,
+						Optional: true,
+						ForceNew: true,
 					},
 				},
 			},
@@ -130,13 +126,15 @@ func networkPacketCaptureSchemaForV0() *schema.Resource {
 	}
 }
 
-func networkPacketCaptureUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(rawState["id"].(string), "/NetworkPacketCaptures/", "/packetCaptures/", 1)
+func (NetworkPacketCaptureV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(rawState["id"].(string), "/NetworkPacketCaptures/", "/packetCaptures/", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -26,9 +28,9 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociation() *schema.Resou
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.NetworkInterfaceApplicationSecurityGroupAssociationV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/network/network_packet_capture_resource.go
+++ b/azurerm/internal/services/network/network_packet_capture_resource.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -12,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -29,9 +31,9 @@ func resourceNetworkPacketCapture() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.NetworkPacketCaptureV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.NetworkPacketCaptureV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/azurerm/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -5,12 +5,14 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/parse"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -30,9 +32,9 @@ func resourceAdvancedThreatProtection() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.AdvancedThreatProtectionV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.AdvancedThreatProtectionV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/securitycenter/migration/subscription_pricing.go
+++ b/azurerm/internal/services/securitycenter/migration/subscription_pricing.go
@@ -1,39 +1,37 @@
 package migration
 
 import (
+	"context"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func SubscriptionPricingV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    subscriptionPricingSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: subscriptionPricingUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = SubscriptionPricingV0ToV1{}
 
-func subscriptionPricingSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"tier": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+type SubscriptionPricingV0ToV1 struct{}
+
+func (SubscriptionPricingV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"tier": {
+			Type:     schema.TypeString,
+			Required: true,
 		},
 	}
 }
 
-func subscriptionPricingUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	log.Println("[DEBUG] Migrating ResourceType from v0 to v1 format")
-	oldId := rawState["id"].(string)
-	newId := strings.Replace(oldId, "/default", "/VirtualMachines", 1)
+func (SubscriptionPricingV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		log.Println("[DEBUG] Migrating ResourceType from v0 to v1 format")
+		oldId := rawState["id"].(string)
+		newId := strings.Replace(oldId, "/default", "/VirtualMachines", 1)
 
-	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 
-	rawState["id"] = newId
+		rawState["id"] = newId
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/securitycenter/migration/subscription_pricing_test.go
+++ b/azurerm/internal/services/securitycenter/migration/subscription_pricing_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"testing"
 )
 
@@ -10,7 +11,7 @@ func TestSecurityCenterSubscriptionPricingMigrateState(t *testing.T) {
 	}
 	expectedId := "/subscriptions/00000000-0000-0000-0000-000000000000/pricings/VirtualMachines"
 
-	rawState, _ := subscriptionPricingUpgradeV0ToV1(inputAttributes, nil)
+	rawState, _ := SubscriptionPricingV0ToV1{}.UpgradeFunc()(context.TODO(), inputAttributes, nil)
 	if rawState["id"].(string) != expectedId {
 		t.Fatalf("ResourceType migration failed, expected %q, got: %q", expectedId, rawState["id"].(string))
 	}

--- a/azurerm/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/securitycenter/migration"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -37,9 +38,9 @@ func resourceSecurityCenterSubscriptionPricing() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.SubscriptionPricingV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.SubscriptionPricingV0ToV1{},
+		}),
 
 		Schema: map[string]*schema.Schema{
 			"tier": {

--- a/azurerm/internal/services/servicebus/migration/namespace.go
+++ b/azurerm/internal/services/servicebus/migration/namespace.go
@@ -1,93 +1,88 @@
 package migration
 
 import (
+	"context"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
-	"github.com/Azure/azure-sdk-for-go/services/servicebus/mgmt/2017-04-01/servicebus"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func NamespaceV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    namespaceSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: namespaceUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = NamespaceV0ToV1{}
 
-func namespaceSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type NamespaceV0ToV1 struct{}
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func (NamespaceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"sku": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"capacity": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-			},
+		"sku": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"default_primary_connection_string": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"capacity": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			ForceNew: true,
+		},
 
-			"default_secondary_connection_string": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"default_primary_connection_string": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"default_primary_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"default_secondary_connection_string": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"default_secondary_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"default_primary_key": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"default_secondary_key": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func namespaceUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	skuName := strings.ToLower(rawState["sku"].(string))
-	premiumSku := strings.ToLower(string(servicebus.Premium))
+func (NamespaceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		skuName := rawState["sku"].(string)
+		if !strings.EqualFold(skuName, "Premium") {
+			delete(rawState, "capacity")
+		}
 
-	if skuName != premiumSku {
-		delete(rawState, "capacity")
+		return rawState, nil
 	}
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/azurerm/internal/services/servicebus/servicebus_namespace_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/servicebus/mgmt/2018-01-01-preview/servicebus"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -41,9 +43,9 @@ func resourceServiceBusNamespace() *schema.Resource {
 		}),
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.NamespaceV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.NamespaceV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/storage/migration/account.go
+++ b/azurerm/internal/services/storage/migration/account.go
@@ -1,203 +1,207 @@
 package migration
 
 import (
+	"context"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func AccountV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
+var _ pluginsdk.StateUpgrade = AccountV0ToV1{}
+
+type AccountV0ToV1 struct{}
+
+func (AccountV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return accountSchemaForV0AndV1()
+}
+
+func (AccountV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    accountSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: accountUpgradeV0ToV1,
-		Version: 0,
+		accountType := rawState["account_type"].(string)
+		split := strings.Split(accountType, "_")
+		rawState["account_tier"] = split[0]
+		rawState["account_replication_type"] = split[1]
+		return rawState, nil
 	}
 }
 
-func AccountV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    accountSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: accountUpgradeV1ToV2,
-		Version: 1,
+var _ pluginsdk.StateUpgrade = AccountV1ToV2{}
+
+type AccountV1ToV2 struct{}
+
+func (AccountV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return accountSchemaForV0AndV1()
+}
+
+func (AccountV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		rawState["account_encryption_source"] = "Microsoft.Storage"
+		return rawState, nil
 	}
 }
 
-func accountSchemaForV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func accountSchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"location": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_kind": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "Storage",
-			},
+		"account_kind": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "Storage",
+		},
 
-			"account_type": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "This field has been split into `account_tier` and `account_replication_type`",
-			},
+		"account_type": {
+			Type:       schema.TypeString,
+			Optional:   true,
+			Computed:   true,
+			Deprecated: "This field has been split into `account_tier` and `account_replication_type`",
+		},
 
-			"account_tier": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"account_tier": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"account_replication_type": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+		"account_replication_type": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 
-			// Only valid for BlobStorage accounts, defaults to "Hot" in create function
-			"access_tier": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
+		// Only valid for BlobStorage accounts, defaults to "Hot" in create function
+		"access_tier": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 
-			"custom_domain": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+		"custom_domain": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-						"use_subdomain": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
+					"use_subdomain": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Default:  false,
 					},
 				},
 			},
+		},
 
-			"enable_blob_encryption": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enable_blob_encryption": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"enable_file_encryption": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enable_file_encryption": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"enable_https_traffic_only": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+		"enable_https_traffic_only": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 
-			"primary_location": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"primary_location": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"secondary_location": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"secondary_location": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"primary_blob_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"primary_blob_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"secondary_blob_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"secondary_blob_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"primary_queue_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"primary_queue_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"secondary_queue_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"secondary_queue_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"primary_table_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"primary_table_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"secondary_table_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"secondary_table_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			// NOTE: The API does not appear to expose a secondary file endpoint
-			"primary_file_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		// NOTE: The API does not appear to expose a secondary file endpoint
+		"primary_file_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"primary_access_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"primary_access_key": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"secondary_access_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"secondary_access_key": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"primary_blob_connection_string": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"primary_blob_connection_string": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"secondary_blob_connection_string": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+		"secondary_blob_connection_string": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+		"tags": {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
-}
-
-func accountUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	accountType := rawState["account_type"].(string)
-	split := strings.Split(accountType, "_")
-	rawState["account_tier"] = split[0]
-	rawState["account_replication_type"] = split[1]
-	return rawState, nil
-}
-
-func accountUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	rawState["account_encryption_source"] = "Microsoft.Storage"
-	return rawState, nil
 }

--- a/azurerm/internal/services/storage/migration/blob.go
+++ b/azurerm/internal/services/storage/migration/blob.go
@@ -1,101 +1,98 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func BlobV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    blobSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: blobUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = BlobV0ToV1{}
 
-func blobSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"storage_account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"storage_container_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"size": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Default:  0,
-			},
-			"content_type": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Default:       "application/octet-stream",
-				ConflictsWith: []string{"source_uri"},
-			},
-			"source": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"source_uri"},
-			},
-			"source_uri": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"source"},
-			},
-			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"parallelism": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  8,
-				ForceNew: true,
-			},
-			"attempts": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  1,
-				ForceNew: true,
-			},
+type BlobV0ToV1 struct{}
+
+func (BlobV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"storage_account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"storage_container_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"size": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			ForceNew: true,
+			Default:  0,
+		},
+		"content_type": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Default:       "application/octet-stream",
+			ConflictsWith: []string{"source_uri"},
+		},
+		"source": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"source_uri"},
+		},
+		"source_uri": {
+			Type:          schema.TypeString,
+			Optional:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"source"},
+		},
+		"url": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"parallelism": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  8,
+			ForceNew: true,
+		},
+		"attempts": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Default:  1,
+			ForceNew: true,
 		},
 	}
 }
 
-func blobUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	environment := meta.(*clients.Client).Account.Environment
+func (BlobV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		environment := meta.(*clients.Client).Account.Environment
 
-	blobName := rawState["name"]
-	containerName := rawState["storage_container_name"]
-	storageAccountName := rawState["storage_account_name"]
-	newID := fmt.Sprintf("https://%s.blob.%s/%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName, blobName)
-	rawState["id"] = newID
+		blobName := rawState["name"]
+		containerName := rawState["storage_container_name"]
+		storageAccountName := rawState["storage_account_name"]
+		newID := fmt.Sprintf("https://%s.blob.%s/%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName, blobName)
+		rawState["id"] = newID
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/storage/migration/blob_test.go
+++ b/azurerm/internal/services/storage/migration/blob_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -38,7 +39,7 @@ func TestBlobV0ToV1(t *testing.T) {
 			"storage_account_name":   "some-account",
 		}
 
-		actual, err := blobUpgradeV0ToV1(input, meta)
+		actual, err := BlobV0ToV1{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}

--- a/azurerm/internal/services/storage/migration/container.go
+++ b/azurerm/internal/services/storage/migration/container.go
@@ -1,64 +1,62 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func ContainerV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    containerSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: containerUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = ContainerV0ToV1{}
 
-func containerSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"storage_account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"container_access_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "private",
-			},
+type ContainerV0ToV1 struct{}
 
-			"properties": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+func (ContainerV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"storage_account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"container_access_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "private",
+		},
+
+		"properties": {
+			Type:     schema.TypeMap,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
 			},
 		},
 	}
 }
 
-func containerUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	environment := meta.(*clients.Client).Account.Environment
+func (ContainerV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		environment := meta.(*clients.Client).Account.Environment
 
-	containerName := rawState["name"]
-	storageAccountName := rawState["storage_account_name"]
-	newID := fmt.Sprintf("https://%s.blob.%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName)
-	rawState["id"] = newID
+		containerName := rawState["name"]
+		storageAccountName := rawState["storage_account_name"]
+		newID := fmt.Sprintf("https://%s.blob.%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName)
+		rawState["id"] = newID
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/storage/migration/container_test.go
+++ b/azurerm/internal/services/storage/migration/container_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -36,7 +37,7 @@ func TestContainerV0ToV1(t *testing.T) {
 			"storage_account_name": "some-account",
 		}
 
-		actual, err := containerUpgradeV0ToV1(input, meta)
+		actual, err := ContainerV0ToV1{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}

--- a/azurerm/internal/services/storage/migration/queue.go
+++ b/azurerm/internal/services/storage/migration/queue.go
@@ -1,50 +1,48 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func QueueV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    queueSchemaForV0().CoreConfigSchema().ImpliedType(),
-		Upgrade: queueUpgradeV0ToV1,
-		Version: 0,
-	}
-}
+var _ pluginsdk.StateUpgrade = QueueV0ToV1{}
 
-func queueSchemaForV0() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"storage_account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+type QueueV0ToV1 struct{}
+
+func (QueueV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"storage_account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
 		},
 	}
 }
 
-func queueUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	environment := meta.(*clients.Client).Account.Environment
+func (QueueV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		environment := meta.(*clients.Client).Account.Environment
 
-	queueName := rawState["name"]
-	storageAccountName := rawState["storage_account_name"]
-	newID := fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, environment.StorageEndpointSuffix, queueName)
-	rawState["id"] = newID
+		queueName := rawState["name"]
+		storageAccountName := rawState["storage_account_name"]
+		newID := fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, environment.StorageEndpointSuffix, queueName)
+		rawState["id"] = newID
 
-	return rawState, nil
+		return rawState, nil
+	}
 }

--- a/azurerm/internal/services/storage/migration/queue_test.go
+++ b/azurerm/internal/services/storage/migration/queue_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -36,7 +37,7 @@ func TestQueueV0ToV1(t *testing.T) {
 			"storage_account_name": "some-account",
 		}
 
-		actual, err := queueUpgradeV0ToV1(input, meta)
+		actual, err := QueueV0ToV1{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}

--- a/azurerm/internal/services/storage/migration/share.go
+++ b/azurerm/internal/services/storage/migration/share.go
@@ -1,95 +1,102 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/file/shares"
 )
 
-func ShareV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    shareSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: shareUpgradeV0ToV1,
-		Version: 0,
+var _ pluginsdk.StateUpgrade = ShareV0ToV1{}
+
+type ShareV0ToV1 struct{}
+
+func (ShareV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return shareSchemaForV0AndV1()
+}
+
+func (ShareV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		shareName := rawState["name"].(string)
+		resourceGroup := rawState["resource_group_name"].(string)
+		accountName := rawState["storage_account_name"].(string)
+
+		id := rawState["id"].(string)
+		newResourceID := fmt.Sprintf("%s/%s/%s", shareName, resourceGroup, accountName)
+		log.Printf("[DEBUG] Updating ID from %q to %q", id, newResourceID)
+
+		rawState["id"] = newResourceID
+		return rawState, nil
 	}
 }
 
-func ShareV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		Type:    shareSchemaForV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: shareUpgradeV1ToV2,
-		Version: 1,
+var _ pluginsdk.StateUpgrade = ShareV1ToV2{}
+
+type ShareV1ToV2 struct{}
+
+func (s ShareV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return shareSchemaForV0AndV1()
+}
+
+func (s ShareV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		id := rawState["id"].(string)
+
+		// name/resourceGroup/accountName
+		parsedId := strings.Split(id, "/")
+		if len(parsedId) != 3 {
+			return rawState, fmt.Errorf("Expected 3 segments in the ID but got %d", len(parsedId))
+		}
+
+		shareName := parsedId[0]
+		accountName := parsedId[2]
+
+		environment := meta.(*clients.Client).Account.Environment
+		client := shares.NewWithEnvironment(environment)
+
+		newResourceId := client.GetResourceID(accountName, shareName)
+		log.Printf("[DEBUG] Updating Resource ID from %q to %q", id, newResourceId)
+
+		rawState["id"] = newResourceId
+
+		return rawState, nil
 	}
 }
 
 // the schema schema was used for both V0 and V1
-func shareSchemaForV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"resource_group_name": azure.SchemaResourceGroupName(),
-			"storage_account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"quota": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Default:      5120,
-				ValidateFunc: validation.IntBetween(1, 5120),
-			},
-			"url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+func shareSchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"storage_account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"quota": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Default:      5120,
+			ValidateFunc: validation.IntBetween(1, 5120),
+		},
+		"url": {
+			Type:     schema.TypeString,
+			Computed: true,
 		},
 	}
-}
-
-func shareUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	shareName := rawState["name"].(string)
-	resourceGroup := rawState["resource_group_name"].(string)
-	accountName := rawState["storage_account_name"].(string)
-
-	id := rawState["id"].(string)
-	newResourceID := fmt.Sprintf("%s/%s/%s", shareName, resourceGroup, accountName)
-	log.Printf("[DEBUG] Updating ID from %q to %q", id, newResourceID)
-
-	rawState["id"] = newResourceID
-	return rawState, nil
-}
-
-func shareUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	id := rawState["id"].(string)
-
-	// name/resourceGroup/accountName
-	parsedId := strings.Split(id, "/")
-	if len(parsedId) != 3 {
-		return rawState, fmt.Errorf("Expected 3 segments in the ID but got %d", len(parsedId))
-	}
-
-	shareName := parsedId[0]
-	accountName := parsedId[2]
-
-	environment := meta.(*clients.Client).Account.Environment
-	client := shares.NewWithEnvironment(environment)
-
-	newResourceId := client.GetResourceID(accountName, shareName)
-	log.Printf("[DEBUG] Updating Resource ID from %q to %q", id, newResourceId)
-
-	rawState["id"] = newResourceId
-
-	return rawState, nil
 }

--- a/azurerm/internal/services/storage/migration/share_test.go
+++ b/azurerm/internal/services/storage/migration/share_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -40,7 +41,7 @@ func TestShareV0ToV1(t *testing.T) {
 			"quota":                5120,
 		}
 
-		actual, err := shareUpgradeV0ToV1(input, meta)
+		actual, err := ShareV0ToV1{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}
@@ -84,7 +85,7 @@ func TestShareV1ToV2(t *testing.T) {
 			"quota":                5120,
 		}
 
-		actual, err := shareUpgradeV1ToV2(input, meta)
+		actual, err := ShareV1ToV2{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}

--- a/azurerm/internal/services/storage/migration/table.go
+++ b/azurerm/internal/services/storage/migration/table.go
@@ -1,78 +1,109 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"log"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
-func TableV0ToV1() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    tableSchemaV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: tableStateUpgradeV0ToV1,
-		Version: 0,
+var _ pluginsdk.StateUpgrade = TableV0ToV1{}
+
+type TableV0ToV1 struct{}
+
+func (TableV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return tableSchemaV0AndV1()
+}
+
+func (TableV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		tableName := rawState["name"].(string)
+		accountName := rawState["storage_account_name"].(string)
+		environment := meta.(*clients.Client).Account.Environment
+
+		id := rawState["id"].(string)
+		newResourceID := fmt.Sprintf("https://%s.table.%s/%s", accountName, environment.StorageEndpointSuffix, tableName)
+		log.Printf("[DEBUG] Updating ID from %q to %q", id, newResourceID)
+
+		rawState["id"] = newResourceID
+		return rawState, nil
 	}
 }
 
-func TableV1ToV2() schema.StateUpgrader {
-	return schema.StateUpgrader{
-		// this should have been applied from pre-0.12 migration system; backporting just in-case
-		Type:    tableSchemaV0AndV1().CoreConfigSchema().ImpliedType(),
-		Upgrade: tableStateUpgradeV1ToV2,
-		Version: 1,
+var _ pluginsdk.StateUpgrade = TableV1ToV2{}
+
+type TableV1ToV2 struct{}
+
+func (TableV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return tableSchemaV0AndV1()
+}
+
+func (TableV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	// this should have been applied from pre-0.12 migration system; backporting just in-case
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		tableName := rawState["name"].(string)
+		accountName := rawState["storage_account_name"].(string)
+		environment := meta.(*clients.Client).Account.Environment
+
+		id := rawState["id"].(string)
+		newResourceID := fmt.Sprintf("https://%s.table.%s/Tables('%s')", accountName, environment.StorageEndpointSuffix, tableName)
+		log.Printf("[DEBUG] Updating ID from %q to %q", id, newResourceID)
+
+		rawState["id"] = newResourceID
+		return rawState, nil
 	}
 }
 
 // the schema schema was used for both V0 and V1
-func tableSchemaV0AndV1() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"storage_account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+func tableSchemaV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"storage_account_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+		"resource_group_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
 
-			"acl": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"access_policy": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"start": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"expiry": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"permissions": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
+		"acl": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"id": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"access_policy": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"start": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"expiry": {
+									Type:     schema.TypeString,
+									Required: true,
+								},
+								"permissions": {
+									Type:     schema.TypeString,
+									Required: true,
 								},
 							},
 						},
@@ -81,30 +112,4 @@ func tableSchemaV0AndV1() *schema.Resource {
 			},
 		},
 	}
-}
-
-func tableStateUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	tableName := rawState["name"].(string)
-	accountName := rawState["storage_account_name"].(string)
-	environment := meta.(*clients.Client).Account.Environment
-
-	id := rawState["id"].(string)
-	newResourceID := fmt.Sprintf("https://%s.table.%s/%s", accountName, environment.StorageEndpointSuffix, tableName)
-	log.Printf("[DEBUG] Updating ID from %q to %q", id, newResourceID)
-
-	rawState["id"] = newResourceID
-	return rawState, nil
-}
-
-func tableStateUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	tableName := rawState["name"].(string)
-	accountName := rawState["storage_account_name"].(string)
-	environment := meta.(*clients.Client).Account.Environment
-
-	id := rawState["id"].(string)
-	newResourceID := fmt.Sprintf("https://%s.table.%s/Tables('%s')", accountName, environment.StorageEndpointSuffix, tableName)
-	log.Printf("[DEBUG] Updating ID from %q to %q", id, newResourceID)
-
-	rawState["id"] = newResourceID
-	return rawState, nil
 }

--- a/azurerm/internal/services/storage/migration/table_test.go
+++ b/azurerm/internal/services/storage/migration/table_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -38,7 +39,7 @@ func TestTableStateV0ToV1(t *testing.T) {
 			"storage_account_name": "account1",
 		}
 
-		actual, err := tableStateUpgradeV0ToV1(input, meta)
+		actual, err := TableV0ToV1{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}
@@ -80,7 +81,7 @@ func TestTableStateV1ToV2(t *testing.T) {
 			"storage_account_name": "account1",
 		}
 
-		actual, err := tableStateUpgradeV1ToV2(input, meta)
+		actual, err := TableV1ToV2{}.UpgradeFunc()(context.TODO(), input, meta)
 		if err != nil {
 			t.Fatalf("Expected no error but got: %s", err)
 		}

--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
-
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-01-01/storage"
 	azautorest "github.com/Azure/go-autorest/autorest"
 	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
@@ -21,8 +19,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -40,10 +40,10 @@ func resourceStorageAccount() *schema.Resource {
 		Delete: resourceStorageAccountDelete,
 
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.AccountV0ToV1(),
-			migration.AccountV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.AccountV0ToV1{},
+			1: migration.AccountV1ToV2{},
+		}),
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/azurerm/internal/services/storage/storage_blob_resource.go
+++ b/azurerm/internal/services/storage/storage_blob_resource.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -26,9 +28,9 @@ func resourceStorageBlob() *schema.Resource {
 		Delete: resourceStorageBlobDelete,
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.BlobV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.BlobV0ToV1{},
+		}),
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/azurerm/internal/services/storage/storage_container_resource.go
+++ b/azurerm/internal/services/storage/storage_container_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -29,9 +31,9 @@ func resourceStorageContainer() *schema.Resource {
 		},
 
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.ContainerV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ContainerV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/storage/storage_queue_resource.go
+++ b/azurerm/internal/services/storage/storage_queue_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -25,9 +27,9 @@ func resourceStorageQueue() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.QueueV0ToV1(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.QueueV0ToV1{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/storage/storage_share_resource.go
+++ b/azurerm/internal/services/storage/storage_share_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -27,10 +29,10 @@ func resourceStorageShare() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.ShareV0ToV1(),
-			migration.ShareV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.ShareV0ToV1{},
+			1: migration.ShareV1ToV2{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/storage/storage_table_resource.go
+++ b/azurerm/internal/services/storage/storage_table_resource.go
@@ -5,14 +5,14 @@ import (
 	"log"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/migration"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/tombuildsstuff/giovanni/storage/2019-12-12/table/tables"
 )
@@ -27,10 +27,10 @@ func resourceStorageTable() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		SchemaVersion: 2,
-		StateUpgraders: []schema.StateUpgrader{
-			migration.TableV0ToV1(),
-			migration.TableV1ToV2(),
-		},
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.TableV0ToV1{},
+			1: migration.TableV1ToV2{},
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/tf/pluginsdk/pluginsdk2.go
+++ b/azurerm/internal/tf/pluginsdk/pluginsdk2.go
@@ -6,7 +6,7 @@ This is tracking the changes necessary for Plugin SDKv2
 1. (DONE) Base Layer
 2. (DONE) Package validation
 	All validation functions need to be moved into `validation` - since otherwise the test namespace needs fixing
-3. Updating the Migration functions to use the new wrapper
+3. (DONE) Updating the Migration functions to use the new wrapper
 4. Updating the Customize Diff functions to use the new wrapper
 5. Updating the Import functions to use the new wrappers
 6. Updating the Migration wrapper and functions to take `ctx` as the first param

--- a/azurerm/internal/tf/pluginsdk/state_upgrades.go
+++ b/azurerm/internal/tf/pluginsdk/state_upgrades.go
@@ -27,7 +27,7 @@ type StateUpgrade interface {
 // which allows us to upgrade the Plugin SDK without breaking all open
 // PR's and attempts to make this interface a little less verbose.
 func StateUpgrades(upgrades map[int]StateUpgrade) []StateUpgrader {
-	versions := make([]int, len(upgrades))
+	versions := make([]int, 0)
 	for version := range versions {
 		versions = append(versions, version)
 	}


### PR DESCRIPTION
This PR switches the migrations over to using the new Plugin SDK wrapper as detailed in #11416 - meaning that each State Migration now takes a `context` which will be populated when we switch over to using Plugin SDKv2

This also fixes a bug I spotted/introduced when refactoring these yesterday regarding the key vault schema (although this was a historical port, so nobody should be using that at this point in time).