### PR TITLE
fix(network_security_group): example name points to the same resource

### DIFF
--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Network Security Gr
 
 ```hcl
 data "azurerm_network_security_group" "example" {
-  name                = azurerm_network_security_group.example.name
+  name                = "example"
   resource_group_name = azurerm_resource_group.example.name
 }
 


### PR DESCRIPTION
There is no point of creating a datasource referencing outputs of the same target resource.