### PR TITLE
`azurerm_kubernetes_cluster`: Add `ingress_application_gateway_identity` export for add-on `ingress_application_gateway`

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -441,7 +441,7 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 			}
 		}
 
-		omsagentIdentity := flattenKubernetesClusterOmsAgentIdentityProfile(omsAgent.Identity)
+		omsagentIdentity := flattenKubernetesClusterAddOnIdentityProfile(omsAgent.Identity)
 
 		omsAgents = append(omsAgents, map[string]interface{}{
 			"enabled":                    enabled,
@@ -477,7 +477,7 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 			subnetId = *v
 		}
 
-		ingressApplicationGatewayIdentity := flattenKubernetesClusterIngressApplicationGatewayIdentityProfile(ingressApplicationGateway.Identity)
+		ingressApplicationGatewayIdentity := flattenKubernetesClusterAddOnIdentityProfile(ingressApplicationGateway.Identity)
 
 		ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
 			"enabled":                              enabled,
@@ -506,37 +506,7 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 	}
 }
 
-func flattenKubernetesClusterOmsAgentIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) []interface{} {
-	if profile == nil {
-		return []interface{}{}
-	}
-
-	identity := make([]interface{}, 0)
-	clientID := ""
-	if clientid := profile.ClientID; clientid != nil {
-		clientID = *clientid
-	}
-
-	objectID := ""
-	if objectid := profile.ObjectID; objectid != nil {
-		objectID = *objectid
-	}
-
-	userAssignedIdentityID := ""
-	if resourceid := profile.ResourceID; resourceid != nil {
-		userAssignedIdentityID = *resourceid
-	}
-
-	identity = append(identity, map[string]interface{}{
-		"client_id":                 clientID,
-		"object_id":                 objectID,
-		"user_assigned_identity_id": userAssignedIdentityID,
-	})
-
-	return identity
-}
-
-func flattenKubernetesClusterIngressApplicationGatewayIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) []interface{} {
+func flattenKubernetesClusterAddOnIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) []interface{} {
 	if profile == nil {
 		return []interface{}{}
 	}

--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -192,6 +192,26 @@ func schemaKubernetesAddOnProfiles() *schema.Schema {
 								Type:     schema.TypeString,
 								Computed: true,
 							},
+							"ingress_application_gateway_identity": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"client_id": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"object_id": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+										"user_assigned_identity_id": {
+											Type:     schema.TypeString,
+											Computed: true,
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -457,12 +477,15 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 			subnetId = *v
 		}
 
+		ingressApplicationGatewayIdentity := flattenKubernetesClusterIngressApplicationGatewayIdentityProfile(ingressApplicationGateway.Identity)
+
 		ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
-			"enabled":              enabled,
-			"gateway_id":           gatewayId,
-			"effective_gateway_id": effectiveGatewayId,
-			"subnet_cidr":          subnetCIDR,
-			"subnet_id":            subnetId,
+			"enabled":                              enabled,
+			"gateway_id":                           gatewayId,
+			"effective_gateway_id":                 effectiveGatewayId,
+			"subnet_cidr":                          subnetCIDR,
+			"subnet_id":                            subnetId,
+			"ingress_application_gateway_identity": ingressApplicationGatewayIdentity,
 		})
 	}
 
@@ -484,6 +507,36 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 }
 
 func flattenKubernetesClusterOmsAgentIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) []interface{} {
+	if profile == nil {
+		return []interface{}{}
+	}
+
+	identity := make([]interface{}, 0)
+	clientID := ""
+	if clientid := profile.ClientID; clientid != nil {
+		clientID = *clientid
+	}
+
+	objectID := ""
+	if objectid := profile.ObjectID; objectid != nil {
+		objectID = *objectid
+	}
+
+	userAssignedIdentityID := ""
+	if resourceid := profile.ResourceID; resourceid != nil {
+		userAssignedIdentityID = *resourceid
+	}
+
+	identity = append(identity, map[string]interface{}{
+		"client_id":                 clientID,
+		"object_id":                 objectID,
+		"user_assigned_identity_id": userAssignedIdentityID,
+	})
+
+	return identity
+}
+
+func flattenKubernetesClusterIngressApplicationGatewayIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) []interface{} {
 	if profile == nil {
 		return []interface{}{}
 	}

--- a/azurerm/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -279,6 +279,9 @@ func testAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
 				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").MatchesOtherKey(
 					check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_id"),
 				),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.client_id").Exists(),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.object_id").Exists(),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.user_assigned_identity_id").Exists(),
 			),
 		},
 		data.ImportStep(),

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -144,6 +144,26 @@ func dataSourceKubernetesCluster() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"ingress_application_gateway_identity": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"client_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"object_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"user_assigned_identity_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -815,7 +835,7 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 			workspaceID = *v
 		}
 
-		omsagentIdentity, err := flattenKubernetesClusterDataSourceOmsAgentIdentityProfile(omsAgent.Identity)
+		omsagentIdentity, err := flattenKubernetesClusterDataSourceAddOnIdentityProfile(omsAgent.Identity)
 		if err != nil {
 			return err
 		}
@@ -883,12 +903,18 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 			subnetId = *v
 		}
 
+		ingressApplicationGatewayIdentity, err := flattenKubernetesClusterDataSourceAddOnIdentityProfile(ingressApplicationGateway.Identity)
+		if err != nil {
+			return err
+		}
+
 		output := map[string]interface{}{
-			"enabled":              enabled,
-			"gateway_id":           gatewayId,
-			"effective_gateway_id": effectiveGatewayId,
-			"subnet_cidr":          subnetCIDR,
-			"subnet_id":            subnetId,
+			"enabled":                              enabled,
+			"gateway_id":                           gatewayId,
+			"effective_gateway_id":                 effectiveGatewayId,
+			"subnet_cidr":                          subnetCIDR,
+			"subnet_id":                            subnetId,
+			"ingress_application_gateway_identity": ingressApplicationGatewayIdentity,
 		}
 		ingressApplicationGateways = append(ingressApplicationGateways, output)
 	}
@@ -897,7 +923,7 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 	return []interface{}{values}
 }
 
-func flattenKubernetesClusterDataSourceOmsAgentIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) ([]interface{}, error) {
+func flattenKubernetesClusterDataSourceAddOnIdentityProfile(profile *containerservice.ManagedClusterAddonProfileIdentity) ([]interface{}, error) {
 	if profile == nil {
 		return []interface{}{}, nil
 	}

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -474,6 +474,9 @@ func testAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayApp
 				),
 				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.subnet_cidr").IsEmpty(),
 				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.subnet_id").IsEmpty(),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.client_id").Exists(),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.object_id").Exists(),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.ingress_application_gateway_identity.0.user_assigned_identity_id").Exists(),
 			),
 		},
 	})

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -272,6 +272,12 @@ An `ingress_application_gateway` block supports the following:
 
 * `subnet_id` - The ID of the subnet on which to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. This attribute is only set when `subnet_id` is specified when configuring the `ingress_application_gateway` addon.
 
+* `ingress_application_gateway_identity` - An `ingress_application_gateway_identity` block as defined below.  
+
+---
+
+The `ingress_application_gateway_identity` block exports the following:
+
 * `client_id` - The Client ID of the user-defined Managed Identity used by the Application Gateway.
 
 * `object_id` - The Object ID of the user-defined Managed Identity used by the Application Gateway.

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -258,6 +258,8 @@ A `azure_policy` block supports the following:
 
 * `enabled` - Is Azure Policy for Kubernetes enabled?
 
+---
+
 An `ingress_application_gateway` block supports the following:
 
 * `enabled` -  Is the Application Gateway ingress controller integrated with this Kubernetes Cluster?
@@ -269,6 +271,12 @@ An `ingress_application_gateway` block supports the following:
 * `subnet_cidr` - The subnet CIDR used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. This attribute is only set when `subnet_cidr` is specified when configuring the `ingress_application_gateway` addon.
 
 * `subnet_id` - The ID of the subnet on which to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. This attribute is only set when `subnet_id` is specified when configuring the `ingress_application_gateway` addon.
+
+* `client_id` - The Client ID of the user-defined Managed Identity used by the Application Gateway.
+
+* `object_id` - The Object ID of the user-defined Managed Identity used by the Application Gateway.
+
+* `user_assigned_identity_id` - The ID of the User Assigned Identity used by the Application Gateway.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -552,22 +552,6 @@ The `kubelet_identity` block exports the following:
 
 ---
 
-The `oms_agent` block exports the following: 
-
-* `oms_agent_identity` - An `oms_agent_identity` block is exported. The exported attributes are defined below.  
-
----
-
-The `oms_agent_identity` block exports the following:
-
-* `client_id` - The Client ID of the user-defined Managed Identity used by the OMS Agents.
-
-* `object_id` - The Object ID of the user-defined Managed Identity used by the OMS Agents.
-
-* `user_assigned_identity_id` - The ID of the User Assigned Identity used by the OMS Agents.
-
----
-
 The `kube_admin_config` and `kube_config` blocks export the following:
 
 * `client_key` - Base64 encoded private key used by clients to authenticate to the Kubernetes cluster.
@@ -601,11 +585,41 @@ The `addon_profile` block exports the following:
 
 * `ingress_application_gateway` - An `ingress_application_gateway` block as defined below.
 
+* `oms_agent` - An `oms_agent` block as defined below.
+
 ---
 
 The `ingress_application_gateway` block exports the following:
 
 * `effective_gateway_id` - The ID of the Application Gateway associated with the ingress controller deployed to this Kubernetes Cluster.
+
+* `ingress_application_gateway_identity` - An `ingress_application_gateway_identity` block is exported. The exported attributes are defined below.  
+
+---
+
+The `ingress_application_gateway_identity` block exports the following:
+
+* `client_id` - The Client ID of the user-defined Managed Identity used by the Application Gateway.
+
+* `object_id` - The Object ID of the user-defined Managed Identity used by the Application Gateway.
+
+* `user_assigned_identity_id` - The ID of the User Assigned Identity used by the Application Gateway.
+
+---
+
+The `oms_agent` block exports the following: 
+
+* `oms_agent_identity` - An `oms_agent_identity` block is exported. The exported attributes are defined below.  
+
+---
+
+The `oms_agent_identity` block exports the following:
+
+* `client_id` - The Client ID of the user-defined Managed Identity used by the OMS Agents.
+
+* `object_id` - The Object ID of the user-defined Managed Identity used by the OMS Agents.
+
+* `user_assigned_identity_id` - The ID of the User Assigned Identity used by the OMS Agents.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #11564

## Acceptance tests

- [x] New functionality tested and passing
  ```
  ❯ make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId'
  ==> Checking that code complies with gofmt requirements...
  ==> Checking that Custom Timeouts are used...
  ==> Checking that acceptance test packages are used...
  TF_ACC=1 go test -v ./azurerm/internal/services/containers -run=TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
  2021/05/07 18:15:43 [DEBUG] not using binary driver name, it's no longer needed
  2021/05/07 18:15:44 [DEBUG] not using binary driver name, it's no longer needed
  === RUN   TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
  === PAUSE TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
  === CONT  TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
  --- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId (1302.15s)
  PASS
  ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers    1306.024s
  ```

  ```
  ❯ make acctests SERVICE='containers' TESTARGS='-run=TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway'
  ==> Checking that code complies with gofmt requirements...
  ==> Checking that Custom Timeouts are used...
  ==> Checking that acceptance test packages are used...
  TF_ACC=1 go test -v ./azurerm/internal/services/containers -run=TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
  2021/05/07 20:59:29 [DEBUG] not using binary driver name, it's no longer needed
  2021/05/07 20:59:30 [DEBUG] not using binary driver name, it's no longer needed
  === RUN   TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway
  === PAUSE TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway
  === CONT  TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway
  --- PASS: TestAccDataSourceKubernetesCluster_addOnProfileIngressApplicationGatewayAppGateway (1341.64s)
  PASS
  ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers  1345.299s
  ```