### PR TITLE
Support for `private_link_access` in `azurerm_storage_account`

### DIFF
--- a/azurerm/internal/services/storage/storage_account_network_rules_resource.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource.go
@@ -93,7 +93,7 @@ func resourceStorageAccountNetworkRules() *schema.Resource {
 				}, false),
 			},
 
-			"resource_access_rules": {
+			"private_endpoint_access_rules": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
@@ -157,7 +157,7 @@ func resourceStorageAccountNetworkRulesCreateUpdate(d *schema.ResourceData, meta
 	rules.Bypass = expandStorageAccountNetworkRuleBypass(d.Get("bypass").(*schema.Set).List())
 	rules.IPRules = expandStorageAccountNetworkRuleIpRules(d.Get("ip_rules").(*schema.Set).List())
 	rules.VirtualNetworkRules = expandStorageAccountNetworkRuleVirtualRules(d.Get("virtual_network_subnet_ids").(*schema.Set).List())
-	rules.ResourceAccessRules = expandStorageAccountResourceAccessRule(d.Get("resource_access_rules").([]interface{}), tenantId)
+	rules.ResourceAccessRules = expandStorageAccountPrivateEndpointAccessRule(d.Get("private_endpoint_access_rules").([]interface{}), tenantId)
 
 	opts := storage.AccountUpdateParameters{
 		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
@@ -206,8 +206,8 @@ func resourceStorageAccountNetworkRulesRead(d *schema.ResourceData, meta interfa
 			return fmt.Errorf("Error setting `bypass`: %+v", err)
 		}
 		d.Set("default_action", string(rules.DefaultAction))
-		if err := d.Set("resource_access_rules", flattenStorageAccountResourceAccessRules(rules.ResourceAccessRules)); err != nil {
-			return fmt.Errorf("setting `resource_access_rules`: %+v", err)
+		if err := d.Set("private_endpoint_access_rules", flattenStorageAccountPrivateEndpointAccessRules(rules.ResourceAccessRules)); err != nil {
+			return fmt.Errorf("setting `private_endpoint_access_rules`: %+v", err)
 		}
 	}
 

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -101,7 +102,7 @@ func resourceStorageAccountNetworkRules() *schema.Resource {
 						"resource_id": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: azure.ValidateResourceID,
+							ValidateFunc: networkValidate.PrivateEndpointID,
 						},
 
 						"tenant_id": {

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource.go
@@ -94,18 +94,18 @@ func resourceStorageAccountNetworkRules() *schema.Resource {
 				}, false),
 			},
 
-			"private_endpoint_access_rules": {
+			"private_link_access": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"resource_id": {
+						"endpoint_resource_id": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: networkValidate.PrivateEndpointID,
 						},
 
-						"tenant_id": {
+						"endpoint_tenant_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
@@ -158,7 +158,7 @@ func resourceStorageAccountNetworkRulesCreateUpdate(d *schema.ResourceData, meta
 	rules.Bypass = expandStorageAccountNetworkRuleBypass(d.Get("bypass").(*schema.Set).List())
 	rules.IPRules = expandStorageAccountNetworkRuleIpRules(d.Get("ip_rules").(*schema.Set).List())
 	rules.VirtualNetworkRules = expandStorageAccountNetworkRuleVirtualRules(d.Get("virtual_network_subnet_ids").(*schema.Set).List())
-	rules.ResourceAccessRules = expandStorageAccountPrivateEndpointAccessRule(d.Get("private_endpoint_access_rules").([]interface{}), tenantId)
+	rules.ResourceAccessRules = expandStorageAccountPrivateLinkAccess(d.Get("private_link_access").([]interface{}), tenantId)
 
 	opts := storage.AccountUpdateParameters{
 		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
@@ -207,8 +207,8 @@ func resourceStorageAccountNetworkRulesRead(d *schema.ResourceData, meta interfa
 			return fmt.Errorf("Error setting `bypass`: %+v", err)
 		}
 		d.Set("default_action", string(rules.DefaultAction))
-		if err := d.Set("private_endpoint_access_rules", flattenStorageAccountPrivateEndpointAccessRules(rules.ResourceAccessRules)); err != nil {
-			return fmt.Errorf("setting `private_endpoint_access_rules`: %+v", err)
+		if err := d.Set("private_link_access", flattenStorageAccountPrivateLinkAccess(rules.ResourceAccessRules)); err != nil {
+			return fmt.Errorf("setting `private_link_access`: %+v", err)
 		}
 	}
 

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource.go
@@ -5,9 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
-
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-01-01/storage"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -15,6 +12,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -95,19 +94,21 @@ func resourceStorageAccountNetworkRules() *schema.Resource {
 			},
 
 			"resource_access_rules": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"resource_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: azure.ValidateResourceID,
 						},
 
 						"tenant_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IsUUID,
 						},
 					},
 				},

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource.go
@@ -157,7 +157,7 @@ func resourceStorageAccountNetworkRulesCreateUpdate(d *schema.ResourceData, meta
 	rules.Bypass = expandStorageAccountNetworkRuleBypass(d.Get("bypass").(*schema.Set).List())
 	rules.IPRules = expandStorageAccountNetworkRuleIpRules(d.Get("ip_rules").(*schema.Set).List())
 	rules.VirtualNetworkRules = expandStorageAccountNetworkRuleVirtualRules(d.Get("virtual_network_subnet_ids").(*schema.Set).List())
-	rules.ResourceAccessRules = expandStorageAccountResourceAccessRule(d.Get("resource_access_rules").(*schema.Set).List(), tenantId)
+	rules.ResourceAccessRules = expandStorageAccountResourceAccessRule(d.Get("resource_access_rules").([]interface{}), tenantId)
 
 	opts := storage.AccountUpdateParameters{
 		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -66,27 +66,27 @@ func TestAccStorageAccountNetworkRules_update(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccountNetworkRules_resourceAccessRules(t *testing.T) {
+func TestAccStorageAccountNetworkRules_privateEndpointAccessRules(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rules", "test")
 	r := StorageAccountNetworkRulesResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.disableResourceAccessRules(data),
+			Config: r.disablePrivateEndpointAccessRules(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That("azurerm_storage_account.test").ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.resourceAccessRules(data),
+			Config: r.privateEndpointAccessRules(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That("azurerm_storage_account.test").ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.disableResourceAccessRules(data),
+			Config: r.disablePrivateEndpointAccessRules(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That("azurerm_storage_account.test").ExistsInAzure(r),
 			),
@@ -266,7 +266,7 @@ resource "azurerm_storage_account_network_rules" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageAccountNetworkRulesResource) disableResourceAccessRules(data acceptance.TestData) string {
+func (r StorageAccountNetworkRulesResource) disablePrivateEndpointAccessRules(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -294,7 +294,7 @@ resource "azurerm_storage_account_network_rules" "test" {
 `, StorageAccountResource{}.networkRulesPrivateEndpointTemplate(data), data.RandomString)
 }
 
-func (r StorageAccountNetworkRulesResource) resourceAccessRules(data acceptance.TestData) string {
+func (r StorageAccountNetworkRulesResource) privateEndpointAccessRules(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -317,9 +317,12 @@ resource "azurerm_storage_account_network_rules" "test" {
   default_action             = "Deny"
   ip_rules                   = ["127.0.0.1"]
   virtual_network_subnet_ids = [azurerm_subnet.test.id]
-  resource_access_rules {
-    resource_id = azurerm_private_endpoint.test.id
-  }
+  private_endpoint_access_rules {
+      resource_id = azurerm_private_endpoint.blob.id
+    }
+    private_endpoint_access_rules {
+      resource_id = azurerm_private_endpoint.table.id
+    }
 }
 `, StorageAccountResource{}.networkRulesPrivateEndpointTemplate(data), data.RandomString)
 }

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -318,11 +318,11 @@ resource "azurerm_storage_account_network_rules" "test" {
   ip_rules                   = ["127.0.0.1"]
   virtual_network_subnet_ids = [azurerm_subnet.test.id]
   private_endpoint_access_rules {
-      resource_id = azurerm_private_endpoint.blob.id
-    }
-    private_endpoint_access_rules {
-      resource_id = azurerm_private_endpoint.table.id
-    }
+    resource_id = azurerm_private_endpoint.blob.id
+  }
+  private_endpoint_access_rules {
+    resource_id = azurerm_private_endpoint.table.id
+  }
 }
 `, StorageAccountResource{}.networkRulesPrivateEndpointTemplate(data), data.RandomString)
 }

--- a/azurerm/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -66,27 +66,27 @@ func TestAccStorageAccountNetworkRules_update(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccountNetworkRules_privateEndpointAccessRules(t *testing.T) {
+func TestAccStorageAccountNetworkRules_privateLinkAccess(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rules", "test")
 	r := StorageAccountNetworkRulesResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.disablePrivateEndpointAccessRules(data),
+			Config: r.disablePrivateLinkAccess(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That("azurerm_storage_account.test").ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.privateEndpointAccessRules(data),
+			Config: r.privateLinkAccess(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That("azurerm_storage_account.test").ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.disablePrivateEndpointAccessRules(data),
+			Config: r.disablePrivateLinkAccess(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That("azurerm_storage_account.test").ExistsInAzure(r),
 			),
@@ -266,7 +266,7 @@ resource "azurerm_storage_account_network_rules" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageAccountNetworkRulesResource) disablePrivateEndpointAccessRules(data acceptance.TestData) string {
+func (r StorageAccountNetworkRulesResource) disablePrivateLinkAccess(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -294,7 +294,7 @@ resource "azurerm_storage_account_network_rules" "test" {
 `, StorageAccountResource{}.networkRulesPrivateEndpointTemplate(data), data.RandomString)
 }
 
-func (r StorageAccountNetworkRulesResource) privateEndpointAccessRules(data acceptance.TestData) string {
+func (r StorageAccountNetworkRulesResource) privateLinkAccess(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -317,11 +317,11 @@ resource "azurerm_storage_account_network_rules" "test" {
   default_action             = "Deny"
   ip_rules                   = ["127.0.0.1"]
   virtual_network_subnet_ids = [azurerm_subnet.test.id]
-  private_endpoint_access_rules {
-    resource_id = azurerm_private_endpoint.blob.id
+  private_link_access {
+    endpoint_resource_id = azurerm_private_endpoint.blob.id
   }
-  private_endpoint_access_rules {
-    resource_id = azurerm_private_endpoint.table.id
+  private_link_access {
+    endpoint_resource_id = azurerm_private_endpoint.table.id
   }
 }
 `, StorageAccountResource{}.networkRulesPrivateEndpointTemplate(data), data.RandomString)

--- a/azurerm/internal/services/storage/storage_account_resource.go
+++ b/azurerm/internal/services/storage/storage_account_resource.go
@@ -287,6 +287,27 @@ func resourceStorageAccount() *schema.Resource {
 								string(storage.DefaultActionDeny),
 							}, false),
 						},
+
+						"resource_access_rules": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource_id": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: azure.ValidateResourceID,
+									},
+
+									"tenant_id": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.IsUUID,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -737,6 +758,7 @@ func resourceStorageAccount() *schema.Resource {
 
 func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	envName := meta.(*clients.Client).Account.Environment.Name
+	tenantId := meta.(*clients.Client).Account.TenantId
 	client := meta.(*clients.Client).Storage.AccountsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -780,7 +802,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 		Kind: storage.Kind(accountKind),
 		AccountPropertiesCreateParameters: &storage.AccountPropertiesCreateParameters{
 			EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly,
-			NetworkRuleSet:         expandStorageAccountNetworkRules(d),
+			NetworkRuleSet:         expandStorageAccountNetworkRules(d, tenantId),
 			IsHnsEnabled:           &isHnsEnabled,
 			EnableNfsV3:            &nfsV3Enabled,
 		},
@@ -964,6 +986,7 @@ func resourceStorageAccountCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceStorageAccountUpdate(d *schema.ResourceData, meta interface{}) error {
 	envName := meta.(*clients.Client).Account.Environment.Name
+	tenantId := meta.(*clients.Client).Account.TenantId
 	client := meta.(*clients.Client).Storage.AccountsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -1126,12 +1149,12 @@ func resourceStorageAccountUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("network_rules") {
 		opts := storage.AccountUpdateParameters{
 			AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
-				NetworkRuleSet: expandStorageAccountNetworkRules(d),
+				NetworkRuleSet: expandStorageAccountNetworkRules(d, tenantId),
 			},
 		}
 
 		if _, err := client.Update(ctx, resourceGroupName, storageAccountName, opts); err != nil {
-			return fmt.Errorf("Error updating Azure Storage Account network_rules %q: %+v", storageAccountName, err)
+			return fmt.Errorf("updating Azure Storage Account network_rules %q: %+v", storageAccountName, err)
 		}
 	}
 
@@ -1646,7 +1669,7 @@ func expandArmStorageAccountRouting(input []interface{}) *storage.RoutingPrefere
 	}
 }
 
-func expandStorageAccountNetworkRules(d *schema.ResourceData) *storage.NetworkRuleSet {
+func expandStorageAccountNetworkRules(d *schema.ResourceData, tenantId string) *storage.NetworkRuleSet {
 	networkRules := d.Get("network_rules").([]interface{})
 	if len(networkRules) == 0 {
 		// Default access is enabled when no network rules are set.
@@ -1658,6 +1681,7 @@ func expandStorageAccountNetworkRules(d *schema.ResourceData) *storage.NetworkRu
 		IPRules:             expandStorageAccountIPRules(networkRule),
 		VirtualNetworkRules: expandStorageAccountVirtualNetworks(networkRule),
 		Bypass:              expandStorageAccountBypass(networkRule),
+		ResourceAccessRules: expandStorageAccountResourceAccessRule(networkRule["resource_access_rules"].([]interface{}), tenantId),
 	}
 
 	if v := networkRule["default_action"]; v != nil {
@@ -1708,6 +1732,25 @@ func expandStorageAccountBypass(networkRule map[string]interface{}) storage.Bypa
 	}
 
 	return storage.Bypass(strings.Join(bypassValues, ", "))
+}
+
+func expandStorageAccountResourceAccessRule(inputs []interface{}, tenantId string) *[]storage.ResourceAccessRule {
+	resourceAccessRules := make([]storage.ResourceAccessRule, 0)
+	if len(inputs) == 0 {
+		return &resourceAccessRules
+	}
+	for _, input := range inputs {
+		accessRule := input.(map[string]interface{})
+		if v := accessRule["tenant_id"].(string); v != "" {
+			tenantId = v
+		}
+		resourceAccessRules = append(resourceAccessRules, storage.ResourceAccessRule{
+			TenantID:   utils.String(tenantId),
+			ResourceID: utils.String(accessRule["resource_id"].(string)),
+		})
+	}
+
+	return &resourceAccessRules
 }
 
 func expandBlobProperties(input []interface{}) *storage.BlobServiceProperties {
@@ -2036,6 +2079,7 @@ func flattenStorageAccountNetworkRules(input *storage.NetworkRuleSet) []interfac
 	networkRules["virtual_network_subnet_ids"] = schema.NewSet(schema.HashString, flattenStorageAccountVirtualNetworks(input.VirtualNetworkRules))
 	networkRules["bypass"] = schema.NewSet(schema.HashString, flattenStorageAccountBypass(input.Bypass))
 	networkRules["default_action"] = string(input.DefaultAction)
+	networkRules["resource_access_rules"] = flattenStorageAccountResourceAccessRules(input.ResourceAccessRules)
 
 	return []interface{}{networkRules}
 }
@@ -2072,6 +2116,31 @@ func flattenStorageAccountVirtualNetworks(input *[]storage.VirtualNetworkRule) [
 	}
 
 	return virtualNetworks
+}
+
+func flattenStorageAccountResourceAccessRules(inputs *[]storage.ResourceAccessRule) []interface{} {
+	if inputs == nil || len(*inputs) == 0 {
+		return []interface{}{}
+	}
+
+	accessRules := make([]interface{}, 0)
+	for _, input := range *inputs {
+		var resourceId, tenantId string
+		if input.ResourceID != nil {
+			resourceId = *input.ResourceID
+		}
+
+		if input.TenantID != nil {
+			tenantId = *input.TenantID
+		}
+
+		accessRules = append(accessRules, map[string]interface{}{
+			"resource_id": resourceId,
+			"tenant_id":   tenantId,
+		})
+	}
+
+	return accessRules
 }
 
 func flattenBlobProperties(input storage.BlobServiceProperties) []interface{} {

--- a/azurerm/internal/services/storage/storage_account_resource_test.go
+++ b/azurerm/internal/services/storage/storage_account_resource_test.go
@@ -514,7 +514,7 @@ func TestAccStorageAccount_networkRulesDeleted(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccount_privateEndpointAccessRules(t *testing.T) {
+func TestAccStorageAccount_privateLinkAccess(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
@@ -527,7 +527,7 @@ func TestAccStorageAccount_privateEndpointAccessRules(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.networkRulesPrivateEndpointAccessRule(data),
+			Config: r.networkRulesPrivateLinkAccess(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1692,7 +1692,7 @@ resource "azurerm_storage_account" "test" {
 `, r.networkRulesTemplate(data), data.RandomString)
 }
 
-func (r StorageAccountResource) networkRulesPrivateEndpointAccessRule(data acceptance.TestData) string {
+func (r StorageAccountResource) networkRulesPrivateLinkAccess(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1707,11 +1707,11 @@ resource "azurerm_storage_account" "test" {
     default_action             = "Deny"
     ip_rules                   = ["127.0.0.1"]
     virtual_network_subnet_ids = [azurerm_subnet.test.id]
-    private_endpoint_access_rules {
-      resource_id = azurerm_private_endpoint.blob.id
+    private_link_access {
+      endpoint_resource_id = azurerm_private_endpoint.blob.id
     }
-    private_endpoint_access_rules {
-      resource_id = azurerm_private_endpoint.table.id
+    private_link_access {
+      endpoint_resource_id = azurerm_private_endpoint.table.id
     }
   }
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -243,6 +243,8 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 * `ip_rules` - (Optional) List of public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed. Private IP address ranges (as defined in [RFC 1918](https://tools.ietf.org/html/rfc1918#section-3)) are not allowed.
 * `virtual_network_subnet_ids` - (Optional) A list of resource ids for subnets.
 
+* `resource_access_rules` - (Optional) A `resource_access_rules` block as defined below.
+
 ~> **Note:** If specifying `network_rules`, one of either `ip_rules` or `virtual_network_subnet_ids` must be specified and `default_action` must be set to `Deny`.
 
 ~> **NOTE:** Network Rules can be defined either directly on the `azurerm_storage_account` resource, or using the `azurerm_storage_account_network_rules` resource - but the two cannot be used together. If both are used against the same Storage Account, spurious changes will occur. When managing Network Rules using this resource, to change from a `default_action` of `Deny` to `Allow` requires defining, rather than removing, the block.
@@ -250,6 +252,14 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 ~> **Note:** The prefix of `ip_rules` must be between 0 and 30 and only supports public IP addresses.
 
 ~> **Note:** [More information on Validation is available here](https://docs.microsoft.com/en-gb/azure/storage/blobs/storage-custom-domain-name)
+
+---
+
+A `resource_access_rules` block supports the following:
+
+* `resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
+
+* `tenant_id` - (Optional) The tenant id of the `azurerm_private_endpoint` of the resource access rule. Defaults to the current tenant id.
 
 ---
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -243,7 +243,7 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 * `ip_rules` - (Optional) List of public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed. Private IP address ranges (as defined in [RFC 1918](https://tools.ietf.org/html/rfc1918#section-3)) are not allowed.
 * `virtual_network_subnet_ids` - (Optional) A list of resource ids for subnets.
 
-* `resource_access_rules` - (Optional) A `resource_access_rules` block as defined below.
+* `private_endpoint_access_rules` - (Optional) One or More `private_endpoint_access_rules` block as defined below.
 
 ~> **Note:** If specifying `network_rules`, one of either `ip_rules` or `virtual_network_subnet_ids` must be specified and `default_action` must be set to `Deny`.
 
@@ -255,7 +255,7 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 
 ---
 
-A `resource_access_rules` block supports the following:
+A `private_endpoint_access_rules` block supports the following:
 
 * `resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -243,7 +243,7 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 * `ip_rules` - (Optional) List of public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed. Private IP address ranges (as defined in [RFC 1918](https://tools.ietf.org/html/rfc1918#section-3)) are not allowed.
 * `virtual_network_subnet_ids` - (Optional) A list of resource ids for subnets.
 
-* `private_endpoint_access_rules` - (Optional) One or More `private_endpoint_access_rules` block as defined below.
+* `private_link_access` - (Optional) One or More `private_link_access` block as defined below.
 
 ~> **Note:** If specifying `network_rules`, one of either `ip_rules` or `virtual_network_subnet_ids` must be specified and `default_action` must be set to `Deny`.
 
@@ -255,11 +255,11 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 
 ---
 
-A `private_endpoint_access_rules` block supports the following:
+A `private_link_access` block supports the following:
 
-* `resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
+* `endpoint_resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
 
-* `tenant_id` - (Optional) The tenant id of the `azurerm_private_endpoint` of the resource access rule. Defaults to the current tenant id.
+* `endpoint_tenant_id` - (Optional) The tenant id of the `azurerm_private_endpoint` of the resource access rule. Defaults to the current tenant id.
 
 ---
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -88,11 +88,11 @@ The following arguments are supported:
 
 -> **NOTE** User has to explicitly set `virtual_network_subnet_ids` to empty slice (`[]`) to remove it.
 
-* `resource_access_rules` - (Optional) A `resource_access_rules` block as defined below.
+* `private_endpoint_access_rules` - (Optional) One or More `private_endpoint_access_rules` block as defined below.
 
 ---
 
-A `resource_access_rules` block supports the following:
+A `private_endpoint_access_rules` block supports the following:
 
 * `resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -88,6 +88,17 @@ The following arguments are supported:
 
 -> **NOTE** User has to explicitly set `virtual_network_subnet_ids` to empty slice (`[]`) to remove it.
 
+* `resource_access_rules` - (Optional) A `resource_access_rules` block as defined below.
+
+---
+
+A `resource_access_rules` block supports the following:
+
+* `resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
+
+* `tenant_id` - (Optional) The tenant id of the `azurerm_private_endpoint` of the resource access rule. Defaults to the current tenant id.
+
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -88,15 +88,15 @@ The following arguments are supported:
 
 -> **NOTE** User has to explicitly set `virtual_network_subnet_ids` to empty slice (`[]`) to remove it.
 
-* `private_endpoint_access_rules` - (Optional) One or More `private_endpoint_access_rules` block as defined below.
+* `private_link_access` - (Optional) One or More `private_link_access` block as defined below.
 
 ---
 
-A `private_endpoint_access_rules` block supports the following:
+A `private_link_access` block supports the following:
 
-* `resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
+* `endpoint_resource_id` - (Required) The resource id of the `azurerm_private_endpoint` of the resource access rule.
 
-* `tenant_id` - (Optional) The tenant id of the `azurerm_private_endpoint` of the resource access rule. Defaults to the current tenant id.
+* `endpoint_tenant_id` - (Optional) The tenant id of the `azurerm_private_endpoint` of the resource access rule. Defaults to the current tenant id.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/11628

=== RUN   TestAccStorageAccount_resourceAccessRules
=== PAUSE TestAccStorageAccount_resourceAccessRules
=== CONT  TestAccStorageAccount_resourceAccessRules
--- PASS: TestAccStorageAccount_resourceAccessRules (465.11s)

=== RUN   TestAccStorageAccountNetworkRules_resourceAccessRules
=== PAUSE TestAccStorageAccountNetworkRules_resourceAccessRules
=== CONT  TestAccStorageAccountNetworkRules_resourceAccessRules
--- PASS: TestAccStorageAccountNetworkRules_resourceAccessRules (381.65s)