### PR TITLE
Support for `analytical_storage_ttl` in `azurerm_cosmosdb_cassandra_table`

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -59,6 +59,14 @@ func resourceCosmosDbCassandraTable() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
 
+			"analytical_storage_ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      -2,
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
+
 			"schema": common.CassandraTableSchemaPropertySchema(),
 
 			"throughput": {
@@ -113,6 +121,10 @@ func resourceCosmosDbCassandraTableCreate(d *schema.ResourceData, meta interface
 
 	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
 		table.CassandraTableCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
+	}
+
+	if analyticalTTL := d.Get("analytical_storage_ttl").(int); analyticalTTL != -2 {
+		table.CassandraTableCreateUpdateProperties.Resource.AnalyticalStorageTTL = utils.Int32(int32(analyticalTTL))
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
@@ -184,7 +196,7 @@ func resourceCosmosDbCassandraTableUpdate(d *schema.ResourceData, meta interface
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
 				return fmt.Errorf("setting Throughput for %s: %+v - "+
-					"If the collection has not been created with an initial throughput, you cannot configure it later.", *id, err)
+					"If the collection has not been created with an initial throughput, you cannot configure it later", *id, err)
 			}
 		}
 
@@ -227,6 +239,10 @@ func resourceCosmosDbCassandraTableRead(d *schema.ResourceData, meta interface{}
 
 			if defaultTTL := res.DefaultTTL; defaultTTL != nil {
 				d.Set("default_ttl", defaultTTL)
+			}
+
+			if analyticalTTL := res.AnalyticalStorageTTL; analyticalTTL != nil {
+				d.Set("analytical_storage_ttl", analyticalTTL)
 			}
 
 			if schema := res.Schema; schema != nil {

--- a/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -241,9 +241,11 @@ func resourceCosmosDbCassandraTableRead(d *schema.ResourceData, meta interface{}
 				d.Set("default_ttl", defaultTTL)
 			}
 
-			if analyticalTTL := res.AnalyticalStorageTTL; analyticalTTL != nil {
-				d.Set("analytical_storage_ttl", analyticalTTL)
+			analyticalTTL := -2
+			if res.AnalyticalStorageTTL != nil {
+				analyticalTTL = int(*res.AnalyticalStorageTTL)
 			}
+			d.Set("analytical_storage_ttl", analyticalTTL)
 
 			if schema := res.Schema; schema != nil {
 				d.Set("schema", flattenTableSchema(schema))

--- a/website/docs/r/cosmosdb_cassandra_table.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_table.html.markdown
@@ -78,6 +78,10 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of Cassandra KeySpace (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `default_ttl` - (Optional) Time to live of the Cosmos DB Cassandra table. Possible values are at least `-1`. `-1` means the Cassandra table never expires.
+
+* `analytical_storage_ttl` - (Optional) Time to live of the Analytical Storage. Possible values are at least `-1`. `-1` means the Analytical Storage never expires. Changing this forces a new resource to be created.
+
 ~> **Note:** throughput has a maximum value of `1000000` unless a higher limit is requested via Azure Support
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/11754

--- PASS: TestAccCosmosDbCassandraTable_analyticalStorageTTL (1101.46s)