### PR TITLE
plugin-sdk: upgrading `appconfiguration` to use the wrapper

### DIFF
--- a/azurerm/internal/services/analysisservices/parse/server_test.go
+++ b/azurerm/internal/services/analysisservices/parse/server_test.go
@@ -1,4 +1,4 @@
-package parse
+package parse_test
 
 // NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
 
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/analysisservices/parse"
 )
 
-var _ resourceid.Formatter = ServerId{}
+var _ resourceid.Formatter = parse.ServerId{}
 
 func TestServerIDFormatter(t *testing.T) {
-	actual := NewServerID("12345678-1234-9876-4563-123456789012", "resGroup1", "Server1").ID()
+	actual := parse.NewServerID("12345678-1234-9876-4563-123456789012", "resGroup1", "Server1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/servers/Server1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -22,7 +23,7 @@ func TestServerID(t *testing.T) {
 	testData := []struct {
 		Input    string
 		Error    bool
-		Expected *ServerId
+		Expected *parse.ServerId
 	}{
 
 		{
@@ -70,7 +71,7 @@ func TestServerID(t *testing.T) {
 		{
 			// valid
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.AnalysisServices/servers/Server1",
-			Expected: &ServerId{
+			Expected: &parse.ServerId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "resGroup1",
 				Name:           "Server1",
@@ -87,7 +88,7 @@ func TestServerID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := ServerID(v.Input)
+		actual, err := parse.ServerID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/analysisservices/validate/server_id_test.go
+++ b/azurerm/internal/services/analysisservices/validate/server_id_test.go
@@ -1,8 +1,12 @@
-package validate
+package validate_test
 
 // NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/analysisservices/validate"
+)
 
 func TestServerID(t *testing.T) {
 	cases := []struct {
@@ -66,7 +70,7 @@ func TestServerID(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Logf("[DEBUG] Testing Value %s", tc.Input)
-		_, errors := ServerID(tc.Input, "test")
+		_, errors := validate.ServerID(tc.Input, "test")
 		valid := len(errors) == 0
 
 		if tc.Valid != valid {

--- a/azurerm/internal/services/appconfiguration/app_configuration_data_source.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_data_source.go
@@ -4,27 +4,27 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func dataSourceAppConfiguration() *schema.Resource {
-	return &schema.Resource{
+func dataSourceAppConfiguration() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
 		Read: dataSourceAppConfigurationRead,
 
-		Timeouts: &schema.ResourceTimeout{
-			Read: schema.DefaultTimeout(5 * time.Minute),
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{
+		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:         schema.TypeString,
+				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ValidateFunc: validate.ConfigurationStoreName,
 			},
@@ -34,32 +34,32 @@ func dataSourceAppConfiguration() *schema.Resource {
 			"location": azure.SchemaLocationForDataSource(),
 
 			"sku": {
-				Type:     schema.TypeString,
+				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
 			"endpoint": {
-				Type:     schema.TypeString,
+				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
 			"primary_read_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -68,22 +68,22 @@ func dataSourceAppConfiguration() *schema.Resource {
 			},
 
 			"secondary_read_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -92,22 +92,22 @@ func dataSourceAppConfiguration() *schema.Resource {
 			},
 
 			"primary_write_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -116,22 +116,22 @@ func dataSourceAppConfiguration() *schema.Resource {
 			},
 
 			"secondary_write_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -144,7 +144,7 @@ func dataSourceAppConfiguration() *schema.Resource {
 	}
 }
 
-func dataSourceAppConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceAppConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppConfiguration.AppConfigurationsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)

--- a/azurerm/internal/services/appconfiguration/app_configuration_data_source_test.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_data_source_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 )
@@ -15,13 +14,13 @@ type AppConfigurationDataSource struct {
 func TestAccAppConfigurationDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_app_configuration", "test")
 
-	data.DataSourceTest(t, []resource.TestStep{
+	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			Config: AppConfigurationResource{}.standard(data),
 		},
 		{
 			Config: AppConfigurationDataSource{}.basic(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(AppConfigurationResource{}),
 				check.That(data.ResourceName).Key("endpoint").Exists(),
 				check.That(data.ResourceName).Key("location").Exists(),

--- a/azurerm/internal/services/appconfiguration/app_configuration_resource.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_resource.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/appconfiguration/mgmt/2020-06-01/appconfiguration"
 	"github.com/hashicorp/go-azure-helpers/response"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -17,22 +15,23 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func resourceAppConfiguration() *schema.Resource {
-	return &schema.Resource{
+func resourceAppConfiguration() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
 		Create: resourceAppConfigurationCreate,
 		Read:   resourceAppConfigurationRead,
 		Update: resourceAppConfigurationUpdate,
 		Delete: resourceAppConfigurationDelete,
 
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -40,9 +39,9 @@ func resourceAppConfiguration() *schema.Resource {
 			return err
 		}),
 
-		Schema: map[string]*schema.Schema{
+		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:         schema.TypeString,
+				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.ConfigurationStoreName,
@@ -51,24 +50,24 @@ func resourceAppConfiguration() *schema.Resource {
 			"location": azure.SchemaLocation(),
 
 			"identity": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"type": {
-							Type:     schema.TypeString,
+							Type:     pluginsdk.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(appconfiguration.IdentityTypeSystemAssigned),
 							}, false),
 						},
 						"principal_id": {
-							Type:     schema.TypeString,
+							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
 						"tenant_id": {
-							Type:     schema.TypeString,
+							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
 					},
@@ -80,7 +79,7 @@ func resourceAppConfiguration() *schema.Resource {
 			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"sku": {
-				Type:     schema.TypeString,
+				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Default:  "free",
 				ValidateFunc: validation.StringInSlice([]string{
@@ -90,27 +89,27 @@ func resourceAppConfiguration() *schema.Resource {
 			},
 
 			"endpoint": {
-				Type:     schema.TypeString,
+				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
 			"primary_read_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -119,22 +118,22 @@ func resourceAppConfiguration() *schema.Resource {
 			},
 
 			"secondary_read_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -143,22 +142,22 @@ func resourceAppConfiguration() *schema.Resource {
 			},
 
 			"primary_write_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -167,22 +166,22 @@ func resourceAppConfiguration() *schema.Resource {
 			},
 
 			"secondary_write_key": {
-				Type:     schema.TypeList,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
 						"id": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"secret": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
 						"connection_string": {
-							Type:      schema.TypeString,
+							Type:      pluginsdk.TypeString,
 							Computed:  true,
 							Sensitive: true,
 						},
@@ -195,7 +194,7 @@ func resourceAppConfiguration() *schema.Resource {
 	}
 }
 
-func resourceAppConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceAppConfigurationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppConfiguration.AppConfigurationsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
@@ -239,7 +238,7 @@ func resourceAppConfigurationCreate(d *schema.ResourceData, meta interface{}) er
 	return resourceAppConfigurationRead(d, meta)
 }
 
-func resourceAppConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceAppConfigurationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppConfiguration.AppConfigurationsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -283,7 +282,7 @@ func resourceAppConfigurationUpdate(d *schema.ResourceData, meta interface{}) er
 	return resourceAppConfigurationRead(d, meta)
 }
 
-func resourceAppConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceAppConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppConfiguration.AppConfigurationsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -337,7 +336,7 @@ func resourceAppConfigurationRead(d *schema.ResourceData, meta interface{}) erro
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 
-func resourceAppConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceAppConfigurationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppConfiguration.AppConfigurationsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/azurerm/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/azurerm/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/parse"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -22,10 +21,10 @@ func TestAccAppConfiguration_free(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.free(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -37,10 +36,10 @@ func TestAccAppConfiguration_standard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.standard(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -52,10 +51,10 @@ func TestAccAppConfiguration_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.standard(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -67,10 +66,10 @@ func TestAccAppConfiguration_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -82,10 +81,10 @@ func TestAccAppConfiguration_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.identity(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -97,17 +96,17 @@ func TestAccAppConfiguration_identityUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.standard(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
 			Config: r.identity(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
 				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
 				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
@@ -117,7 +116,7 @@ func TestAccAppConfiguration_identityUpdated(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.standard(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
@@ -129,23 +128,23 @@ func TestAccAppConfiguration_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration", "test")
 	r := AppConfigurationResource{}
 
-	data.ResourceTest(t, r, []resource.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		{
 			Config: r.completeUpdated(data),
-			Check: resource.ComposeTestCheckFunc(
+			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 	})
 }
 
-func (t AppConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
+func (t AppConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ConfigurationStoreID(state.ID)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/appconfiguration/parse/configuration_store_test.go
+++ b/azurerm/internal/services/appconfiguration/parse/configuration_store_test.go
@@ -1,4 +1,4 @@
-package parse
+package parse_test
 
 // NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
 
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/parse"
 )
 
-var _ resourceid.Formatter = ConfigurationStoreId{}
+var _ resourceid.Formatter = parse.ConfigurationStoreId{}
 
 func TestConfigurationStoreIDFormatter(t *testing.T) {
-	actual := NewConfigurationStoreID("12345678-1234-9876-4563-123456789012", "group1", "store1").ID()
+	actual := parse.NewConfigurationStoreID("12345678-1234-9876-4563-123456789012", "group1", "store1").ID()
 	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.AppConfiguration/configurationStores/store1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
@@ -22,7 +23,7 @@ func TestConfigurationStoreID(t *testing.T) {
 	testData := []struct {
 		Input    string
 		Error    bool
-		Expected *ConfigurationStoreId
+		Expected *parse.ConfigurationStoreId
 	}{
 
 		{
@@ -70,7 +71,7 @@ func TestConfigurationStoreID(t *testing.T) {
 		{
 			// valid
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.AppConfiguration/configurationStores/store1",
-			Expected: &ConfigurationStoreId{
+			Expected: &parse.ConfigurationStoreId{
 				SubscriptionId: "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:  "group1",
 				Name:           "store1",
@@ -87,7 +88,7 @@ func TestConfigurationStoreID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := ConfigurationStoreID(v.Input)
+		actual, err := parse.ConfigurationStoreID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/appconfiguration/registration.go
+++ b/azurerm/internal/services/appconfiguration/registration.go
@@ -1,7 +1,7 @@
 package appconfiguration
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
 type Registration struct{}
@@ -19,15 +19,15 @@ func (r Registration) WebsiteCategories() []string {
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
-func (r Registration) SupportedDataSources() map[string]*schema.Resource {
-	return map[string]*schema.Resource{
+func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{
 		"azurerm_app_configuration": dataSourceAppConfiguration(),
 	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service
-func (r Registration) SupportedResources() map[string]*schema.Resource {
-	return map[string]*schema.Resource{
+func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{
 		"azurerm_app_configuration": resourceAppConfiguration(),
 	}
 }

--- a/azurerm/internal/services/appconfiguration/validate/configuration_store_id_test.go
+++ b/azurerm/internal/services/appconfiguration/validate/configuration_store_id_test.go
@@ -1,8 +1,12 @@
-package validate
+package validate_test
 
 // NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/validate"
+)
 
 func TestConfigurationStoreID(t *testing.T) {
 	cases := []struct {
@@ -66,7 +70,7 @@ func TestConfigurationStoreID(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Logf("[DEBUG] Testing Value %s", tc.Input)
-		_, errors := ConfigurationStoreID(tc.Input, "test")
+		_, errors := validate.ConfigurationStoreID(tc.Input, "test")
 		valid := len(errors) == 0
 
 		if tc.Valid != valid {

--- a/azurerm/internal/tf/pluginsdk/pluginsdk2.go
+++ b/azurerm/internal/tf/pluginsdk/pluginsdk2.go
@@ -8,7 +8,7 @@ This is tracking the changes necessary for Plugin SDKv2
 	All validation functions need to be moved into `validation` - since otherwise the test namespace needs fixing
 3. (DONE) Updating the Migration functions to use the new wrapper
 4. (DONE) Updating the Customize Diff functions to use the new wrapper
-5. Updating the Import functions to use the new wrappers
+5. (DONE) Updating the Import functions to use the new wrappers
 
 6. Update the `validate` package tests to include `_test` suffix for the package name
 	At the same time, add the package name to the generator to reflect this:

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -12,7 +12,11 @@ import (
 	"unicode"
 )
 
-var packagesUsingAlias = map[string]struct{}{}
+var packagesUsingAlias = map[string]struct{}{
+        "advisor": {},
+        "analysisservices": {},
+        "appconfiguration": {},
+}
 
 func main() {
 	servicePackagePath := flag.String("path", "", "The relative path to the service package")

--- a/azurerm/internal/tools/generator-resource-id/main.go
+++ b/azurerm/internal/tools/generator-resource-id/main.go
@@ -13,9 +13,9 @@ import (
 )
 
 var packagesUsingAlias = map[string]struct{}{
-        "advisor": {},
-        "analysisservices": {},
-        "appconfiguration": {},
+	"advisor":          {},
+	"analysisservices": {},
+	"appconfiguration": {},
 }
 
 func main() {


### PR DESCRIPTION
This PR upgrades the `appconfiguration` package via the plugin sdk script to using the Plugin SDK wrapper, enabling us to ultimately move towards Plugin SDKv2 without a breaking change