### PR TITLE
`mssql_database`: Support field `creation_source_database_id` on import for Secondary db

### DIFF
--- a/azurerm/internal/services/mssql/mssql_database_resource_test.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource_test.go
@@ -268,7 +268,7 @@ func TestAccMsSqlDatabase_createSecondaryMode(t *testing.T) {
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
-		data.ImportStep("creation_source_database_id", "sample_name"),
+		data.ImportStep("sample_name"),
 	})
 }
 
@@ -286,7 +286,7 @@ func TestAccMsSqlDatabase_scaleReplicaSetWithFailovergroup(t *testing.T) {
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
-		data.ImportStep("creation_source_database_id"),
+		data.ImportStep(),
 		{
 			Config: r.scaleReplicaSetWithFailovergroup(data, "GP_Gen5_8", 25),
 			Check: resource.ComposeTestCheckFunc(
@@ -296,7 +296,7 @@ func TestAccMsSqlDatabase_scaleReplicaSetWithFailovergroup(t *testing.T) {
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_8"),
 			),
 		},
-		data.ImportStep("creation_source_database_id"),
+		data.ImportStep(),
 		{
 			Config: r.scaleReplicaSetWithFailovergroup(data, "GP_Gen5_2", 5),
 			Check: resource.ComposeTestCheckFunc(
@@ -306,7 +306,7 @@ func TestAccMsSqlDatabase_scaleReplicaSetWithFailovergroup(t *testing.T) {
 				check.That(data.ResourceName).Key("sku_name").HasValue("GP_Gen5_2"),
 			),
 		},
-		data.ImportStep("creation_source_database_id"),
+		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
Fixes #11681

Acceptance tests are adjusted to catch the bug. 

The current implementation to set `creation_source_database_id` on import mimics the lookup behaviour of Azure Portal for replicated databases. Question is whether to fix it this way or by making `creation_source_database_id` changeable and only required when creating a Secondary DB.

## Acceptance tests
```
❯ make acctests SERVICE='mssql' TESTARGS='-run=TestAccMsSqlDatabase_createSecondaryMode'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/mssql -run=TestAccMsSqlDatabase_createSecondaryMode -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/05/13 21:30:52 [DEBUG] not using binary driver name, it's no longer needed
2021/05/13 21:30:54 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccMsSqlDatabase_createSecondaryMode
=== PAUSE TestAccMsSqlDatabase_createSecondaryMode
=== CONT  TestAccMsSqlDatabase_createSecondaryMode
--- PASS: TestAccMsSqlDatabase_createSecondaryMode (396.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql       400.960s
```