### PR TITLE
`azurem_kubernetes_cluster`/`azurerm_kubernetes_cluster_node_pool`: support for `node_public_ip_prefix_id`

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -265,6 +265,11 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 							Computed: true,
 						},
 
+						"node_public_ip_prefix_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
 						"upgrade_settings": upgradeSettingsForDataSourceSchema(),
 					},
 				},
@@ -990,6 +995,11 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 			name = *profile.Name
 		}
 
+		nodePublicIPPrefixID := ""
+		if profile.NodePublicIPPrefixID != nil {
+			nodePublicIPPrefixID = *profile.NodePublicIPPrefixID
+		}
+
 		osDiskSizeGb := 0
 		if profile.OsDiskSizeGB != nil {
 			osDiskSizeGb = int(*profile.OsDiskSizeGB)
@@ -1037,24 +1047,25 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 		}
 
 		agentPoolProfiles = append(agentPoolProfiles, map[string]interface{}{
-			"availability_zones":    utils.FlattenStringSlice(profile.AvailabilityZones),
-			"count":                 count,
-			"enable_auto_scaling":   enableAutoScaling,
-			"enable_node_public_ip": enableNodePublicIP,
-			"max_count":             maxCount,
-			"max_pods":              maxPods,
-			"min_count":             minCount,
-			"name":                  name,
-			"node_labels":           nodeLabels,
-			"node_taints":           nodeTaints,
-			"orchestrator_version":  orchestratorVersion,
-			"os_disk_size_gb":       osDiskSizeGb,
-			"os_type":               string(profile.OsType),
-			"tags":                  tags.Flatten(profile.Tags),
-			"type":                  string(profile.Type),
-			"upgrade_settings":      flattenUpgradeSettings(profile.UpgradeSettings),
-			"vm_size":               vmSize,
-			"vnet_subnet_id":        vnetSubnetId,
+			"availability_zones":       utils.FlattenStringSlice(profile.AvailabilityZones),
+			"count":                    count,
+			"enable_auto_scaling":      enableAutoScaling,
+			"enable_node_public_ip":    enableNodePublicIP,
+			"max_count":                maxCount,
+			"max_pods":                 maxPods,
+			"min_count":                minCount,
+			"name":                     name,
+			"node_labels":              nodeLabels,
+			"node_public_ip_prefix_id": nodePublicIPPrefixID,
+			"node_taints":              nodeTaints,
+			"orchestrator_version":     orchestratorVersion,
+			"os_disk_size_gb":          osDiskSizeGb,
+			"os_type":                  string(profile.OsType),
+			"tags":                     tags.Flatten(profile.Tags),
+			"type":                     string(profile.Type),
+			"upgrade_settings":         flattenUpgradeSettings(profile.UpgradeSettings),
+			"vm_size":                  vmSize,
+			"vnet_subnet_id":           vnetSubnetId,
 		})
 	}
 

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -975,6 +975,11 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 			count = int(*profile.Count)
 		}
 
+		enableNodePublicIP := false
+		if profile.EnableNodePublicIP != nil {
+			enableNodePublicIP = *profile.EnableNodePublicIP
+		}
+
 		minCount := 0
 		if profile.MinCount != nil {
 			minCount = int(*profile.MinCount)
@@ -1034,11 +1039,6 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 		nodeTaints := make([]string, 0)
 		if profile.NodeTaints != nil {
 			nodeTaints = *profile.NodeTaints
-		}
-
-		enableNodePublicIP := false
-		if profile.EnableNodePublicIP != nil {
-			enableNodePublicIP = *profile.EnableNodePublicIP
 		}
 
 		vmSize := ""

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -35,7 +35,7 @@ var kubernetesDataSourceTests = map[string]func(t *testing.T){
 	"autoscalingNoAvailabilityZones":                   testAccDataSourceKubernetesCluster_autoscalingNoAvailabilityZones,
 	"autoscalingWithAvailabilityZones":                 testAccDataSourceKubernetesCluster_autoscalingWithAvailabilityZones,
 	"nodeLabels":                                       testAccDataSourceKubernetesCluster_nodeLabels,
-	"enableNodePublicIP":                               testAccDataSourceKubernetesCluster_enableNodePublicIP,
+	"nodePublicIP":                                     testAccDataSourceKubernetesCluster_nodePublicIP,
 	"privateCluster":                                   testAccDataSourceKubernetesCluster_privateCluster,
 }
 
@@ -596,20 +596,21 @@ func testAccDataSourceKubernetesCluster_nodeLabels(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceKubernetesCluster_enableNodePublicIP(t *testing.T) {
+func TestAccDataSourceKubernetesCluster_nodePublicIP(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
-	testAccDataSourceKubernetesCluster_enableNodePublicIP(t)
+	testAccDataSourceKubernetesCluster_nodePublicIP(t)
 }
 
-func testAccDataSourceKubernetesCluster_enableNodePublicIP(t *testing.T) {
+func testAccDataSourceKubernetesCluster_nodePublicIP(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.enableNodePublicIPConfig(data),
+			Config: r.nodePublicIPConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("agent_pool_profile.0.enable_node_public_ip").HasValue("true"),
+				check.That(data.ResourceName).Key("agent_pool_profile.0.node_public_ip_prefix_id").Exists(),
 			),
 		},
 	})
@@ -857,7 +858,7 @@ data "azurerm_kubernetes_cluster" "test" {
 `, KubernetesClusterResource{}.nodeLabelsConfig(data, labels))
 }
 
-func (KubernetesClusterDataSource) enableNodePublicIPConfig(data acceptance.TestData) string {
+func (KubernetesClusterDataSource) nodePublicIPConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -865,5 +866,5 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.enableNodePublicIPConfig(data, true))
+`, KubernetesClusterResource{}.nodePublicIPPrefixConfig(data))
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -95,6 +95,11 @@ func dataSourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				},
 			},
 
+			"node_public_ip_prefix_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"node_taints": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
@@ -240,6 +245,8 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 		if err := d.Set("node_labels", props.NodeLabels); err != nil {
 			return fmt.Errorf("setting `node_labels`: %+v", err)
 		}
+
+		d.Set("node_public_ip_prefix_id", props.NodePublicIPPrefixID)
 
 		if err := d.Set("node_taints", utils.FlattenStringSlice(props.NodeTaints)); err != nil {
 			return fmt.Errorf("setting `node_taints`: %+v", err)

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -306,7 +306,6 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		EnableAutoScaling:      utils.Bool(enableAutoScaling),
 		EnableNodePublicIP:     utils.Bool(d.Get("enable_node_public_ip").(bool)),
 		Mode:                   mode,
-		NodePublicIPPrefixID:   utils.String(d.Get("node_public_ip_prefix_id").(string)),
 		ScaleSetPriority:       containerservice.ScaleSetPriority(priority),
 		Tags:                   tags.Expand(t),
 		Type:                   containerservice.AgentPoolTypeVirtualMachineScaleSets,
@@ -352,6 +351,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	nodeLabelsRaw := d.Get("node_labels").(map[string]interface{})
 	if nodeLabels := utils.ExpandMapStringPtrString(nodeLabelsRaw); len(nodeLabels) > 0 {
 		profile.NodeLabels = nodeLabels
+	}
+
+	if nodePublicIPPrefixID := d.Get("node_public_ip_prefix_id").(string); nodePublicIPPrefixID != "" {
+		profile.NodePublicIPPrefixID = utils.String(nodePublicIPPrefixID)
 	}
 
 	nodeTaintsRaw := d.Get("node_taints").([]interface{})

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -92,10 +92,9 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 			},
 
 			"enable_node_public_ip": {
-				Type:         pluginsdk.TypeBool,
-				Optional:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"node_public_ip_prefix_id"},
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
 			},
 
 			"eviction_policy": {
@@ -148,9 +147,10 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 			},
 
 			"node_public_ip_prefix_id": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"enable_node_public_ip"},
 			},
 
 			"node_taints": {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1243,14 +1243,22 @@ provider "azurerm" {
 
 %s
 
-resource "azurerm_kubernetes_cluster_node_pool" "test" {
-  name                  = "internal"
-  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_DS2_v2"
-  node_count            = 1
-  enable_node_public_ip = true
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpipprefix%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  prefix_length       = 31
 }
-`, r.templateConfig(data))
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                     = "internal"
+  kubernetes_cluster_id    = azurerm_kubernetes_cluster.test.id
+  vm_size                  = "Standard_DS2_v2"
+  node_count               = 1
+  enable_node_public_ip    = true
+  node_public_ip_prefix_id = azurerm_public_ip_prefix.test.id
+}
+`, r.templateConfig(data), data.RandomInteger)
 }
 
 func (r KubernetesClusterNodePoolResource) nodeTaintsConfig(data acceptance.TestData) string {

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -63,10 +63,9 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				},
 
 				"enable_node_public_ip": {
-					Type:         pluginsdk.TypeBool,
-					Optional:     true,
-					ForceNew:     true,
-					RequiredWith: []string{"default_node_pool.0.node_public_ip_prefix_id"},
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					ForceNew: true,
 				},
 
 				"enable_host_encryption": {
@@ -117,6 +116,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					Optional:     true,
 					ForceNew:     true,
 					ValidateFunc: azure.ValidateResourceID,
+					RequiredWith: []string{"default_node_pool.0.enable_node_public_ip"},
 				},
 
 				"node_taints": {

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -114,11 +114,15 @@ A `agent_pool_profile` block exports the following:
 
 * `enable_auto_scaling` - If the auto-scaler is enabled.
 
+* `enable_node_public_ip` - If the Public IPs for the nodes in this Agent Pool are enabled.
+
 * `min_count` - Minimum number of nodes for auto-scaling
 
 * `max_count` - Maximum number of nodes for auto-scaling
 
 * `name` - The name assigned to this pool of agents.
+
+* `node_public_ip_prefix_id` - Resource ID for the Public IP Addresses Prefix for the nodes in this Agent Pool.
 
 * `os_disk_size_gb` - The size of the Agent VM's Operating System Disk in GB.
 

--- a/website/docs/d/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/d/kubernetes_cluster_node_pool.html.markdown
@@ -60,6 +60,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `node_labels` - A map of Kubernetes Labels applied to each Node in this Node Pool.
 
+* `node_public_ip_prefix_id` - Resource ID for the Public IP Addresses Prefix for the nodes in this Agent Pool.
+
 * `node_taints` - A map of Kubernetes Taints applied to each Node in this Node Pool.
 
 * `orchestrator_version` - The version of Kubernetes configured on each Node in this Node Pool.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -307,9 +307,11 @@ A `default_node_pool` block supports the following:
 
 * `enable_host_encryption` - (Optional) Should the nodes in the Default Node Pool have host encryption enabled? Defaults to `false`.
 
-* `enable_node_public_ip` - (Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to `false`.
+* `enable_node_public_ip` - (Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
+
+* `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.
 
 * `node_labels` - (Optional) A map of Kubernetes labels which should be applied to nodes in the Default Node Pool. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 ~> **NOTE:** Additional fields must be configured depending on the value of this field - see below.
 
-* `enable_node_public_ip` - (Optional) Should each node have a Public IP Address? Defaults to `false`.
+* `enable_node_public_ip` - (Optional) Should each node have a Public IP Address? Defaults to `false`.  Changing this forces a new resource to be created.
 
 * `eviction_policy` - (Optional) The Eviction Policy which should be used for Virtual Machines within the Virtual Machine Scale Set powering this Node Pool. Possible values are `Deallocate` and `Delete`. Changing this forces a new resource to be created.
 
@@ -90,6 +90,8 @@ The following arguments are supported:
 * `mode` - (Optional) Should this Node Pool be used for System or User resources? Possible values are `System` and `User`. Defaults to `User`.
 
 * `node_labels` - (Optional) A map of Kubernetes labels which should be applied to nodes in this Node Pool. Changing this forces a new resource to be created.
+
+* `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.
 
 * `node_taints` - (Optional) A list of Kubernetes taints which should be applied to nodes in the agent pool (e.g `key=value:NoSchedule`). Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Fixes #11424

## Tasks done:
- [x] Add Node Public IP Prefix for `kubernetes_cluster` resource
  - [x] Acctest added (`TestAccKubernetesCluster_nodePublicIPPrefix`)
  - [x] Acctest fixed, `enable_node_public_ip` cannot be changed (`TestAccKubernetesCluster_enableNodePublicIP`)
  - [x] Docs
- [x] Add Node Public IP Prefix for `kubernetes_cluster` data source
  - [x] Acctest adjusted (`TestAccDataSourceKubernetesCluster_enableNodePublicIP` -> `TestAccDataSourceKubernetesCluster_nodePublicIP`) 
  - [x] Docs
  - [x] Reordered some code 
- [x] Add Node Public IP Prefix for `kubernetes_cluster_node_pool` resource
  - [x] Acctest adjusted for `kubernetes_cluster_node_pool` resource (`TestAccKubernetesClusterNodePool_enableNodePublicIP` -> `TestAccKubernetesClusterNodePool_nodePublicIP`)
  - [x] Docs
- [x] Add Node Public IP Prefix for `kubernetes_cluster_node_pool` data source
  - [x] Docs

## Acceptance tests:
```
❯ make acctests SERVICE='containers' TESTARGS='-run=nodePublicIP\|NodePublicIP'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/containers -run=nodePublicIP\|NodePublicIP -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/05/08 18:18:13 [DEBUG] not using binary driver name, it's no longer needed
2021/05/08 18:18:14 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataSourceKubernetesCluster_nodePublicIP
=== PAUSE TestAccDataSourceKubernetesCluster_nodePublicIP
=== RUN   TestAccKubernetesCluster_enableNodePublicIP
=== PAUSE TestAccKubernetesCluster_enableNodePublicIP
=== RUN   TestAccKubernetesCluster_nodePublicIPPrefix
=== PAUSE TestAccKubernetesCluster_nodePublicIPPrefix
=== RUN   TestAccKubernetesClusterNodePool_nodePublicIP
=== PAUSE TestAccKubernetesClusterNodePool_nodePublicIP
=== CONT  TestAccDataSourceKubernetesCluster_nodePublicIP
=== CONT  TestAccKubernetesClusterNodePool_nodePublicIP
=== CONT  TestAccKubernetesCluster_nodePublicIPPrefix
=== CONT  TestAccKubernetesCluster_enableNodePublicIP
--- PASS: TestAccKubernetesCluster_nodePublicIPPrefix (626.92s)
--- PASS: TestAccKubernetesCluster_enableNodePublicIP (671.72s)
--- PASS: TestAccDataSourceKubernetesCluster_nodePublicIP (675.04s)
--- PASS: TestAccKubernetesClusterNodePool_nodePublicIP (976.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers     980.290s
```
 
