### PR TITLE
Update SQL DW SKU validation

### DIFF
--- a/azurerm/internal/services/mssql/validate/database_sku_name.go
+++ b/azurerm/internal/services/mssql/validate/database_sku_name.go
@@ -9,7 +9,7 @@ import (
 
 func DatabaseSkuName() schema.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile(`(?i)(^(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))$|^((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))$|^((GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80))$|^(BC_M_(8|10|12|14|16|18|20|24|32|64|128))$|^(Basic)$|^(ElasticPool)$|^(S(0|1|2|3|4|6|7|9|12))$|^(P(1|2|4|6|11|15))$|^(DW(1|2|3|4|5|6|7|8|9)000*c)$|^(DS(1|2|3|4|5|6|10|12|15|20)00)$)`),
+		regexp.MustCompile(`(?i)(^(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))$|^((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))$|^((GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80))$|^(BC_M_(8|10|12|14|16|18|20|24|32|64|128))$|^(Basic)$|^(ElasticPool)$|^(S(0|1|2|3|4|6|7|9|12))$|^(P(1|2|4|6|11|15))$|^(DW(1|2|3|4|5|6|7|8|9)5?000*c)$|^(DS(1|2|3|4|5|6|10|12|15|20)00)$)`),
 
 		`This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
 	)


### PR DESCRIPTION
When attempting to create a SQL Pool / SQL DW database with a service level of DW1500c, it fails with the following message:
> Error: invalid value for sku_name (This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.)

Looking at the SKU regex validation, it seems like it's just slightly out of date; from the Microsoft docs, the current list is:
DW100c
DW200c
DW300c
DW400c
DW500c
DW1000c
DW1500c
DW2000c
DW2500c
DW3000c
DW5000c
DW6000c
DW7500c
DW10000c
DW15000c
DW30000c

So this PR allows DW1500c, DW15000c, and so on for the SKU name.