### PR TITLE
fix(bastion_host): Add ForceNew field to ipconf values

### DIFF
--- a/azurerm/internal/services/network/bastion_host_resource.go
+++ b/azurerm/internal/services/network/bastion_host_resource.go
@@ -61,16 +61,19 @@ func resourceBastionHost() *schema.Resource {
 						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: validate.BastionIPConfigName,
 						},
 						"subnet_id": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: azure.ValidateResourceID,
 						},
 						"public_ip_address_id": {
 							Type:         schema.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: azure.ValidateResourceID,
 						},
 					},


### PR DESCRIPTION
Fixes:
https://github.com/terraform-providers/terraform-provider-azurerm/issues/10600

Add ForceNew fields to values in IP Configuration for Bastion Host resource:
* Name
* Subnet ID
* Public IP Address ID

Behaviour then is like for like with Azure Portal where a user has to rebuild Bastion Hosts.
