### PR TITLE
fix(devspaces): remove devspaces provider auto-registration

### DIFF
--- a/azurerm/internal/provider/services.go
+++ b/azurerm/internal/provider/services.go
@@ -31,7 +31,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datalake"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/devspace"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/devtestlabs"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/digitaltwins"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns"
@@ -139,7 +138,6 @@ func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 		databoxedge.Registration{},
 		datashare.Registration{},
 		desktopvirtualization.Registration{},
-		devspace.Registration{},
 		devtestlabs.Registration{},
 		digitaltwins.Registration{},
 		dns.Registration{},

--- a/azurerm/internal/provider/services.go
+++ b/azurerm/internal/provider/services.go
@@ -139,6 +139,7 @@ func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 		databoxedge.Registration{},
 		datashare.Registration{},
 		desktopvirtualization.Registration{},
+		devspace.Registration{},
 		devtestlabs.Registration{},
 		digitaltwins.Registration{},
 		dns.Registration{},

--- a/azurerm/internal/provider/services.go
+++ b/azurerm/internal/provider/services.go
@@ -31,6 +31,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datalake"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/desktopvirtualization"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/devspace"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/devtestlabs"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/digitaltwins"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns"

--- a/azurerm/internal/resourceproviders/required.go
+++ b/azurerm/internal/resourceproviders/required.go
@@ -33,7 +33,6 @@ func Required() map[string]struct{} {
 		"Microsoft.DBforPostgreSQL":         {},
 		"Microsoft.DesktopVirtualization":   {},
 		"Microsoft.Devices":                 {},
-		"Microsoft.DevSpaces":               {},
 		"Microsoft.DevTestLab":              {},
 		"Microsoft.DocumentDB":              {},
 		"Microsoft.EventGrid":               {},


### PR DESCRIPTION
# Summary
* Remove DevSpaces provider auto-registration.
* Closes #11821 

## Notes
* Since DevSpaces is retired, the associated resources should probably be removed, this PR only fixes the immediate provider auto-registration issue on new subscriptions.
* https://docs.microsoft.com/en-us/azure/dev-spaces/