### PR TITLE
`postgresql_server`: Wait for restart PostgreSQL replicas to prevent failures

### DIFF
--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -754,10 +754,10 @@ func (r PostgreSQLServerResource) createReplica(data acceptance.TestData, sku st
 
 resource "azurerm_postgresql_server" "replica" {
   name                = "acctest-psql-server-%[2]d-replica"
-  location            = azurerm_resource_group.test.location
+  location            = "%[3]s"
   resource_group_name = azurerm_resource_group.test.name
 
-  sku_name = "%[3]s"
+  sku_name = "%[4]s"
   version  = "11"
 
   create_mode               = "Replica"
@@ -765,7 +765,7 @@ resource "azurerm_postgresql_server" "replica" {
 
   ssl_enforcement_enabled = true
 }
-`, r.template(data, sku, "11"), data.RandomInteger, sku)
+`, r.template(data, sku, "11"), data.RandomInteger, data.Locations.Secondary, sku)
 }
 
 func (r PostgreSQLServerResource) createReplicas(data acceptance.TestData, sku string) string {
@@ -774,10 +774,10 @@ func (r PostgreSQLServerResource) createReplicas(data acceptance.TestData, sku s
 
 resource "azurerm_postgresql_server" "replica1" {
   name                = "acctest-psql-server-%[2]d-replica1"
-  location            = azurerm_resource_group.test.location
+  location            = "%[3]s"
   resource_group_name = azurerm_resource_group.test.name
 
-  sku_name = "%[3]s"
+  sku_name = "%[4]s"
   version  = "11"
 
   create_mode               = "Replica"
@@ -791,7 +791,7 @@ resource "azurerm_postgresql_server" "replica2" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  sku_name = "%[3]s"
+  sku_name = "%[4]s"
   version  = "11"
 
   create_mode               = "Replica"
@@ -799,7 +799,7 @@ resource "azurerm_postgresql_server" "replica2" {
 
   ssl_enforcement_enabled = true
 }
-`, r.template(data, sku, "11"), data.RandomInteger, sku)
+`, r.template(data, sku, "11"), data.RandomInteger, data.Locations.Secondary, sku)
 }
 
 func (r PostgreSQLServerResource) createPointInTimeRestore(data acceptance.TestData, version, restoreTime string) string {

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -755,7 +755,7 @@ func (r PostgreSQLServerResource) createReplica(data acceptance.TestData, sku st
 resource "azurerm_resource_group" "replica" {
   name     = "acctestRG-psql-%[2]d-replica"
   location = "%[3]s"
-}  
+}
 
 resource "azurerm_postgresql_server" "replica" {
   name                = "acctest-psql-server-%[2]d-replica"

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -752,10 +752,15 @@ func (r PostgreSQLServerResource) createReplica(data acceptance.TestData, sku st
 	return fmt.Sprintf(`
 %[1]s
 
+resource "azurerm_resource_group" "replica" {
+  name     = "acctestRG-psql-%[2]d-replica"
+  location = "%[3]s"
+}  
+
 resource "azurerm_postgresql_server" "replica" {
   name                = "acctest-psql-server-%[2]d-replica"
   location            = "%[3]s"
-  resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.replica.name
 
   sku_name = "%[4]s"
   version  = "11"
@@ -772,10 +777,15 @@ func (r PostgreSQLServerResource) createReplicas(data acceptance.TestData, sku s
 	return fmt.Sprintf(`
 %[1]s
 
+resource "azurerm_resource_group" "replica1" {
+  name     = "acctestRG-psql-%[2]d-replica1"
+  location = "%[3]s"
+}
+
 resource "azurerm_postgresql_server" "replica1" {
   name                = "acctest-psql-server-%[2]d-replica1"
   location            = "%[3]s"
-  resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.replica1.name
 
   sku_name = "%[4]s"
   version  = "11"


### PR DESCRIPTION
Fixes #11318

When scaling replica's in a different region, the database is restarted. By putting in a wait condition this is circumvented.