### PR TITLE
Add note to avoid conflicts when enabling AGIC

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -456,6 +456,8 @@ An `ingress_application_gateway` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the subnet on which to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.
 
+-> **NOTE** If using `enabled` in conjunction with `only_critical_addons_enabled`, the AGIC pod will fail to start. A seperate `azurerm_kubernetes_cluster_node_pool` is required to run the AGIC pod successfully. This is because AGIC is classed as a "non-critical addon". 
+
 ---
 
 A `role_based_access_control` block supports the following:


### PR DESCRIPTION
As discussed here https://github.com/terraform-providers/terraform-provider-azurerm/issues/11845. There is a conflict when enabling the AGIC ingress controller and tainting the default node pool with "CriticalAddonsOnly=true:NoSchedule". After specifying a separate node pool, the AGIC pod will attempt to find a node pool that can accommodate it.