### PR TITLE
azurerm_virtual_network_gateway(_connection): Fix acctest failures

### DIFF
--- a/azurerm/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -777,7 +777,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 
   type                       = "Vpn"
   vpn_type                   = "RouteBased"
-  sku                        = "VpnGw1"
+  sku                        = "VpnGw1AZ"
   private_ip_address_enabled = true
   ip_configuration {
     name                          = "vnetGatewayConfig"
@@ -847,7 +847,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 
   type     = "Vpn"
   vpn_type = "RouteBased"
-  sku      = "VpnGw1"
+  sku      = "VpnGw1AZ"
   ip_configuration {
     name                          = "vnetGatewayConfig"
     public_ip_address_id          = azurerm_public_ip.test.id

--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -337,6 +337,7 @@ func resourceVirtualNetworkGateway() *schema.Resource {
 						//lintignore:XS003
 						"peering_addresses": {
 							Type:     schema.TypeList,
+							Computed: true,
 							Optional: true,
 							MinItems: 1,
 							MaxItems: 2,

--- a/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
@@ -179,10 +179,6 @@ func TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth(t *testing.T) {
 			Config: r.vpnClientConfigAzureAdAuth(data),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("vpn_client_configuration.0.aad_tenant").HasValue(fmt.Sprintf("https://login.microsoftonline.com/%s/", data.RandomString)),
-				check.That(data.ResourceName).Key("vpn_client_configuration.0.aad_audience").HasValue("41b23e61-6c1e-4545-b367-cd054e0ed4b4"),
-				check.That(data.ResourceName).Key("vpn_client_configuration.0.aad_issuer").HasValue(fmt.Sprintf("https://sts.windows.net/%s/", data.RandomString)),
-				check.That(data.ResourceName).Key("vpn_client_configuration.0.vpn_client_protocols.#").HasValue("1"),
 			),
 		},
 	})
@@ -1058,7 +1054,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 
   type                       = "Vpn"
   vpn_type                   = "RouteBased"
-  sku                        = "VpnGw1"
+  sku                        = "VpnGw1AZ"
   private_ip_address_enabled = true
 
   custom_route {
@@ -1113,7 +1109,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 
   type                       = "Vpn"
   vpn_type                   = "RouteBased"
-  sku                        = "VpnGw1"
+  sku                        = "VpnGw1AZ"
   private_ip_address_enabled = false
 
   custom_route {

--- a/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource_test.go
@@ -181,6 +181,7 @@ func TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 


### PR DESCRIPTION
Fix following acctest failures:


```bash
💢 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccVirtualNetworkGatewayConnection_useLocalAzureIpAddressEnabled|TestAccVirtualNetworkGateway_privateIpAddressEnabled|TestAccVirtualNetworkGateway_activeActive|TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth"
2021/05/17 14:43:45 [DEBUG] not using binary driver name, it's no longer needed
2021/05/17 14:43:45 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccVirtualNetworkGatewayConnection_useLocalAzureIpAddressEnabled
=== PAUSE TestAccVirtualNetworkGatewayConnection_useLocalAzureIpAddressEnabled
=== RUN   TestAccVirtualNetworkGateway_activeActive
=== PAUSE TestAccVirtualNetworkGateway_activeActive
=== RUN   TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
=== PAUSE TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
=== RUN   TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA
=== PAUSE TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA
=== RUN   TestAccVirtualNetworkGateway_privateIpAddressEnabled
=== PAUSE TestAccVirtualNetworkGateway_privateIpAddressEnabled
=== CONT  TestAccVirtualNetworkGatewayConnection_useLocalAzureIpAddressEnabled
=== CONT  TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA
=== CONT  TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth
=== CONT  TestAccVirtualNetworkGateway_activeActive
=== CONT  TestAccVirtualNetworkGateway_privateIpAddressEnabled
--- PASS: TestAccVirtualNetworkGateway_activeActive (1565.88s)
--- PASS: TestAccVirtualNetworkGateway_activeActiveEnableBgpWithAPIPA (1769.03s)
--- PASS: TestAccVirtualNetworkGateway_vpnClientConfigAzureAdAuth (1854.31s)
--- PASS: TestAccVirtualNetworkGateway_privateIpAddressEnabled (4550.10s)
--- PASS: TestAccVirtualNetworkGatewayConnection_useLocalAzureIpAddressEnabled (5030.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     5030.423s
```