### PR TITLE
`azurerm_container_registry_token` - modify `name` validation

### DIFF
--- a/azurerm/internal/services/containers/container_registry_token_data_source.go
+++ b/azurerm/internal/services/containers/container_registry_token_data_source.go
@@ -25,7 +25,7 @@ func dataSourceContainerRegistryToken() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validate.ContainerRegistryName,
+				ValidateFunc: validate.ContainerRegistryTokenName,
 			},
 
 			"container_registry_name": {

--- a/azurerm/internal/services/containers/container_registry_token_resource.go
+++ b/azurerm/internal/services/containers/container_registry_token_resource.go
@@ -39,7 +39,7 @@ func resourceContainerRegistryToken() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.ContainerRegistryName,
+				ValidateFunc: validate.ContainerRegistryTokenName,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/internal/services/containers/container_registry_token_resource_test.go
+++ b/azurerm/internal/services/containers/container_registry_token_resource_test.go
@@ -130,7 +130,7 @@ data "azurerm_container_registry_scope_map" "pull_repos" {
 }
 
 resource "azurerm_container_registry_token" "test" {
-  name                    = "testtoken%d"
+  name                    = "testtoken-%d"
   resource_group_name     = azurerm_resource_group.test.name
   container_registry_name = azurerm_container_registry.test.name
   scope_map_id            = data.azurerm_container_registry_scope_map.pull_repos.id

--- a/azurerm/internal/services/containers/validate/container_registry_token_name.go
+++ b/azurerm/internal/services/containers/validate/container_registry_token_name.go
@@ -1,0 +1,12 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+)
+
+func ContainerRegistryTokenName(v interface{}, k string) (warnings []string, errors []error) {
+	return validation.StringMatch(regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{4,48}$`), fmt.Sprintf("only alpha numeric characters (optionally separated by dash) in length of 5 to 50 are allowed in %q", k))(v, k)
+}

--- a/azurerm/internal/services/containers/validate/container_registry_token_name_test.go
+++ b/azurerm/internal/services/containers/validate/container_registry_token_name_test.go
@@ -1,0 +1,68 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers/validate"
+)
+
+func TestContainerRegistryTokenName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "four",
+			ErrCount: 1,
+		},
+		{
+			Value:    "5five",
+			ErrCount: 1,
+		},
+		{
+			Value:    "five-123",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello-world",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello_world",
+			ErrCount: 1,
+		},
+		{
+			Value:    "helloWorld",
+			ErrCount: 0,
+		},
+		{
+			Value:    "helloworld12",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello@world",
+			ErrCount: 1,
+		},
+
+		{
+			Value:    "qfvbdsbvipqdbwsbddbdcwqffewsqwcdw21ddwqwd3324120",
+			ErrCount: 0,
+		},
+		{
+			Value:    "qfvbdsbvipqdbwsbddbdcwqffewsqwcdw21ddwqwd33241202",
+			ErrCount: 0,
+		},
+		{
+			Value:    "qfvbdsbvipqdbwsbddbdcwqfjjfewsqwcdw21ddwqwd3324120",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validate.ContainerRegistryTokenName(tc.Value, "azurerm_container_registry_token")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Azure RM Container Registry Token Name to trigger a validation error: %v", errors)
+		}
+	}
+}


### PR DESCRIPTION
The reason why not reuse the `validate.ContainerRegistryName` is that the validation on service side differs from container registry and container registry token. E.g. the former allows starting with a digit, but the latter doesn't.

Fix #11545