### PR TITLE
`azurerm_container_registry` - Support for `zone_redundancy_enabled` for both the ACR and each `georeplications` block

### DIFF
--- a/azurerm/internal/services/containers/container_registry_resource.go
+++ b/azurerm/internal/services/containers/container_registry_resource.go
@@ -675,6 +675,9 @@ func applyGeoReplicationLocations(d *pluginsdk.ResourceData, meta interface{}, r
 
 	// delete previously deployed locations
 	for _, replication := range oldGeoReplications {
+		if replication.Location == nil {
+			continue
+		}
 		oldLocation := azure.NormalizeLocation(*replication.Location)
 
 		future, err := replicationClient.Delete(ctx, resourceGroup, name, oldLocation)
@@ -688,6 +691,9 @@ func applyGeoReplicationLocations(d *pluginsdk.ResourceData, meta interface{}, r
 
 	// create new geo-replication locations
 	for _, replication := range newGeoReplications {
+		if replication.Location == nil {
+			continue
+		}
 		locationToCreate := azure.NormalizeLocation(*replication.Location)
 		future, err := replicationClient.Create(ctx, resourceGroup, name, locationToCreate, replication)
 		if err != nil {

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -122,7 +122,7 @@ The following arguments are supported:
 * `trust_policy` - (Optional) A `trust_policy` block as documented below.
 
 * `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`.
-  
+
   ~> **NOTE:** `quarantine_policy_enabled`, `retention_policy`, `trust_policy` and `zone_redundancy_enabled` are only supported on resources with the `Premium` SKU.
 
 * `identity` - (Optional) An `identity` block as documented below.
@@ -135,7 +135,7 @@ The following arguments are supported:
 
 * `location` - (Required) A location where the container registry should be geo-replicated.
 
-* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication? Defaults to `false`.
+* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication location? Defaults to `false`.
 
 * `tags` - (Optional) A mapping of tags to assign to this replication location.
 
@@ -199,7 +199,7 @@ The following arguments are supported:
 
 * `key_vault_key_id` - (Required) The ID of the Key Vault Key.
 
-* `identity_client_id`  - (Required) The client ID of the managed identity associated with the encryption key. 
+* `identity_client_id`  - (Required) The client ID of the managed identity associated with the encryption key.
 
 ~> **NOTE** The managed identity used in `encryption` also needs to be part of the `identity` block under `identity_ids`
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -121,17 +121,25 @@ The following arguments are supported:
 
 * `trust_policy` - (Optional) A `trust_policy` block as documented below.
 
+* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`.
+  
+  ~> **NOTE:** `quarantine_policy_enabled`, `retention_policy`, `trust_policy` and `zone_redundancy_enabled` are only supported on resources with the `Premium` SKU.
+
 * `identity` - (Optional) An `identity` block as documented below.
 
 * `encryption` - (Optional) An `encryption` block as documented below.
 
-~> **NOTE:** `quarantine_policy_enabled`, `retention_policy` and `trust_policy` are only supported on resources with the `Premium` SKU.
+---
 
 `georeplications` supports the following:
 
 * `location` - (Required) A location where the container registry should be geo-replicated.
 
+* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication? Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags to assign to this replication location.
+
+---
 
 `network_rule_set` supports the following:
 
@@ -145,11 +153,15 @@ The following arguments are supported:
 
 ~> **NOTE:** Azure automatically configures Network Rules - to remove these you'll need to specify an `network_rule_set` block with `default_action` set to `Deny`.
 
+---
+
 `ip_rule` supports the following:
 
 * `action` - (Required) The behaviour for requests matching this rule. At this time the only supported value is `Allow`
 
 * `ip_range` - (Required) The CIDR block from which requests will match the rule.
+
+---
 
 `virtual_network` supports the following:
 
@@ -157,9 +169,13 @@ The following arguments are supported:
 
 * `subnet_id` - (Required) The subnet id from which requests will match the rule.
 
+---
+
 `trust_policy` supports the following:
 
 * `enabled` - (Optional) Boolean value that indicates whether the policy is enabled.
+
+---
 
 `retention_policy` supports the following:
 
@@ -167,11 +183,15 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Boolean value that indicates whether the policy is enabled.
 
+---
+
 `identity` supports the following:
 
 * `type` - (Required) The type of Managed Identity which should be assigned to the Container Registry. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
 
 * `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Container Registry.
+
+---
 
 `encryption` supports the following:
 


### PR DESCRIPTION
This PR adds support for `zone_redundancy_enabled` for both the ACR and each `georeplications` block, which fixes #11672.

A notable change in this PR is that it modifies the type of `georeplications` from `TypeSet` to `TypeList`, which is due to hashicorp/terraform-plugin-sdk#160. Also the original author has [confirmed that the API will return the list in reserved order](https://github.com/terraform-providers/terraform-provider-azurerm/pull/11200#discussion_r612188447), so there is no good reason to have to use a set here.

## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=2h ./azurerm/internal/services/containers -run="TestAccContainerRegistry_"
2021/05/14 13:47:27 [DEBUG] not using binary driver name, it's no longer needed
2021/05/14 13:47:27 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccContainerRegistry_basic_basic
=== PAUSE TestAccContainerRegistry_basic_basic
=== RUN   TestAccContainerRegistry_requiresImport
=== PAUSE TestAccContainerRegistry_requiresImport
=== RUN   TestAccContainerRegistry_basic_standard
=== PAUSE TestAccContainerRegistry_basic_standard
=== RUN   TestAccContainerRegistry_basic_premium
=== PAUSE TestAccContainerRegistry_basic_premium
=== RUN   TestAccContainerRegistry_basic_basic2Premium2basic
=== PAUSE TestAccContainerRegistry_basic_basic2Premium2basic
=== RUN   TestAccContainerRegistry_complete
=== PAUSE TestAccContainerRegistry_complete
=== RUN   TestAccContainerRegistry_update
=== PAUSE TestAccContainerRegistry_update
=== RUN   TestAccContainerRegistry_geoReplicationLocation
=== PAUSE TestAccContainerRegistry_geoReplicationLocation
=== RUN   TestAccContainerRegistry_geoReplication
=== PAUSE TestAccContainerRegistry_geoReplication
=== RUN   TestAccContainerRegistry_geoReplicationSwitch
=== PAUSE TestAccContainerRegistry_geoReplicationSwitch
=== RUN   TestAccContainerRegistry_networkAccessProfileIp
=== PAUSE TestAccContainerRegistry_networkAccessProfileIp
=== RUN   TestAccContainerRegistry_networkAccessProfile_update
=== PAUSE TestAccContainerRegistry_networkAccessProfile_update
=== RUN   TestAccContainerRegistry_networkAccessProfileVnet
=== PAUSE TestAccContainerRegistry_networkAccessProfileVnet
=== RUN   TestAccContainerRegistry_policies
=== PAUSE TestAccContainerRegistry_policies
=== RUN   TestAccContainerRegistry_identity
=== PAUSE TestAccContainerRegistry_identity
=== RUN   TestAccContainerRegistry_zoneRedundancy
=== PAUSE TestAccContainerRegistry_zoneRedundancy
=== RUN   TestAccContainerRegistry_geoReplicationZoneRedundancy
=== PAUSE TestAccContainerRegistry_geoReplicationZoneRedundancy
=== CONT  TestAccContainerRegistry_basic_basic
=== CONT  TestAccContainerRegistry_geoReplicationSwitch
=== CONT  TestAccContainerRegistry_complete
=== CONT  TestAccContainerRegistry_identity
=== CONT  TestAccContainerRegistry_geoReplicationLocation
=== CONT  TestAccContainerRegistry_geoReplication
--- PASS: TestAccContainerRegistry_basic_basic (172.81s)
=== CONT  TestAccContainerRegistry_update
--- PASS: TestAccContainerRegistry_complete (176.78s)
=== CONT  TestAccContainerRegistry_basic_premium
--- PASS: TestAccContainerRegistry_identity (194.99s)
=== CONT  TestAccContainerRegistry_basic_basic2Premium2basic
--- PASS: TestAccContainerRegistry_basic_premium (180.83s)
=== CONT  TestAccContainerRegistry_geoReplicationZoneRedundancy
--- PASS: TestAccContainerRegistry_geoReplicationSwitch (378.23s)
=== CONT  TestAccContainerRegistry_basic_standard
--- PASS: TestAccContainerRegistry_update (245.52s)
=== CONT  TestAccContainerRegistry_requiresImport
--- PASS: TestAccContainerRegistry_basic_basic2Premium2basic (324.12s)
=== CONT  TestAccContainerRegistry_zoneRedundancy
--- PASS: TestAccContainerRegistry_basic_standard (169.08s)
=== CONT  TestAccContainerRegistry_networkAccessProfileVnet
--- PASS: TestAccContainerRegistry_requiresImport (191.15s)
=== CONT  TestAccContainerRegistry_policies
2021/05/14 13:57:45 [DEBUG] AzureRM Request:
GET /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-210514134727780387/providers/Microsoft.ContainerRegistry/registries/testAccCr210514134727780387/replications?api-version=2020-11-01-preview HTTP/1.1
Host: management.azure.com
User-Agent: Go/go1.16 (amd64-linux) go-autorest/v14.2.1 Azure-SDK-For-Go/v54.0.0 containerregistry/2020-11-01-preview HashiCorp Terraform/0.14.9 (+https://www.terraform.io) Terraform Plugin SDK/1.17.2 terraform-provider-azurerm/dev pid-222c6c49-1b0a-5959-a213-6608f9eb8820
X-Ms-Correlation-Request-Id: cbe6900d-a69d-ffba-70e0-fa67f765af54
Accept-Encoding: gzip


--- PASS: TestAccContainerRegistry_geoReplicationZoneRedundancy (279.08s)
=== CONT  TestAccContainerRegistry_networkAccessProfile_update
--- PASS: TestAccContainerRegistry_geoReplicationLocation (654.12s)
=== CONT  TestAccContainerRegistry_networkAccessProfileIp
--- PASS: TestAccContainerRegistry_geoReplication (699.85s)
--- PASS: TestAccContainerRegistry_networkAccessProfileVnet (214.26s)
--- PASS: TestAccContainerRegistry_zoneRedundancy (282.00s)
--- PASS: TestAccContainerRegistry_networkAccessProfileIp (181.86s)
--- PASS: TestAccContainerRegistry_policies (1536.41s)
--- PASS: TestAccContainerRegistry_networkAccessProfile_update (1750.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers  2387.534s

```