### PR TITLE
`azurerm_cosmosdb_mongo_collection`: add `analytical_storage_ttl` argument

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -1603,6 +1603,42 @@ resource "azurerm_cosmosdb_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(kind), string(consistency))
 }
 
+func (CosmosDBAccountResource) mongoAnalyticalStorage(data acceptance.TestData, consistency documentdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "MongoDB"
+
+  analytical_storage_enabled = true
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, string(consistency))
+}
+
 func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency documentdb.DefaultConsistencyLevel, locationCount int) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("name").Exists(),

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -83,6 +83,12 @@ func resourceCosmosDbMongoCollection() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
 
+			"analytical_storage_ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
+
 			"throughput": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -172,6 +178,10 @@ func resourceCosmosDbMongoCollectionCreate(d *schema.ResourceData, meta interfac
 		},
 	}
 
+	if analyticalStorageTTL, ok := d.GetOk("analytical_storage_ttl"); ok {
+		db.MongoDBCollectionCreateUpdateProperties.Resource.AnalyticalStorageTTL = utils.Int32(int32(analyticalStorageTTL.(int)))
+	}
+
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
 		if throughput != 0 {
 			db.MongoDBCollectionCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
@@ -239,6 +249,10 @@ func resourceCosmosDbMongoCollectionUpdate(d *schema.ResourceData, meta interfac
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},
+	}
+
+	if analyticalStorageTTL, ok := d.GetOk("analytical_storage_ttl"); ok {
+		db.MongoDBCollectionCreateUpdateProperties.Resource.AnalyticalStorageTTL = utils.Int32(int32(analyticalStorageTTL.(int)))
 	}
 
 	if shardKey := d.Get("shard_key").(string); shardKey != "" {
@@ -337,6 +351,8 @@ func resourceCosmosDbMongoCollectionRead(d *schema.ResourceData, meta interface{
 			if err := d.Set("system_indexes", systemIndexes); err != nil {
 				return fmt.Errorf("failed to set `system_indexes`: %+v", err)
 			}
+
+			d.Set("analytical_storage_ttl", res.AnalyticalStorageTTL)
 		}
 	}
 

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -94,8 +94,9 @@ func resourceCosmosDbSQLContainer() *schema.Resource {
 			"autoscale_settings": common.DatabaseAutoscaleSettingsSchema(),
 
 			"analytical_storage_ttl": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntAtLeast(-1),
 			},
 
 			"default_ttl": {

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `-1` or `0`, items are not automatically expired.
 * `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
+* `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this Mongo Collection. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 * `index` - (Optional) One or more `index` blocks as defined below.
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `shard_key` to be set.


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./azurerm/internal/services/cosmos -timeout=1000m -run 'TestAccCosmosDbMongoCollection_analyticalStorageTTL'
2021/05/16 09:31:21 [DEBUG] not using binary driver name, it's no longer needed
2021/05/16 09:31:22 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccCosmosDbMongoCollection_analyticalStorageTTL
=== PAUSE TestAccCosmosDbMongoCollection_analyticalStorageTTL
=== CONT  TestAccCosmosDbMongoCollection_analyticalStorageTTL
--- PASS: TestAccCosmosDbMongoCollection_analyticalStorageTTL (1068.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos	1070.943s
```

![image](https://user-images.githubusercontent.com/805046/118389471-6e479a00-b62a-11eb-9724-5d666869f66b.png)


Fixes #11733