### PR TITLE
Empty resource group name gives less-misleading error

### DIFF
--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -95,8 +95,10 @@ func ValidateResourceGroupName(v interface{}, k string) (warnings []string, erro
 		errors = append(errors, fmt.Errorf("%q may not end with a period", k))
 	}
 
-	// regex pulled from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate
-	if matched := regexp.MustCompile(`^[-\w._()]+$`).Match([]byte(value)); !matched {
+	if len(value) == 0 {
+		errors = append(errors, fmt.Errorf("%q cannot be blank", k))
+	} else if matched := regexp.MustCompile(`^[-\w._()]+$`).Match([]byte(value)); !matched {
+		// regex pulled from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, dash, underscores, parentheses and periods", k))
 	}
 

--- a/azurerm/helpers/azure/resource_group_test.go
+++ b/azurerm/helpers/azure/resource_group_test.go
@@ -1,6 +1,7 @@
 package azure_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -11,10 +12,12 @@ func TestValidateResourceGroupName(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
+		Message  string
 	}{
 		{
 			Value:    "",
 			ErrCount: 1,
+			Message:  "cannot be blank",
 		},
 		{
 			Value:    "hello",
@@ -64,6 +67,13 @@ func TestValidateResourceGroupName(t *testing.T) {
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected "+
 				"validateResourceGroupName to trigger '%d' errors for '%s' - got '%d'", tc.ErrCount, tc.Value, len(errors))
+		} else if len(errors) == 1 && tc.Message != "" {
+			var errorMessage = errors[0].Error()
+
+			if !strings.Contains(errorMessage, tc.Message) {
+				t.Fatalf("Expected "+
+					"validateResourceGroupName to report an error including '%s' for '%s' - got '%s'", tc.Message, tc.Value, errorMessage)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Addresses issue #11511.

We now return a specific error message when a resource group name is empty, rather than a list of disallowed characters that an empty string -- by definition -- can't possibly contain.