### PR TITLE
Raise function app `pre_warmed_instance_count` instance count to 20 to match actual limit

### DIFF
--- a/azurerm/internal/services/web/function_app.go
+++ b/azurerm/internal/services/web/function_app.go
@@ -70,7 +70,7 @@ func schemaAppServiceFunctionAppSiteConfig() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 10),
+					ValidateFunc: validation.IntBetween(0, 20),
 				},
 
 				"scm_ip_restriction": schemaAppServiceIpRestriction(),


### PR DESCRIPTION
Caps `pre_warmed_instance_count` for premium function apps to 20 to match documented limit.

Fixes #11583 