### PR TITLE
Add PreAttack tactic to Sentinel scheduled alert rule

### DIFF
--- a/azurerm/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/azurerm/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -109,6 +109,7 @@ func resourceSentinelAlertRuleScheduled() *schema.Resource {
 						string(securityinsight.AttackTacticLateralMovement),
 						string(securityinsight.AttackTacticPersistence),
 						string(securityinsight.AttackTacticPrivilegeEscalation),
+						string(securityinsight.AttackTacticPreAttack),
 					}, false),
 				},
 			},


### PR DESCRIPTION
The missing PreAttack tactic was added to the azure-sdk-for-go v54.0.0.