### PR TITLE
azurerm_cdn_endpoint - fix API error when given an empty `origin_host_header`

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -238,7 +238,6 @@ func resourceCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
-	originHostHeader := d.Get("origin_host_header").(string)
 	originPath := d.Get("origin_path").(string)
 	probePath := d.Get("probe_path").(string)
 	optimizationType := d.Get("optimization_type").(string)
@@ -250,9 +249,12 @@ func resourceCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
 			IsHTTPAllowed:              &httpAllowed,
 			IsHTTPSAllowed:             &httpsAllowed,
 			QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(cachingBehaviour),
-			OriginHostHeader:           utils.String(originHostHeader),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("origin_host_header"); ok {
+		endpoint.EndpointProperties.OriginHostHeader = utils.String(v.(string))
 	}
 
 	if _, ok := d.GetOk("content_types_to_compress"); ok {
@@ -343,7 +345,6 @@ func resourceCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
-	hostHeader := d.Get("origin_host_header").(string)
 	originPath := d.Get("origin_path").(string)
 	probePath := d.Get("probe_path").(string)
 	optimizationType := d.Get("optimization_type").(string)
@@ -354,9 +355,12 @@ func resourceCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
 			IsHTTPAllowed:              utils.Bool(httpAllowed),
 			IsHTTPSAllowed:             utils.Bool(httpsAllowed),
 			QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(cachingBehaviour),
-			OriginHostHeader:           utils.String(hostHeader),
 		},
 		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("origin_host_header"); ok {
+		endpoint.EndpointPropertiesUpdateParameters.OriginHostHeader = utils.String(v.(string))
 	}
 
 	if _, ok := d.GetOk("content_types_to_compress"); ok {

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -71,13 +71,6 @@ func TestAccCdnEndpoint_updateHostHeader(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.hostHeader(data, ""),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
 			Config: r.hostHeader(data, "www.example2.com"),
 			Check: resource.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `origin` - (Required) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options. Each `origin` block supports fields documented below.
 
-* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
+* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins.
 
 * `origin_path` - (Optional) The path used at for origin requests.
 


### PR DESCRIPTION
Confirmed with service team, the request payload can't contain an empty string for the `origin_host_header`, otherwise, the service will raise following error:

```
{
  "error": {
    "code": "BadRequest",
    "message": "OriginHostHeader \"\" is invalid. It must be a valid domain name, IP version 4, or IP version 6."
  }
}
```

Also update the document of this property to remove the line about default, since that is not true.

Meanwhile, this should fix some of the acctest failures.

Fixes #8870, #11107.