### PR TITLE
New feature: azurerm_data_factory_pipeline - Add optional folder parameter

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -86,6 +87,12 @@ func resourceDataFactoryPipeline() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
+			"folder": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -135,6 +142,13 @@ func resourceDataFactoryPipelineCreateUpdate(d *schema.ResourceData, meta interf
 	} else {
 		annotations := make([]interface{}, 0)
 		pipeline.Annotations = &annotations
+	}
+
+	if v, ok := d.GetOk("folder"); ok {
+		name := v.(string)
+		pipeline.Folder = &datafactory.PipelineFolder{
+			Name: &name,
+		}
 	}
 
 	config := datafactory.PipelineResource{
@@ -196,6 +210,12 @@ func resourceDataFactoryPipelineRead(d *schema.ResourceData, meta interface{}) e
 		annotations := flattenDataFactoryAnnotations(props.Annotations)
 		if err := d.Set("annotations", annotations); err != nil {
 			return fmt.Errorf("setting `annotations`: %+v", err)
+		}
+
+		if folder := props.Folder; folder != nil {
+			if folder.Name != nil {
+				d.Set("folder", folder.Name)
+			}
 		}
 
 		variables := flattenDataFactoryVariables(props.Variables)

--- a/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -56,6 +56,7 @@ func TestAccDataFactoryPipeline_update(t *testing.T) {
 				check.That(data.ResourceName).Key("annotations.#").HasValue("2"),
 				check.That(data.ResourceName).Key("description").HasValue("test description2"),
 				check.That(data.ResourceName).Key("variables.%").HasValue("3"),
+				check.That(data.ResourceName).Key("folder").HasValue("test-folder"),
 			),
 		},
 		data.ImportStep(),
@@ -218,7 +219,8 @@ resource "azurerm_data_factory_pipeline" "test" {
   data_factory_name   = azurerm_data_factory.test.name
   annotations         = ["test1", "test2"]
   description         = "test description2"
-
+  folder              = "test-folder"
+  
   parameters = {
     test  = "testparameter"
     test2 = "testparameter2"

--- a/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -220,7 +220,7 @@ resource "azurerm_data_factory_pipeline" "test" {
   annotations         = ["test1", "test2"]
   description         = "test description2"
   folder              = "test-folder"
-  
+
   parameters = {
     test  = "testparameter"
     test2 = "testparameter2"

--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `annotations` - (Optional) List of tags that can be used for describing the Data Factory Pipeline.
 
+* `folder` - (Optional) The folder that this Pipeline is in. If not specified, the Pipeline will appear at the root level.
+
 * `parameters` - (Optional) A map of parameters to associate with the Data Factory Pipeline.
 
 * `variables` - (Optional) A map of variables to associate with the Data Factory Pipeline.


### PR DESCRIPTION
Test output (minus debug logs):
```
➜  ~/go/src/github.com/terraform-providers/terraform-provider-azurerm: git:(f/datafactory-pipeline-folder) make acctests SERVICE='datafactory/data_factory_pipeline_resource_test.go' TESTTIMEOUT='60m'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go  -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataFactoryPipeline_basic
=== PAUSE TestAccDataFactoryPipeline_basic
=== RUN   TestAccDataFactoryPipeline_update
=== PAUSE TestAccDataFactoryPipeline_update
=== RUN   TestAccDataFactoryPipeline_activities
=== PAUSE TestAccDataFactoryPipeline_activities
=== CONT  TestAccDataFactoryPipeline_basic
=== CONT  TestAccDataFactoryPipeline_activities
=== CONT  TestAccDataFactoryPipeline_update
--- PASS: TestAccDataFactoryPipeline_basic (113.28s)
--- PASS: TestAccDataFactoryPipeline_update (150.46s)
--- PASS: TestAccDataFactoryPipeline_activities (199.26s)
PASS
ok  	command-line-arguments	(cached)
```