### PR TITLE
`azurerm_cosmosdb_sql_container`: add `analytical_storage_ttl` argument

### DIFF
--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 
+* `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this SQL container. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
+
 * `conflict_resolution_policy` - (Optional)  A `conflict_resolution_policy` blocks as defined below.
 
 ---


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./azurerm/internal/services/cosmos -timeout=1000m -run 'TestAccCosmosDbSqlContainer_analyticalStorageTTL'
2021/05/11 10:28:44 [DEBUG] not using binary driver name, it's no longer needed
2021/05/11 10:28:47 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccCosmosDbSqlContainer_analyticalStorageTTL
=== PAUSE TestAccCosmosDbSqlContainer_analyticalStorageTTL
=== CONT  TestAccCosmosDbSqlContainer_analyticalStorageTTL
--- PASS: TestAccCosmosDbSqlContainer_analyticalStorageTTL (1009.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos	1017.167s

```

![image](https://user-images.githubusercontent.com/805046/117786792-2c8fab80-b246-11eb-9eaa-04df17b42688.png)


Fixes #10198