### PR TITLE
"azurerm_kubernetes_cluster" supports "fips_enabled", "kubelet_disk_type", "license" and "azurerm_kubernetes_cluster_node_pool" supports "fips_enabled", "kubelet_disk_type"

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -120,7 +120,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 			"kubelet_disk_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  containerservice.KubeletDiskTypeOS,
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(containerservice.KubeletDiskTypeOS),
 				}, false),

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -111,6 +111,21 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 
 			"linux_os_config": schemaNodePoolLinuxOSConfig(),
 
+			"fips_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"kubelet_disk_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  containerservice.KubeletDiskTypeOS,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(containerservice.KubeletDiskTypeOS),
+				}, false),
+			},
+
 			"max_count": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
@@ -308,7 +323,9 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 	profile := containerservice.ManagedClusterAgentPoolProfileProperties{
 		OsType:                 containerservice.OSType(osType),
 		EnableAutoScaling:      utils.Bool(enableAutoScaling),
+		EnableFIPS:             utils.Bool(d.Get("fips_enabled").(bool)),
 		EnableNodePublicIP:     utils.Bool(d.Get("enable_node_public_ip").(bool)),
+		KubeletDiskType:        containerservice.KubeletDiskType(d.Get("kubelet_disk_type").(string)),
 		Mode:                   mode,
 		ScaleSetPriority:       containerservice.ScaleSetPriority(priority),
 		Tags:                   tags.Expand(t),
@@ -647,6 +664,8 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("enable_auto_scaling", props.EnableAutoScaling)
 		d.Set("enable_node_public_ip", props.EnableNodePublicIP)
 		d.Set("enable_host_encryption", props.EnableEncryptionAtHost)
+		d.Set("fips_enabled", props.EnableFIPS)
+		d.Set("kubelet_disk_type", string(props.KubeletDiskType))
 
 		evictionPolicy := ""
 		if props.ScaleSetEvictionPolicy != "" {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -26,6 +26,7 @@ var kubernetesNodePoolTests = map[string]func(t *testing.T){
 	"errorForAvailabilitySet":        testAccKubernetesClusterNodePool_errorForAvailabilitySet,
 	"kubeletAndLinuxOSConfig":        testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig,
 	"kubeletAndLinuxOSConfigPartial": testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial,
+	"other":                          testAccKubernetesClusterNodePool_other,
 	"multiplePools":                  testAccKubernetesClusterNodePool_multiplePools,
 	"manualScale":                    testAccKubernetesClusterNodePool_manualScale,
 	"manualScaleMultiplePools":       testAccKubernetesClusterNodePool_manualScaleMultiplePools,
@@ -195,6 +196,27 @@ func testAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial(t *testing.
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.kubeletAndLinuxOSConfigPartial(data),
+			Check: acceptance.ComposeTestCheckFunc(
+
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesClusterNodePool_other(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesClusterNodePool_other(t)
+}
+
+func testAccKubernetesClusterNodePool_other(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.other(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1869,6 +1891,25 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   min_count             = 1
   max_count             = 1
   node_count            = 1
+}
+`, r.templateConfig(data))
+}
+
+func (r KubernetesClusterNodePoolResource) other(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 3
+  fips_enabled          = true
+  kubelet_disk_type     = "OS"
 }
 `, r.templateConfig(data))
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -25,6 +25,7 @@ var kubernetesOtherTests = map[string]func(t *testing.T){
 	"tags":                              testAccKubernetesCluster_tags,
 	"windowsProfile":                    testAccKubernetesCluster_windowsProfile,
 	"windowsProfileLicense":             testAccKubernetesCluster_windowsProfileLicense,
+	"updateWindowsProfileLicense":       TestAccKubernetesCluster_updateWindowsProfileLicense,
 	"outboundTypeLoadBalancer":          testAccKubernetesCluster_outboundTypeLoadBalancer,
 	"privateClusterOn":                  testAccKubernetesCluster_privateClusterOn,
 	"privateClusterOff":                 testAccKubernetesCluster_privateClusterOff,
@@ -470,6 +471,40 @@ func testAccKubernetesCluster_windowsProfileLicense(t *testing.T) {
 		data.ImportStep(
 			"windows_profile.0.admin_password",
 		),
+	})
+}
+
+func TestAccKubernetesCluster_updateWindowsProfileLicense(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_updateWindowsProfileLicense(t)
+}
+
+func testAccKubernetesCluster_updateWindowsProfileLicense(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsProfileConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("windows_profile.0.admin_password"),
+		{
+			Config: r.windowsProfileLicense(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("windows_profile.0.admin_password"),
+		{
+			Config: r.windowsProfileConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("windows_profile.0.admin_password"),
 	})
 }
 

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1081,13 +1081,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%d"
-k
+
   default_node_pool {
-    name                 = "default"
-    node_count           = 1
-    vm_size              = "Standard_DS2_v2"
-    fips_enabled         = true
-    kubelet_disk_type    = "OS"
+    name              = "default"
+    node_count        = 1
+    vm_size           = "Standard_DS2_v2"
+    fips_enabled      = true
+    kubelet_disk_type = "OS"
   }
 
   identity {

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -24,6 +24,7 @@ var kubernetesOtherTests = map[string]func(t *testing.T){
 	"upgradeConfig":                     testAccKubernetesCluster_upgrade,
 	"tags":                              testAccKubernetesCluster_tags,
 	"windowsProfile":                    testAccKubernetesCluster_windowsProfile,
+	"windowsProfileLicense":             testAccKubernetesCluster_windowsProfileLicense,
 	"outboundTypeLoadBalancer":          testAccKubernetesCluster_outboundTypeLoadBalancer,
 	"privateClusterOn":                  testAccKubernetesCluster_privateClusterOn,
 	"privateClusterOff":                 testAccKubernetesCluster_privateClusterOff,
@@ -442,6 +443,28 @@ func testAccKubernetesCluster_windowsProfile(t *testing.T) {
 				check.That(data.ResourceName).Key("default_node_pool.0.max_pods").Exists(),
 				check.That(data.ResourceName).Key("linux_profile.0.admin_username").Exists(),
 				check.That(data.ResourceName).Key("windows_profile.0.admin_username").Exists(),
+			),
+		},
+		data.ImportStep(
+			"windows_profile.0.admin_password",
+		),
+	})
+}
+
+func TestAccKubernetesCluster_windowsProfileLicense(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_windowsProfileLicense(t)
+}
+
+func testAccKubernetesCluster_windowsProfileLicense(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsProfileLicense(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(
@@ -1299,6 +1322,59 @@ resource "azurerm_kubernetes_cluster" "test" {
   windows_profile {
     admin_username = "azureuser"
     admin_password = "P@55W0rd1234!h@2h1C0rP"
+  }
+
+  # the default node pool /has/ to be Linux agents - Windows agents can be added via the node pools resource
+  default_node_pool {
+    name       = "np"
+    node_count = 3
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin     = "azure"
+    network_policy     = "azure"
+    dns_service_ip     = "10.10.0.10"
+    docker_bridge_cidr = "172.18.0.1/16"
+    service_cidr       = "10.10.0.0/16"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (KubernetesClusterResource) windowsProfileLicense(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  windows_profile {
+    admin_username = "azureuser"
+    admin_password = "P@55W0rd1234!h@2h1C0rP"
+    license        = "Windows_Server"
   }
 
   # the default node pool /has/ to be Linux agents - Windows agents can be added via the node pools resource

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -689,6 +689,14 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Sensitive:    true,
 							ValidateFunc: validation.StringLenBetween(8, 123),
 						},
+						"license": {
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(containerservice.LicenseTypeNone),
+								string(containerservice.LicenseTypeWindowsServer),
+							}, false),
+						},
 					},
 				},
 			},
@@ -1657,13 +1665,13 @@ func expandKubernetesClusterWindowsProfile(input []interface{}) *containerservic
 	}
 
 	config := input[0].(map[string]interface{})
-
-	adminUsername := config["admin_username"].(string)
-	adminPassword := config["admin_password"].(string)
-
 	profile := containerservice.ManagedClusterWindowsProfile{
-		AdminUsername: &adminUsername,
-		AdminPassword: &adminPassword,
+		AdminUsername: utils.String(config["admin_username"].(string)),
+		AdminPassword: utils.String(config["admin_password"].(string)),
+	}
+
+	if v := config["license"].(string); v != "" {
+		profile.LicenseType = containerservice.LicenseType(v)
 	}
 
 	return &profile
@@ -1689,6 +1697,7 @@ func flattenKubernetesClusterWindowsProfile(profile *containerservice.ManagedClu
 		map[string]interface{}{
 			"admin_password": adminPassword,
 			"admin_username": adminUsername,
+			"license":        string(profile.LicenseType),
 		},
 	}
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -18,8 +18,8 @@ type KubernetesClusterResource struct {
 }
 
 var (
-	olderKubernetesVersion   = "1.18.14"
-	currentKubernetesVersion = "1.19.9"
+	olderKubernetesVersion   = "1.18.19"
+	currentKubernetesVersion = "1.19.11"
 )
 
 func TestAccKubernetes_all(t *testing.T) {

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -89,7 +89,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				"kubelet_disk_type": {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
-					Default:  containerservice.KubeletDiskTypeOS,
+					Computed: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						string(containerservice.KubeletDiskTypeOS),
 					}, false),

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -80,6 +80,21 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 
 				"linux_os_config": schemaNodePoolLinuxOSConfig(),
 
+				"fips_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					ForceNew: true,
+				},
+
+				"kubelet_disk_type": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  containerservice.KubeletDiskTypeOS,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(containerservice.KubeletDiskTypeOS),
+					}, false),
+				},
+
 				"max_count": {
 					Type:     pluginsdk.TypeInt,
 					Optional: true,
@@ -548,6 +563,8 @@ func ConvertDefaultNodePoolToAgentPool(input *[]containerservice.ManagedClusterA
 			MaxCount:                  defaultCluster.MaxCount,
 			MinCount:                  defaultCluster.MinCount,
 			EnableAutoScaling:         defaultCluster.EnableAutoScaling,
+			EnableFIPS:                defaultCluster.EnableFIPS,
+			KubeletDiskType:           defaultCluster.KubeletDiskType,
 			Type:                      defaultCluster.Type,
 			OrchestratorVersion:       defaultCluster.OrchestratorVersion,
 			ProximityPlacementGroupID: defaultCluster.ProximityPlacementGroupID,
@@ -589,8 +606,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]containerservice.Manag
 
 	profile := containerservice.ManagedClusterAgentPoolProfile{
 		EnableAutoScaling:      utils.Bool(enableAutoScaling),
+		EnableFIPS:             utils.Bool(raw["fips_enabled"].(bool)),
 		EnableNodePublicIP:     utils.Bool(raw["enable_node_public_ip"].(bool)),
 		EnableEncryptionAtHost: utils.Bool(raw["enable_host_encryption"].(bool)),
+		KubeletDiskType:        containerservice.KubeletDiskType(raw["kubelet_disk_type"].(string)),
 		Name:                   utils.String(raw["name"].(string)),
 		NodeLabels:             nodeLabels,
 		NodeTaints:             nodeTaints,
@@ -907,6 +926,11 @@ func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolPro
 		enableAutoScaling = *agentPool.EnableAutoScaling
 	}
 
+	enableFIPS := false
+	if agentPool.EnableFIPS != nil {
+		enableFIPS = *agentPool.EnableFIPS
+	}
+
 	enableNodePublicIP := false
 	if agentPool.EnableNodePublicIP != nil {
 		enableNodePublicIP = *agentPool.EnableNodePublicIP
@@ -1000,6 +1024,8 @@ func FlattenDefaultNodePool(input *[]containerservice.ManagedClusterAgentPoolPro
 			"enable_auto_scaling":          enableAutoScaling,
 			"enable_node_public_ip":        enableNodePublicIP,
 			"enable_host_encryption":       enableHostEncryption,
+			"fips_enabled":                 enableFIPS,
+			"kubelet_disk_type":            string(agentPool.KubeletDiskType),
 			"max_count":                    maxCount,
 			"max_pods":                     maxPods,
 			"min_count":                    minCount,

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -317,7 +317,7 @@ A `default_node_pool` block supports the following:
 
 ~> NOTE: FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
 
-* `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
+* `kubelet_disk_type` - (Optional) The type of disk used by kubelet. At this time the only possible value is `OS`.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 
@@ -614,7 +614,7 @@ A `windows_profile` block supports the following:
 
 * `admin_password` - (Required) The Admin Password for Windows VMs. Length must be between 14 and 123 characters.
 
-* `license` - (Optional) The license for Windows VMs. Possible values are `None` and `Windows_Server`.
+* `license` - (Optional) Specifies the type of on-premise license which should be used for Node Pool Windows Virtual Machine. At this time the only possible value is `Windows_Server`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -612,6 +612,8 @@ A `windows_profile` block supports the following:
 
 * `admin_password` - (Required) The Admin Password for Windows VMs. Length must be between 14 and 123 characters.
 
+* `license` - (Optional) The license for Windows VMs. Possible values are `None` and `Windows_Server`.
+
 ---
 
 A `upgrade_settings` block supports the following:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -315,6 +315,8 @@ A `default_node_pool` block supports the following:
 
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.
 
+~> NOTE: FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
+
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -313,6 +313,10 @@ A `default_node_pool` block supports the following:
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below.
 
+* `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.
+
+* `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
+
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 
 * `node_public_ip_prefix_id` - (Optional) Resource ID for the Public IP Addresses Prefix for the nodes in this Node Pool. `enable_node_public_ip` should be `true`. Changing this forces a new resource to be created.

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 ~> NOTE: FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
 
-* `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
+* `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible Values are `OS`.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -85,9 +85,15 @@ The following arguments are supported:
 
 -> **Note:** An Eviction Policy can only be configured when `priority` is set to `Spot`.
 
+<<<<<<< HEAD
 * `kubelet_config` - (Optional) A `kubelet_config` block as defined below.
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below.
+=======
+* `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.
+
+* `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
+>>>>>>> "azurerm_kubernetes_cluster", "azurerm_kubernetes_cluster_node_pool" supports "fips_enabled", "kubelet_disk_type"
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -85,15 +85,13 @@ The following arguments are supported:
 
 -> **Note:** An Eviction Policy can only be configured when `priority` is set to `Spot`.
 
-<<<<<<< HEAD
 * `kubelet_config` - (Optional) A `kubelet_config` block as defined below.
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below.
-=======
+
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
->>>>>>> "azurerm_kubernetes_cluster", "azurerm_kubernetes_cluster_node_pool" supports "fips_enabled", "kubelet_disk_type"
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -91,6 +91,8 @@ The following arguments are supported:
 
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this forces a new resource to be created.
 
+~> NOTE: FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
+
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Defaults to `OS`. Possible Values are `OS`.
 
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent. Changing this forces a new resource to be created.


### PR DESCRIPTION
to test the `fips_enabled` property, `Microsoft.ContainerService/FIPSPreview` feature must be enabled.

`kubelet_disk_type` currently only supports `OS`, `Temporary` will be supported in future.

![image](https://user-images.githubusercontent.com/2786738/119325836-deea5880-bcb3-11eb-9e6b-82d6eaaa1470.png)
