### PR TITLE
`postgresql_server`: `public_network_access_enabled` fixed on createReplica

### DIFF
--- a/azurerm/internal/services/postgres/postgresql_server_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource.go
@@ -609,7 +609,7 @@ func resourcePostgreSQLServerCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	// Issue tracking REST API update: https://github.com/Azure/azure-rest-api-specs/issues/14117
+	// Issue tracking the REST API update failure: https://github.com/Azure/azure-rest-api-specs/issues/14117
 	if mode == postgresql.CreateModeReplica {
 		log.Printf("[INFO] changing `public_network_access_enabled` for AzureRM PostgreSQL Server %q (Resource Group %q)", name, resourceGroup)
 		properties := postgresql.ServerUpdateParameters{

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -768,7 +768,8 @@ resource "azurerm_postgresql_server" "replica" {
   create_mode               = "Replica"
   creation_source_server_id = azurerm_postgresql_server.test.id
 
-  ssl_enforcement_enabled = true
+  public_network_access_enabled = false
+  ssl_enforcement_enabled       = true
 }
 `, r.template(data, sku, "11"), data.RandomInteger, data.Locations.Secondary, sku)
 }


### PR DESCRIPTION
Fixes #11346

Upstream issue tracked here: https://github.com/Azure/azure-rest-api-specs/issues/14117