### PR TITLE
fix acc test for private link service endpoint connection DS

### DIFF
--- a/azurerm/internal/services/network/private_link_service_endpoint_connections_data_source_test.go
+++ b/azurerm/internal/services/network/private_link_service_endpoint_connections_data_source_test.go
@@ -43,5 +43,5 @@ data "azurerm_private_link_service_endpoint_connections" "test" {
   service_id          = azurerm_private_endpoint.test.private_service_connection.0.private_connection_resource_id
   resource_group_name = azurerm_resource_group.test.name
 }
-`, PrivateLinkServiceResource{}.basic(data))
+`, PrivateEndpointResource{}.basic(data))
 }


### PR DESCRIPTION
## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=3h ./azurerm/internal/services/network -run="TestAccDataSourcePrivateLinkServiceEndpointConnections_complete"
2021/05/20 16:14:20 [DEBUG] not using binary driver name, it's no longer needed
2021/05/20 16:14:20 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataSourcePrivateLinkServiceEndpointConnections_complete
=== PAUSE TestAccDataSourcePrivateLinkServiceEndpointConnections_complete
=== CONT  TestAccDataSourcePrivateLinkServiceEndpointConnections_complete
--- PASS: TestAccDataSourcePrivateLinkServiceEndpointConnections_complete (246.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     246.208s
```