### PR TITLE
Correct azurerm_vpn_site link attribute name

### DIFF
--- a/website/docs/r/vpn_gateway_connection.html.markdown
+++ b/website/docs/r/vpn_gateway_connection.html.markdown
@@ -44,11 +44,11 @@ resource "azurerm_vpn_site" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   virtual_wan_id      = azurerm_virtual_wan.example.id
-  vpn_site_link {
+  link {
     name       = "link1"
     ip_address = "10.1.0.0"
   }
-  vpn_site_link {
+  link {
     name       = "link2"
     ip_address = "10.2.0.0"
   }


### PR DESCRIPTION
Correct in line with documentation available at https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/vpn_site