### PR TITLE
#11615: CosmosDB Account: Increase max value for max_staleness_prefix

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -172,7 +172,7 @@ func resourceCosmosDbAccount() *schema.Resource {
 							Optional:         true,
 							Computed:         true,
 							DiffSuppressFunc: suppressConsistencyPolicyStalenessConfiguration,
-							ValidateFunc:     validation.IntBetween(10, 1000000), // single region values
+							ValidateFunc:     validation.IntBetween(10, 2147483647), // single region values
 						},
 					},
 				},


### PR DESCRIPTION
fixes #11615 - see issue for more info

This MR increases the maximum value of Cosmos DB account "Bounded Staleness" max_staleness_prefix from 1000000 to 2147483647 - this brings the value in line with the documentation + allows higher number of stale requests to be tolerated by a Cosmos DB account.

## The bug
### Expected Behaviour

<!--- What should have happened? --->

According to the terraform documentation on the Cosmos DB account "Consistency Policy". It looks like the "Bounded Staleness" policy's "max_staleness_prefix" should have a maximum value of 2147483647 (~2 billion).

See [terraform docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#max_staleness_prefix)

And see [AzureRM documentation](https://docs.microsoft.com/en-us/java/api/com.azure.resourcemanager.cosmos.models.consistencypolicy.withmaxstalenessprefix?view=azure-java-stable) - which notes value maximum value of 2147483647 for max_staleness_prefix on multi-region Cosmos DB accounts.


### Actual Behaviour

<!--- What actually happened? --->

Terraform seems to have a limiting maximum of 1 million:
```
 expected consistency_policy.0.max_staleness_prefix to be in the range (10 - 1000000), got 2147483647

  on main.tf line 43, in resource "azurerm_cosmosdb_account" "my_cosmos_db_account":
  43: resource "azurerm_cosmosdb_account" "my_cosmos_db_account" {
```

Problematic because my use case involves Cosmos DB account usage with potentially higher number of stale requests than 1 million - so current tolerance is too low. 
