### PR TITLE
Remove `change_feed` in `azurerm_storage_account` `blob_properties` and fix 

### DIFF
--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -272,21 +272,6 @@ func resourceStorageAccount() *schema.Resource {
 							},
 						},
 
-						"change_feed": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"retention_in_days": {
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validation.IntBetween(1, 146000),
-									},
-								},
-							},
-						},
-
 						"versioning_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -782,10 +767,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 		if accountKind != string(storage.FileStorage) {
 			blobClient := meta.(*clients.Client).Storage.BlobServicesClient
 
-			blobProperties, err := expandBlobProperties(val.([]interface{}), isHnsEnabled, accountKind)
-			if err != nil {
-				return err
-			}
+			blobProperties := expandBlobProperties(val.([]interface{}))
 
 			if _, err = blobClient.SetServiceProperties(ctx, resourceGroupName, storageAccountName, *blobProperties); err != nil {
 				return fmt.Errorf("Error updating Azure Storage Account `blob_properties` %q: %+v", storageAccountName, err)
@@ -1043,10 +1025,7 @@ func resourceStorageAccountUpdate(d *schema.ResourceData, meta interface{}) erro
 		// FileStorage does not support blob settings
 		if accountKind != string(storage.FileStorage) {
 			blobClient := meta.(*clients.Client).Storage.BlobServicesClient
-			blobProperties, err := expandBlobProperties(d.Get("blob_properties").([]interface{}), d.Get("is_hns_enabled").(bool), accountKind)
-			if err != nil {
-				return err
-			}
+			blobProperties := expandBlobProperties(d.Get("blob_properties").([]interface{}))
 
 			if _, err = blobClient.SetServiceProperties(ctx, resourceGroupName, storageAccountName, *blobProperties); err != nil {
 				return fmt.Errorf("Error updating Azure Storage Account `blob_properties` %q: %+v", storageAccountName, err)
@@ -1502,16 +1481,13 @@ func expandStorageAccountBypass(networkRule map[string]interface{}) storage.Bypa
 	return storage.Bypass(strings.Join(bypassValues, ", "))
 }
 
-func expandBlobProperties(input []interface{}, isHnsEnabled bool, accountKind string) (*storage.BlobServiceProperties, error) {
+func expandBlobProperties(input []interface{}) *storage.BlobServiceProperties {
 	props := storage.BlobServiceProperties{
 		BlobServicePropertiesProperties: &storage.BlobServicePropertiesProperties{
 			Cors: &storage.CorsRules{
 				CorsRules: &[]storage.CorsRule{},
 			},
 			IsVersioningEnabled: utils.Bool(false),
-			ChangeFeed: &storage.ChangeFeed{
-				Enabled: utils.Bool(false),
-			},
 			LastAccessTimeTrackingPolicy: &storage.LastAccessTimeTrackingPolicy{
 				Enable: utils.Bool(false),
 			},
@@ -1523,7 +1499,7 @@ func expandBlobProperties(input []interface{}, isHnsEnabled bool, accountKind st
 	}
 
 	if len(input) == 0 || input[0] == nil {
-		return &props, nil
+		return &props
 	}
 
 	v := input[0].(map[string]interface{})
@@ -1537,12 +1513,6 @@ func expandBlobProperties(input []interface{}, isHnsEnabled bool, accountKind st
 
 	props.IsVersioningEnabled = utils.Bool(v["versioning_enabled"].(bool))
 
-	changeFeed, err := expandBlobPropertiesChangeFeed(v["change_feed"].([]interface{}), isHnsEnabled, accountKind)
-	if err != nil {
-		return nil, err
-	}
-	props.ChangeFeed = changeFeed
-
 	if version, ok := v["default_service_version"].(string); ok && version != "" {
 		props.DefaultServiceVersion = utils.String(version)
 	}
@@ -1550,7 +1520,7 @@ func expandBlobProperties(input []interface{}, isHnsEnabled bool, accountKind st
 	props.LastAccessTimeTrackingPolicy = &storage.LastAccessTimeTrackingPolicy{
 		Enable: utils.Bool(v["last_access_time_enabled"].(bool)),
 	}
-	return &props, nil
+	return &props
 }
 
 func expandBlobPropertiesDeleteRetentionPolicy(input []interface{}) *storage.DeleteRetentionPolicy {
@@ -1600,34 +1570,6 @@ func expandBlobPropertiesCors(input []interface{}) *storage.CorsRules {
 	blobCorsRules.CorsRules = &corsRules
 
 	return &blobCorsRules
-}
-
-func expandBlobPropertiesChangeFeed(inputs []interface{}, isHnsEnabled bool, accountKind string) (*storage.ChangeFeed, error) {
-	if len(inputs) == 0 {
-		return &storage.ChangeFeed{
-			Enabled: utils.Bool(false),
-		}, nil
-	}
-
-	if isHnsEnabled {
-		return nil, fmt.Errorf("`change_feed` in `blob_properties` cannot be enabled when `is_hns_enabled` is enabled")
-	}
-
-	if accountKind != string(storage.BlobStorage) && accountKind != string(storage.StorageV2) {
-		return nil, fmt.Errorf("`change_feed` can only be configured when `account_kind` is set to `BlobStorage` or `StorageV2`")
-	}
-
-	result := storage.ChangeFeed{
-		Enabled: utils.Bool(true),
-	}
-
-	if inputs[0] != nil {
-		input := inputs[0].(map[string]interface{})
-		if v, ok := input["retention_in_days"].(int); ok && v != 0 {
-			result.RetentionInDays = utils.Int32(int32(v))
-		}
-	}
-	return &result, nil
 }
 
 func expandQueueProperties(input []interface{}) (queues.StorageServiceProperties, error) {
@@ -1865,7 +1807,6 @@ func flattenBlobProperties(input storage.BlobServiceProperties) []interface{} {
 		map[string]interface{}{
 			"cors_rule":                         flattenedCorsRules,
 			"delete_retention_policy":           flattenedDeletePolicy,
-			"change_feed":                       flattenBlobPropertiesChangeFeed(input.BlobServicePropertiesProperties.ChangeFeed),
 			"versioning_enabled":                versioning,
 			"default_service_version":           defaultServiceVersion,
 			"last_access_time_enabled":          LastAccessTimeTrackingPolicy,
@@ -1938,25 +1879,6 @@ func flattenBlobPropertiesDeleteRetentionPolicy(input *storage.DeleteRetentionPo
 	}
 
 	return deleteRetentionPolicy
-}
-
-func flattenBlobPropertiesChangeFeed(input *storage.ChangeFeed) []interface{} {
-	changeFeed := make([]interface{}, 0)
-
-	if input == nil || input.Enabled == nil || !*input.Enabled {
-		return changeFeed
-	}
-
-	days := 0
-	if input.RetentionInDays != nil {
-		days = int(*input.RetentionInDays)
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"retention_in_days": days,
-		},
-	}
 }
 
 func flattenQueueProperties(input *queues.StorageServiceProperties) []interface{} {

--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -1621,11 +1621,12 @@ func expandBlobPropertiesChangeFeed(inputs []interface{}, isHnsEnabled bool, acc
 		Enabled: utils.Bool(true),
 	}
 
-	input := inputs[0].(map[string]interface{})
-	if v, ok := input["retention_in_days"].(int); ok && v != 0 {
-		result.RetentionInDays = utils.Int32(int32(v))
+	if inputs[0] != nil {
+		input := inputs[0].(map[string]interface{})
+		if v, ok := input["retention_in_days"].(int); ok && v != 0 {
+			result.RetentionInDays = utils.Int32(int32(v))
+		}
 	}
-
 	return &result, nil
 }
 
@@ -1843,10 +1844,6 @@ func flattenBlobProperties(input storage.BlobServiceProperties) []interface{} {
 	flattenedContainerDeletePolicy := make([]interface{}, 0)
 	if containerDeletePolicy := input.BlobServicePropertiesProperties.ContainerDeleteRetentionPolicy; containerDeletePolicy != nil {
 		flattenedContainerDeletePolicy = flattenBlobPropertiesDeleteRetentionPolicy(containerDeletePolicy)
-	}
-
-	if len(flattenedCorsRules) == 0 && len(flattenedDeletePolicy) == 0 && len(flattenedContainerDeletePolicy) == 0 {
-		return []interface{}{}
 	}
 
 	versioning := false

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -778,7 +778,7 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "LRS"
 
   tags = {
-        %s
+            %s
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, tags)
@@ -1527,10 +1527,6 @@ resource "azurerm_storage_account" "test" {
     default_service_version  = "2019-07-07"
     versioning_enabled       = true
     last_access_time_enabled = true
-    change_feed {
-      retention_in_days = 3
-    }
-
     container_delete_retention_policy {
       days = 7
     }
@@ -1607,7 +1603,6 @@ resource "azurerm_storage_account" "test" {
 
   blob_properties {
     versioning_enabled = true
-    change_feed {}
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -528,10 +528,6 @@ func TestAccStorageAccount_blobProperties(t *testing.T) {
 			Config: r.blobPropertiesUpdated2(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("blob_properties.0.cors_rule.#").HasValue("2"),
-				check.That(data.ResourceName).Key("blob_properties.0.delete_retention_policy.0.days").HasValue("7"),
-				check.That(data.ResourceName).Key("blob_properties.0.versioning_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("blob_properties.0.default_service_version").HasValue("2020-06-12"),
 			),
 		},
 		data.ImportStep(),

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -524,6 +524,17 @@ func TestAccStorageAccount_blobProperties(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.blobPropertiesUpdated2(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("blob_properties.0.cors_rule.#").HasValue("2"),
+				check.That(data.ResourceName).Key("blob_properties.0.delete_retention_policy.0.days").HasValue("7"),
+				check.That(data.ResourceName).Key("blob_properties.0.versioning_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("blob_properties.0.default_service_version").HasValue("2020-06-12"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -771,7 +782,7 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "LRS"
 
   tags = {
-    %s
+        %s
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, tags)
@@ -1574,6 +1585,33 @@ resource "azurerm_storage_account" "test" {
 
     container_delete_retention_policy {
     }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) blobPropertiesUpdated2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestAzureRMSA-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  blob_properties {
+    versioning_enabled = true
+    change_feed {}
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -139,8 +139,6 @@ A `blob_properties` block supports the following:
 
 * `versioning_enabled` - (Optional) Is versioning enabled? Default to `false`.
 
-* `change_feed` - (Optional) A `change_feed` block as defined below.
-
 * `default_service_version` - (Optional) The API Version which should be used by default for requests to the Data Plane API if an incoming request doesn't specify an API Version. Defaults to `2020-06-12`.
 
 * `last_access_time_enabled` - (Optional) Is the last access time based tracking enabled? Default to `false`.
@@ -180,12 +178,6 @@ A `delete_retention_policy` block supports the following:
 A `container_delete_retention_policy` block supports the following:
 
 * `days` - (Optional) Specifies the number of days that the container should be retained, between `1` and `365` days. Defaults to `7`.
-
----
-
-A `change_feed` block supports the following:
-
-* `retention_in_days` - (Optional) The duration of changeFeed retention in days, between `1` and `146000` days. A null value indicates an infinite retention of the change feed.
 
 ---
 


### PR DESCRIPTION
Remove `change_feed`  because `retention_in_days` in `change_feed` is blocked to be released now.

Fix when only  `versioning` are enabled.

Fix PR https://github.com/terraform-providers/terraform-provider-azurerm/pull/11301 

=== RUN   TestAccStorageAccount_blobProperties
=== PAUSE TestAccStorageAccount_blobProperties
=== CONT  TestAccStorageAccount_blobProperties
--- PASS: TestAccStorageAccount_blobProperties (344.82s)