### PR TITLE
Support for Debuggable Provider Binaries

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
+	"flag"
 	"log"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm"
@@ -11,7 +14,25 @@ func main() {
 	// remove date and time stamp from log output as the plugin SDK already adds its own
 	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: azurerm.Provider,
-	})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debuggable", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	if debugMode {
+		// This is needed so Terraform doesn't default to expecting protocol 4.
+		// TODO: remove below line once the provider migrates to plugin SDK v2.
+		os.Setenv("PLUGIN_PROTOCOL_VERSIONS", "5")
+		err := plugin.Debug(context.Background(), "registry.terraform.io/hashicorp/azurerm",
+			&plugin.ServeOpts{
+				ProviderFunc: azurerm.Provider,
+			})
+		if err != nil {
+			log.Println(err.Error())
+		}
+	} else {
+		plugin.Serve(&plugin.ServeOpts{
+			ProviderFunc: azurerm.Provider,
+		})
+	}
 }


### PR DESCRIPTION
Add supports for the debuggable provider binaries. Though this is meant to be a [plugin SDK v2 feature](https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#support-for-debuggable-provider-binaries), whilst it actually works for current v1 SDK version we are using.

The benefit of using the debuggable provider binaries is that it makes it simpler to debug existing Terraform provisionings/configs, without needing to reproduce it via AccTest and do the debug during running the AccTest.

[![asciicast](https://asciinema.org/a/3fdGE7iAYmoCZoXtFLlIczRit.svg)](https://asciinema.org/a/3fdGE7iAYmoCZoXtFLlIczRit)