### PR TITLE
azurerm_container_registry - `encryption.0.key_vault_key_id` allows versionless id

### DIFF
--- a/azurerm/internal/services/containers/container_registry_resource.go
+++ b/azurerm/internal/services/containers/container_registry_resource.go
@@ -200,7 +200,7 @@ func resourceContainerRegistry() *schema.Resource {
 						"key_vault_key_id": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: keyVaultValidate.NestedItemId,
+							ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
 						},
 					},
 				},


### PR DESCRIPTION
Fixes #11774 