### PR TITLE
fix/docs - remove unsupported argument `subscription_id` from example resource declaration of `azurerm_consumption_budget_resource_group`

### DIFF
--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -13,8 +13,6 @@ Manages a Resource Group Consumption Budget.
 ## Example Usage
 
 ```hcl
-data "azurerm_subscription" "current" {}
-
 resource "azurerm_resource_group" "example" {
   name     = "example"
   location = "eastus"

--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -28,7 +28,6 @@ resource "azurerm_monitor_action_group" "test" {
 
 resource "azurerm_consumption_budget_resource_group" "example" {
   name              = "example"
-  subscription_id   = data.azurerm_subscription.current.subscription_id
   resource_group_id = azurerm_resource_group.example.id
 
   amount     = 1000


### PR DESCRIPTION
See title.