### PR TITLE
fix acc test for NSR

### DIFF
--- a/azurerm/internal/services/network/network_security_rule_resource_test.go
+++ b/azurerm/internal/services/network/network_security_rule_resource_test.go
@@ -63,7 +63,7 @@ func TestAccNetworkSecurityRule_disappears(t *testing.T) {
 }
 
 func TestAccNetworkSecurityRule_addingRules(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_network_security_rule", "test")
+	data := acceptance.BuildTestData(t, "azurerm_network_security_rule", "test1")
 	r := NetworkSecurityRuleResource{}
 
 	data.ResourceTest(t, r, []resource.TestStep{


### PR DESCRIPTION
## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccNetworkSecurityRule_addingRules"
2021/05/20 13:59:22 [DEBUG] not using binary driver name, it's no longer needed
2021/05/20 13:59:22 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccNetworkSecurityRule_addingRules
=== PAUSE TestAccNetworkSecurityRule_addingRules
=== CONT  TestAccNetworkSecurityRule_addingRules
--- PASS: TestAccNetworkSecurityRule_addingRules (268.32s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     268.488s
```