### PR TITLE
azurerm_storage_account_management_policy - rule name can contains `-`

### DIFF
--- a/azurerm/internal/services/storage/storage_management_policy_resource.go
+++ b/azurerm/internal/services/storage/storage_management_policy_resource.go
@@ -49,7 +49,7 @@ func resourceStorageManagementPolicy() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringMatch(
-								regexp.MustCompile(`^[a-zA-Z0-9]*$`),
+								regexp.MustCompile(`^[a-zA-Z0-9-]*$`),
 								"A rule name can contain any combination of alpha numeric characters.",
 							),
 						},

--- a/azurerm/internal/services/storage/storage_management_policy_resource_test.go
+++ b/azurerm/internal/services/storage/storage_management_policy_resource_test.go
@@ -400,7 +400,7 @@ resource "azurerm_storage_management_policy" "test" {
   storage_account_id = azurerm_storage_account.test.id
 
   rule {
-    name    = "rule1"
+    name    = "rule-1"
     enabled = true
     filters {
       prefix_match = ["container1/prefix1"]


### PR DESCRIPTION
Fixes #11648 