### PR TITLE
azurerm_virtual_network_gateway - mark `peering_addresses` as O+C

### DIFF
--- a/azurerm/internal/services/network/virtual_network_gateway_resource.go
+++ b/azurerm/internal/services/network/virtual_network_gateway_resource.go
@@ -338,6 +338,7 @@ func resourceVirtualNetworkGateway() *schema.Resource {
 						"peering_addresses": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							MinItems: 1,
 							MaxItems: 2,
 							Elem: &schema.Resource{


### PR DESCRIPTION
Fixes #11758 