### PR TITLE
fix TC for lighthouse

### DIFF
--- a/azurerm/internal/services/lighthouse/lighthouse_assignment_resource_test.go
+++ b/azurerm/internal/services/lighthouse/lighthouse_assignment_resource_test.go
@@ -25,6 +25,10 @@ func TestAccLighthouseAssignment_basic(t *testing.T) {
 	// ObjectId for user, usergroup or service principal from second Tenant needs to be set as a environment variable ARM_PRINCIPAL_ID_ALT_TENANT.
 	secondTenantID := os.Getenv("ARM_TENANT_ID_ALT")
 	principalID := os.Getenv("ARM_PRINCIPAL_ID_ALT_TENANT")
+	if secondTenantID == "" || principalID == "" {
+		t.Skip("Skipping as ARM_TENANT_ID_ALT and/or ARM_PRINCIPAL_ID_ALT_TENANT are not specified")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_lighthouse_assignment", "test")
 	r := LighthouseAssignmentResource{}
 
@@ -40,10 +44,14 @@ func TestAccLighthouseAssignment_basic(t *testing.T) {
 }
 
 func TestAccLighthouseAssignment_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_lighthouse_assignment", "test")
-	r := LighthouseAssignmentResource{}
 	secondTenantID := os.Getenv("ARM_TENANT_ID_ALT")
 	principalID := os.Getenv("ARM_PRINCIPAL_ID_ALT_TENANT")
+	if secondTenantID == "" || principalID == "" {
+		t.Skip("Skipping as ARM_TENANT_ID_ALT and/or ARM_PRINCIPAL_ID_ALT_TENANT are not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_lighthouse_assignment", "test")
+	r := LighthouseAssignmentResource{}
 	id := uuid.New().String()
 
 	data.ResourceTest(t, r, []resource.TestStep{
@@ -62,10 +70,14 @@ func TestAccLighthouseAssignment_requiresImport(t *testing.T) {
 }
 
 func TestAccLighthouseAssignment_emptyID(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_lighthouse_assignment", "test")
-	r := LighthouseAssignmentResource{}
 	secondTenantID := os.Getenv("ARM_TENANT_ID_ALT")
 	principalID := os.Getenv("ARM_PRINCIPAL_ID_ALT_TENANT")
+	if secondTenantID == "" || principalID == "" {
+		t.Skip("Skipping as ARM_TENANT_ID_ALT and/or ARM_PRINCIPAL_ID_ALT_TENANT are not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_lighthouse_assignment", "test")
+	r := LighthouseAssignmentResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
@@ -110,6 +122,7 @@ resource "azurerm_lighthouse_definition" "test" {
   name               = "acctest-LD-%d"
   description        = "Acceptance Test Lighthouse Definition"
   managing_tenant_id = "%s"
+  scope              = data.azurerm_subscription.primary.id
 
   authorization {
     principal_id       = "%s"
@@ -155,6 +168,7 @@ resource "azurerm_lighthouse_definition" "test" {
   name               = "acctest-LD-%d"
   description        = "Acceptance Test Lighthouse Definition"
   managing_tenant_id = "%s"
+  scope              = data.azurerm_subscription.primary.id
 
   authorization {
     principal_id       = "%s"


### PR DESCRIPTION
1. if env is not set, skip the acctest
2. `scope` is a required property in resource `azurerm_lighthouse_definition`

the acctest result when providing the required env
![image](https://user-images.githubusercontent.com/2786738/116034538-08549c00-a696-11eb-8641-d41dade854fe.png)
