### PR TITLE
`azurerm_healthcare_service`: Add `public_network_access_enabled` argument

### DIFF
--- a/azurerm/internal/services/healthcare/healthcare_service_resource.go
+++ b/azurerm/internal/services/healthcare/healthcare_service_resource.go
@@ -188,6 +188,16 @@ func resourceHealthcareService() *schema.Resource {
 				},
 			},
 
+			"public_network_access": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(healthcareapis.Enabled),
+					string(healthcareapis.Disabled),
+				}, false),
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -236,6 +246,10 @@ func resourceHealthcareServiceCreateUpdate(d *schema.ResourceData, meta interfac
 			CorsConfiguration:           expandAzureRMhealthcareapisCorsConfiguration(d),
 			AuthenticationConfiguration: expandAzureRMhealthcareapisAuthentication(d),
 		},
+	}
+
+	if publicNetworkAccess, ok := d.GetOk("public_network_access"); ok {
+		healthcareServiceDescription.Properties.PublicNetworkAccess = healthcareapis.PublicNetworkAccess(publicNetworkAccess.(string))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, healthcareServiceDescription)
@@ -307,6 +321,7 @@ func resourceHealthcareServiceRead(d *schema.ResourceData, meta interface{}) err
 		}
 		d.Set("cosmosdb_key_vault_key_versionless_id", cosmodDbKeyVaultKeyVersionlessId)
 		d.Set("cosmosdb_throughput", cosmosDbThroughput)
+		d.Set("public_network_access", props.PublicNetworkAccess)
 
 		if err := d.Set("authentication_configuration", flattenHealthcareAuthConfig(props.AuthenticationConfiguration)); err != nil {
 			return fmt.Errorf("Error setting `authentication_configuration`: %+v", err)

--- a/azurerm/internal/services/healthcare/healthcare_service_resource.go
+++ b/azurerm/internal/services/healthcare/healthcare_service_resource.go
@@ -191,7 +191,7 @@ func resourceHealthcareService() *schema.Resource {
 			"public_network_access_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
+				Default:  true,
 			},
 
 			"tags": tags.Schema(),
@@ -244,12 +244,11 @@ func resourceHealthcareServiceCreateUpdate(d *schema.ResourceData, meta interfac
 		},
 	}
 
-	if publicNetworkAccess, ok := d.GetOk("public_network_access_enabled"); ok {
-		if publicNetworkAccess.(bool) {
-			healthcareServiceDescription.Properties.PublicNetworkAccess = healthcareapis.Enabled
-		} else {
-			healthcareServiceDescription.Properties.PublicNetworkAccess = healthcareapis.Disabled
-		}
+	publicNetworkAccess := d.Get("public_network_access_enabled").(bool)
+	if !publicNetworkAccess {
+		healthcareServiceDescription.Properties.PublicNetworkAccess = healthcareapis.Disabled
+	} else {
+		healthcareServiceDescription.Properties.PublicNetworkAccess = healthcareapis.Enabled
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, healthcareServiceDescription)

--- a/azurerm/internal/services/healthcare/healthcare_service_resource_test.go
+++ b/azurerm/internal/services/healthcare/healthcare_service_resource_test.go
@@ -361,7 +361,7 @@ resource "azurerm_healthcare_service" "test" {
   cosmosdb_throughput                   = 400
   cosmosdb_key_vault_key_versionless_id = azurerm_key_vault_key.test.versionless_id
 
-  public_network_access = "Disabled"
+  public_network_access_enabled = false
 }
 `, data.RandomInteger, location, data.RandomString, data.RandomIntOfLength(17)) // name can only be 24 chars long
 }

--- a/azurerm/internal/services/healthcare/healthcare_service_resource_test.go
+++ b/azurerm/internal/services/healthcare/healthcare_service_resource_test.go
@@ -62,6 +62,21 @@ func TestAccHealthCareService_complete(t *testing.T) {
 	})
 }
 
+func TestAccHealthCareService_publicNetworkAccessDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_healthcare_service", "test")
+	r := HealthCareServiceResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.publicNetworkAccessDisabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (HealthCareServiceResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.ServiceID(state.ID)
 	if err != nil {
@@ -231,6 +246,122 @@ resource "azurerm_healthcare_service" "test" {
 
   cosmosdb_throughput                   = 400
   cosmosdb_key_vault_key_versionless_id = azurerm_key_vault_key.test.versionless_id
+}
+`, data.RandomInteger, location, data.RandomString, data.RandomIntOfLength(17)) // name can only be 24 chars long
+}
+
+func (HealthCareServiceResource) publicNetworkAccessDisabled(data acceptance.TestData) string {
+	// currently only supported in "ukwest", "northcentralus", "westus2".
+	location := "westus2"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+}
+
+provider "azuread" {}
+
+data "azurerm_client_config" "current" {
+}
+
+data "azuread_service_principal" "cosmosdb" {
+  display_name = "Azure Cosmos DB"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-health-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  purge_protection_enabled   = true
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "list",
+      "create",
+      "delete",
+      "get",
+      "purge",
+      "update",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azuread_service_principal.cosmosdb.id
+
+    key_permissions = [
+      "get",
+      "unwrapKey",
+      "wrapKey",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "examplekey"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_healthcare_service" "test" {
+  name                = "testacc%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    environment = "production"
+    purpose     = "AcceptanceTests"
+  }
+
+  access_policy_object_ids = [
+    data.azurerm_client_config.current.object_id,
+  ]
+
+  authentication_configuration {
+    authority           = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}"
+    audience            = "https://azurehealthcareapis.com"
+    smart_proxy_enabled = true
+  }
+
+  cors_configuration {
+    allowed_origins    = ["http://www.example.com", "http://www.example2.com"]
+    allowed_headers    = ["*"]
+    allowed_methods    = ["GET", "PUT"]
+    max_age_in_seconds = 500
+    allow_credentials  = true
+  }
+
+  cosmosdb_throughput                   = 400
+  cosmosdb_key_vault_key_versionless_id = azurerm_key_vault_key.test.versionless_id
+
+  public_network_access = "Disabled"
 }
 `, data.RandomInteger, location, data.RandomString, data.RandomIntOfLength(17)) // name can only be 24 chars long
 }

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -61,6 +61,7 @@ The following arguments are supported:
 ~> **Please Note** In order to use a `Custom Key` from Key Vault for encryption you must grant Azure Cosmos DB Service access to your key vault. For instructions on how to configure your Key Vault correctly please refer to the [product documentation](https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-setup-cmk#add-an-access-policy-to-your-azure-key-vault-instance)
 
 * `cors_configuration` - (Optional) A `cors_configuration` block as defined below.
+* `public_network_access` - (Optional) Whether public network access is enabled or disabled for this service instance. Possible values are: `Enabled` and `Disabled`.
 * `kind` - (Optional) The type of the service. Values at time of publication are: `fhir`, `fhir-Stu3` and `fhir-R4`. Default value is `fhir`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 ~> **Please Note** In order to use a `Custom Key` from Key Vault for encryption you must grant Azure Cosmos DB Service access to your key vault. For instructions on how to configure your Key Vault correctly please refer to the [product documentation](https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-setup-cmk#add-an-access-policy-to-your-azure-key-vault-instance)
 
 * `cors_configuration` - (Optional) A `cors_configuration` block as defined below.
-* `public_network_access` - (Optional) Whether public network access is enabled or disabled for this service instance. Possible values are: `Enabled` and `Disabled`.
+* `public_network_access_enabled` - (Optional) Whether public network access is enabled or disabled for this service instance.
 * `kind` - (Optional) The type of the service. Values at time of publication are: `fhir`, `fhir-Stu3` and `fhir-R4`. Default value is `fhir`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./azurerm/internal/services/healthcare -timeout=1000m -run 'TestAccHealthCareService_publicNetworkAccessDisabled'
2021/05/16 10:09:20 [DEBUG] not using binary driver name, it's no longer needed
2021/05/16 10:09:20 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccHealthCareService_publicNetworkAccessDisabled
=== PAUSE TestAccHealthCareService_publicNetworkAccessDisabled
=== CONT  TestAccHealthCareService_publicNetworkAccessDisabled
--- PASS: TestAccHealthCareService_publicNetworkAccessDisabled (1139.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/healthcare	1140.778s
```

![image](https://user-images.githubusercontent.com/805046/118390458-748c4500-b62f-11eb-9656-758b38a7a732.png)


Fixes #11730