### PR TITLE
azurerm_application_gateway - update the document about `frontend_ip_configuration.public_ip_address_id`

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -256,7 +256,7 @@ A `frontend_ip_configuration` block supports the following:
 
 * `private_ip_address` - (Optional) The Private IP Address to use for the Application Gateway.
 
-* `public_ip_address_id` - (Optional) The ID of a Public IP Address which the Application Gateway should use. The allocation method for the Public IP Address depends on the `sku` of this Application Gateway. Please checkout the [Azure document](https://docs.microsoft.com/en-us/azure/virtual-network/public-ip-addresses#application-gateways) for details.
+* `public_ip_address_id` - (Optional) The ID of a Public IP Address which the Application Gateway should use. The allocation method for the Public IP Address depends on the `sku` of this Application Gateway. Please refer to the [Azure documentation for public IP addresses](https://docs.microsoft.com/en-us/azure/virtual-network/public-ip-addresses#application-gateways) for details.
 
 * `private_ip_address_allocation` - (Optional) The Allocation Method for the Private IP Address. Possible values are `Dynamic` and `Static`.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -256,9 +256,7 @@ A `frontend_ip_configuration` block supports the following:
 
 * `private_ip_address` - (Optional) The Private IP Address to use for the Application Gateway.
 
-* `public_ip_address_id` - (Optional) The ID of a Public IP Address which the Application Gateway should use.
-
--> **NOTE:** The Allocation Method for this Public IP Address should be set to `Dynamic`.
+* `public_ip_address_id` - (Optional) The ID of a Public IP Address which the Application Gateway should use. The allocation method for the Public IP Address depends on the `sku` of this Application Gateway. Please checkout the [Azure document](https://docs.microsoft.com/en-us/azure/virtual-network/public-ip-addresses#application-gateways) for details.
 
 * `private_ip_address_allocation` - (Optional) The Allocation Method for the Private IP Address. Possible values are `Dynamic` and `Static`.
 


### PR DESCRIPTION
Fix #11679.

Both cases are covered in current AccTest, which passed in TC:

- `Static`: [`TestAccApplicationGateway_V2SKUCapacity`](https://github.com/terraform-providers/terraform-provider-azurerm/blob/fc8e4efc4d33c2a2749df44ba2083717b2a8f63f/azurerm/internal/services/network/application_gateway_resource_test.go#L916)
- `Dynamic`: [`TestAccApplicationGateway_basic`](https://github.com/terraform-providers/terraform-provider-azurerm/blob/fc8e4efc4d33c2a2749df44ba2083717b2a8f63f/azurerm/internal/services/network/application_gateway_resource_test.go#L25)