### PR TITLE
fix failure TC for Batch RP

### DIFF
--- a/azurerm/internal/services/batch/batch_account_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_account_data_source_test.go
@@ -131,7 +131,11 @@ data "azurerm_batch_account" "test" {
 func (BatchAccountDataSource) userSubscription(data acceptance.TestData, tenantID string, subscriptionID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 provider "azuread" {}
@@ -164,7 +168,8 @@ resource "azurerm_key_vault" "test" {
       "get",
       "list",
       "set",
-      "delete"
+      "delete",
+      "recover"
     ]
 
   }

--- a/azurerm/internal/services/batch/batch_account_data_source_test.go
+++ b/azurerm/internal/services/batch/batch_account_data_source_test.go
@@ -131,11 +131,7 @@ data "azurerm_batch_account" "test" {
 func (BatchAccountDataSource) userSubscription(data acceptance.TestData, tenantID string, subscriptionID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy = false
-    }
-  }
+  features {}
 }
 
 provider "azuread" {}

--- a/azurerm/internal/services/batch/batch_account_resource_test.go
+++ b/azurerm/internal/services/batch/batch_account_resource_test.go
@@ -240,11 +240,7 @@ resource "azurerm_batch_account" "test" {
 func (BatchAccountResource) userSubscription(data acceptance.TestData, tenantID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy = false
-    }
-  }
+  features {}
 }
 
 provider "azuread" {}

--- a/azurerm/internal/services/batch/batch_account_resource_test.go
+++ b/azurerm/internal/services/batch/batch_account_resource_test.go
@@ -240,7 +240,11 @@ resource "azurerm_batch_account" "test" {
 func (BatchAccountResource) userSubscription(data acceptance.TestData, tenantID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 provider "azuread" {}
@@ -273,7 +277,8 @@ resource "azurerm_key_vault" "test" {
       "get",
       "list",
       "set",
-      "delete"
+      "delete",
+      "recover"
     ]
 
   }


### PR DESCRIPTION
according to https://docs.microsoft.com/en-us/azure/batch/batch-account-create-portal#create-a-key-vault

```
Azure Batch must be given a minimum of Get, List, Set, and Delete permissions. For Key Vaults with soft-delete enabled, Azure Batch must also be given Recover permission.
```

now, new created key vault will auto enable soft delete, so need to add `recover` permission

![image](https://user-images.githubusercontent.com/2786738/118239099-ed728c00-b4cb-11eb-9301-a3b3e2a72a43.png)
