### PR TITLE
azurerm_virtual_network_gateway_connection: Update allowed ipsec_policy attributes

### DIFF
--- a/azurerm/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -205,6 +205,8 @@ func resourceVirtualNetworkGatewayConnection() *schema.Resource {
 								string(network.AES256),
 								string(network.DES),
 								string(network.DES3),
+								string(network.GCMAES128),
+								string(network.GCMAES256),
 							}, true),
 						},
 
@@ -262,9 +264,11 @@ func resourceVirtualNetworkGatewayConnection() *schema.Resource {
 								string(network.PfsGroupECP384),
 								string(network.PfsGroupNone),
 								string(network.PfsGroupPFS1),
+								string(network.PfsGroupPFS14),
 								string(network.PfsGroupPFS2),
 								string(network.PfsGroupPFS2048),
 								string(network.PfsGroupPFS24),
+								string(network.PfsGroupPFSMM),
 							}, true),
 						},
 

--- a/azurerm/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -550,11 +550,11 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 
   ipsec_policy {
     dh_group         = "DHGroup14"
-    ike_encryption   = "AES256"
+    ike_encryption   = "GCMAES256"
     ike_integrity    = "SHA256"
     ipsec_encryption = "AES256"
     ipsec_integrity  = "SHA256"
-    pfs_group        = "PFS2048"
+    pfs_group        = "PFS14"
     sa_datasize      = 102400000
     sa_lifetime      = 27000
   }

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -278,10 +278,10 @@ The `ipsec_policy` block supports:
     `ECP256`, `ECP384`, or `None`.
 
 * `ike_encryption` - (Required) The IKE encryption algorithm. Valid
-    options are `AES128`, `AES192`, `AES256`, `DES`, or `DES3`.
+    options are `AES128`, `AES192`, `AES256`, `DES`, `DES3`, `GCMAES128`, or `GCMAES256`.
 
 * `ike_integrity` - (Required) The IKE integrity algorithm. Valid
-    options are `MD5`, `SHA1`, `SHA256`, or `SHA384`.
+    options are `GCMAES128`, `GCMAES256`, `MD5`, `SHA1`, `SHA256`, or `SHA384`.
 
 * `ipsec_encryption` - (Required) The IPSec encryption algorithm. Valid
     options are `AES128`, `AES192`, `AES256`, `DES`, `DES3`, `GCMAES128`, `GCMAES192`, `GCMAES256`, or `None`.
@@ -290,7 +290,7 @@ The `ipsec_policy` block supports:
     options are `GCMAES128`, `GCMAES192`, `GCMAES256`, `MD5`, `SHA1`, or `SHA256`.
 
 * `pfs_group` - (Required) The DH group used in IKE phase 2 for new child SA.
-    Valid options are `ECP256`, `ECP384`, `PFS1`, `PFS2`, `PFS2048`, `PFS24`,
+    Valid options are `ECP256`, `ECP384`, `PFS1`, `PFS14`, `PFS2`, `PFS2048`, `PFS24`, `PFSMM`,
     or `None`.
 
 * `sa_datasize` - (Optional) The IPSec SA payload size in KB. Must be at least


### PR DESCRIPTION
The SDK allows some attributes of `azurerm_virtual_network_gateway_connection.ipsec_policy` to take values not currently permitted by the provider:
* `ike_encryption` can also be `GCMAES128` or `GCMAES256`.
* `pfs_group` can also be `PFS14` or `PFSMM`.

This PR fixes the validation logic to allow these, and also updates the doc for `ike_integrity` to match the existing code.