### PR TITLE
`azurerm_redis_cache`: add `replicas_per_master` attribute

### DIFF
--- a/azurerm/internal/services/redis/redis_cache_resource.go
+++ b/azurerm/internal/services/redis/redis_cache_resource.go
@@ -282,6 +282,8 @@ func resourceRedisCache() *schema.Resource {
 			"replicas_per_master": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				// Can't make more than 3 replicas in portal, assuming it's a limitation
+				ValidateFunc: validation.IntBetween(1, 3),
 			},
 
 			"tags": tags.Schema(),

--- a/azurerm/internal/services/redis/redis_cache_resource.go
+++ b/azurerm/internal/services/redis/redis_cache_resource.go
@@ -279,6 +279,11 @@ func resourceRedisCache() *schema.Resource {
 				Default:  true,
 			},
 
+			"replicas_per_master": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -343,6 +348,10 @@ func resourceRedisCacheCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("shard_count"); ok {
 		shardCount := int32(v.(int))
 		parameters.ShardCount = &shardCount
+	}
+
+	if v, ok := d.GetOk("replicas_per_master"); ok {
+		parameters.ReplicasPerMaster = utils.Int32(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("private_static_ip_address"); ok {
@@ -439,6 +448,12 @@ func resourceRedisCacheUpdate(d *schema.ResourceData, meta interface{}) error {
 		if d.HasChange("shard_count") {
 			shardCount := int32(v.(int))
 			parameters.ShardCount = &shardCount
+		}
+	}
+
+	if v, ok := d.GetOk("replicas_per_master"); ok {
+		if d.HasChange("replicas_per_master") {
+			parameters.ReplicasPerMaster = utils.Int32(int32(v.(int)))
 		}
 	}
 
@@ -562,6 +577,7 @@ func resourceRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("subnet_id", subnetId)
 
 		d.Set("public_network_access_enabled", props.PublicNetworkAccess == redis.Enabled)
+		d.Set("replicas_per_master", props.ReplicasPerMaster)
 	}
 
 	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration)

--- a/azurerm/internal/services/redis/redis_cache_resource_test.go
+++ b/azurerm/internal/services/redis/redis_cache_resource_test.go
@@ -397,6 +397,20 @@ func TestAccRedisCache_WithoutAuth(t *testing.T) {
 	})
 }
 
+func TestAccRedisCache_ReplicasPerMaster(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache", "test")
+	r := RedisCacheResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.replicasPerMaster(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (t RedisCacheResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.CacheID(state.ID)
 	if err != nil {
@@ -1000,6 +1014,30 @@ resource "azurerm_redis_cache" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (RedisCacheResource) replicasPerMaster(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 3
+  family              = "P"
+  sku_name            = "Premium"
+  enable_non_ssl_port = false
+  replicas_per_master = 3
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func testCheckSSLInConnectionString(resourceName string, propertyName string, requireSSL bool) resource.TestCheckFunc {

--- a/azurerm/internal/services/redis/redis_cache_resource_test.go
+++ b/azurerm/internal/services/redis/redis_cache_resource_test.go
@@ -1023,7 +1023,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-redis-%d"
   location = "%s"
 }
 

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `replicas_per_master` - (Optional) Amount of replicas to create per master for this Redis Cache.
 
+~> **Note:** Configuring the number of replicas per master is only available when using the Premium SKU and cannot be used in conjunction with shards.
+
 * `shard_count` - (Optional) *Only available when using the Premium SKU* The number of Shards to create on the Redis Cluster.
 
 * `subnet_id` - (Optional) *Only available when using the Premium SKU* The ID of the Subnet within which the Redis Cache should be deployed. This Subnet must only contain Azure Cache for Redis instances without any other type of resources. Changing this forces a new resource to be created.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `redis_configuration` - (Optional) A `redis_configuration` as defined below - with some limitations by SKU - defaults/details are shown below.
 
+* `replicas_per_master` - (Optional) Amount of replicas to create per master for this Redis Cache.
+
 * `shard_count` - (Optional) *Only available when using the Premium SKU* The number of Shards to create on the Redis Cluster.
 
 * `subnet_id` - (Optional) *Only available when using the Premium SKU* The ID of the Subnet within which the Redis Cache should be deployed. This Subnet must only contain Azure Cache for Redis instances without any other type of resources. Changing this forces a new resource to be created.


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./azurerm/internal/services/redis -timeout=1000m -run 'TestAccRedisCache_ReplicasPerMaster'
2021/05/14 09:40:28 [DEBUG] not using binary driver name, it's no longer needed
2021/05/14 09:40:29 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccRedisCache_ReplicasPerMaster
=== PAUSE TestAccRedisCache_ReplicasPerMaster
=== CONT  TestAccRedisCache_ReplicasPerMaster
--- PASS: TestAccRedisCache_ReplicasPerMaster (1706.39s)
PASS
```

![image](https://user-images.githubusercontent.com/805046/118238618-07df4200-b499-11eb-858b-15e3e7cb67fd.png)

Fixes #11687