### PR TITLE
azurerm_network_connection_monitor - support `coverage_level`, `excluded_ip_addresses`, `included_ip_addresses`, `target_resource_id`, `resource_type`

### DIFF
--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -871,12 +871,11 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]network.ConnectionMonitorE
 		}
 
 		v := map[string]interface{}{
-			"name":               name,
-			"address":            address,
-			"resource_id":        resourceId,
-			"type":               endpointType,
-			"filter":             flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
-			"virtual_machine_id": resourceId,
+			"name":        name,
+			"address":     address,
+			"resource_id": resourceId,
+			"type":        endpointType,
+			"filter":      flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
 		}
 
 		results = append(results, v)

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -624,7 +624,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) (*[]network.Con
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
-		if v["resource_id"].(string) != "" && v["virtual_machine_id"] != "" {
+		if v["resource_id"].(string) != "" && v["virtual_machine_id"].(string) != "" {
 			return nil, fmt.Errorf("`resource_id` and `virtual_machine_id` cannot be set together")
 		}
 

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -251,7 +251,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							),
 						},
 
-						"type": {
+						"target_resource_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
@@ -709,7 +709,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) (*[]network.Con
 			result.ResourceID = utils.String(resourceId.(string))
 		}
 
-		if endpointType := v["type"]; endpointType != "" {
+		if endpointType := v["target_resource_type"]; endpointType != "" {
 			result.Type = network.EndpointType(endpointType.(string))
 		}
 
@@ -944,12 +944,12 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]network.ConnectionMonitorE
 		}
 
 		v := map[string]interface{}{
-			"name":               name,
-			"address":            address,
-			"coverage_level":     coverageLevel,
-			"target_resource_id": resourceId,
-			"type":               endpointType,
-			"filter":             flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
+			"name":                 name,
+			"address":              address,
+			"coverage_level":       coverageLevel,
+			"target_resource_id":   resourceId,
+			"target_resource_type": endpointType,
+			"filter":               flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
 		}
 
 		if scope := item.Scope; scope != nil {

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -207,6 +207,8 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							ValidateFunc: validation.Any(
 								computeValidate.VirtualMachineID,
 								logAnalyticsValidate.LogAnalyticsWorkspaceID,
+								networkValidate.SubnetID,
+								networkValidate.VirtualNetworkID,
 							),
 						},
 

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -176,7 +176,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
-								Type:         schema.TypeString,
+								Type: schema.TypeString,
 								ValidateFunc: validation.Any(
 									validation.IsIPv4Address,
 									validation.IsIPv6Address,
@@ -230,7 +230,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
-								Type:         schema.TypeString,
+								Type: schema.TypeString,
 								ValidateFunc: validation.Any(
 									validation.IsIPv4Address,
 									validation.IsIPv6Address,

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-07-01/network"
@@ -13,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	logAnalyticsValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
@@ -219,11 +219,11 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 						},
 
 						"virtual_machine_id": {
-							Type:       schema.TypeString,
-							Optional:   true,
-							Computed:   true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
 							ValidateFunc: computeValidate.VirtualMachineID,
-							Deprecated: "Deprecated in favour of `resource_id` since the service API supports more endpoint types",
+							Deprecated:   "Deprecated in favour of `resource_id` since the service API supports more resource types",
 						},
 					},
 				},

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -869,11 +869,12 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]network.ConnectionMonitorE
 		}
 
 		v := map[string]interface{}{
-			"name":        name,
-			"address":     address,
-			"resource_id": resourceId,
-			"type":        endpointType,
-			"filter":      flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
+			"name":               name,
+			"address":            address,
+			"resource_id":        resourceId,
+			"type":               endpointType,
+			"filter":             flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
+			"virtual_machine_id": resourceId,
 		}
 
 		results = append(results, v)

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -218,6 +218,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							}, false),
 						},
 
+						// TODO 3.0 - remove this property
 						"virtual_machine_id": {
 							Type:         schema.TypeString,
 							Optional:     true,

--- a/azurerm/internal/services/network/network_connection_monitor_resource.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource.go
@@ -172,7 +172,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							}, false),
 						},
 
-						"excluded_addresses": {
+						"excluded_ip_addresses": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
@@ -226,7 +226,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							},
 						},
 
-						"included_addresses": {
+						"included_ip_addresses": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
@@ -239,7 +239,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							},
 						},
 
-						"resource_id": {
+						"target_resource_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
@@ -269,7 +269,7 @@ func resourceNetworkConnectionMonitor() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: computeValidate.VirtualMachineID,
-							Deprecated:   "This property has been renamed to `resource_id` and will be removed in v3.0 of the provider.",
+							Deprecated:   "This property has been renamed to `target_resource_id` and will be removed in v3.0 of the provider.",
 						},
 					},
 				},
@@ -662,8 +662,8 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) (*[]network.Con
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
-		if v["resource_id"] != nil && v["resource_id"].(string) != "" && v["virtual_machine_id"] != nil && v["virtual_machine_id"].(string) != "" {
-			return nil, fmt.Errorf("`resource_id` and `virtual_machine_id` cannot be set together")
+		if v["target_resource_id"] != nil && v["target_resource_id"].(string) != "" && v["virtual_machine_id"] != nil && v["virtual_machine_id"].(string) != "" {
+			return nil, fmt.Errorf("`target_resource_id` and `virtual_machine_id` cannot be set together")
 		}
 
 		result := network.ConnectionMonitorEndpoint{
@@ -679,8 +679,8 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) (*[]network.Con
 			result.CoverageLevel = network.CoverageLevel(coverageLevel.(string))
 		}
 
-		excludedItems := v["excluded_addresses"].(*schema.Set).List()
-		includedItems := v["included_addresses"].(*schema.Set).List()
+		excludedItems := v["excluded_ip_addresses"].(*schema.Set).List()
+		includedItems := v["included_ip_addresses"].(*schema.Set).List()
 		if len(excludedItems) != 0 || len(includedItems) != 0 {
 			result.Scope = &network.ConnectionMonitorEndpointScope{}
 
@@ -705,7 +705,7 @@ func expandNetworkConnectionMonitorEndpoint(input []interface{}) (*[]network.Con
 			}
 		}
 
-		if resourceId := v["resource_id"]; resourceId != "" {
+		if resourceId := v["target_resource_id"]; resourceId != "" {
 			result.ResourceID = utils.String(resourceId.(string))
 		}
 
@@ -944,12 +944,12 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]network.ConnectionMonitorE
 		}
 
 		v := map[string]interface{}{
-			"name":           name,
-			"address":        address,
-			"coverage_level": coverageLevel,
-			"resource_id":    resourceId,
-			"type":           endpointType,
-			"filter":         flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
+			"name":               name,
+			"address":            address,
+			"coverage_level":     coverageLevel,
+			"target_resource_id": resourceId,
+			"type":               endpointType,
+			"filter":             flattenNetworkConnectionMonitorEndpointFilter(item.Filter),
 		}
 
 		if scope := item.Scope; scope != nil {
@@ -962,7 +962,7 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]network.ConnectionMonitorE
 					}
 				}
 
-				v["included_addresses"] = includedAddresses
+				v["included_ip_addresses"] = includedAddresses
 			}
 
 			if excludeScope := scope.Exclude; excludeScope != nil {
@@ -974,7 +974,7 @@ func flattenNetworkConnectionMonitorEndpoint(input *[]network.ConnectionMonitorE
 					}
 				}
 
-				v["excluded_addresses"] = excludedAddresses
+				v["excluded_ip_addresses"] = excludedAddresses
 			}
 		}
 

--- a/azurerm/internal/services/network/network_connection_monitor_resource_test.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource_test.go
@@ -905,10 +905,10 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    type               = "MMAWorkspaceMachine"
-    address            = "test.internal.domain.com"
-    target_resource_id = azurerm_log_analytics_workspace.test.id
+    name                 = "source"
+    target_resource_type = "MMAWorkspaceMachine"
+    address              = "test.internal.domain.com"
+    target_resource_id   = azurerm_log_analytics_workspace.test.id
   }
 
   endpoint {
@@ -948,7 +948,7 @@ resource "azurerm_network_connection_monitor" "test" {
 
   endpoint {
     name                  = "source"
-    type                  = "AzureVNet"
+    target_resource_type  = "AzureVNet"
     target_resource_id    = azurerm_virtual_network.test.id
     included_ip_addresses = azurerm_subnet.test.address_prefixes
     excluded_ip_addresses = ["10.0.2.2", "10.0.2.3"]
@@ -999,7 +999,7 @@ resource "azurerm_network_connection_monitor" "test" {
 
   endpoint {
     name                  = "source"
-    type                  = "AzureVNet"
+    target_resource_type  = "AzureVNet"
     target_resource_id    = azurerm_virtual_network.test.id
     included_ip_addresses = azurerm_subnet.test2.address_prefixes
     excluded_ip_addresses = ["10.0.3.2"]

--- a/azurerm/internal/services/network/network_connection_monitor_resource_test.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource_test.go
@@ -172,7 +172,7 @@ func testAccNetworkConnectionMonitor_missingDestination(t *testing.T) {
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
 			Config:      r.missingDestinationConfig(data),
-			ExpectError: regexp.MustCompile("must have at least 2 endpoints"),
+			ExpectError: regexp.MustCompile("should have at least one destination"),
 		},
 	})
 }
@@ -791,8 +791,8 @@ resource "azurerm_network_connection_monitor" "test" {
   }
 
   endpoint {
-    name    = "destination"
-    address = "terraform.io"
+    name               = "destination"
+    target_resource_id = azurerm_virtual_machine.dest.id
   }
 
   test_configuration {
@@ -822,7 +822,7 @@ resource "azurerm_network_connection_monitor" "test" {
 
   depends_on = [azurerm_virtual_machine_extension.src]
 }
-`, r.baseConfig(data), data.RandomInteger)
+`, r.baseWithDestConfig(data), data.RandomInteger)
 }
 
 func (r NetworkConnectionMonitorResource) icmpConfigurationConfig(data acceptance.TestData) string {

--- a/azurerm/internal/services/network/network_connection_monitor_resource_test.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource_test.go
@@ -423,8 +423,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -470,8 +470,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
 
     filter {
       item {
@@ -535,13 +535,13 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
-    name        = "destination"
-    resource_id = azurerm_virtual_machine.dest.id
+    name               = "destination"
+    target_resource_id = azurerm_virtual_machine.dest.id
   }
 
   test_configuration {
@@ -575,14 +575,14 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
-    name        = "destination"
-    resource_id = azurerm_virtual_machine.dest.id
-    address     = azurerm_network_interface.dest.private_ip_address
+    name               = "destination"
+    target_resource_id = azurerm_virtual_machine.dest.id
+    address            = azurerm_network_interface.dest.private_ip_address
   }
 
   test_configuration {
@@ -616,8 +616,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
 
     filter {
       item {
@@ -630,8 +630,8 @@ resource "azurerm_network_connection_monitor" "test" {
   }
 
   endpoint {
-    name        = "destination"
-    resource_id = azurerm_virtual_machine.dest.id
+    name               = "destination"
+    target_resource_id = azurerm_virtual_machine.dest.id
   }
 
   test_configuration {
@@ -671,8 +671,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   test_configuration {
@@ -706,13 +706,13 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
-    name        = "destination"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "destination"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   test_configuration {
@@ -746,8 +746,8 @@ resource "azurerm_network_connection_monitor" "import" {
   location           = azurerm_network_connection_monitor.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -786,8 +786,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -835,8 +835,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.src.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -883,10 +883,10 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name        = "source"
-    type        = "MMAWorkspaceMachine"
-    address     = "test.internal.domain.com"
-    resource_id = azurerm_log_analytics_workspace.test.id
+    name               = "source"
+    type               = "MMAWorkspaceMachine"
+    address            = "test.internal.domain.com"
+    target_resource_id = azurerm_log_analytics_workspace.test.id
   }
 
   endpoint {

--- a/azurerm/internal/services/network/network_connection_monitor_resource_test.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource_test.go
@@ -234,11 +234,18 @@ func testAccNetworkConnectionMonitor_icmpConfiguration(t *testing.T) {
 	})
 }
 
-func testAccNetworkConnectionMonitor_updateEndpointType(t *testing.T) {
+func testAccNetworkConnectionMonitor_endpointType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_connection_monitor", "test")
 	r := NetworkConnectionMonitorResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.endpointType(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.basicAddressConfig(data),
 			Check: resource.ComposeTestCheckFunc(
@@ -876,10 +883,10 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    type               = "MMAWorkspaceMachine"
-    address            = "test.internal.domain.com"
-    resource_id        = azurerm_log_analytics_workspace.test.id
+    name        = "source"
+    type        = "MMAWorkspaceMachine"
+    address     = "test.internal.domain.com"
+    resource_id = azurerm_log_analytics_workspace.test.id
   }
 
   endpoint {

--- a/azurerm/internal/services/network/network_connection_monitor_resource_test.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource_test.go
@@ -234,13 +234,13 @@ func testAccNetworkConnectionMonitor_icmpConfiguration(t *testing.T) {
 	})
 }
 
-func testAccNetworkConnectionMonitor_endpointType(t *testing.T) {
+func testAccNetworkConnectionMonitor_endpointDeprecated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_connection_monitor", "test")
 	r := NetworkConnectionMonitorResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.endpointType(data),
+			Config: r.endpointDeprecated(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -254,7 +254,7 @@ func testAccNetworkConnectionMonitor_endpointType(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.endpointType(data),
+			Config: r.endpointDeprecated(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -865,7 +865,7 @@ resource "azurerm_network_connection_monitor" "test" {
 `, r.baseConfig(data), data.RandomInteger)
 }
 
-func (r NetworkConnectionMonitorResource) endpointType(data acceptance.TestData) string {
+func (r NetworkConnectionMonitorResource) endpointDeprecated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/internal/services/network/network_connection_monitor_resource_test.go
+++ b/azurerm/internal/services/network/network_connection_monitor_resource_test.go
@@ -423,8 +423,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -470,8 +470,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
 
     filter {
       item {
@@ -535,13 +535,13 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
-    name               = "destination"
-    virtual_machine_id = azurerm_virtual_machine.dest.id
+    name        = "destination"
+    resource_id = azurerm_virtual_machine.dest.id
   }
 
   test_configuration {
@@ -575,14 +575,14 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
-    name               = "destination"
-    virtual_machine_id = azurerm_virtual_machine.dest.id
-    address            = azurerm_network_interface.dest.private_ip_address
+    name        = "destination"
+    resource_id = azurerm_virtual_machine.dest.id
+    address     = azurerm_network_interface.dest.private_ip_address
   }
 
   test_configuration {
@@ -616,8 +616,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
 
     filter {
       item {
@@ -630,8 +630,8 @@ resource "azurerm_network_connection_monitor" "test" {
   }
 
   endpoint {
-    name               = "destination"
-    virtual_machine_id = azurerm_virtual_machine.dest.id
+    name        = "destination"
+    resource_id = azurerm_virtual_machine.dest.id
   }
 
   test_configuration {
@@ -671,8 +671,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   test_configuration {
@@ -706,13 +706,13 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
-    name               = "destination"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "destination"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   test_configuration {
@@ -746,8 +746,8 @@ resource "azurerm_network_connection_monitor" "import" {
   location           = azurerm_network_connection_monitor.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -786,8 +786,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {
@@ -835,8 +835,8 @@ resource "azurerm_network_connection_monitor" "test" {
   location           = azurerm_network_watcher.test.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.src.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.src.id
   }
 
   endpoint {

--- a/azurerm/internal/services/network/network_watcher_resource_test.go
+++ b/azurerm/internal/services/network/network_watcher_resource_test.go
@@ -53,7 +53,7 @@ func TestAccNetworkWatcher(t *testing.T) {
 			"httpConfiguration":              testAccNetworkConnectionMonitor_httpConfiguration,
 			"icmpConfiguration":              testAccNetworkConnectionMonitor_icmpConfiguration,
 			"bothAddressAndVirtualMachineId": testAccNetworkConnectionMonitor_withAddressAndVirtualMachineId,
-			"endpointType":                   testAccNetworkConnectionMonitor_updateEndpointType,
+			"endpointType":                   testAccNetworkConnectionMonitor_endpointType,
 		},
 		"PacketCapture": {
 			"localDisk":                  testAccNetworkPacketCapture_localDisk,

--- a/azurerm/internal/services/network/network_watcher_resource_test.go
+++ b/azurerm/internal/services/network/network_watcher_resource_test.go
@@ -53,6 +53,7 @@ func TestAccNetworkWatcher(t *testing.T) {
 			"httpConfiguration":              testAccNetworkConnectionMonitor_httpConfiguration,
 			"icmpConfiguration":              testAccNetworkConnectionMonitor_icmpConfiguration,
 			"bothAddressAndVirtualMachineId": testAccNetworkConnectionMonitor_withAddressAndVirtualMachineId,
+			"endpointType":                   testAccNetworkConnectionMonitor_updateEndpointType,
 		},
 		"PacketCapture": {
 			"localDisk":                  testAccNetworkPacketCapture_localDisk,

--- a/azurerm/internal/services/network/network_watcher_resource_test.go
+++ b/azurerm/internal/services/network/network_watcher_resource_test.go
@@ -54,6 +54,7 @@ func TestAccNetworkWatcher(t *testing.T) {
 			"icmpConfiguration":              testAccNetworkConnectionMonitor_icmpConfiguration,
 			"bothAddressAndVirtualMachineId": testAccNetworkConnectionMonitor_withAddressAndVirtualMachineId,
 			"endpointType":                   testAccNetworkConnectionMonitor_endpointDeprecated,
+			"updateEndpoint":                 testAccNetworkConnectionMonitor_updateEndpointIPAddressAndCoverageLevel,
 		},
 		"PacketCapture": {
 			"localDisk":                  testAccNetworkPacketCapture_localDisk,

--- a/azurerm/internal/services/network/network_watcher_resource_test.go
+++ b/azurerm/internal/services/network/network_watcher_resource_test.go
@@ -53,7 +53,7 @@ func TestAccNetworkWatcher(t *testing.T) {
 			"httpConfiguration":              testAccNetworkConnectionMonitor_httpConfiguration,
 			"icmpConfiguration":              testAccNetworkConnectionMonitor_icmpConfiguration,
 			"bothAddressAndVirtualMachineId": testAccNetworkConnectionMonitor_withAddressAndVirtualMachineId,
-			"endpointType":                   testAccNetworkConnectionMonitor_endpointType,
+			"endpointType":                   testAccNetworkConnectionMonitor_endpointDeprecated,
 		},
 		"PacketCapture": {
 			"localDisk":                  testAccNetworkPacketCapture_localDisk,

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -193,7 +193,7 @@ A `endpoint` block supports the following:
 
 * `filter` - (Optional) A `filter` block as defined below.
 
-* `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible values are `AzureSubnet`, `AzureVM`, `AzureVNet`, `ExternalAddress`, `MMAWorkspaceMachine` and `MMAWorkspaceNetwork`.
+* `target_resource_type` - (Optional) The endpoint type of the Network Connection Monitor. Possible values are `AzureSubnet`, `AzureVM`, `AzureVNet`, `ExternalAddress`, `MMAWorkspaceMachine` and `MMAWorkspaceNetwork`.
 
 * `virtual_machine_id` - (Optional / **Deprecated**) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor. This property is deprecated in favour of `target_resource_id`.
 

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -183,6 +183,10 @@ A `endpoint` block supports the following:
 
 * `address` - (Optional) The IP address or domain name of the Network Connection Monitor endpoint.
 
+* `excluded_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be excluded to the Network Connection Monitor endpoint.
+
+* `included_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be included to the Network Connection Monitor endpoint.
+
 * `resource_id` - (Optional) The resource ID which is used as the endpoint by the Network Connection Monitor.
 
 * `filter` - (Optional) A `filter` block as defined below.
@@ -190,6 +194,8 @@ A `endpoint` block supports the following:
 * `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible values are `AzureSubnet`, `AzureVM`, `AzureVNet`, `ExternalAddress`, `MMAWorkspaceMachine` and `MMAWorkspaceNetwork`.
 
 * `virtual_machine_id` - (Optional / **Deprecated**) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor. This property is deprecated in favour of `resource_id`.
+
+* `coverage_level` - (Optional) The test coverage for the Network Connection Monitor endpoint. Possible values are `AboveAverage`, `Average`, `BelowAverage`, `Default`, `Full` and `Low`.
 
 ---
 

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -183,6 +183,8 @@ A `endpoint` block supports the following:
 
 * `address` - (Optional) The IP address or domain name of the Network Connection Monitor endpoint.
 
+* `coverage_level` - (Optional) The test coverage for the Network Connection Monitor endpoint. Possible values are `AboveAverage`, `Average`, `BelowAverage`, `Default`, `Full` and `Low`.
+
 * `excluded_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be excluded to the Network Connection Monitor endpoint.
 
 * `included_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be included to the Network Connection Monitor endpoint.
@@ -194,8 +196,6 @@ A `endpoint` block supports the following:
 * `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible values are `AzureSubnet`, `AzureVM`, `AzureVNet`, `ExternalAddress`, `MMAWorkspaceMachine` and `MMAWorkspaceNetwork`.
 
 * `virtual_machine_id` - (Optional / **Deprecated**) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor. This property is deprecated in favour of `resource_id`.
-
-* `coverage_level` - (Optional) The test coverage for the Network Connection Monitor endpoint. Possible values are `AboveAverage`, `Average`, `BelowAverage`, `Default`, `Full` and `Low`.
 
 ---
 

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -187,9 +187,9 @@ A `endpoint` block supports the following:
 
 * `filter` - (Optional) A `filter` block as defined below.
 
-* `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible value is `MMAWorkspaceMachine`.
+* `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible values are `AzureSubnet`, `AzureVM`, `AzureVNet`, `ExternalAddress`, `MMAWorkspaceMachine` and `MMAWorkspaceNetwork`.
 
-* `virtual_machine_id` - (Optional/ **Deprecated) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor.
+* `virtual_machine_id` - (Optional / **Deprecated**) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor. This property is deprecated in favour of `resource_id`.
 
 ---
 

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -107,8 +107,8 @@ resource "azurerm_network_connection_monitor" "example" {
   location             = azurerm_network_watcher.example.location
 
   endpoint {
-    name        = "source"
-    resource_id = azurerm_virtual_machine.example.id
+    name               = "source"
+    target_resource_id = azurerm_virtual_machine.example.id
 
     filter {
       item {
@@ -195,7 +195,7 @@ A `endpoint` block supports the following:
 
 * `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible values are `AzureSubnet`, `AzureVM`, `AzureVNet`, `ExternalAddress`, `MMAWorkspaceMachine` and `MMAWorkspaceNetwork`.
 
-* `virtual_machine_id` - (Optional / **Deprecated**) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor. This property is deprecated in favour of `resource_id`.
+* `virtual_machine_id` - (Optional / **Deprecated**) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor. This property is deprecated in favour of `target_resource_id`.
 
 ---
 

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -107,8 +107,8 @@ resource "azurerm_network_connection_monitor" "example" {
   location             = azurerm_network_watcher.example.location
 
   endpoint {
-    name               = "source"
-    virtual_machine_id = azurerm_virtual_machine.example.id
+    name        = "source"
+    resource_id = azurerm_virtual_machine.example.id
 
     filter {
       item {

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -185,11 +185,11 @@ A `endpoint` block supports the following:
 
 * `coverage_level` - (Optional) The test coverage for the Network Connection Monitor endpoint. Possible values are `AboveAverage`, `Average`, `BelowAverage`, `Default`, `Full` and `Low`.
 
-* `excluded_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be excluded to the Network Connection Monitor endpoint.
+* `excluded_ip_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be excluded to the Network Connection Monitor endpoint.
 
-* `included_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be included to the Network Connection Monitor endpoint.
+* `included_ip_addresses` - (Optional) A list of IPv4/IPv6 subnet masks or IPv4/IPv6 IP addresses to be included to the Network Connection Monitor endpoint.
 
-* `resource_id` - (Optional) The resource ID which is used as the endpoint by the Network Connection Monitor.
+* `target_resource_id` - (Optional) The resource ID which is used as the endpoint by the Network Connection Monitor.
 
 * `filter` - (Optional) A `filter` block as defined below.
 

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -183,9 +183,13 @@ A `endpoint` block supports the following:
 
 * `address` - (Optional) The IP address or domain name of the Network Connection Monitor endpoint.
 
+* `resource_id` - (Optional) The resource ID which is used as the endpoint by the Network Connection Monitor.
+
 * `filter` - (Optional) A `filter` block as defined below.
 
-* `virtual_machine_id` - (Optional) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor.
+* `type` - (Optional) The endpoint type of the Network Connection Monitor. Possible value is `MMAWorkspaceMachine`.
+
+* `virtual_machine_id` - (Optional/ **Deprecated) The ID of the Virtual Machine which is used as the endpoint by the Network Connection Monitor.
 
 ---
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/10423