### PR TITLE
Add note to SQL server doc to use mssql resource instead

### DIFF
--- a/website/docs/d/sql_database.html.markdown
+++ b/website/docs/d/sql_database.html.markdown
@@ -36,8 +36,8 @@ output "sql_database_id" {
 
 * `id` - The SQL Database ID.
 
-* `collation` - The name of the collation. 
-    
+* `collation` - The name of the collation.
+
 * `creation_date` - The creation date of the SQL Database.
 
 * `default_secondary_location` - The default secondary location of the SQL Database.
@@ -51,17 +51,17 @@ output "sql_database_id" {
 * `location` - The location of the Resource Group in which the SQL Server exists.
 
 * `name` - The name of the database.
-    
+
 * `read_scale` - Indicate if read-only connections will be redirected to a high-available replica.
 
 * `requested_service_objective_id` - The ID pertaining to the performance level of the database.
- 
+
 * `requested_service_objective_name` - The name pertaining to the performance level of the database. 
 
 * `resource_group_name` - The name of the resource group in which the database resides. This will always be the same resource group as the Database Server.
 
 * `server_name` - The name of the SQL Server on which to create the database.
-    
+
 * `tags` - A mapping of tags assigned to the resource.
 
 ## Timeouts

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Allows you to manage an Azure SQL Database
 
+~> **Note:** Deprecated! Please use [mssql_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) for all future Microsoft SQL Azure Database Server uses.
+
 ~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
 ## Example Usage
@@ -61,6 +63,7 @@ resource "azurerm_sql_database" "example" {
   }
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -89,7 +92,7 @@ The following arguments are supported:
 
 * `requested_service_objective_id` - (Optional) A GUID/UUID corresponding to a configured Service Level Objective for the Azure SQL database which can be used to configure a performance level.
 .
-* `requested_service_objective_name` - (Optional) The service objective name for the database. Valid values depend on edition and location and may include `S0`, `S1`, `S2`, `S3`, `P1`, `P2`, `P4`, `P6`, `P11` and `ElasticPool`. You can list the available names with the cli: ```shell az sql db list-editions -l westus -o table ```. For further information please see [Azure CLI - az sql db](https://docs.microsoft.com/en-us/cli/azure/sql/db?view=azure-cli-latest#az-sql-db-list-editions).
+* `requested_service_objective_name` - (Optional) The service objective name for the database. Valid values depend on edition and location and may include `S0`, `S1`, `S2`, `S3`, `P1`, `P2`, `P4`, `P6`, `P11` and `ElasticPool`. You can list the available names with the cli: `shell az sql db list-editions -l westus -o table`. For further information please see [Azure CLI - az sql db](https://docs.microsoft.com/en-us/cli/azure/sql/db?view=azure-cli-latest#az-sql-db-list-editions).
 
 * `source_database_deletion_date` - (Optional) The deletion date time of the source database. Only applies to deleted databases where `create_mode` is `PointInTimeRestore`.
 

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages a Microsoft SQL Azure Database Server.
 
+~> **Note:** This resource provides usage of Microsoft SQL Azure Database server using an older `sku` based model. [It is recommended going forward](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10217#issuecomment-762036693) to use [`azurerm_mssql_server`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_server) resource which provides support for `vcores`.
+
 ~> **Note:** All arguments including the administrator login and password will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
@@ -50,6 +52,7 @@ resource "azurerm_sql_server" "example" {
   }
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
As per issues #10217 and #6502 it seems clear that the SQL server API usage using `sku`s has not been as of yet deprecated, but a warning or note notifying new users of the situation seems appropriate. 

While I was here also removed trailing spaces on the files I opened. 

Am happy to make any adjustments, but as a new user to SQL on Azure it took quite some digging and understand as to why the `sql_server` and `mssql_server` existed, and I feel that some note at the top would have been very helpful.