### PR TITLE
fix acc test for public IP

### DIFF
--- a/azurerm/internal/services/network/public_ip_resource_test.go
+++ b/azurerm/internal/services/network/public_ip_resource_test.go
@@ -319,7 +319,7 @@ func TestAccPublicIpStatic_importIdError(t *testing.T) {
 			ImportState:       true,
 			ImportStateVerify: true,
 			ImportStateId:     fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.Network/publicIPAdresses/acctestpublicip-%d", os.Getenv("ARM_SUBSCRIPTION_ID"), data.RandomInteger, data.RandomInteger),
-			ExpectError:       regexp.MustCompile("Error parsing supplied resource id."),
+			ExpectError:       regexp.MustCompile("Error: parsing Resource ID"),
 		},
 	})
 }


### PR DESCRIPTION
## Test Result

```
💤 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccPublicIpStatic_importIdError"
2021/05/20 14:12:33 [DEBUG] not using binary driver name, it's no longer needed
2021/05/20 14:12:33 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccPublicIpStatic_importIdError
=== PAUSE TestAccPublicIpStatic_importIdError
=== CONT  TestAccPublicIpStatic_importIdError
--- PASS: TestAccPublicIpStatic_importIdError (159.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     159.977s
```