### PR TITLE
fix acc test for route filter

### DIFF
--- a/azurerm/internal/services/network/route_filter_resource_test.go
+++ b/azurerm/internal/services/network/route_filter_resource_test.go
@@ -71,7 +71,8 @@ func TestAccRouteFilter_disappears(t *testing.T) {
 
 	data.ResourceTest(t, r, []resource.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
-			Config: r.basic,
+			Config:       r.basic,
+			TestResource: r,
 		}),
 	})
 }


### PR DESCRIPTION
Also verified this is the only place that misses to set the `TestResource` among the codebase.

## Test Result

```
💤 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccRouteFilter_disappears"
2021/05/20 14:40:37 [DEBUG] not using binary driver name, it's no longer needed
2021/05/20 14:40:37 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccRouteFilter_disappears
=== PAUSE TestAccRouteFilter_disappears
=== CONT  TestAccRouteFilter_disappears
--- PASS: TestAccRouteFilter_disappears (166.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     166.629s
```