### PR TITLE
`postgresql_server`: Update a PostgreSQL Replica to `create_mode` = "Default"

### DIFF
--- a/azurerm/internal/services/postgres/postgresql_server_resource.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource.go
@@ -79,8 +79,7 @@ func resourcePostgreSQLServer() *schema.Resource {
 				}
 
 				d.Set("create_mode", "Default")
-				d.Set("creation_source_server_id", "")
-				if *resp.ReplicationRole != "Master" && *resp.ReplicationRole != "None" {
+				if resp.ReplicationRole != nil && *resp.ReplicationRole != "Master" && *resp.ReplicationRole != "None" {
 					d.Set("create_mode", *resp.ReplicationRole)
 
 					masterServerId, err := parse.ServerID(*resp.MasterServerID)

--- a/azurerm/internal/services/postgres/postgresql_server_resource_test.go
+++ b/azurerm/internal/services/postgres/postgresql_server_resource_test.go
@@ -338,7 +338,7 @@ func TestAccPostgreSQLServer_updateReplicaToDefault(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("creation_source_server_id"),
 	})
 }
 


### PR DESCRIPTION
Fixes #11330

## Acceptance tests
- [x] New acceptance test for new functionality: `TestAccPostgreSQLServer_updateReplicaToDefault`
   ```bash
   ❯ make acctests SERVICE='postgres' TESTARGS='-run=updateReplicaToDefault'
  ==> Checking that code complies with gofmt requirements...
  ==> Checking that Custom Timeouts are used...
  ==> Checking that acceptance test packages are used...
  TF_ACC=1 go test -v ./azurerm/internal/services/postgres -run=updateReplicaToDefault -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
  2021/04/25 23:41:55 [DEBUG] not using binary driver name, it's no longer needed
  2021/04/25 23:41:56 [DEBUG] not using binary driver name, it's no longer needed
  === RUN   TestAccPostgreSQLServer_updateReplicaToDefault
  === PAUSE TestAccPostgreSQLServer_updateReplicaToDefault
  === CONT  TestAccPostgreSQLServer_updateReplicaToDefault
  --- PASS: TestAccPostgreSQLServer_updateReplicaToDefault (884.38s)
  PASS
  ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres    887.796s
   ``` 
