### PR TITLE
Support for `access_key_metadata_writes_enabled`, `mongo_server_version` and `network_acl_bypass` in `azurerm_cosmosdb_account`

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -281,12 +281,6 @@ func resourceCosmosDbAccount() *schema.Resource {
 				Default:  true,
 			},
 
-			"cassandra_connector_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
 			"mongo_server_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -477,7 +471,6 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 			PublicNetworkAccess:                publicNetworkAccess,
 			EnableAnalyticalStorage:            utils.Bool(enableAnalyticalStorage),
 			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("key_based_meta_write_access_enabled").(bool)),
-			EnableCassandraConnector:           utils.Bool(d.Get("cassandra_connector_enabled").(bool)),
 			NetworkACLBypass:                   documentdb.NetworkACLBypass(d.Get("network_acl_bypass").(string)),
 			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
 		},
@@ -595,7 +588,6 @@ func resourceCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) err
 			PublicNetworkAccess:                publicNetworkAccess,
 			EnableAnalyticalStorage:            utils.Bool(enableAnalyticalStorage),
 			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("key_based_meta_write_access_enabled").(bool)),
-			EnableCassandraConnector:           utils.Bool(d.Get("cassandra_connector_enabled").(bool)),
 			NetworkACLBypass:                   documentdb.NetworkACLBypass(d.Get("network_acl_bypass").(string)),
 			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
 		},
@@ -734,7 +726,6 @@ func resourceCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) error
 		}
 
 		d.Set("key_based_meta_write_access_enabled", !*props.DisableKeyBasedMetadataWriteAccess)
-		d.Set("cassandra_connector_enabled", props.EnableCassandraConnector)
 		if apiProps := props.APIProperties; apiProps != nil {
 			d.Set("mongo_server_version", apiProps.ServerVersion)
 		}

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -109,14 +109,12 @@ func resourceCosmosDbAccount() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
 			},
 
 			"analytical_storage_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-				ForceNew: true,
 			},
 
 			"public_network_access_enabled": {
@@ -277,6 +275,48 @@ func resourceCosmosDbAccount() *schema.Resource {
 				Default:  false,
 			},
 
+			"key_based_meta_write_access_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"cassandra_connector_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"mongo_server_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(documentdb.ThreeFullStopTwo),
+					string(documentdb.ThreeFullStopSix),
+					string(documentdb.FourFullStopZero),
+				}, false),
+			},
+
+			"network_acl_bypass": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(documentdb.NetworkACLBypassNone),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(documentdb.NetworkACLBypassNone),
+					string(documentdb.NetworkACLBypassAzureServices),
+				}, false),
+			},
+
+			"network_acl_bypass_ids": {
+				Type:     schema.TypeList,
+				Optional: true, Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: azure.ValidateResourceID,
+				},
+			},
+
 			// computed
 			"endpoint": {
 				Type:     schema.TypeString,
@@ -379,7 +419,7 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing CosmosDB Account %q (Resource Group %q): %s", name, resourceGroup, err)
+				return fmt.Errorf("checking for presence of existing CosmosDB Account %q (Resource Group %q): %s", name, resourceGroup, err)
 			}
 		}
 
@@ -403,7 +443,7 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		// todo remove when https://github.com/Azure/azure-sdk-for-go/issues/9891 is fixed
 		if !utils.ResponseWasStatusCode(r, http.StatusInternalServerError) {
-			return fmt.Errorf("Error checking if CosmosDB Account %q already exists (Resource Group %q): %+v", name, resourceGroup, err)
+			return fmt.Errorf("checking if CosmosDB Account %q already exists (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	} else {
 		if !utils.ResponseWasNotFound(r) {
@@ -412,7 +452,7 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	geoLocations, err := expandAzureRmCosmosDBAccountGeoLocations(d)
 	if err != nil {
-		return fmt.Errorf("Error expanding CosmosDB Account %q (Resource Group %q) geo locations: %+v", name, resourceGroup, err)
+		return fmt.Errorf("expanding CosmosDB Account %q (Resource Group %q) geo locations: %+v", name, resourceGroup, err)
 	}
 
 	publicNetworkAccess := documentdb.Enabled
@@ -424,20 +464,30 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 		Location: utils.String(location),
 		Kind:     documentdb.DatabaseAccountKind(kind),
 		DatabaseAccountCreateUpdateProperties: &documentdb.DatabaseAccountCreateUpdateProperties{
-			DatabaseAccountOfferType:      utils.String(offerType),
-			IPRules:                       common.CosmosDBIpRangeFilterToIpRules(ipRangeFilter),
-			IsVirtualNetworkFilterEnabled: utils.Bool(isVirtualNetworkFilterEnabled),
-			EnableFreeTier:                utils.Bool(enableFreeTier),
-			EnableAutomaticFailover:       utils.Bool(enableAutomaticFailover),
-			ConsistencyPolicy:             expandAzureRmCosmosDBAccountConsistencyPolicy(d),
-			Locations:                     &geoLocations,
-			Capabilities:                  expandAzureRmCosmosDBAccountCapabilities(d),
-			VirtualNetworkRules:           expandAzureRmCosmosDBAccountVirtualNetworkRules(d),
-			EnableMultipleWriteLocations:  utils.Bool(enableMultipleWriteLocations),
-			PublicNetworkAccess:           publicNetworkAccess,
-			EnableAnalyticalStorage:       utils.Bool(enableAnalyticalStorage),
+			DatabaseAccountOfferType:           utils.String(offerType),
+			IPRules:                            common.CosmosDBIpRangeFilterToIpRules(ipRangeFilter),
+			IsVirtualNetworkFilterEnabled:      utils.Bool(isVirtualNetworkFilterEnabled),
+			EnableFreeTier:                     utils.Bool(enableFreeTier),
+			EnableAutomaticFailover:            utils.Bool(enableAutomaticFailover),
+			ConsistencyPolicy:                  expandAzureRmCosmosDBAccountConsistencyPolicy(d),
+			Locations:                          &geoLocations,
+			Capabilities:                       expandAzureRmCosmosDBAccountCapabilities(d),
+			VirtualNetworkRules:                expandAzureRmCosmosDBAccountVirtualNetworkRules(d),
+			EnableMultipleWriteLocations:       utils.Bool(enableMultipleWriteLocations),
+			PublicNetworkAccess:                publicNetworkAccess,
+			EnableAnalyticalStorage:            utils.Bool(enableAnalyticalStorage),
+			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("key_based_meta_write_access_enabled").(bool)),
+			EnableCassandraConnector:           utils.Bool(d.Get("cassandra_connector_enabled").(bool)),
+			NetworkACLBypass:                   documentdb.NetworkACLBypass(d.Get("network_acl_bypass").(string)),
+			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("mongo_server_version"); ok {
+		account.DatabaseAccountCreateUpdateProperties.APIProperties = &documentdb.APIProperties{
+			ServerVersion: documentdb.ServerVersion(v.(string)),
+		}
 	}
 
 	if keyVaultKeyIDRaw, ok := d.GetOk("key_vault_key_id"); ok {
@@ -452,16 +502,16 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 	consistencyPolicy := account.DatabaseAccountCreateUpdateProperties.ConsistencyPolicy
 	if len(geoLocations) > 1 && consistencyPolicy != nil && consistencyPolicy.DefaultConsistencyLevel == documentdb.BoundedStaleness {
 		if msp := consistencyPolicy.MaxStalenessPrefix; msp != nil && *msp < 100000 {
-			return fmt.Errorf("Error max_staleness_prefix (%d) must be greater then 100000 when more then one geo_location is used", *msp)
+			return fmt.Errorf("max_staleness_prefix (%d) must be greater then 100000 when more then one geo_location is used", *msp)
 		}
 		if mis := consistencyPolicy.MaxIntervalInSeconds; mis != nil && *mis < 300 {
-			return fmt.Errorf("Error max_interval_in_seconds (%d) must be greater then 300 (5min) when more then one geo_location is used", *mis)
+			return fmt.Errorf("max_interval_in_seconds (%d) must be greater then 300 (5min) when more then one geo_location is used", *mis)
 		}
 	}
 
 	resp, err := resourceCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account, d)
 	if err != nil {
-		return fmt.Errorf("Error creating CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("creating CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	id := resp.ID
@@ -532,18 +582,22 @@ func resourceCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) err
 		Location: utils.String(location),
 		Kind:     documentdb.DatabaseAccountKind(kind),
 		DatabaseAccountCreateUpdateProperties: &documentdb.DatabaseAccountCreateUpdateProperties{
-			DatabaseAccountOfferType:      utils.String(offerType),
-			IPRules:                       common.CosmosDBIpRangeFilterToIpRules(ipRangeFilter),
-			IsVirtualNetworkFilterEnabled: utils.Bool(isVirtualNetworkFilterEnabled),
-			EnableFreeTier:                utils.Bool(enableFreeTier),
-			EnableAutomaticFailover:       utils.Bool(enableAutomaticFailover),
-			Capabilities:                  expandAzureRmCosmosDBAccountCapabilities(d),
-			ConsistencyPolicy:             expandAzureRmCosmosDBAccountConsistencyPolicy(d),
-			Locations:                     &oldLocations,
-			VirtualNetworkRules:           expandAzureRmCosmosDBAccountVirtualNetworkRules(d),
-			EnableMultipleWriteLocations:  resp.EnableMultipleWriteLocations,
-			PublicNetworkAccess:           publicNetworkAccess,
-			EnableAnalyticalStorage:       utils.Bool(enableAnalyticalStorage),
+			DatabaseAccountOfferType:           utils.String(offerType),
+			IPRules:                            common.CosmosDBIpRangeFilterToIpRules(ipRangeFilter),
+			IsVirtualNetworkFilterEnabled:      utils.Bool(isVirtualNetworkFilterEnabled),
+			EnableFreeTier:                     utils.Bool(enableFreeTier),
+			EnableAutomaticFailover:            utils.Bool(enableAutomaticFailover),
+			Capabilities:                       expandAzureRmCosmosDBAccountCapabilities(d),
+			ConsistencyPolicy:                  expandAzureRmCosmosDBAccountConsistencyPolicy(d),
+			Locations:                          &oldLocations,
+			VirtualNetworkRules:                expandAzureRmCosmosDBAccountVirtualNetworkRules(d),
+			EnableMultipleWriteLocations:       resp.EnableMultipleWriteLocations,
+			PublicNetworkAccess:                publicNetworkAccess,
+			EnableAnalyticalStorage:            utils.Bool(enableAnalyticalStorage),
+			DisableKeyBasedMetadataWriteAccess: utils.Bool(!d.Get("key_based_meta_write_access_enabled").(bool)),
+			EnableCassandraConnector:           utils.Bool(d.Get("cassandra_connector_enabled").(bool)),
+			NetworkACLBypass:                   documentdb.NetworkACLBypass(d.Get("network_acl_bypass").(string)),
+			NetworkACLBypassResourceIds:        utils.ExpandStringSlice(d.Get("network_acl_bypass_ids").([]interface{})),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -637,44 +691,55 @@ func resourceCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	d.Set("kind", string(resp.Kind))
-	d.Set("offer_type", string(resp.DatabaseAccountOfferType))
-	d.Set("ip_range_filter", common.CosmosDBIpRulesToIpRangeFilter(resp.IPRules))
-	d.Set("endpoint", resp.DocumentEndpoint)
 
-	d.Set("enable_free_tier", resp.EnableFreeTier)
-	d.Set("analytical_storage_enabled", resp.EnableAnalyticalStorage)
-	d.Set("public_network_access_enabled", resp.PublicNetworkAccess == documentdb.Enabled)
+	if props := resp.DatabaseAccountGetProperties; props != nil {
+		d.Set("offer_type", string(props.DatabaseAccountOfferType))
+		d.Set("ip_range_filter", common.CosmosDBIpRulesToIpRangeFilter(props.IPRules))
+		d.Set("endpoint", props.DocumentEndpoint)
 
-	if v := resp.IsVirtualNetworkFilterEnabled; v != nil {
-		d.Set("is_virtual_network_filter_enabled", resp.IsVirtualNetworkFilterEnabled)
-	}
+		d.Set("enable_free_tier", props.EnableFreeTier)
+		d.Set("analytical_storage_enabled", props.EnableAnalyticalStorage)
+		d.Set("public_network_access_enabled", props.PublicNetworkAccess == documentdb.Enabled)
 
-	if v := resp.EnableAutomaticFailover; v != nil {
-		d.Set("enable_automatic_failover", resp.EnableAutomaticFailover)
-	}
+		if v := resp.IsVirtualNetworkFilterEnabled; v != nil {
+			d.Set("is_virtual_network_filter_enabled", props.IsVirtualNetworkFilterEnabled)
+		}
 
-	if v := resp.KeyVaultKeyURI; v != nil {
-		d.Set("key_vault_key_id", resp.KeyVaultKeyURI)
-	}
+		if v := resp.EnableAutomaticFailover; v != nil {
+			d.Set("enable_automatic_failover", props.EnableAutomaticFailover)
+		}
 
-	if v := resp.EnableMultipleWriteLocations; v != nil {
-		d.Set("enable_multiple_write_locations", resp.EnableMultipleWriteLocations)
-	}
+		if v := resp.KeyVaultKeyURI; v != nil {
+			d.Set("key_vault_key_id", props.KeyVaultKeyURI)
+		}
 
-	if err = d.Set("consistency_policy", flattenAzureRmCosmosDBAccountConsistencyPolicy(resp.ConsistencyPolicy)); err != nil {
-		return fmt.Errorf("Error setting CosmosDB Account %q `consistency_policy` (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
-	}
+		if v := resp.EnableMultipleWriteLocations; v != nil {
+			d.Set("enable_multiple_write_locations", props.EnableMultipleWriteLocations)
+		}
 
-	if err = d.Set("geo_location", flattenAzureRmCosmosDBAccountGeoLocations(resp.DatabaseAccountGetProperties)); err != nil {
-		return fmt.Errorf("Error setting `geo_location`: %+v", err)
-	}
+		if err = d.Set("consistency_policy", flattenAzureRmCosmosDBAccountConsistencyPolicy(props.ConsistencyPolicy)); err != nil {
+			return fmt.Errorf("setting CosmosDB Account %q `consistency_policy` (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
 
-	if err = d.Set("capabilities", flattenAzureRmCosmosDBAccountCapabilities(resp.Capabilities)); err != nil {
-		return fmt.Errorf("Error setting `capabilities`: %+v", err)
-	}
+		if err = d.Set("geo_location", flattenAzureRmCosmosDBAccountGeoLocations(props)); err != nil {
+			return fmt.Errorf("setting `geo_location`: %+v", err)
+		}
 
-	if err = d.Set("virtual_network_rule", flattenAzureRmCosmosDBAccountVirtualNetworkRules(resp.VirtualNetworkRules)); err != nil {
-		return fmt.Errorf("Error setting `virtual_network_rule`: %+v", err)
+		if err = d.Set("capabilities", flattenAzureRmCosmosDBAccountCapabilities(props.Capabilities)); err != nil {
+			return fmt.Errorf("setting `capabilities`: %+v", err)
+		}
+
+		if err = d.Set("virtual_network_rule", flattenAzureRmCosmosDBAccountVirtualNetworkRules(props.VirtualNetworkRules)); err != nil {
+			return fmt.Errorf("setting `virtual_network_rule`: %+v", err)
+		}
+
+		d.Set("key_based_meta_write_access_enabled", !*props.DisableKeyBasedMetadataWriteAccess)
+		d.Set("cassandra_connector_enabled", props.EnableCassandraConnector)
+		if apiProps := props.APIProperties; apiProps != nil {
+			d.Set("mongo_server_version", apiProps.ServerVersion)
+		}
+		d.Set("network_acl_bypass", props.NetworkACLBypass)
+		d.Set("network_acl_bypass_ids", utils.FlattenStringSlice(props.NetworkACLBypassResourceIds))
 	}
 
 	readEndpoints := make([]string, 0)

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -295,7 +295,7 @@ func resourceCosmosDbAccount() *schema.Resource {
 				}, false),
 			},
 
-			"network_acl_bypass_for_azure_servers": {
+			"network_acl_bypass_for_azure_services": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -453,7 +453,7 @@ func resourceCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	networkByPass := documentdb.NetworkACLBypassNone
-	if d.Get("network_acl_bypass_for_azure_servers").(bool) {
+	if d.Get("network_acl_bypass_for_azure_services").(bool) {
 		networkByPass = documentdb.NetworkACLBypassAzureServices
 	}
 
@@ -573,7 +573,7 @@ func resourceCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	networkByPass := documentdb.NetworkACLBypassNone
-	if d.Get("network_acl_bypass_for_azure_servers").(bool) {
+	if d.Get("network_acl_bypass_for_azure_services").(bool) {
 		networkByPass = documentdb.NetworkACLBypassAzureServices
 	}
 
@@ -737,7 +737,7 @@ func resourceCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) error
 		if apiProps := props.APIProperties; apiProps != nil {
 			d.Set("mongo_server_version", apiProps.ServerVersion)
 		}
-		d.Set("network_acl_bypass_for_azure_servers", props.NetworkACLBypass == documentdb.NetworkACLBypassAzureServices)
+		d.Set("network_acl_bypass_for_azure_services", props.NetworkACLBypass == documentdb.NetworkACLBypassAzureServices)
 		d.Set("network_acl_bypass_ids", utils.FlattenStringSlice(props.NetworkACLBypassResourceIds))
 	}
 

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -927,8 +927,8 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 2
   }
 
-  key_based_meta_write_access_enabled = false
-  network_acl_bypass                  = "AzureServices"
+  access_key_metadata_writes_enabled   = false
+  network_acl_bypass_for_azure_servers = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -981,8 +981,8 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 2
   }
 
-  key_based_meta_write_access_enabled = false
-  network_acl_bypass                  = "AzureServices"
+  access_key_metadata_writes_enabled   = false
+  network_acl_bypass_for_azure_servers = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -1110,9 +1110,7 @@ resource "azurerm_cosmosdb_account" "test" {
     location          = "%[6]s"
     failover_priority = 2
   }
-  enable_free_tier                    = true
-  analytical_storage_enabled          = true
-  key_based_meta_write_access_enabled = true
+  access_key_metadata_writes_enabled = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -1160,9 +1158,7 @@ resource "azurerm_cosmosdb_account" "test" {
     location          = "%[5]s"
     failover_priority = 2
   }
-  enable_free_tier                    = true
-  analytical_storage_enabled          = true
-  key_based_meta_write_access_enabled = true
+  access_key_metadata_writes_enabled = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -1720,8 +1716,8 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 0
   }
 
-  network_acl_bypass     = "AzureServices"
-  network_acl_bypass_ids = [azurerm_synapse_workspace.test.id]
+  network_acl_bypass_for_azure_servers = true
+  network_acl_bypass_ids               = [azurerm_synapse_workspace.test.id]
 }
 `, r.basicWithNetworkBypassTemplate(data), data.RandomInteger, string(kind), string(consistency))
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -928,8 +928,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   key_based_meta_write_access_enabled = false
-  cassandra_connector_enabled         = false
-  network_acl_bypass                 = "AzureServices"
+  network_acl_bypass                  = "AzureServices"
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -983,8 +982,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   key_based_meta_write_access_enabled = false
-  cassandra_connector_enabled         = false
-  network_acl_bypass                 = "AzureServices"
+  network_acl_bypass                  = "AzureServices"
 }
 `, r.completePreReqs(data), data.RandomInteger, string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -1112,10 +1110,9 @@ resource "azurerm_cosmosdb_account" "test" {
     location          = "%[6]s"
     failover_priority = 2
   }
-  enable_free_tier                   = true
-  analytical_storage_enabled         = true
+  enable_free_tier                    = true
+  analytical_storage_enabled          = true
   key_based_meta_write_access_enabled = true
-  cassandra_connector_enabled         = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -1163,10 +1160,9 @@ resource "azurerm_cosmosdb_account" "test" {
     location          = "%[5]s"
     failover_priority = 2
   }
-  enable_free_tier                   = true
-  analytical_storage_enabled         = true
+  enable_free_tier                    = true
+  analytical_storage_enabled          = true
   key_based_meta_write_access_enabled = true
-  cassandra_connector_enabled         = false
 }
 `, r.completePreReqs(data), data.RandomInteger, string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -927,8 +927,8 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 2
   }
 
-  access_key_metadata_writes_enabled   = false
-  network_acl_bypass_for_azure_servers = true
+  access_key_metadata_writes_enabled    = false
+  network_acl_bypass_for_azure_services = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -981,8 +981,8 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 2
   }
 
-  access_key_metadata_writes_enabled   = false
-  network_acl_bypass_for_azure_servers = true
+  access_key_metadata_writes_enabled    = false
+  network_acl_bypass_for_azure_services = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(consistency), data.Locations.Secondary, data.Locations.Ternary)
 }
@@ -1716,8 +1716,8 @@ resource "azurerm_cosmosdb_account" "test" {
     failover_priority = 0
   }
 
-  network_acl_bypass_for_azure_servers = true
-  network_acl_bypass_ids               = [azurerm_synapse_workspace.test.id]
+  network_acl_bypass_for_azure_services = true
+  network_acl_bypass_ids                = [azurerm_synapse_workspace.test.id]
 }
 `, r.basicWithNetworkBypassTemplate(data), data.RandomInteger, string(kind), string(consistency))
 }

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -108,8 +108,6 @@ The following arguments are supported:
 
 * `key_based_meta_write_access_enabled` - (Optional) Is write operations on metadata resources (databases, containers, throughput) via account keys enabled? Defaults to `true`.
 
-* `cassandra_connector_enabled` - (Optional) Is the cassandra connector on the Cosmos DB account enabled? Defaults to `false`.
-
 * `mongo_server_version` - (Optional) The Server Version of a MongoDB account. Possible values are `4.0`, `3.6`, and `3.2`. Changing this forces a new resource to be created.
 
 * `network_acl_bypass` - (Optional) The services which are allowed to bypass firewall checks. Possible values are `None` and `AzureServices`. Defaults to `None`.

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -106,6 +106,18 @@ The following arguments are supported:
 
 * `enable_multiple_write_locations` - (Optional) Enable multi-master support for this Cosmos DB account.
 
+* `key_based_meta_write_access_enabled` - (Optional) Is write operations on metadata resources (databases, containers, throughput) via account keys enabled? Defaults to `true`.
+
+* `cassandra_connector_enabled` - (Optional) Is the cassandra connector on the Cosmos DB account enabled? Defaults to `false`.
+
+* `mongo_server_version` - (Optional) The Server Version of a MongoDB account. Possible values are `4.0`, `3.6`, and `3.2`. Changing this forces a new resource to be created.
+
+* `network_acl_bypass` - (Optional) The services which are allowed to bypass firewall checks. Possible values are `None` and `AzureServices`. Defaults to `None`.
+
+* `network_acl_bypass_ids` - (Optional) A list of resource Ids for Network Acl Bypass for this Cosmos DB account.
+
+---
+
 `consistency_policy` Configures the database consistency and supports the following:
 
 * `consistency_level` - (Required) The Consistency Level to use for this CosmosDB Account - can be either `BoundedStaleness`, `Eventual`, `Session`, `Strong` or `ConsistentPrefix`.
@@ -114,6 +126,8 @@ The following arguments are supported:
 
 ~> **Note**: `max_interval_in_seconds` and `max_staleness_prefix` can only be set to custom values when `consistency_level` is set to `BoundedStaleness` - otherwise they will return the default values shown above.
 
+---
+
 `geo_location` Configures the geographic locations the data is replicated to and supports the following:
 
 * `prefix` - (Optional) The string used to generate the document endpoints for this region. If not specified it defaults to `${cosmosdb_account.name}-${location}`. Changing this causes the location to be deleted and re-provisioned and cannot be changed for the location with failover priority `0`.
@@ -121,11 +135,15 @@ The following arguments are supported:
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
 * `zone_redundant` - (Optional) Should zone redundancy be enabled for this region? Defaults to `false`.
 
+---
+
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 
 * `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableTable`, `EnableServerless`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`.
 
 **NOTE:** The `prefix` and `failover_priority` fields of a location cannot be changed for the location with a failover priority of `0`.
+
+---
 
 `virtual_network_rule` Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -106,13 +106,13 @@ The following arguments are supported:
 
 * `enable_multiple_write_locations` - (Optional) Enable multi-master support for this Cosmos DB account.
 
-* `key_based_meta_write_access_enabled` - (Optional) Is write operations on metadata resources (databases, containers, throughput) via account keys enabled? Defaults to `true`.
+* `access_key_metadata_writes_enabled` - (Optional) Is write operations on metadata resources (databases, containers, throughput) via account keys enabled? Defaults to `true`.
 
 * `mongo_server_version` - (Optional) The Server Version of a MongoDB account. Possible values are `4.0`, `3.6`, and `3.2`. Changing this forces a new resource to be created.
 
-* `network_acl_bypass` - (Optional) The services which are allowed to bypass firewall checks. Possible values are `None` and `AzureServices`. Defaults to `None`.
+* `network_acl_bypass_for_azure_servers` - (Optional) If azure services can bypass ACLs. Defaults to `false`.
 
-* `network_acl_bypass_ids` - (Optional) A list of resource Ids for Network Acl Bypass for this Cosmos DB account.
+* `network_acl_bypass_ids` - (Optional) The list of resource Ids for Network Acl Bypass for this Cosmos DB account.
 
 ---
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -110,7 +110,7 @@ The following arguments are supported:
 
 * `mongo_server_version` - (Optional) The Server Version of a MongoDB account. Possible values are `4.0`, `3.6`, and `3.2`. Changing this forces a new resource to be created.
 
-* `network_acl_bypass_for_azure_servers` - (Optional) If azure services can bypass ACLs. Defaults to `false`.
+* `network_acl_bypass_for_azure_services` - (Optional) If azure services can bypass ACLs. Defaults to `false`.
 
 * `network_acl_bypass_ids` - (Optional) The list of resource Ids for Network Acl Bypass for this Cosmos DB account.
 


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/11487