### PR TITLE
`azurerm_synapse_spark_pool` - `spark_version` now supports `3.0`

### DIFF
--- a/azurerm/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/azurerm/internal/services/synapse/synapse_spark_pool_resource.go
@@ -150,6 +150,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 				Default:  "2.4",
 				ValidateFunc: validation.StringInSlice([]string{
 					"2.4",
+					"3.0",
 				}, false),
 			},
 

--- a/azurerm/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/azurerm/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -52,7 +52,7 @@ func TestAccSynapseSparkPool_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data),
+			Config: r.complete(data, "2.4"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -75,7 +75,52 @@ func TestAccSynapseSparkPool_update(t *testing.T) {
 		},
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
 		{
-			Config: r.complete(data),
+			Config: r.complete(data, "2.4"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+	})
+}
+
+func TestAccSynapseSpark3Pool_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
+	r := SynapseSparkPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data, "3.0"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// not returned by service
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+	})
+}
+
+func TestAccSynapseSpark3Pool_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
+	r := SynapseSparkPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
+		{
+			Config: r.complete(data, "3.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -138,7 +183,7 @@ resource "azurerm_synapse_spark_pool" "import" {
 `, config)
 }
 
-func (r SynapseSparkPoolResource) complete(data acceptance.TestData) string {
+func (r SynapseSparkPoolResource) complete(data acceptance.TestData, sparkVersion string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -168,13 +213,13 @@ EOF
 
   spark_log_folder    = "/logs"
   spark_events_folder = "/events"
-  spark_version       = "2.4"
+  spark_version       = "%s"
 
   tags = {
     ENV = "Test"
   }
 }
-`, template, data.RandomString)
+`, template, data.RandomString, sparkVersion)
 }
 
 func (r SynapseSparkPoolResource) template(data acceptance.TestData) string {

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible value is `2.4`. Defaults to `2.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` and `3.0`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
Fixes #11970

```
❯ make acctests SERVICE='synapse' TESTARGS='-run=TestAccSynapseSpark3Pool_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/synapse -run=TestAccSynapseSpark3Pool_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/05/26 18:02:43 [DEBUG] not using binary driver name, it's no longer needed
2021/05/26 18:02:43 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccSynapseSpark3Pool_complete
=== PAUSE TestAccSynapseSpark3Pool_complete
=== RUN   TestAccSynapseSpark3Pool_update
=== PAUSE TestAccSynapseSpark3Pool_update
=== CONT  TestAccSynapseSpark3Pool_complete
=== CONT  TestAccSynapseSpark3Pool_update
--- PASS: TestAccSynapseSpark3Pool_complete (1533.91s)
--- PASS: TestAccSynapseSpark3Pool_update (1707.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/synapse	1708.478s
```