### PR TITLE
azurerm_virtual_network - fix acc test

### DIFF
--- a/azurerm/internal/services/network/virtual_network_resource.go
+++ b/azurerm/internal/services/network/virtual_network_resource.go
@@ -100,10 +100,12 @@ func resourceVirtualNetwork() *schema.Resource {
 				},
 			},
 
+			// TODO 3.0: Remove this property
 			"vm_protection_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Default:    false,
+				Deprecated: "This is deprecated in favor of `ddos_protection_plan`",
 			},
 
 			"guid": {

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -93,8 +93,6 @@ The following arguments are supported:
 
 -> **NOTE** Since `subnet` can be configured both inline and via the separate `azurerm_subnet` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
 
-* `vm_protection_enabled` - (Optional) Whether to enable VM protection for all the subnets in this Virtual Network. Defaults to `false`.
-
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
This PR fixes the acctest of vnet. The failures are caused by two reasons:

- After using the binary test framework, during the **check** the state is got from the output of `terraform show` (via tf-exec), which simply unamrshal the output to its json representation, then convert the json repr to `terraform.State`. In this process, there is no reflection on the schema, meaning it has no knowledge about whether current list is a `Set` or a plain `List`. The end result is that we can now index into a `Set` just as indexing into a `List`, means we can index from 0: https://github.com/terraform-providers/terraform-provider-azurerm/blob/50fdd7ec237129491bbb6ef8946d743d3512a804/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_new.go#L141-L150
  
  Additionally, the framework will even error out if you are trying to use the hash to index. This is why the test cases are failing.

- Since network API 2020-07-01, the `vmProtection` property is not functional and never returned from the API in the `GET` response. So we have to deprecate it also in the provider code. See: https://github.com/Azure/azure-cli/issues/14059#issuecomment-667289923

After these changes, all the test cases for vnet are passing in my local:

```bash
💢 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccVirtualNetwork_"
2021/05/18 14:57:46 [DEBUG] not using binary driver name, it's no longer needed
2021/05/18 14:57:46 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccVirtualNetwork_basic
=== PAUSE TestAccVirtualNetwork_basic
=== RUN   TestAccVirtualNetwork_complete
=== PAUSE TestAccVirtualNetwork_complete
=== RUN   TestAccVirtualNetwork_basicUpdated
=== PAUSE TestAccVirtualNetwork_basicUpdated
=== RUN   TestAccVirtualNetwork_requiresImport
=== PAUSE TestAccVirtualNetwork_requiresImport
=== RUN   TestAccVirtualNetwork_ddosProtectionPlan
=== PAUSE TestAccVirtualNetwork_ddosProtectionPlan
=== RUN   TestAccVirtualNetwork_disappears
=== PAUSE TestAccVirtualNetwork_disappears
=== RUN   TestAccVirtualNetwork_withTags
=== PAUSE TestAccVirtualNetwork_withTags
=== RUN   TestAccVirtualNetwork_deleteSubnet
=== PAUSE TestAccVirtualNetwork_deleteSubnet
=== RUN   TestAccVirtualNetwork_bgpCommunity
=== PAUSE TestAccVirtualNetwork_bgpCommunity
=== CONT  TestAccVirtualNetwork_basic
=== CONT  TestAccVirtualNetwork_disappears
=== CONT  TestAccVirtualNetwork_requiresImport
=== CONT  TestAccVirtualNetwork_ddosProtectionPlan
=== CONT  TestAccVirtualNetwork_bgpCommunity
=== CONT  TestAccVirtualNetwork_deleteSubnet
=== CONT  TestAccVirtualNetwork_withTags
=== CONT  TestAccVirtualNetwork_basicUpdated
2021/05/18 14:59:35 [DEBUG] Determining which Resource Providers require Registration
2021/05/18 14:59:35 [DEBUG] All required Resource Providers are registered
--- PASS: TestAccVirtualNetwork_disappears (173.50s)
=== CONT  TestAccVirtualNetwork_complete
--- PASS: TestAccVirtualNetwork_basic (186.90s)
2021/05/18 15:00:55 [DEBUG] TF_ACCTEST_REATTACH set to 1 and acctest.TestHelper is not nil, using reattach-based testing
--- PASS: TestAccVirtualNetwork_requiresImport (209.58s)
--- PASS: TestAccVirtualNetwork_withTags (246.33s)
--- PASS: TestAccVirtualNetwork_ddosProtectionPlan (250.32s)
--- PASS: TestAccVirtualNetwork_basicUpdated (263.83s)
--- PASS: TestAccVirtualNetwork_deleteSubnet (265.12s)
--- PASS: TestAccVirtualNetwork_bgpCommunity (328.34s)
--- PASS: TestAccVirtualNetwork_complete (161.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     334.910s
```

