### PR TITLE
`azurerm_static_site`: Add support for `tags` attribute

### DIFF
--- a/azurerm/internal/services/web/static_site_resource.go
+++ b/azurerm/internal/services/web/static_site_resource.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -74,6 +75,8 @@ func resourceStaticSite() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tags.Schema(),
 		},
 	}
 }
@@ -110,6 +113,7 @@ func resourceStaticSiteCreateOrUpdate(d *schema.ResourceData, meta interface{}) 
 		},
 		StaticSite: &web.StaticSite{},
 		Location:   &loc,
+		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if _, err := client.CreateOrUpdateStaticSite(ctx, id.ResourceGroup, id.Name, siteEnvelope); err != nil {
@@ -178,7 +182,7 @@ func resourceStaticSiteRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.Set("api_key", apiKey)
 
-	return nil
+	return tags.FlattenAndSet(d, resp.Tags)
 }
 
 func resourceStaticSiteDelete(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/internal/services/web/static_site_resource_test.go
+++ b/azurerm/internal/services/web/static_site_resource_test.go
@@ -29,6 +29,7 @@ func TestAccAzureStaticSite_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_host_name").Exists(),
 				check.That(data.ResourceName).Key("api_key").Exists(),
+				check.That(data.ResourceName).Key("tags.environment").HasValue("acceptance"),
 			),
 		},
 		data.ImportStep(),
@@ -82,6 +83,10 @@ resource "azurerm_static_site" "test" {
   name                = "acctestSS-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    environment = "acceptance"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/static_site.html.markdown
+++ b/website/docs/r/static_site.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Static Web App should exist. Changing this forces a new Static Web App to be created.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 


### PR DESCRIPTION

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/web -timeout=1000m -run='TestAccAzureStaticSite_basic'
2021/05/25 10:38:13 [DEBUG] not using binary driver name, it's no longer needed
2021/05/25 10:38:13 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccAzureStaticSite_basic
=== PAUSE TestAccAzureStaticSite_basic
=== CONT  TestAccAzureStaticSite_basic
--- PASS: TestAccAzureStaticSite_basic (156.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web	158.219s
```

Fixes #11837