### PR TITLE
Remove default value for `default_service_version` in `blob_properties` in `azurerm_storage_account`

### DIFF
--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -288,7 +288,7 @@ func resourceStorageAccount() *schema.Resource {
 						"default_service_version": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Default:      "2020-06-12",
+							Computed:     true,
 							ValidateFunc: validate.BlobPropertiesDefaultServiceVersion,
 						},
 

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -535,7 +535,6 @@ func TestAccStorageAccount_blobProperties(t *testing.T) {
 				check.That(data.ResourceName).Key("blob_properties.0.cors_rule.#").HasValue("2"),
 				check.That(data.ResourceName).Key("blob_properties.0.delete_retention_policy.0.days").HasValue("7"),
 				check.That(data.ResourceName).Key("blob_properties.0.versioning_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("blob_properties.0.default_service_version").HasValue("2020-06-12"),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
The `default_service_version` may change over time. So it may cause breaking changes in the future.