### PR TITLE
azurerm_key_vault_certificate: Compute key_size when key_type is lowercase

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -144,6 +144,9 @@ func resourceKeyVaultCertificate() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 										ForceNew: true,
+										DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+											return old == strings.ToUpper(new)
+										},
 										ValidateFunc: validation.StringInSlice([]string{
 											string(keyvault.EC),
 											string(keyvault.ECHSM),
@@ -706,7 +709,7 @@ func expandKeyVaultCertificatePolicy(d *schema.ResourceData) (*keyvault.Certific
 	props := properties[0].(map[string]interface{})
 
 	curve := props["curve"].(string)
-	keyType := props["key_type"].(string)
+	keyType := strings.ToUpper(props["key_type"].(string))
 	keySize := props["key_size"].(int)
 
 	if keyType == string(keyvault.EC) || keyType == string(keyvault.ECHSM) {

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -751,7 +751,7 @@ resource "azurerm_key_vault_certificate" "test" {
     key_properties {
       curve      = "P-521"
       exportable = true
-      key_type   = "EC"
+      key_type   = "ec"
       reuse_key  = true
     }
 


### PR DESCRIPTION
#10867 computes `key_properties.key_size` when `key_properties.key_type` is `EC`, but not when it's `ec` (which is also allowed by that PR). Let's fix that.