### PR TITLE
Support Redis Replicas configuration

### DIFF
--- a/azurerm/internal/services/redis/redis_cache_resource.go
+++ b/azurerm/internal/services/redis/redis_cache_resource.go
@@ -100,6 +100,11 @@ func resourceRedisCache() *schema.Resource {
 				}, false),
 			},
 
+			"replicas_per_master": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
 			"shard_count": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -340,6 +345,11 @@ func resourceRedisCacheCreate(d *schema.ResourceData, meta interface{}) error {
 		Tags: expandedTags,
 	}
 
+	if v, ok := d.GetOk("replicas_per_master"); ok {
+		replicasPerMaster := int32(v.(int))
+		parameters.ReplicasPerMaster = &replicasPerMaster
+	}
+
 	if v, ok := d.GetOk("shard_count"); ok {
 		shardCount := int32(v.(int))
 		parameters.ShardCount = &shardCount
@@ -433,6 +443,13 @@ func resourceRedisCacheUpdate(d *schema.ResourceData, meta interface{}) error {
 			},
 		},
 		Tags: expandedTags,
+	}
+
+	if v, ok := d.GetOk("replicas_per_master"); ok {
+		if d.HasChange("replicas_per_master") {
+			replicasPerMaster := int32(v.(int))
+			parameters.replicasPerMaster = &replicasPerMaster
+		}
 	}
 
 	if v, ok := d.GetOk("shard_count"); ok {
@@ -545,6 +562,9 @@ func resourceRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("minimum_tls_version", string(props.MinimumTLSVersion))
 		d.Set("port", props.Port)
 		d.Set("enable_non_ssl_port", props.EnableNonSslPort)
+		if props.RepliasPerMaster != nil {
+			d.Set("replicas_per_master", props.ReplicasPerMaster)
+		}
 		if props.ShardCount != nil {
 			d.Set("shard_count", props.ShardCount)
 		}

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `redis_configuration` - (Optional) A `redis_configuration` as defined below - with some limitations by SKU - defaults/details are shown below.
 
+* `replicas_per_master` - (Optional) *Only available when using the Premium SKU* The number of Replicas to create per master on the Redis Cluster. *Cannot be used in conjunction with shards*
+
 * `shard_count` - (Optional) *Only available when using the Premium SKU* The number of Shards to create on the Redis Cluster.
 
 * `subnet_id` - (Optional) *Only available when using the Premium SKU* The ID of the Subnet within which the Redis Cache should be deployed. This Subnet must only contain Azure Cache for Redis instances without any other type of resources. Changing this forces a new resource to be created.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -69,7 +69,9 @@ The following arguments are supported:
 
 * `redis_configuration` - (Optional) A `redis_configuration` as defined below - with some limitations by SKU - defaults/details are shown below.
 
-* `replicas_per_master` - (Optional) *Only available when using the Premium SKU* The number of Replicas to create per master on the Redis Cluster. *Cannot be used in conjunction with shards*
+* `replicas_per_master` - (Optional) The number of Replicas to create per master on the Redis Cluster.
+
+~> **Note:** Configuring the number of replicas per faster is only available when using the Premium SKU and cannot be used in conjunction with shards.
 
 * `shard_count` - (Optional) *Only available when using the Premium SKU* The number of Shards to create on the Redis Cluster.
 

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `replicas_per_master` - (Optional) The number of Replicas to create per master on the Redis Cluster.
 
-~> **Note:** Configuring the number of replicas per faster is only available when using the Premium SKU and cannot be used in conjunction with shards.
+~> **Note:** Configuring the number of replicas per master is only available when using the Premium SKU and cannot be used in conjunction with shards.
 
 * `shard_count` - (Optional) *Only available when using the Premium SKU* The number of Shards to create on the Redis Cluster.
 


### PR DESCRIPTION
A Redis cluster can be configured with more than one replica per master.
See
https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-multi-replicas
for documentation. ReplicasPerMaster is supported in the Go SDK.

Without the ability to set replicas we are unable to set up Redis to be
fully zone redundant. One must have as many nodes aS there are zones.
THe default replica count is 1, for a total of two nodes, which would
only support two zones of redundancy. Many regions have three zones.
