### PR TITLE
 GNUMakefile: Remove `GO111MODULE=on` and `GOFLAGS=-mod=vendor` env vars

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,8 +5,6 @@ TESTTIMEOUT=180m
 
 .EXPORT_ALL_VARIABLES:
   TF_SCHEMA_PANIC_ON_ERROR=1
-  GO111MODULE=on
-  GOFLAGS=-mod=vendor
 
 default: build
 


### PR DESCRIPTION
The two environment variables populated in the GNUMakefile: `GO111MODULE=on` and `GOFLAGS=-mod=vendor` need to remove, since:

- Module mode is now on by default since v1.16
- Setting `GOFLAGS=-mod=vendor` causes `go install` failed with: *cannot query module due to -mod=vendor*