### PR TITLE
Fix `backup` in `azurerm_cosmosdb_account` when `type` is `Continuous`

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -330,14 +330,14 @@ func resourceCosmosDbAccount() *schema.Resource {
 						"interval_in_minutes": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      240,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(60, 1440),
 						},
 
 						"retention_in_hours": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							Default:      8,
+							Computed:     true,
 							ValidateFunc: validation.IntBetween(8, 720),
 						},
 					},

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -646,8 +646,6 @@ func TestAccCosmosDBAccount_backup(t *testing.T) {
 			Check: resource.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("backup.0.type").HasValue("Periodic"),
-				check.That(data.ResourceName).Key("backup.0.interval_in_minutes").HasValue("240"),
-				check.That(data.ResourceName).Key("backup.0.retention_in_hours").HasValue("8"),
 			),
 		},
 		data.ImportStep(),
@@ -1774,7 +1772,9 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   backup {
-    type = "Periodic"
+    type                = "Periodic"
+    interval_in_minutes = 60
+    retention_in_hours  = 8
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(kind), string(consistency))


### PR DESCRIPTION
Sorry that I have set the default value for `interval_in_minutes` and `retention_in_hours` to cause the test fails when `type` in `backup` is `Continuous`.

Error: expanding `backup`: `interval_in_minutes` can not be set when `type` in`backup` is `Continuous` 
        
          with azurerm_cosmosdb_account.test,
          on terraform_plugin_test.tf line 11, in resource "azurerm_cosmosdb_account" "test":
          11: resource "azurerm_cosmosdb_account" "test" {
        
--- FAIL: TestAccCosmosDBAccount_backupContinuous (82.66s)

I think it doesn't break users. Because by default, no matter we update 0 or default value for the two fields, the service will always return default values. 