### PR TITLE
fix acc tests for virtual machine

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1623,7 +1623,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_DS3_V2"
+  size                = "Standard_DS3_v2"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -158,7 +158,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   name                = "acctestVM-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_D2S_V3"
+  size                = "Standard_D2s_v3"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_disk_os_resource_test.go
@@ -424,7 +424,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     "azurerm_key_vault_access_policy.disk-encryption",
   ]
 }
-`, r.disksOSDisk_diskEncryptionSetDependencies(data), data.RandomInteger)
+`, r.disksOSDisk_diskEncryptionSetResource(data), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineScaleSetResource) disksOSDiskEphemeral(data acceptance.TestData) string {

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_resource_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_resource_test.go
@@ -575,7 +575,7 @@ func TestAccVirtualMachineScaleSet_multipleAssignedMSI(t *testing.T) {
 			Config: r.multipleAssignedMSI(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned, UserAssigned"),
 				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
 				resource.TestMatchResourceAttr(data.ResourceName, "identity.0.principal_id", validate.UUIDRegExp),
 			),

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -705,7 +705,7 @@ func TestAccWindowsVirtualMachine_otherUltraSsdDefault(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.otherUltraSsdDefault(data),
+			Config: r.otherUltraSsd(data, false),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("additional_capabilities.0.ultra_ssd_enabled").HasValue("false"),
@@ -723,7 +723,7 @@ func TestAccWindowsVirtualMachine_otherUltraSsdEnabled(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.otherUltraSsdEnabled(data),
+			Config: r.otherUltraSsd(data, true),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("additional_capabilities.0.ultra_ssd_enabled").HasValue("true"),
@@ -741,7 +741,7 @@ func TestAccWindowsVirtualMachine_otherUltraSsdUpdated(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		{
-			Config: r.otherUltraSsdDefault(data),
+			Config: r.otherUltraSsd(data, false),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("additional_capabilities.0.ultra_ssd_enabled").HasValue("false"),
@@ -751,7 +751,7 @@ func TestAccWindowsVirtualMachine_otherUltraSsdUpdated(t *testing.T) {
 			"admin_password",
 		),
 		{
-			Config: r.otherUltraSsdEnabled(data),
+			Config: r.otherUltraSsd(data, true),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("additional_capabilities.0.ultra_ssd_enabled").HasValue("true"),
@@ -2081,7 +2081,7 @@ resource "azurerm_windows_virtual_machine" "test" {
 `, r.template(data))
 }
 
-func (r WindowsVirtualMachineResource) otherUltraSsdDefault(data acceptance.TestData) string {
+func (r WindowsVirtualMachineResource) otherUltraSsd(data acceptance.TestData, ultraSsdEnabled bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -2089,38 +2089,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
-  network_interface_ids = [
-    azurerm_network_interface.test.id,
-  ]
-  zone = 1
-
-  os_disk {
-    caching              = "ReadWrite"
-    storage_account_type = "Standard_LRS"
-  }
-
-  source_image_reference {
-    publisher = "MicrosoftWindowsServer"
-    offer     = "WindowsServer"
-    sku       = "2016-Datacenter"
-    version   = "latest"
-  }
-}
-`, r.template(data))
-}
-
-func (r WindowsVirtualMachineResource) otherUltraSsdEnabled(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_F2"
+  size                = "Standard_D2s_v3"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
@@ -2141,10 +2110,10 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   additional_capabilities {
-    ultra_ssd_enabled = true
+    ultra_ssd_enabled = %t
   }
 }
-`, r.template(data))
+`, r.template(data), ultraSsdEnabled)
 }
 
 func (r WindowsVirtualMachineResource) otherWinRMHTTP(data acceptance.TestData) string {
@@ -2379,7 +2348,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_DS3_V2"
+  size                = "Standard_DS3_v2"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -182,7 +182,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  size                = "Standard_D2S_V3"
+  size                = "Standard_D2s_v3"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [


### PR DESCRIPTION
The fixed acc tests are listed as follows.

```

=== RUN   TestAccLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD
=== PAUSE TestAccLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD
=== CONT  TestAccLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD
--- PASS: TestAccLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD (384.11s)

=== RUN   TestAccLinuxVirtualMachine_otherEncryptionAtHostEnabledWithCMK
=== PAUSE TestAccLinuxVirtualMachine_otherEncryptionAtHostEnabledWithCMK
=== CONT  TestAccLinuxVirtualMachine_otherEncryptionAtHostEnabledWithCMK
--- PASS: TestAccLinuxVirtualMachine_otherEncryptionAtHostEnabledWithCMK (289.43s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet (277.17s)

=== RUN   TestAccVirtualMachineScaleSet_multipleAssignedMSI
=== PAUSE TestAccVirtualMachineScaleSet_multipleAssignedMSI
=== CONT  TestAccVirtualMachineScaleSet_multipleAssignedMSI
--- PASS: TestAccVirtualMachineScaleSet_multipleAssignedMSI (427.22s)

=== RUN   TestAccWindowsVirtualMachine_otherUltraSsdEnabled
=== PAUSE TestAccWindowsVirtualMachine_otherUltraSsdEnabled
=== CONT  TestAccWindowsVirtualMachine_otherUltraSsdEnabled
--- PASS: TestAccWindowsVirtualMachine_otherUltraSsdEnabled (406.52s)

=== RUN   TestAccWindowsVirtualMachine_otherUltraSsdDefault
=== PAUSE TestAccWindowsVirtualMachine_otherUltraSsdDefault
=== CONT  TestAccWindowsVirtualMachine_otherUltraSsdDefault
--- PASS: TestAccWindowsVirtualMachine_otherUltraSsdDefault (523.49s)

=== RUN   TestAccWindowsVirtualMachine_otherUltraSsdUpdated
=== PAUSE TestAccWindowsVirtualMachine_otherUltraSsdUpdated
=== CONT  TestAccWindowsVirtualMachine_otherUltraSsdUpdated
--- PASS: TestAccWindowsVirtualMachine_otherUltraSsdUpdated (686.35s)

=== RUN   TestAccWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD
=== PAUSE TestAccWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD
=== CONT  TestAccWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD
--- PASS: TestAccWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD (513.60s)

=== RUN   TestAccWindowsVirtualMachine_otherEncryptionAtHostEnabledWithCMK
=== PAUSE TestAccWindowsVirtualMachine_otherEncryptionAtHostEnabledWithCMK
=== CONT  TestAccWindowsVirtualMachine_otherEncryptionAtHostEnabledWithCMK
--- PASS: TestAccWindowsVirtualMachine_otherEncryptionAtHostEnabledWithCMK (276.38s)
```