### PR TITLE
azurerm_virtual_network_gateway_connection - update `shared_key`

### DIFF
--- a/azurerm/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -341,6 +341,18 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *schema.ResourceData,
 		return fmt.Errorf("Error waiting for completion of Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
+	if properties.SharedKey != nil && !d.IsNewResource() {
+		future, err := client.SetSharedKey(ctx, resGroup, name, network.ConnectionSharedKey{
+			Value: properties.SharedKey,
+		})
+		if err != nil {
+			return fmt.Errorf("Updating Shared Key for Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
+		}
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Waiting for updating Shared Key for Virtual Network Gateway Connection %q (Resource Group %q): %+v", name, resGroup, err)
+		}
+	}
+
 	read, err := client.Get(ctx, resGroup, name)
 	if err != nil {
 		return err


### PR DESCRIPTION
The `PUT` operation on the vnet gw connection will not update the `shared_key`, users have to use a dedicated sharedKey endpoint to do this. This issue causes the acctest for `TestAccVirtualNetworkGatewayConnection_updatingSharedKey` failed.

Fixes: #11673 