### PR TITLE
[DataSource] `azurerm_redis_enterprise_database` - Expose support for Redis Enterprise Database

### DIFF
--- a/azurerm/internal/services/redisenterprise/redis_enterprise_database_data_source.go
+++ b/azurerm/internal/services/redisenterprise/redis_enterprise_database_data_source.go
@@ -1,0 +1,77 @@
+package redisenterprise
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/redisenterprise/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/redisenterprise/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+)
+
+func dataSourceRedisEnterpriseDatabase() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRedisEnterpriseDatabaseRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"cluster_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.RedisEnterpriseClusterID,
+			},
+
+			"primary_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+func dataSourceRedisEnterpriseDatabaseRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).RedisEnterprise.DatabaseClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	clusterId, err := parse.RedisEnterpriseClusterID(d.Get("cluster_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := parse.NewRedisEnterpriseDatabaseID(subscriptionId, d.Get("resource_group_name").(string), clusterId.RedisEnterpriseName, d.Get("name").(string))
+
+	keysResp, err := client.ListKeys(ctx, id.ResourceGroup, id.RedisEnterpriseName, id.DatabaseName)
+	if err != nil {
+		return fmt.Errorf("listing keys for Redis Enterprise Database %q (Resource Group %q / Cluster Name %q): %+v", id.DatabaseName, id.ResourceGroup, id.RedisEnterpriseName, err)
+	}
+
+	d.SetId(id.ID())
+	d.Set("name", id.DatabaseName)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("cluster_id", clusterId.ID())
+	d.Set("primary_access_key", keysResp.PrimaryKey)
+	d.Set("secondary_access_key", keysResp.SecondaryKey)
+
+	return nil
+}

--- a/azurerm/internal/services/redisenterprise/redis_enterprise_database_data_source_test.go
+++ b/azurerm/internal/services/redisenterprise/redis_enterprise_database_data_source_test.go
@@ -1,0 +1,47 @@
+package redisenterprise_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type RedisEnterpriseDatabaseDataSource struct {
+}
+
+func TestAccRedisEnterpriseDatabaseDataSource_standard(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_redis_enterprise_database", "test")
+	r := RedisEnterpriseDatabaseDataSource{}
+
+	resourceGroupName := fmt.Sprintf("acctestRG-redisEnterprise-%d", data.RandomInteger)
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.dataSource(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("default"),
+				check.That(data.ResourceName).Key("resource_group_name").HasValue(resourceGroupName),
+				check.That(data.ResourceName).Key("cluster_id").Exists(),
+				check.That(data.ResourceName).Key("primary_access_key").Exists(),
+				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
+			),
+		},
+	})
+}
+
+func (r RedisEnterpriseDatabaseDataSource) dataSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_redis_enterprise_database" "test" {
+  depends_on = [azurerm_redis_enterprise_database.test]
+
+  name                = "default"
+  resource_group_name = azurerm_resource_group.test.name
+  cluster_id          = azurerm_redis_enterprise_cluster.test.id
+}
+`, RedisenterpriseDatabaseResource{}.basic(data))
+}

--- a/azurerm/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/azurerm/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -363,7 +363,7 @@ func flattenArmDatabaseModuleArray(input *[]redisenterprise.Module) []interface{
 		if item.Args != nil {
 			args = *item.Args
 			// new behavior if you do not pass args the RP sets the args to "PARTITIONS AUTO" by default
-			// which causes the the database to be force new on every plan after creation
+			// (for RediSearch) which causes the the database to be force new on every plan after creation
 			// feels like an RP bug, but I added this workaround...
 			// NOTE: You also cannot set the args to PARTITIONS AUTO by default else you will get an error on create:
 			// Code="InvalidRequestBody" Message="The value of the parameter 'properties.modules' is invalid."

--- a/azurerm/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/azurerm/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -175,6 +175,18 @@ func resourceRedisEnterpriseDatabase() *schema.Resource {
 				Default:      10000,
 				ValidateFunc: validation.IntBetween(0, 65353),
 			},
+
+			"primary_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 	}
 }
@@ -259,6 +271,11 @@ func resourceRedisEnterpriseDatabaseRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("retrieving Redis Enterprise Database %q (Resource Group %q / Cluster Name %q): %+v", id.DatabaseName, id.ResourceGroup, id.RedisEnterpriseName, err)
 	}
 
+	keysResp, err := client.ListKeys(ctx, id.ResourceGroup, id.RedisEnterpriseName, id.DatabaseName)
+	if err != nil {
+		return fmt.Errorf("listing keys for Redis Enterprise Database %q (Resource Group %q / Cluster Name %q): %+v", id.DatabaseName, id.ResourceGroup, id.RedisEnterpriseName, err)
+	}
+
 	d.Set("name", id.DatabaseName)
 	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("cluster_id", parse.NewRedisEnterpriseClusterID(id.SubscriptionId, id.ResourceGroup, id.RedisEnterpriseName).ID())
@@ -275,6 +292,9 @@ func resourceRedisEnterpriseDatabaseRead(d *schema.ResourceData, meta interface{
 		// }
 		d.Set("port", props.Port)
 	}
+
+	d.Set("primary_access_key", keysResp.PrimaryKey)
+	d.Set("secondary_access_key", keysResp.SecondaryKey)
 
 	return nil
 }
@@ -342,6 +362,14 @@ func flattenArmDatabaseModuleArray(input *[]redisenterprise.Module) []interface{
 		args := ""
 		if item.Args != nil {
 			args = *item.Args
+			// new behavior if you do not pass args the RP sets the args to "PARTITIONS AUTO" by default
+			// which causes the the database to be force new on every plan after creation
+			// feels like an RP bug, but I added this workaround...
+			// NOTE: You also cannot set the args to PARTITIONS AUTO by default else you will get an error on create:
+			// Code="InvalidRequestBody" Message="The value of the parameter 'properties.modules' is invalid."
+			if strings.EqualFold(args, "PARTITIONS AUTO") {
+				args = ""
+			}
 		}
 
 		var version string

--- a/azurerm/internal/services/redisenterprise/registration.go
+++ b/azurerm/internal/services/redisenterprise/registration.go
@@ -20,7 +20,9 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
-	return nil
+	return map[string]*schema.Resource{
+		"azurerm_redis_enterprise_database": dataSourceRedisEnterpriseDatabase(),
+	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service

--- a/website/docs/d/redis_enterprise_database.html.markdown
+++ b/website/docs/d/redis_enterprise_database.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Use this data source to access information about an existing Redis Enterprise Database
 
+!> **NOTE:** If you are using a this data source in the same configuration file where the Redis Enterprise Database resource is defined you will need to add a `depends_on` referece to the Redis Enterprise Database resource in the data source definition HCL to avoid a race condition in the Terraform Dependency Graph creation (e.g. depends_on = [azurerm_redis_enterprise_database.example]).
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/redis_enterprise_database.html.markdown
+++ b/website/docs/d/redis_enterprise_database.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Redis Enterprise"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_redis_enterprise_database"
+description: |-
+  Gets information about an existing Redis Enterprise Database.
+
+---
+
+# Data Source: azurerm_redis_enterprise_database
+
+Use this data source to access information about an existing Redis Enterprise Database
+
+## Example Usage
+
+```hcl
+data "azurerm_redis_enterprise_database" "example" {
+  name                = "default"
+  resource_group_name = azurerm_resource_group.example.name
+  cluster_id          = azurerm_redis_enterprise_cluster.example.id
+}
+
+output "redis_enterprise_database_name" {
+  value       = data.azurerm_redis_enterprise_database.example.name
+  description = "The Name of The Redis Enterprise Database"
+}
+
+output "redis_enterprise_database_cluster_id" {
+  value       = data.azurerm_redis_enterprise_database.example.cluster_id
+  description = "The Redis Enterprise Cluster ID that is hosting the Redis Enterprise DB instance."
+}
+
+output "redis_enterprise_database_id" {
+  value       = data.azurerm_redis_enterprise_database.example.id
+  description = "The Redis Enterprise DB ID."
+}
+
+output "redis_enterprise_database_primary_key" {
+  value       = data.azurerm_redis_enterprise_database.example.primary_access_key
+  description = "The Redis Enterprise DB primary key."
+}
+
+output "redis_enterprise_database_secondary_key" {
+  value       = data.azurerm_redis_enterprise_database.example.secondary_access_key
+  description = "The Redis Enterprise DB secondary key."
+}
+```
+
+## Argument Reference
+
+* `name` - The name of the Redis Enterprise Database.
+
+* `resource_group_name` - The name of the resource group the Redis Enterprise Database instance is located in.
+
+* `cluster_id` - The resource ID of Redis Enterprise Cluster which hosts the Redis Enterprise Database instance.
+
+## Attribute Reference
+
+* `id` - The Redis Enterprise Database ID.
+
+* `name` - The Redis Enterprise Database name.
+
+* `cluster_id` - The Redis Enterprise Cluster ID that is hosting the Redis Enterprise Database.
+
+* `primary_access_key` - The Primary Access Key for the Redis Enterprise Database instance.
+
+* `secondary_access_key` - The Secondary Access Key for the Redis Enterprise Database instance.
+
+---
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Redis Enterprise Database.

--- a/website/docs/d/redis_enterprise_database.html.markdown
+++ b/website/docs/d/redis_enterprise_database.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Use this data source to access information about an existing Redis Enterprise Database
 
-!> **NOTE:** If you are using a this data source in the same configuration file where the Redis Enterprise Database resource is defined you will need to add a `depends_on` referece to the Redis Enterprise Database resource in the data source definition HCL to avoid a race condition in the Terraform Dependency Graph creation (e.g. depends_on = [azurerm_redis_enterprise_database.example]).
-
 ## Example Usage
 
 ```hcl
@@ -20,21 +18,6 @@ data "azurerm_redis_enterprise_database" "example" {
   name                = "default"
   resource_group_name = azurerm_resource_group.example.name
   cluster_id          = azurerm_redis_enterprise_cluster.example.id
-}
-
-output "redis_enterprise_database_name" {
-  value       = data.azurerm_redis_enterprise_database.example.name
-  description = "The Name of The Redis Enterprise Database"
-}
-
-output "redis_enterprise_database_cluster_id" {
-  value       = data.azurerm_redis_enterprise_database.example.cluster_id
-  description = "The Redis Enterprise Cluster ID that is hosting the Redis Enterprise DB instance."
-}
-
-output "redis_enterprise_database_id" {
-  value       = data.azurerm_redis_enterprise_database.example.id
-  description = "The Redis Enterprise DB ID."
 }
 
 output "redis_enterprise_database_primary_key" {

--- a/website/docs/r/redis_enterprise_database.html.markdown
+++ b/website/docs/r/redis_enterprise_database.html.markdown
@@ -70,6 +70,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Redis Enterprise Database.
 
+* `primary_access_key` - The Primary Access Key for the Redis Enterprise Database Instance.
+
+* `secondary_access_key` - The Secondary Access Key for the Redis Enterprise Database Instance.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
Add data source for Redis Enterprise Database which exposes the following fields:

* `primary_access_key`
* `secondary_access_key`

(fixes #11691)