### PR TITLE
fix TC for containers

### DIFF
--- a/azurerm/internal/services/containers/container_group_resource_test.go
+++ b/azurerm/internal/services/containers/container_group_resource_test.go
@@ -63,12 +63,12 @@ func TestAccContainerGroup_multipleAssignedIdentities(t *testing.T) {
 			Config: r.MultipleAssignedIdentities(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned, UserAssigned"),
 				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
 				resource.TestMatchResourceAttr(data.ResourceName, "identity.0.principal_id", validate.UUIDRegExp),
 			),
 		},
-		data.ImportStep("identity.0.principal_id"),
+		data.ImportStep(),
 	})
 }
 

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -20,7 +20,7 @@ type KubernetesClusterResource struct {
 
 var (
 	olderKubernetesVersion   = "1.18.14"
-	currentKubernetesVersion = "1.19.6"
+	currentKubernetesVersion = "1.19.9"
 )
 
 func TestAccKubernetes_all(t *testing.T) {


### PR DESCRIPTION
list all available kubernetes version: `az aks get-versions --location westus`
`1.19.6` is not supported, that's why a lot of acctests fail.