### PR TITLE
fix a crash when body format changed

### DIFF
--- a/azurerm/internal/services/logic/logic_app_action_http_resource.go
+++ b/azurerm/internal/services/logic/logic_app_action_http_resource.go
@@ -1,6 +1,7 @@
 package logic
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2019-05-01/logic"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
@@ -62,8 +64,10 @@ func resourceLogicAppActionHTTP() *pluginsdk.Resource {
 			},
 
 			"body": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 
 			"headers": {
@@ -101,6 +105,9 @@ func resourceLogicAppActionHTTP() *pluginsdk.Resource {
 }
 
 func resourceLogicAppActionHTTPCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	logicAppId := d.Get("logic_app_id").(string)
+	name := d.Get("name").(string)
+
 	headersRaw := d.Get("headers").(map[string]interface{})
 	headers, err := expandLogicAppActionHttpHeaders(headersRaw)
 	if err != nil {
@@ -113,8 +120,13 @@ func resourceLogicAppActionHTTPCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		"headers": headers,
 	}
 
-	if v, ok := d.GetOk("body"); ok {
-		inputs["body"] = v.(string)
+	// storing action's body in json object to keep consistent with azure portal
+	if bodyRaw, ok := d.GetOk("body"); ok {
+		var body map[string]interface{}
+		if err := json.Unmarshal([]byte(bodyRaw.(string)), &body); err != nil {
+			return fmt.Errorf("error unmarshalling JSON for Action %q: %+v", name, err)
+		}
+		inputs["body"] = body
 	}
 
 	action := map[string]interface{}{
@@ -126,8 +138,6 @@ func resourceLogicAppActionHTTPCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		action["runAfter"] = expandLogicAppActionRunAfter(v.(*pluginsdk.Set).List())
 	}
 
-	logicAppId := d.Get("logic_app_id").(string)
-	name := d.Get("name").(string)
 	err = resourceLogicAppActionUpdate(d, meta, logicAppId, name, action, "azurerm_logic_app_action_http")
 	if err != nil {
 		return err
@@ -186,7 +196,17 @@ func resourceLogicAppActionHTTPRead(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if body := inputs["body"]; body != nil {
-		d.Set("body", body.(string))
+		// TODO: remove in 3.0, this is preserved for backward compatibility
+		if v, ok := body.(string); ok {
+			d.Set("body", v)
+		} else {
+			// if user edit workflow in portal, the body becomes json object
+			v, err := json.Marshal(body)
+			if err != nil {
+				return fmt.Errorf("error serializing `body` for Action %q: %+v", name, err)
+			}
+			d.Set("body", string(v))
+		}
 	}
 
 	if headers := inputs["headers"]; headers != nil {


### PR DESCRIPTION
To address this issue https://github.com/terraform-providers/terraform-provider-azurerm/issues/5163

After deploying tf configs, user can edit it on azure portal, although user may not change any codes in code view, but if user click save button, then the attribute body's format will be changed to json object, then it caused crash.

```
=== RUN   TestAccLogicAppActionHttp_basic
=== PAUSE TestAccLogicAppActionHttp_basic
=== CONT  TestAccLogicAppActionHttp_basic
--- PASS: TestAccLogicAppActionHttp_basic(167.12s)
=== RUN   TestAccLogicAppActionHttp_requiresImport
=== PAUSE TestAccLogicAppActionHttp_requiresImport
=== CONT  TestAccLogicAppActionHttp_requiresImport
--- PASS: TestAccLogicAppActionHttp_requiresImport(187.29s)
=== RUN   TestAccLogicAppActionHttp_headers
=== PAUSE TestAccLogicAppActionHttp_headers
=== CONT  TestAccLogicAppActionHttp_headers
--- PASS: TestAccLogicAppActionHttp_headers (166.74s)
=== RUN   TestAccLogicAppActionHttp_disappears
=== PAUSE TestAccLogicAppActionHttp_disappears
=== CONT  TestAccLogicAppActionHttp_disappears
--- PASS: TestAccLogicAppActionHttp_disappears (251.27s)
=== RUN   TestAccLogicAppActionHttp_runAfter
=== PAUSE TestAccLogicAppActionHttp_runAfter
=== CONT  TestAccLogicAppActionHttp_runAfter
--- PASS: TestAccLogicAppActionHttp_runAfter (272.41s)
```