### PR TITLE
Support for `conflict_resolution_policy` in `azurerm_cosmosdb_sql_container`

### DIFF
--- a/azurerm/internal/services/cosmos/common/conflict_resolution_policy.go
+++ b/azurerm/internal/services/cosmos/common/conflict_resolution_policy.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-01-15/documentdb"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func ExpandCosmosDbConflicResolutionPolicy(inputs []interface{}) *documentdb.ConflictResolutionPolicy {
+	if len(inputs) == 0 || inputs[0] == nil {
+		return nil
+	}
+
+	input := inputs[0].(map[string]interface{})
+	conflictResolutionMode := input["mode"].(string)
+	conflict := &documentdb.ConflictResolutionPolicy{
+		Mode: documentdb.ConflictResolutionMode(conflictResolutionMode),
+	}
+
+	if conflictResolutionPath, ok := input["conflict_resolution_path"].(string); ok {
+		conflict.ConflictResolutionPath = utils.String(conflictResolutionPath)
+	}
+
+	if conflictResolutionProcedure, ok := input["conflict_resolution_procedure"].(string); ok {
+		conflict.ConflictResolutionProcedure = utils.String(conflictResolutionProcedure)
+	}
+
+	return conflict
+}
+
+func FlattenCosmosDbConflictResolutionPolicy(input *documentdb.ConflictResolutionPolicy) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+	conflictResolutionPolicy := make(map[string]interface{})
+
+	conflictResolutionPolicy["mode"] = string(input.Mode)
+	var path, procedure string
+	if input.ConflictResolutionPath != nil {
+		path = *input.ConflictResolutionPath
+	}
+	if input.ConflictResolutionProcedure != nil {
+		procedure = *input.ConflictResolutionProcedure
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"mode":                          string(input.Mode),
+			"conflict_resolution_path":      path,
+			"conflict_resolution_procedure": procedure,
+		},
+	}
+}

--- a/azurerm/internal/services/cosmos/common/schema.go
+++ b/azurerm/internal/services/cosmos/common/schema.go
@@ -189,3 +189,37 @@ func CosmosDbIndexingPolicySchema() *schema.Schema {
 		},
 	}
 }
+
+func ConflictResolutionPolicy() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"mode": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(documentdb.LastWriterWins),
+						string(documentdb.Custom),
+					}, false),
+				},
+
+				"conflict_resolution_path": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"conflict_resolution_procedure": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
@@ -170,11 +170,6 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
     included_paths = ["/*"]
     excluded_paths = ["/\"_etag\"/?"]
   }
-
-  conflict_resolution_policy {
-    mode                     = "LastWriterWins"
-    conflict_resolution_path = "/_ts"
-  }
 }
 `, CosmosGremlinDatabaseResource{}.basic(data), data.RandomInteger)
 }
@@ -195,11 +190,6 @@ resource "azurerm_cosmosdb_gremlin_graph" "import" {
     indexing_mode  = "Consistent"
     included_paths = ["/*"]
     excluded_paths = ["/\"_etag\"/?"]
-  }
-
-  conflict_resolution_policy {
-    mode                     = "LastWriterWins"
-    conflict_resolution_path = "/_ts"
   }
 }
 `, r.basic(data))
@@ -277,11 +267,6 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
     excluded_paths = ["/\"_etag\"/?"]
   }
 
-  conflict_resolution_policy {
-    mode                     = "LastWriterWins"
-    conflict_resolution_path = "/_ts"
-  }
-
   unique_key {
     paths = ["/definition/id1", "/definition/id2"]
   }
@@ -309,11 +294,6 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
     indexing_mode  = "Consistent"
     included_paths = ["/*"]
     excluded_paths = ["/\"_etag\"/?"]
-  }
-
-  conflict_resolution_policy {
-    mode                     = "LastWriterWins"
-    conflict_resolution_path = "/_ts"
   }
 }
 `, CosmosGremlinDatabaseResource{}.basic(data), data.RandomInteger, maxThroughput)

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -82,6 +82,8 @@ func resourceCosmosDbSQLContainer() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 2),
 			},
 
+			"conflict_resolution_policy": common.ConflictResolutionPolicy(),
+
 			"throughput": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -135,11 +137,11 @@ func resourceCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interface{}
 	existing, err := client.GetSQLContainer(ctx, resourceGroup, account, database, name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("Error checking for presence of creating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
+			return fmt.Errorf("checking for presence of creating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
 		}
 	} else {
 		if existing.ID == nil && *existing.ID == "" {
-			return fmt.Errorf("Error generating import ID for Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
+			return fmt.Errorf("generating import ID for Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
 		}
 
 		return tf.ImportAsExistsError("azurerm_cosmosdb_sql_container", *existing.ID)
@@ -148,7 +150,7 @@ func resourceCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interface{}
 	indexingPolicy := common.ExpandAzureRmCosmosDbIndexingPolicy(d)
 	err = common.ValidateAzureRmCosmosDbIndexingPolicy(indexingPolicy)
 	if err != nil {
-		return fmt.Errorf("Error generating indexing policy for Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
+		return fmt.Errorf("generating indexing policy for Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
 	}
 
 	db := documentdb.SQLContainerCreateUpdateParameters{
@@ -156,6 +158,8 @@ func resourceCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interface{}
 			Resource: &documentdb.SQLContainerResource{
 				ID:             &name,
 				IndexingPolicy: indexingPolicy,
+
+				ConflictResolutionPolicy: common.ExpandCosmosDbConflicResolutionPolicy(d.Get("conflict_resolution_policy").([]interface{})),
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},
@@ -194,20 +198,20 @@ func resourceCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interface{}
 
 	future, err := client.CreateUpdateSQLContainer(ctx, resourceGroup, account, database, name, db)
 	if err != nil {
-		return fmt.Errorf("Error issuing create/update request for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
+		return fmt.Errorf("issuing create/update request for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting on create/update future for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
+		return fmt.Errorf("waiting on create/update future for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
 	}
 
 	resp, err := client.GetSQLContainer(ctx, resourceGroup, account, database, name)
 	if err != nil {
-		return fmt.Errorf("Error making get request for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
+		return fmt.Errorf("making get request for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", name, account, database, err)
 	}
 
 	if resp.ID == nil {
-		return fmt.Errorf("Error getting ID from Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
+		return fmt.Errorf("getting ID from Cosmos SQL Container %q (Account: %q, Database: %q)", name, account, database)
 	}
 
 	d.SetId(*resp.ID)
@@ -227,7 +231,7 @@ func resourceCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interface{}
 
 	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
 	if err != nil {
-		return fmt.Errorf("Error updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
+		return fmt.Errorf("updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
 	}
 
 	partitionkeypaths := d.Get("partition_key_path").(string)
@@ -235,7 +239,7 @@ func resourceCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interface{}
 	indexingPolicy := common.ExpandAzureRmCosmosDbIndexingPolicy(d)
 	err = common.ValidateAzureRmCosmosDbIndexingPolicy(indexingPolicy)
 	if err != nil {
-		return fmt.Errorf("Error updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
+		return fmt.Errorf("updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
 	}
 
 	db := documentdb.SQLContainerCreateUpdateParameters{
@@ -271,11 +275,11 @@ func resourceCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interface{}
 
 	future, err := client.CreateUpdateSQLContainer(ctx, id.ResourceGroup, id.DatabaseAccountName, id.SqlDatabaseName, id.ContainerName, db)
 	if err != nil {
-		return fmt.Errorf("Error issuing create/update request for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
+		return fmt.Errorf("issuing create/update request for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting on create/update future for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
+		return fmt.Errorf("waiting on create/update future for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
 	}
 
 	if common.HasThroughputChange(d) {
@@ -283,13 +287,13 @@ func resourceCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interface{}
 		throughputFuture, err := client.UpdateSQLContainerThroughput(ctx, id.ResourceGroup, id.DatabaseAccountName, id.SqlDatabaseName, id.ContainerName, *throughputParameters)
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
-				return fmt.Errorf("Error setting Throughput for Cosmos SQL Container %q (Account: %q, Database: %q): %+v - "+
-					"If the collection has not been created with an initial throughput, you cannot configure it later.", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
+				return fmt.Errorf("setting Throughput for Cosmos SQL Container %q (Account: %q, Database: %q): %+v - "+
+					"If the collection has not been created with an initial throughput, you cannot configure it later", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
 			}
 		}
 
 		if err = throughputFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("Error waiting on ThroughputUpdate future for Cosmos Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
+			return fmt.Errorf("waiting on ThroughputUpdate future for Cosmos Container %q (Account: %q, Database: %q): %+v", id.ContainerName, id.DatabaseAccountName, id.SqlDatabaseName, err)
 		}
 	}
 
@@ -315,7 +319,7 @@ func resourceCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Cosmos SQL Container %q (Account: %q): %+v", id.SqlDatabaseName, id.ContainerName, err)
+		return fmt.Errorf("reading Cosmos SQL Container %q (Account: %q): %+v", id.SqlDatabaseName, id.ContainerName, err)
 	}
 
 	d.Set("name", id.ContainerName)
@@ -328,7 +332,7 @@ func resourceCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{}) 
 			if pk := res.PartitionKey; pk != nil {
 				if paths := pk.Paths; paths != nil {
 					if len(*paths) > 1 {
-						return fmt.Errorf("Error reading PartitionKey Paths, more then 1 returned")
+						return fmt.Errorf("reading PartitionKey Paths, more then 1 returned")
 					} else if len(*paths) == 1 {
 						d.Set("partition_key_path", (*paths)[0])
 					}
@@ -340,7 +344,7 @@ func resourceCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{}) 
 
 			if ukp := res.UniqueKeyPolicy; ukp != nil {
 				if err := d.Set("unique_key", flattenCosmosSQLContainerUniqueKeys(ukp.UniqueKeys)); err != nil {
-					return fmt.Errorf("Error setting `unique_key`: %+v", err)
+					return fmt.Errorf("setting `unique_key`: %+v", err)
 				}
 			}
 
@@ -350,6 +354,10 @@ func resourceCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{}) 
 
 			if indexingPolicy := res.IndexingPolicy; indexingPolicy != nil {
 				d.Set("indexing_policy", common.FlattenAzureRmCosmosDbIndexingPolicy(indexingPolicy))
+			}
+
+			if err := d.Set("conflict_resolution_policy", common.FlattenCosmosDbConflictResolutionPolicy(res.ConflictResolutionPolicy)); err != nil {
+				return fmt.Errorf("setting `conflict_resolution_policy`: %+v", err)
 			}
 		}
 	}

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -177,6 +177,21 @@ func TestAccCosmosDbSqlContainer_partition_key_version(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDbSqlContainer_customConflictResolutionPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_container", "test")
+	r := CosmosSqlContainerResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.conflictResolutionPolicy(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t CosmosSqlContainerResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.SqlContainerID(state.ID)
 	if err != nil {
@@ -410,4 +425,23 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   partition_key_version = %[3]d
 }
 `, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger, version)
+}
+
+func (CosmosSqlContainerResource) conflictResolutionPolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/definition/id"
+
+  conflict_resolution_policy {
+    mode                          = "Custom"
+    conflict_resolution_procedure = "dbs/{0}/colls/{1}/sprocs/{2}"
+  }
+}
+`, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger)
 }

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below. Changing this forces a new resource to be created.
 
-* `conflict_resolution_policy` - (Required) The conflict resolution policy for the graph. One or more `conflict_resolution_policy` blocks as defined below. Changing this forces a new resource to be created.
+* `conflict_resolution_policy` - (Optional)  A `conflict_resolution_policy` blocks as defined below.
 
 * `unique_key` (Optional) One or more `unique_key` blocks as defined below. Changing this forces a new resource to be created.
 

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 
+* `conflict_resolution_policy` - (Optional)  A `conflict_resolution_policy` blocks as defined below.
+
 ---
 
 An `autoscale_settings` block supports the following:
@@ -110,6 +112,16 @@ An `index` block supports the following:
 * `path` - Path for which the indexing behaviour applies to.
 
 * `order` - Order of the index. Possible values are `Ascending` or `Descending`.
+
+---
+
+A `conflict_resolution_policy` block supports the following:
+
+* `mode` - (Required) Indicates the conflict resolution mode. Possible values include: `LastWriterWins`, `Custom`.
+
+* `conflict_resolution_path` - (Optional) The conflict resolution path in the case of `LastWriterWins` mode.
+
+* `conflict_resolution_procedure` - (Optional) The procedure to resolve conflicts in the case of `Custom` mode.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/11516

changes on gremlin graph:
`conflict_resolution_policy` changes from Required to Optional and Computed. All tests have passed.

sql container:
=== RUN   TestAccCosmosDbSqlContainer_basic
=== PAUSE TestAccCosmosDbSqlContainer_basic
=== CONT  TestAccCosmosDbSqlContainer_basic
--- PASS: TestAccCosmosDbSqlContainer_basic (1243.44s)
=== RUN   TestAccCosmosDbSqlContainer_basic_serverless
=== PAUSE TestAccCosmosDbSqlContainer_basic_serverless
=== CONT  TestAccCosmosDbSqlContainer_basic_serverless
--- PASS: TestAccCosmosDbSqlContainer_basic_serverless (1285.10s)
=== RUN   TestAccCosmosDbSqlContainer_complete
=== PAUSE TestAccCosmosDbSqlContainer_complete
=== CONT  TestAccCosmosDbSqlContainer_complete
--- PASS: TestAccCosmosDbSqlContainer_complete (1316.33s)
=== RUN   TestAccCosmosDbSqlContainer_update
=== PAUSE TestAccCosmosDbSqlContainer_update
=== CONT  TestAccCosmosDbSqlContainer_update
--- PASS: TestAccCosmosDbSqlContainer_update (1589.50s)
=== RUN   TestAccCosmosDbSqlContainer_autoscale
=== PAUSE TestAccCosmosDbSqlContainer_autoscale
=== CONT  TestAccCosmosDbSqlContainer_autoscale
--- PASS: TestAccCosmosDbSqlContainer_autoscale (1915.56s)
=== RUN   TestAccCosmosDbSqlContainer_indexing_policy
=== PAUSE TestAccCosmosDbSqlContainer_indexing_policy
=== CONT  TestAccCosmosDbSqlContainer_indexing_policy
--- PASS: TestAccCosmosDbSqlContainer_indexing_policy (1883.89s)
=== RUN   TestAccCosmosDbSqlContainer_partition_key_version
=== PAUSE TestAccCosmosDbSqlContainer_partition_key_version
=== CONT  TestAccCosmosDbSqlContainer_partition_key_version
--- PASS: TestAccCosmosDbSqlContainer_partition_key_version (1335.42s)
=== RUN   TestAccCosmosDbSqlContainer_customConflictResolutionPolicy
=== PAUSE TestAccCosmosDbSqlContainer_customConflictResolutionPolicy
=== CONT  TestAccCosmosDbSqlContainer_customConflictResolutionPolicy
--- PASS: TestAccCosmosDbSqlContainer_customConflictResolutionPolicy (1364.63s)

gremlin graph:
=== RUN   TestAccCosmosDbGremlinGraph_basic
=== PAUSE TestAccCosmosDbGremlinGraph_basic
=== CONT  TestAccCosmosDbGremlinGraph_basic
--- PASS: TestAccCosmosDbGremlinGraph_basic (1312.91s)
=== RUN   TestAccCosmosDbGremlinGraph_requiresImport
=== PAUSE TestAccCosmosDbGremlinGraph_requiresImport
=== CONT  TestAccCosmosDbGremlinGraph_requiresImport
--- PASS: TestAccCosmosDbGremlinGraph_requiresImport (1407.86s)
=== RUN   TestAccCosmosDbGremlinGraph_customConflictResolutionPolicy
=== PAUSE TestAccCosmosDbGremlinGraph_customConflictResolutionPolicy
=== CONT  TestAccCosmosDbGremlinGraph_customConflictResolutionPolicy
--- PASS: TestAccCosmosDbGremlinGraph_customConflictResolutionPolicy (1325.06s)
=== RUN   TestAccCosmosDbGremlinGraph_indexPolicy
=== PAUSE TestAccCosmosDbGremlinGraph_indexPolicy
=== CONT  TestAccCosmosDbGremlinGraph_indexPolicy
--- PASS: TestAccCosmosDbGremlinGraph_indexPolicy (1264.18s)
=== RUN   TestAccCosmosDbGremlinGraph_update
=== PAUSE TestAccCosmosDbGremlinGraph_update
=== CONT  TestAccCosmosDbGremlinGraph_update
--- PASS: TestAccCosmosDbGremlinGraph_update (1738.12s)
=== RUN   TestAccCosmosDbGremlinGraph_autoscale
=== PAUSE TestAccCosmosDbGremlinGraph_autoscale
=== CONT  TestAccCosmosDbGremlinGraph_autoscale
--- PASS: TestAccCosmosDbGremlinGraph_autoscale (1985.56s)
