### PR TITLE
`azurerm_hdinsight_kafka_cluster`: Add support for `encryption_in_transit_enabled` argument

### DIFF
--- a/azurerm/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -408,6 +408,28 @@ func TestAccHDInsightKafkaCluster_restProxy(t *testing.T) {
 	})
 }
 
+func TestAccHDInsightKafkaCluster_encryptionInTransitEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
+	r := HDInsightKafkaClusterResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.encryptionInTransitEnabled(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("roles.0.head_node.0.password",
+			"roles.0.head_node.0.vm_size",
+			"roles.0.worker_node.0.password",
+			"roles.0.worker_node.0.vm_size",
+			"roles.0.zookeeper_node.0.password",
+			"roles.0.zookeeper_node.0.vm_size",
+			"roles.0.kafka_management_node.0.password",
+			"roles.0.kafka_management_node.0.vm_size",
+			"storage_account"),
+	})
+}
+
 func (t HDInsightKafkaClusterResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
 	id, err := parse.ClusterID(state.ID)
 	if err != nil {
@@ -1304,4 +1326,58 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r HDInsightKafkaClusterResource) encryptionInTransitEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_kafka_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "4.0"
+  tier                = "Standard"
+
+  encryption_in_transit_enabled = true
+
+  component_version {
+    kafka = "2.1"
+  }
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size                  = "Standard_D3_V2"
+      username                 = "acctestusrvm"
+      password                 = "AccTestvdSC4daf986!"
+      target_instance_count    = 3
+      number_of_disks_per_node = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -105,6 +105,8 @@ The following arguments are supported:
 
 * `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
 
+* `encryption_in_transit_enabled` - (Optional) Whether encryption in transit is enabled for this HDInsight Kafka Cluster. Changing this forces a new resource to be created.
+
 ~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
 
 ---

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight Kafka Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
-* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are `1.0`, `1.1` or `1.2`. Changing this forces a new resource to be created.
 
 * `encryption_in_transit_enabled` - (Optional) Whether encryption in transit is enabled for this HDInsight Kafka Cluster. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./azurerm/internal/services/hdinsight -timeout=1000m -run 'TestAccHDInsightKafkaCluster_encryptionInTransitEnabled'
2021/05/16 10:44:36 [DEBUG] not using binary driver name, it's no longer needed
2021/05/16 10:44:36 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccHDInsightKafkaCluster_encryptionInTransitEnabled
=== PAUSE TestAccHDInsightKafkaCluster_encryptionInTransitEnabled
=== CONT  TestAccHDInsightKafkaCluster_encryptionInTransitEnabled
--- PASS: TestAccHDInsightKafkaCluster_encryptionInTransitEnabled (1073.48s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hdinsight	1074.850s
```

![image](https://user-images.githubusercontent.com/805046/118391414-74db0f00-b634-11eb-8ece-d153ab9477b4.png)


Fixes #11732