### PR TITLE
`azurerm_route_table`: Update docs to indicate that tags can be used for `address_prefix`

### DIFF
--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -64,7 +64,7 @@ Elements of `route` support:
 
 * `name` - (Required) The name of the route.
 
-* `address_prefix` - (Required) The destination CIDR to which the route applies, such as 10.1.0.0/16
+* `address_prefix` - (Required) The destination CIDR to which the route applies, such as 10.1.0.0/16. Tags such as `VirtualNetwork`, `AzureLoadBalancer` or `Internet` can also be used.
 
 * `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.
 


### PR DESCRIPTION

Fixes #11836