### PR TITLE
fix acc test for `TestAccApplicationGateway_sslCertificate_keyvault_version`

### DIFF
--- a/azurerm/internal/services/network/application_gateway_resource_test.go
+++ b/azurerm/internal/services/network/application_gateway_resource_test.go
@@ -1702,7 +1702,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id               = "${data.azurerm_client_config.test.tenant_id}"
     object_id               = "${data.azurerm_client_config.test.object_id}"
     secret_permissions      = ["delete", "get", "set"]
-    certificate_permissions = ["create", "delete", "get", "import"]
+    certificate_permissions = ["create", "delete", "get", "import", "purge"]
   }
 
   access_policy {
@@ -3470,7 +3470,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id               = data.azurerm_client_config.test.tenant_id
     object_id               = data.azurerm_client_config.test.object_id
     secret_permissions      = ["delete", "get", "set"]
-    certificate_permissions = ["create", "delete", "get", "import"]
+    certificate_permissions = ["create", "delete", "get", "import", "purge"]
   }
 
   access_policy {
@@ -3620,7 +3620,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id               = data.azurerm_client_config.test.tenant_id
     object_id               = data.azurerm_client_config.test.object_id
     secret_permissions      = ["delete", "get", "set"]
-    certificate_permissions = ["create", "delete", "get", "import"]
+    certificate_permissions = ["create", "delete", "get", "import", "purge"]
   }
 
   access_policy {


### PR DESCRIPTION
The test previously failed for the lack of `purge` permissions on the certificates.

## Test Result

```
💤 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccApplicationGateway_sslCertificate_keyvault_version"
2021/05/20 13:33:20 [DEBUG] not using binary driver name, it's no longer needed
2021/05/20 13:33:20 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccApplicationGateway_sslCertificate_keyvault_versionless
=== PAUSE TestAccApplicationGateway_sslCertificate_keyvault_versionless
=== RUN   TestAccApplicationGateway_sslCertificate_keyvault_versioned
=== PAUSE TestAccApplicationGateway_sslCertificate_keyvault_versioned
=== CONT  TestAccApplicationGateway_sslCertificate_keyvault_versionless
=== CONT  TestAccApplicationGateway_sslCertificate_keyvault_versioned
--- PASS: TestAccApplicationGateway_sslCertificate_keyvault_versioned (1143.65s)
--- PASS: TestAccApplicationGateway_sslCertificate_keyvault_versionless (1143.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     1143.964s
```