### PR TITLE
`azurerm_monitor_activity_log_alert` - support for `Security` event type for Azure Service Health alerts

### DIFF
--- a/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -168,7 +168,7 @@ func resourceMonitorActivityLogAlert() *schema.Resource {
 												"Maintenance",
 												"Informational",
 												"ActionRequired",
-												"Security"
+												"Security",
 											},
 												false,
 											),

--- a/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -168,6 +168,7 @@ func resourceMonitorActivityLogAlert() *schema.Resource {
 												"Maintenance",
 												"Informational",
 												"ActionRequired",
+												"Security"
 											},
 												false,
 											),

--- a/azurerm/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/azurerm/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -474,7 +474,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   criteria {
     category = "ServiceHealth"
     service_health {
-      events    = ["Incident", "Maintenance", "ActionRequired"]
+      events    = ["Incident", "Maintenance", "ActionRequired", "Security"]
       services  = ["Action Groups"]
       locations = ["Global", "West Europe", "East US"]
     }

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -102,7 +102,7 @@ A `criteria` block supports the following:
 
 A `service_health` block supports the following:
 
-* `events` (Optional) Events this alert will monitor Possible values are `Incident`, `Maintenance`, `Informational`, and `ActionRequired`.
+* `events` (Optional) Events this alert will monitor Possible values are `Incident`, `Maintenance`, `Informational`, `ActionRequired` and `Security`.
 * `locations` (Optional) Locations this alert will monitor. For example, `West Europe`. Defaults to `Global`.
 * `services` (Optional) Services this alert will monitor. For example, `Activity Logs & Alerts`, `Action Groups`. Defaults to all Services.
 


### PR DESCRIPTION
Hi,

This PR adds support for missing `Security` event type in allowed values for `events` argument in `service_health` configuration block in `azurerm_monitor_activity_log_alert` resource.

Closes #11801 