### PR TITLE
`managed_disk`: Option to configure `tier` on managed disks

### DIFF
--- a/azurerm/internal/services/compute/managed_disk_resource.go
+++ b/azurerm/internal/services/compute/managed_disk_resource.go
@@ -302,8 +302,10 @@ func resourceManagedDiskCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if v := d.Get("tier"); v != 0 {
-		tier := v.(string)
+	if tier := d.Get("tier").(string); tier != "" {
+		if storageAccountType != string(compute.PremiumZRS) && storageAccountType != string(compute.PremiumLRS) {
+			return fmt.Errorf("`tier` can only be specified when `storage_account_type` is set to `Premium_LRS` or `Premium_ZRS`")
+		}
 		props.Tier = &tier
 	}
 
@@ -366,6 +368,9 @@ func resourceManagedDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("tier") {
+		if storageAccountType != string(compute.PremiumZRS) && storageAccountType != string(compute.PremiumLRS) {
+			return fmt.Errorf("`tier` can only be specified when `storage_account_type` is set to `Premium_LRS` or `Premium_ZRS`")
+		}
 		shouldShutDown = true
 		tier := d.Get("tier").(string)
 		diskUpdate.Tier = &tier

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -117,6 +117,11 @@ The following arguments are supported:
 
 * `storage_account_id` - (Optional) The ID of the Storage Account where the `source_uri` is located. Required when `create_option` is set to `Import`.  Changing this forces a new resource to be created.
 
+* `tier` - (Optional) The disk performance tier to use. Possible values are documented [here](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-change-performance). This feature is currently supported only for premium SSDs.
+
+~> **NOTE:** Changing this value is disruptive if the disk is attached to a Virtual Machine. The VM will be shut down and de-allocated as required by Azure to action the change. Terraform will attempt to start the machine again after the update if it was in a `running` state when the apply was started.
+
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `zones` - (Optional) A collection containing the availability zone to allocate the Managed Disk in.


### PR DESCRIPTION
Fixes #11585

Tasks:
- [x] Implement the option
- [x] Document the option
- [x] Run existing Acceptance tests (3 existing failures, regarding KV problems)
- [x] Create an Acceptance test
- [x] Validate configuration (option only available for Premium SSDs)