### PR TITLE
eventhub: refactoring on top of the generated SDK 

### DIFF
--- a/azurerm/internal/services/eventhub/client/client.go
+++ b/azurerm/internal/services/eventhub/client/client.go
@@ -1,39 +1,67 @@
 package client
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/consumergroups"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubs"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubsclusters"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/namespaces"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/networkrulesets"
 )
 
 type Client struct {
-	ClusterClient                 *eventhub.ClustersClient
-	ConsumerGroupClient           *eventhub.ConsumerGroupsClient
-	DisasterRecoveryConfigsClient *eventhub.DisasterRecoveryConfigsClient
-	EventHubsClient               *eventhub.EventHubsClient
-	NamespacesClient              *eventhub.NamespacesClient
+	ClusterClient                       *eventhubsclusters.EventHubsClustersClient
+	ConsumerGroupClient                 *consumergroups.ConsumerGroupsClient
+	DisasterRecoveryConfigsClient       *disasterrecoveryconfigs.DisasterRecoveryConfigsClient
+	DisasterRecoveryNameAvailableClient *checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityDisasterRecoveryConfigsClient
+	EventHubsClient                     *eventhubs.EventHubsClient
+	EventHubAuthorizationRulesClient    *authorizationruleseventhubs.AuthorizationRulesEventHubsClient
+	NamespacesClient                    *namespaces.NamespacesClient
+	NamespaceAuthorizationRulesClient   *authorizationrulesnamespaces.AuthorizationRulesNamespacesClient
+	NetworkRuleSetsClient               *networkrulesets.NetworkRuleSetsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
-	ClustersClient := eventhub.NewClustersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&ClustersClient.Client, o.ResourceManagerAuthorizer)
+	clustersClient := eventhubsclusters.NewEventHubsClustersClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&clustersClient.Client, o.ResourceManagerAuthorizer)
 
-	EventHubsClient := eventhub.NewEventHubsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&EventHubsClient.Client, o.ResourceManagerAuthorizer)
+	consumerGroupsClient := consumergroups.NewConsumerGroupsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&consumerGroupsClient.Client, o.ResourceManagerAuthorizer)
 
-	DisasterRecoveryConfigsClient := eventhub.NewDisasterRecoveryConfigsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&DisasterRecoveryConfigsClient.Client, o.ResourceManagerAuthorizer)
+	disasterRecoveryConfigsClient := disasterrecoveryconfigs.NewDisasterRecoveryConfigsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&disasterRecoveryConfigsClient.Client, o.ResourceManagerAuthorizer)
 
-	ConsumerGroupClient := eventhub.NewConsumerGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&ConsumerGroupClient.Client, o.ResourceManagerAuthorizer)
+	disasterRecoveryNameAvailableClient := checknameavailabilitydisasterrecoveryconfigs.NewCheckNameAvailabilityDisasterRecoveryConfigsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&disasterRecoveryNameAvailableClient.Client, o.ResourceManagerAuthorizer)
 
-	NamespacesClient := eventhub.NewNamespacesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&NamespacesClient.Client, o.ResourceManagerAuthorizer)
+	eventhubsClient := eventhubs.NewEventHubsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&eventhubsClient.Client, o.ResourceManagerAuthorizer)
+
+	eventHubAuthorizationRulesClient := authorizationruleseventhubs.NewAuthorizationRulesEventHubsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&eventHubAuthorizationRulesClient.Client, o.ResourceManagerAuthorizer)
+
+	namespacesClient := namespaces.NewNamespacesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&namespacesClient.Client, o.ResourceManagerAuthorizer)
+
+	namespaceAuthorizationRulesClient := authorizationrulesnamespaces.NewAuthorizationRulesNamespacesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&namespaceAuthorizationRulesClient.Client, o.ResourceManagerAuthorizer)
+
+	networkRuleSetsClient := networkrulesets.NewNetworkRuleSetsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&networkRuleSetsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		ClusterClient:                 &ClustersClient,
-		ConsumerGroupClient:           &ConsumerGroupClient,
-		DisasterRecoveryConfigsClient: &DisasterRecoveryConfigsClient,
-		EventHubsClient:               &EventHubsClient,
-		NamespacesClient:              &NamespacesClient,
+		ClusterClient:                       &clustersClient,
+		ConsumerGroupClient:                 &consumerGroupsClient,
+		DisasterRecoveryConfigsClient:       &disasterRecoveryConfigsClient,
+		DisasterRecoveryNameAvailableClient: &disasterRecoveryNameAvailableClient,
+		EventHubsClient:                     &eventhubsClient,
+		EventHubAuthorizationRulesClient:    &eventHubAuthorizationRulesClient,
+		NamespacesClient:                    &namespacesClient,
+		NamespaceAuthorizationRulesClient:   &namespaceAuthorizationRulesClient,
+		NetworkRuleSetsClient:               &networkRuleSetsClient,
 	}
 }

--- a/azurerm/internal/services/eventhub/client/client.go
+++ b/azurerm/internal/services/eventhub/client/client.go
@@ -14,15 +14,15 @@ import (
 )
 
 type Client struct {
-	ClusterClient                       *eventhubsclusters.EventHubsClustersClient
-	ConsumerGroupClient                 *consumergroups.ConsumerGroupsClient
-	DisasterRecoveryConfigsClient       *disasterrecoveryconfigs.DisasterRecoveryConfigsClient
-	DisasterRecoveryNameAvailableClient *checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityDisasterRecoveryConfigsClient
-	EventHubsClient                     *eventhubs.EventHubsClient
-	EventHubAuthorizationRulesClient    *authorizationruleseventhubs.AuthorizationRulesEventHubsClient
-	NamespacesClient                    *namespaces.NamespacesClient
-	NamespaceAuthorizationRulesClient   *authorizationrulesnamespaces.AuthorizationRulesNamespacesClient
-	NetworkRuleSetsClient               *networkrulesets.NetworkRuleSetsClient
+	ClusterClient                          *eventhubsclusters.EventHubsClustersClient
+	ConsumerGroupClient                    *consumergroups.ConsumerGroupsClient
+	DisasterRecoveryConfigsClient          *disasterrecoveryconfigs.DisasterRecoveryConfigsClient
+	DisasterRecoveryNameAvailabilityClient *checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityDisasterRecoveryConfigsClient
+	EventHubsClient                        *eventhubs.EventHubsClient
+	EventHubAuthorizationRulesClient       *authorizationruleseventhubs.AuthorizationRulesEventHubsClient
+	NamespacesClient                       *namespaces.NamespacesClient
+	NamespaceAuthorizationRulesClient      *authorizationrulesnamespaces.AuthorizationRulesNamespacesClient
+	NetworkRuleSetsClient                  *networkrulesets.NetworkRuleSetsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -35,8 +35,8 @@ func NewClient(o *common.ClientOptions) *Client {
 	disasterRecoveryConfigsClient := disasterrecoveryconfigs.NewDisasterRecoveryConfigsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&disasterRecoveryConfigsClient.Client, o.ResourceManagerAuthorizer)
 
-	disasterRecoveryNameAvailableClient := checknameavailabilitydisasterrecoveryconfigs.NewCheckNameAvailabilityDisasterRecoveryConfigsClientWithBaseURI(o.ResourceManagerEndpoint)
-	o.ConfigureClient(&disasterRecoveryNameAvailableClient.Client, o.ResourceManagerAuthorizer)
+	disasterRecoveryNameAvailabilityClient := checknameavailabilitydisasterrecoveryconfigs.NewCheckNameAvailabilityDisasterRecoveryConfigsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&disasterRecoveryNameAvailabilityClient.Client, o.ResourceManagerAuthorizer)
 
 	eventhubsClient := eventhubs.NewEventHubsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&eventhubsClient.Client, o.ResourceManagerAuthorizer)
@@ -54,14 +54,14 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&networkRuleSetsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		ClusterClient:                       &clustersClient,
-		ConsumerGroupClient:                 &consumerGroupsClient,
-		DisasterRecoveryConfigsClient:       &disasterRecoveryConfigsClient,
-		DisasterRecoveryNameAvailableClient: &disasterRecoveryNameAvailableClient,
-		EventHubsClient:                     &eventhubsClient,
-		EventHubAuthorizationRulesClient:    &eventHubAuthorizationRulesClient,
-		NamespacesClient:                    &namespacesClient,
-		NamespaceAuthorizationRulesClient:   &namespaceAuthorizationRulesClient,
-		NetworkRuleSetsClient:               &networkRuleSetsClient,
+		ClusterClient:                          &clustersClient,
+		ConsumerGroupClient:                    &consumerGroupsClient,
+		DisasterRecoveryConfigsClient:          &disasterRecoveryConfigsClient,
+		DisasterRecoveryNameAvailabilityClient: &disasterRecoveryNameAvailabilityClient,
+		EventHubsClient:                        &eventhubsClient,
+		EventHubAuthorizationRulesClient:       &eventHubAuthorizationRulesClient,
+		NamespacesClient:                       &namespacesClient,
+		NamespaceAuthorizationRulesClient:      &namespaceAuthorizationRulesClient,
+		NetworkRuleSetsClient:                  &networkRuleSetsClient,
 	}
 }

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_data_source.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_data_source.go
@@ -4,12 +4,16 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubs"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func EventHubAuthorizationRuleDataSource() *schema.Resource {
@@ -71,7 +75,9 @@ func EventHubAuthorizationRuleDataSource() *schema.Resource {
 }
 
 func EventHubAuthorizationRuleDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.EventHubsClient
+	eventHubsClient := meta.(*clients.Client).Eventhub.EventHubsClient
+	rulesClient := meta.(*clients.Client).Eventhub.EventHubAuthorizationRulesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -80,32 +86,36 @@ func EventHubAuthorizationRuleDataSourceRead(d *schema.ResourceData, meta interf
 	eventHubName := d.Get("eventhub_name").(string)
 	namespaceName := d.Get("namespace_name").(string)
 
-	resp, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
+	id := eventhubs.NewAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, eventHubName, name)
+	resp, err := eventHubsClient.GetAuthorizationRule(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error: EventHub Authorization Rule %q (Resource Group %q) was not found", name, resourceGroup)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("Error: EventHub Authorization Rule %s: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.SetId(*resp.ID)
+	d.SetId(id.ID())
+	d.Set("name", id.Name)
+	d.Set("eventhub_name", id.EventhubName)
+	d.Set("namespace_name", id.NamespaceName)
+	d.Set("resource_group_name", id.ResourceGroup)
 
-	d.Set("name", name)
-	d.Set("eventhub_name", eventHubName)
-	d.Set("namespace_name", namespaceName)
-	d.Set("resource_group_name", resourceGroup)
-
-	keysResp, err := client.ListKeys(ctx, resourceGroup, namespaceName, eventHubName, name)
+	localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
+	keysResp, err := rulesClient.EventHubsListKeys(ctx, localId)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule List Keys %s: %+v", name, err)
+		return fmt.Errorf("listing keys for %s: %+v", id, err)
 	}
 
-	d.Set("primary_key", keysResp.PrimaryKey)
-	d.Set("secondary_key", keysResp.SecondaryKey)
-	d.Set("primary_connection_string", keysResp.PrimaryConnectionString)
-	d.Set("secondary_connection_string", keysResp.SecondaryConnectionString)
-	d.Set("primary_connection_string_alias", keysResp.AliasPrimaryConnectionString)
-	d.Set("secondary_connection_string_alias", keysResp.AliasSecondaryConnectionString)
+	if model := keysResp.Model; model != nil {
+		d.Set("primary_key", model.PrimaryKey)
+		d.Set("secondary_key", model.SecondaryKey)
+		d.Set("primary_connection_string", model.PrimaryConnectionString)
+		d.Set("secondary_connection_string", model.SecondaryConnectionString)
+		d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
+		d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+
+	}
 
 	return nil
 }

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_data_source.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_data_source.go
@@ -114,7 +114,6 @@ func EventHubAuthorizationRuleDataSourceRead(d *schema.ResourceData, meta interf
 		d.Set("secondary_connection_string", model.SecondaryConnectionString)
 		d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
 		d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
-
 	}
 
 	return nil

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -155,7 +155,7 @@ func resourceEventHubAuthorizationRuleRead(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.NamespaceName)
+	localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
 	keysResp, err := authorizationRulesClient.EventHubsListKeys(ctx, localId)
 	if err != nil {
 		return fmt.Errorf("listing keys for %s: %+v", *id, err)

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -5,17 +5,18 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
+	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubs"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceEventHubAuthorizationRule() *schema.Resource {
@@ -65,113 +66,109 @@ func resourceEventHubAuthorizationRule() *schema.Resource {
 }
 
 func resourceEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.EventHubsClient
+	eventhubsClient := meta.(*clients.Client).Eventhub.EventHubsClient
+	authorizationRulesClient := meta.(*clients.Client).Eventhub.EventHubAuthorizationRulesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM EventHub Authorization Rule creation.")
 
-	name := d.Get("name").(string)
-	namespaceName := d.Get("namespace_name").(string)
-	eventHubName := d.Get("eventhub_name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-
+	id := eventhubs.NewAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("eventhub_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
+		existing, err := eventhubsClient.GetAuthorizationRule(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing EventHub Authorization Rule %q (EventHub %q / Namespace %q / Resource Group %q): %s", name, eventHubName, namespaceName, resourceGroup, err)
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_eventhub_authorization_rule", *existing.ID)
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_eventhub_authorization_rule", id.ID())
 		}
 	}
 
-	locks.ByName(eventHubName, eventHubResourceName)
-	defer locks.UnlockByName(eventHubName, eventHubResourceName)
+	locks.ByName(id.EventhubName, eventHubResourceName)
+	defer locks.UnlockByName(id.EventhubName, eventHubResourceName)
 
-	locks.ByName(namespaceName, eventHubNamespaceResourceName)
-	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
+	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	parameters := eventhub.AuthorizationRule{
-		Name: &name,
-		AuthorizationRuleProperties: &eventhub.AuthorizationRuleProperties{
+	parameters := authorizationruleseventhubs.AuthorizationRule{
+		Name: &id.Name,
+		Properties: &authorizationruleseventhubs.AuthorizationRuleProperties{
 			Rights: expandEventHubAuthorizationRuleRights(d),
 		},
 	}
 
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		if _, err := client.CreateOrUpdateAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name, parameters); err != nil {
-			return resource.NonRetryableError(fmt.Errorf("Error creating Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q): %+v", name, eventHubName, namespaceName, resourceGroup, err))
+		localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
+		if _, err := authorizationRulesClient.EventHubsCreateOrUpdateAuthorizationRule(ctx, localId, parameters); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("creating %s: %+v", id, err))
 		}
 
-		read, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
+		read, err := eventhubsClient.GetAuthorizationRule(ctx, id)
 		if err != nil {
-			if utils.ResponseWasNotFound(read.Response) {
-				return resource.RetryableError(fmt.Errorf("Expected instance of the Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) to be created but was in non existent state, retrying", name, eventHubName, namespaceName, resourceGroup))
+			if response.WasNotFound(read.HttpResponse) {
+				return resource.RetryableError(fmt.Errorf("expected %s to be created but was in non existent state, retrying", id))
 			}
-			return resource.NonRetryableError(fmt.Errorf("Expected instance of Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) could not be found", name, eventHubName, namespaceName, resourceGroup))
+			return resource.NonRetryableError(fmt.Errorf("Expected %s was not be found", id))
 		}
 
-		if read.ID == nil {
-			return resource.NonRetryableError(fmt.Errorf("Cannot read Authorization Rule %q (event Hub %q / Namespace %q / Resource Group %q) ID", name, eventHubName, namespaceName, resourceGroup))
-		}
-
-		d.SetId(*read.ID)
+		d.SetId(id.ID())
 
 		return resource.NonRetryableError(resourceEventHubAuthorizationRuleRead(d, meta))
 	})
 }
 
 func resourceEventHubAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.EventHubsClient
+	eventHubsClient := meta.(*clients.Client).Eventhub.EventHubsClient
+	authorizationRulesClient := meta.(*clients.Client).Eventhub.EventHubAuthorizationRulesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := eventhubs.AuthorizationRuleID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Path["authorizationRules"]
-	resourceGroup := id.ResourceGroup
-	namespaceName := id.Path["namespaces"]
-	eventHubName := id.Path["eventhubs"]
-
-	resp, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
+	resp, err := eventHubsClient.GetAuthorizationRule(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule %s: %+v", name, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("eventhub_name", eventHubName)
-	d.Set("namespace_name", namespaceName)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("name", id.Name)
+	d.Set("eventhub_name", id.EventhubName)
+	d.Set("namespace_name", id.NamespaceName)
+	d.Set("resource_group_name", id.ResourceGroup)
 
-	if properties := resp.AuthorizationRuleProperties; properties != nil {
-		listen, send, manage := flattenEventHubAuthorizationRuleRights(properties.Rights)
-		d.Set("manage", manage)
-		d.Set("listen", listen)
-		d.Set("send", send)
+	if model := resp.Model; model != nil {
+		if properties := model.Properties; properties != nil {
+			listen, send, manage := flattenEventHubAuthorizationRuleRights(properties.Rights)
+			d.Set("manage", manage)
+			d.Set("listen", listen)
+			d.Set("send", send)
+		}
 	}
 
-	keysResp, err := client.ListKeys(ctx, resourceGroup, namespaceName, eventHubName, name)
+	localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.NamespaceName)
+	keysResp, err := authorizationRulesClient.EventHubsListKeys(ctx, localId)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule List Keys %s: %+v", name, err)
+		return fmt.Errorf("listing keys for %s: %+v", *id, err)
 	}
 
-	d.Set("primary_key", keysResp.PrimaryKey)
-	d.Set("secondary_key", keysResp.SecondaryKey)
-	d.Set("primary_connection_string", keysResp.PrimaryConnectionString)
-	d.Set("secondary_connection_string", keysResp.SecondaryConnectionString)
-	d.Set("primary_connection_string_alias", keysResp.AliasPrimaryConnectionString)
-	d.Set("secondary_connection_string_alias", keysResp.AliasSecondaryConnectionString)
+	if model := keysResp.Model; model != nil {
+		d.Set("primary_key", model.PrimaryKey)
+		d.Set("secondary_key", model.SecondaryKey)
+		d.Set("primary_connection_string", model.PrimaryConnectionString)
+		d.Set("secondary_connection_string", model.SecondaryConnectionString)
+		d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
+		d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+	}
 
 	return nil
 }
@@ -181,25 +178,20 @@ func resourceEventHubAuthorizationRuleDelete(d *schema.ResourceData, meta interf
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := eventhubs.AuthorizationRuleID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Path["authorizationRules"]
-	resourceGroup := id.ResourceGroup
-	namespaceName := id.Path["namespaces"]
-	eventHubName := id.Path["eventhubs"]
+	locks.ByName(id.EventhubName, eventHubResourceName)
+	defer locks.UnlockByName(id.EventhubName, eventHubResourceName)
 
-	locks.ByName(eventHubName, eventHubResourceName)
-	defer locks.UnlockByName(eventHubName, eventHubResourceName)
+	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	locks.ByName(namespaceName, eventHubNamespaceResourceName)
-	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
-
-	if resp, err := eventhubClient.DeleteAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name); err != nil {
-		if !utils.ResponseWasNotFound(resp) {
-			return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Authorization Rule '%s': %+v", name, err)
+	if resp, err := eventhubClient.DeleteAuthorizationRule(ctx, *id); err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("deleting %s: %+v", *id, err)
 		}
 	}
 

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource_test.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubs"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -172,21 +173,17 @@ func TestAccEventHubAuthorizationRule_withAliasConnectionString(t *testing.T) {
 }
 
 func (EventHubAuthorizationRuleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := eventhubs.AuthorizationRuleID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	name := id.Path["authorizationRules"]
-	namespaceName := id.Path["namespaces"]
-	eventHubName := id.Path["eventhubs"]
-
-	resp, err := clients.Eventhub.EventHubsClient.GetAuthorizationRule(ctx, id.ResourceGroup, namespaceName, eventHubName, name)
+	resp, err := clients.Eventhub.EventHubsClient.GetAuthorizationRule(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Event Hub Authorization Rule %q (eventhub %s / namespace %s / resource group: %s) does not exist", name, eventHubName, namespaceName, id.ResourceGroup)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.AuthorizationRuleProperties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubsclusters"
+
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -15,7 +18,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
@@ -30,7 +32,7 @@ func resourceEventHubCluster() *schema.Resource {
 		Update: resourceEventHubClusterCreateUpdate,
 		Delete: resourceEventHubClusterDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.ClusterID(id)
+			_, err := eventhubsclusters.ClusterID(id)
 			return err
 		}),
 
@@ -71,51 +73,38 @@ func resourceEventHubCluster() *schema.Resource {
 
 func resourceEventHubClusterCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Eventhub.ClusterClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 	log.Printf("[INFO] preparing arguments for Azure ARM EventHub Cluster creation.")
 
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-
+	id := eventhubsclusters.NewClusterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, name)
+		existing, err := client.ClustersGet(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing EventHub Cluster %q (Resource Group %q): %s", name, resourceGroup, err)
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_eventhub_cluster", *existing.ID)
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_eventhub_cluster", id.ID())
 		}
 	}
 
-	cluster := eventhub.Cluster{
+	cluster := eventhubsclusters.Cluster{
 		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
-		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+		Tags:     expandTags(d.Get("tags").(map[string]interface{})),
 		Sku:      expandEventHubClusterSkuName(d.Get("sku_name").(string)),
 	}
 
-	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, cluster)
-	if err != nil {
-		return fmt.Errorf("creating EventHub Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)
+	if err := client.ClustersCreateOrUpdateThenPoll(ctx, id, cluster); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of EventHub Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)
+	if d.IsNewResource() {
+		d.SetId(id.ID())
 	}
-
-	read, err := client.Get(ctx, resourceGroup, name)
-	if err != nil {
-		return fmt.Errorf("making Read request on Azure EventHub Cluster %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-
-	if read.ID == nil || *read.ID == "" {
-		return fmt.Errorf("cannot read EventHub Cluster %s (Resource Group %s) ID", name, resourceGroup)
-	}
-
-	d.SetId(*read.ID)
 
 	return resourceEventHubClusterRead(d, meta)
 }
@@ -125,63 +114,66 @@ func resourceEventHubClusterRead(d *schema.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.ClusterID(d.Id())
+	id, err := eventhubsclusters.ClusterID(d.Id())
 	if err != nil {
 		return err
 	}
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := client.ClustersGet(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("making Read request on Azure EventHub Cluster %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", resp.Name)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("sku_name", flattenEventHubClusterSkuName(resp.Sku))
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+
+	if model := resp.Model; model != nil {
+		d.Set("sku_name", flattenEventHubClusterSkuName(model.Sku))
+		d.Set("location", location.NormalizeNilable(model.Location))
+
+		return tags.FlattenAndSet(d, flattenTags(model.Tags))
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceEventHubClusterDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Eventhub.ClusterClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	id, err := parse.ClusterID(d.Id())
+	id, err := eventhubsclusters.ClusterID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	// The EventHub Cluster can't be deleted until four hours after creation so we'll keep retrying until it can be deleted.
 	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+		future, err := client.ClustersDelete(ctx, *id)
 		if err != nil {
-			if response.WasNotFound(future.Response()) {
+			if response.WasNotFound(future.HttpResponse) {
 				return nil
 			}
-			if strings.Contains(err.Error(), "Cluster cannot be deleted until four hours after its creation time") || future.Response().StatusCode == 429 {
+			if strings.Contains(err.Error(), "Cluster cannot be deleted until four hours after its creation time") || future.HttpResponse.StatusCode == 429 {
 				return resource.RetryableError(fmt.Errorf("expected eventhub cluster to be deleted but was in pending creation state, retrying"))
 			}
-			return resource.NonRetryableError(fmt.Errorf("issuing delete request for EventHub Cluster %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err))
+			return resource.NonRetryableError(fmt.Errorf("deleting %s: %+v", *id, err))
 		}
 
-		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			if future.Response().StatusCode == 404 {
+		if err := future.Poller.PollUntilDone(); err != nil {
+			if response.WasNotFound(future.HttpResponse) {
 				return nil
 			}
-			return resource.NonRetryableError(fmt.Errorf("deleting EventHub Cluster %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err))
+			return resource.NonRetryableError(fmt.Errorf("deleting %s: %+v", *id, err))
 		}
 
 		return nil
 	})
 }
 
-func expandEventHubClusterSkuName(skuName string) *eventhub.ClusterSku {
+func expandEventHubClusterSkuName(skuName string) *eventhubsclusters.ClusterSku {
 	if len(skuName) == 0 {
 		return nil
 	}
@@ -191,16 +183,16 @@ func expandEventHubClusterSkuName(skuName string) *eventhub.ClusterSku {
 		return nil
 	}
 
-	return &eventhub.ClusterSku{
-		Name:     utils.String(name),
-		Capacity: utils.Int32(capacity),
+	return &eventhubsclusters.ClusterSku{
+		Name:     eventhubsclusters.ClusterSkuName(name),
+		Capacity: utils.Int64(int64(capacity)),
 	}
 }
 
-func flattenEventHubClusterSkuName(input *eventhub.ClusterSku) string {
-	if input == nil || input.Name == nil {
+func flattenEventHubClusterSkuName(input *eventhubsclusters.ClusterSku) string {
+	if input == nil {
 		return ""
 	}
 
-	return fmt.Sprintf("%s_%d", *input.Name, *input.Capacity)
+	return fmt.Sprintf("%s_%d", string(input.Name), *input.Capacity)
 }

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -163,7 +163,7 @@ func resourceEventHubClusterDelete(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if err := future.Poller.PollUntilDone(); err != nil {
-			if response.WasNotFound(future.HttpResponse) {
+			if response.WasNotFound(future.Poller.HttpResponse) {
 				return nil
 			}
 			return resource.NonRetryableError(fmt.Errorf("deleting %s: %+v", *id, err))

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -190,7 +190,7 @@ func expandEventHubClusterSkuName(skuName string) *eventhubsclusters.ClusterSku 
 }
 
 func flattenEventHubClusterSkuName(input *eventhubsclusters.ClusterSku) string {
-	if input == nil {
+	if input == nil || input.Capacity == nil {
 		return ""
 	}
 

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubsclusters"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -62,17 +63,17 @@ func TestAccEventHubCluster_update(t *testing.T) {
 }
 
 func (EventHubClusterResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.ClusterID(state.ID)
+	id, err := eventhubsclusters.ClusterID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Eventhub.ClusterClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Eventhub.ClusterClient.ClustersGet(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ClusterProperties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubClusterResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/eventhub/eventhub_consumer_group_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_consumer_group_resource.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
+	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/consumergroups"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -84,24 +84,24 @@ func (r ConsumerGroupResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.Eventhub.ConsumerGroupClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
-			id := parse.NewEventHubConsumerGroupID(subscriptionId, state.ResourceGroupName, state.NamespaceName, state.EventHubName, state.Name)
-			existing, err := client.Get(ctx, state.ResourceGroupName, state.NamespaceName, state.EventHubName, state.Name)
-			if err != nil && !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for the presence of an existing Consumer Group %q: %+v", state.Name, err)
+			id := consumergroups.NewConsumergroupID(subscriptionId, state.ResourceGroupName, state.NamespaceName, state.EventHubName, state.Name)
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
 			}
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			parameters := eventhub.ConsumerGroup{
+			parameters := consumergroups.ConsumerGroup{
 				Name: utils.String(state.Name),
-				ConsumerGroupProperties: &eventhub.ConsumerGroupProperties{
+				Properties: &consumergroups.ConsumerGroupProperties{
 					UserMetadata: utils.String(state.UserMetadata),
 				},
 			}
 
-			if _, err := client.CreateOrUpdate(ctx, state.ResourceGroupName, state.NamespaceName, state.EventHubName, state.Name, parameters); err != nil {
-				return fmt.Errorf("creating Consumer Group %q (EventHub %q / Namespace %q / Resource Group %q): %+v", state.Name, state.EventHubName, state.NamespaceName, state.ResourceGroupName, err)
+			if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
 			metadata.SetID(id)
@@ -114,7 +114,7 @@ func (r ConsumerGroupResource) Create() sdk.ResourceFunc {
 func (r ConsumerGroupResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			id, err := parse.EventHubConsumerGroupID(metadata.ResourceData.Id())
+			id, err := consumergroups.ConsumergroupID(metadata.ResourceData.Id())
 			if err != nil {
 				return err
 			}
@@ -128,15 +128,15 @@ func (r ConsumerGroupResource) Update() sdk.ResourceFunc {
 			metadata.Logger.Infof("updating Consumer Group %q..", state.Name)
 			client := metadata.Client.Eventhub.ConsumerGroupClient
 
-			parameters := eventhub.ConsumerGroup{
-				Name: utils.String(id.ConsumergroupName),
-				ConsumerGroupProperties: &eventhub.ConsumerGroupProperties{
+			parameters := consumergroups.ConsumerGroup{
+				Name: utils.String(id.Name),
+				Properties: &consumergroups.ConsumerGroupProperties{
 					UserMetadata: utils.String(state.UserMetadata),
 				},
 			}
 
-			if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.ConsumergroupName, parameters); err != nil {
-				return fmt.Errorf("updating Consumer Group %q (EventHub %q / Namespace %q / Resource Group %q): %+v", id.ConsumergroupName, id.EventhubName, id.NamespaceName, id.ResourceGroup, err)
+			if _, err := client.CreateOrUpdate(ctx, *id, parameters); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 
 			return nil
@@ -149,29 +149,29 @@ func (r ConsumerGroupResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Eventhub.ConsumerGroupClient
-			id, err := parse.EventHubConsumerGroupID(metadata.ResourceData.Id())
+			id, err := consumergroups.ConsumergroupID(metadata.ResourceData.Id())
 			if err != nil {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving Consumer Group %q..", id.ConsumergroupName)
-			resp, err := client.Get(ctx, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.ConsumergroupName)
+			metadata.Logger.Infof("retrieving Consumer Group %q..", id.Name)
+			resp, err := client.Get(ctx, *id)
 			if err != nil {
-				if utils.ResponseWasNotFound(resp.Response) {
+				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading Consumer Group %q (EventHub %q / Namespace %q / Resource Group %q): %+v", id.ConsumergroupName, id.EventhubName, id.NamespaceName, id.ResourceGroup, err)
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
 			state := ConsumerGroupObject{
-				Name:              id.ConsumergroupName,
+				Name:              id.Name,
 				NamespaceName:     id.NamespaceName,
 				EventHubName:      id.EventhubName,
 				ResourceGroupName: id.ResourceGroup,
 			}
 
-			if props := resp.ConsumerGroupProperties; props != nil {
-				state.UserMetadata = utils.NormalizeNilableString(props.UserMetadata)
+			if model := resp.Model; model != nil && model.Properties != nil {
+				state.UserMetadata = utils.NormalizeNilableString(model.Properties.UserMetadata)
 			}
 
 			return metadata.Encode(&state)
@@ -184,15 +184,15 @@ func (r ConsumerGroupResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Eventhub.ConsumerGroupClient
-			id, err := parse.EventHubConsumerGroupID(metadata.ResourceData.Id())
+			id, err := consumergroups.ConsumergroupID(metadata.ResourceData.Id())
 			if err != nil {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Consumer Group %q..", id.ConsumergroupName)
-			if resp, err := client.Delete(ctx, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.ConsumergroupName); err != nil {
-				if !utils.ResponseWasNotFound(resp) {
-					return fmt.Errorf("deleting Consumer Group %q (EventHub %q / Namespace %q / Resource Group %q): %+v", id.ConsumergroupName, id.EventhubName, id.NamespaceName, id.ResourceGroup, err)
+			metadata.Logger.Infof("deleting Consumer Group %q..", id.Name)
+			if resp, err := client.Delete(ctx, *id); err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("deleting %s: %+v", id, err)
 				}
 			}
 

--- a/azurerm/internal/services/eventhub/eventhub_consumer_group_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_consumer_group_resource_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/consumergroups"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -88,17 +89,17 @@ func TestAccEventHubConsumerGroup_userMetadataUpdate(t *testing.T) {
 }
 
 func (EventHubConsumerGroupResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.EventHubConsumerGroupID(state.ID)
+	id, err := consumergroups.ConsumergroupID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Eventhub.ConsumerGroupClient.Get(ctx, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.ConsumergroupName)
+	resp, err := clients.Eventhub.ConsumerGroupClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ConsumerGroupProperties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubConsumerGroupResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_data_source.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_data_source.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func EventHubNamespaceDataSourceAuthorizationRule() *schema.Resource {
@@ -90,49 +92,48 @@ func EventHubNamespaceDataSourceAuthorizationRule() *schema.Resource {
 }
 
 func EventHubNamespaceDataSourceAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	client := meta.(*clients.Client).Eventhub.NamespaceAuthorizationRulesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-	namespaceName := d.Get("namespace_name").(string)
-
-	resp, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, name)
+	id := authorizationrulesnamespaces.NewAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
+	resp, err := client.NamespacesGetAuthorizationRule(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("EventHub Authorization Rule %q (Resource Group %q / Namespace Name %q) was not found", name, resourceGroup, namespaceName)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
 		}
-		return fmt.Errorf("retrieving EventHub Authorization Rule %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("retrieving EventHub Authorization Rule %q (Resource Group %q): `id` was nil", name, resourceGroup)
+	d.SetId(id.ID())
+
+	d.Set("name", id.Name)
+	d.Set("namespace_name", id.NamespaceName)
+	d.Set("resource_group_name", id.ResourceGroup)
+
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			listen, send, manage := flattenEventHubAuthorizationRuleRights(props.Rights)
+			d.Set("manage", manage)
+			d.Set("listen", listen)
+			d.Set("send", send)
+		}
 	}
-	d.SetId(*resp.ID)
 
-	d.Set("name", name)
-	d.Set("namespace_name", namespaceName)
-	d.Set("resource_group_name", resourceGroup)
-
-	if props := resp.AuthorizationRuleProperties; props != nil {
-		listen, send, manage := flattenEventHubAuthorizationRuleRights(props.Rights)
-		d.Set("manage", manage)
-		d.Set("listen", listen)
-		d.Set("send", send)
-	}
-
-	keysResp, err := client.ListKeys(ctx, resourceGroup, namespaceName, name)
+	keysResp, err := client.NamespacesListKeys(ctx, id)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule List Keys %s: %+v", name, err)
+		return fmt.Errorf("listing keys for %s: %+v", id, err)
 	}
 
-	d.Set("primary_key", keysResp.PrimaryKey)
-	d.Set("secondary_key", keysResp.SecondaryKey)
-	d.Set("primary_connection_string", keysResp.PrimaryConnectionString)
-	d.Set("secondary_connection_string", keysResp.SecondaryConnectionString)
-	d.Set("primary_connection_string_alias", keysResp.AliasPrimaryConnectionString)
-	d.Set("secondary_connection_string_alias", keysResp.AliasSecondaryConnectionString)
+	if model := keysResp.Model; model != nil {
+		d.Set("primary_key", model.PrimaryKey)
+		d.Set("secondary_key", model.SecondaryKey)
+		d.Set("primary_connection_string", model.PrimaryConnectionString)
+		d.Set("secondary_connection_string", model.SecondaryConnectionString)
+		d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
+		d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+	}
 
 	return nil
 }

--- a/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
@@ -5,18 +5,17 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
+	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/migration"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceEventHubNamespaceAuthorizationRule() *schema.Resource {
@@ -65,108 +64,100 @@ func resourceEventHubNamespaceAuthorizationRule() *schema.Resource {
 }
 
 func resourceEventHubNamespaceAuthorizationRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	client := meta.(*clients.Client).Eventhub.NamespaceAuthorizationRulesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace Authorization Rule creation.")
 
-	name := d.Get("name").(string)
-	namespaceName := d.Get("namespace_name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-
+	id := authorizationrulesnamespaces.NewAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, name)
+		existing, err := client.NamespacesGetAuthorizationRule(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing EventHub Namespace Authorization Rule %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_eventhub_namespace_authorization_rule", *existing.ID)
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_eventhub_namespace_authorization_rule", id.ID())
 		}
 	}
 
-	locks.ByName(namespaceName, eventHubNamespaceResourceName)
-	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
+	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	parameters := eventhub.AuthorizationRule{
-		Name: &name,
-		AuthorizationRuleProperties: &eventhub.AuthorizationRuleProperties{
+	parameters := authorizationrulesnamespaces.AuthorizationRule{
+		Name: &id.Name,
+		Properties: &authorizationrulesnamespaces.AuthorizationRuleProperties{
 			Rights: expandEventHubAuthorizationRuleRights(d),
 		},
 	}
 
-	if _, err := client.CreateOrUpdateAuthorizationRule(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
-		return fmt.Errorf("Error creating/updating EventHub Namespace Authorization Rule %q (Resource Group %q): %+v", name, resourceGroup, err)
+	if _, err := client.NamespacesCreateOrUpdateAuthorizationRule(ctx, id, parameters); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	read, err := client.GetAuthorizationRule(ctx, resourceGroup, namespaceName, name)
-	if err != nil {
-		return err
-	}
-
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read EventHub Namespace Authorization Rule %s (resource group %s) ID", name, resourceGroup)
-	}
-
-	d.SetId(*read.ID)
-
+	d.SetId(id.ID())
 	return resourceEventHubNamespaceAuthorizationRuleRead(d, meta)
 }
 
 func resourceEventHubNamespaceAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	client := meta.(*clients.Client).Eventhub.NamespaceAuthorizationRulesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NamespaceAuthorizationRuleID(d.Id())
+	id, err := authorizationrulesnamespaces.AuthorizationRuleID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.GetAuthorizationRule(ctx, id.ResourceGroup, id.NamespaceName, id.AuthorizationRuleName)
+	resp, err := client.NamespacesGetAuthorizationRule(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("retrieving Authorization Rule %q (EventHub Namespace %q / Resource Group %q) : %+v", id.AuthorizationRuleName, id.NamespaceName, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.Set("name", id.AuthorizationRuleName)
+	d.Set("name", id.Name)
 	d.Set("namespace_name", id.NamespaceName)
 	d.Set("resource_group_name", id.ResourceGroup)
 
-	if properties := resp.AuthorizationRuleProperties; properties != nil {
-		listen, send, manage := flattenEventHubAuthorizationRuleRights(properties.Rights)
-		d.Set("manage", manage)
-		d.Set("listen", listen)
-		d.Set("send", send)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			listen, send, manage := flattenEventHubAuthorizationRuleRights(props.Rights)
+			d.Set("manage", manage)
+			d.Set("listen", listen)
+			d.Set("send", send)
+		}
 	}
 
-	keysResp, err := client.ListKeys(ctx, id.ResourceGroup, id.NamespaceName, id.AuthorizationRuleName)
+	keysResp, err := client.NamespacesListKeys(ctx, *id)
 	if err != nil {
-		return fmt.Errorf("retrieving Keys for Authorization Rule %q (EventHub Namespace %q / Resource Group %q): %+v", id.AuthorizationRuleName, id.NamespaceName, id.ResourceGroup, err)
+		return fmt.Errorf("listing keys for %s: %+v", id, err)
 	}
 
-	d.Set("primary_key", keysResp.PrimaryKey)
-	d.Set("secondary_key", keysResp.SecondaryKey)
-	d.Set("primary_connection_string", keysResp.PrimaryConnectionString)
-	d.Set("secondary_connection_string", keysResp.SecondaryConnectionString)
-	d.Set("primary_connection_string_alias", keysResp.AliasPrimaryConnectionString)
-	d.Set("secondary_connection_string_alias", keysResp.AliasSecondaryConnectionString)
+	if model := keysResp.Model; model != nil {
+		d.Set("primary_key", model.PrimaryKey)
+		d.Set("secondary_key", model.SecondaryKey)
+		d.Set("primary_connection_string", model.PrimaryConnectionString)
+		d.Set("secondary_connection_string", model.SecondaryConnectionString)
+		d.Set("primary_connection_string_alias", model.AliasPrimaryConnectionString)
+		d.Set("secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+	}
 
 	return nil
 }
 
 func resourceEventHubNamespaceAuthorizationRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	eventhubClient := meta.(*clients.Client).Eventhub.NamespacesClient
+	eventhubClient := meta.(*clients.Client).Eventhub.NamespaceAuthorizationRulesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NamespaceAuthorizationRuleID(d.Id())
+	id, err := authorizationrulesnamespaces.AuthorizationRuleID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -174,8 +165,8 @@ func resourceEventHubNamespaceAuthorizationRuleDelete(d *schema.ResourceData, me
 	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
 	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	if _, err := eventhubClient.DeleteAuthorizationRule(ctx, id.ResourceGroup, id.NamespaceName, id.AuthorizationRuleName); err != nil {
-		return fmt.Errorf("deleting Authorization Rule %q (EventHub Namespace %q / Resource Group %q): %+v", id.AuthorizationRuleName, id.NamespaceName, id.ResourceGroup, err)
+	if _, err := eventhubClient.NamespacesDeleteAuthorizationRule(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource_test.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -172,17 +173,17 @@ func TestAccEventHubNamespaceAuthorizationRule_multi(t *testing.T) {
 }
 
 func (EventHubNamespaceAuthorizationRuleResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.NamespaceAuthorizationRuleID(state.ID)
+	id, err := authorizationrulesnamespaces.AuthorizationRuleID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Eventhub.NamespacesClient.GetAuthorizationRule(ctx, id.ResourceGroup, id.NamespaceName, id.AuthorizationRuleName)
+	resp, err := clients.Eventhub.NamespaceAuthorizationRulesClient.NamespacesGetAuthorizationRule(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.AuthorizationRuleProperties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/azurerm/internal/services/eventhub/eventhub_namespace_data_source.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_data_source.go
@@ -5,12 +5,17 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/namespaces"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func EventHubNamespaceDataSource() *schema.Resource {
@@ -109,51 +114,57 @@ func EventHubNamespaceDataSource() *schema.Resource {
 
 func EventHubNamespaceDataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	authorizationRulesClient := meta.(*clients.Client).Eventhub.NamespaceAuthorizationRulesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	name := d.Get("name").(string)
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	id := namespaces.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	resp, err := client.Get(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error: EventHub Namespace %q (Resource Group %q) was not found", name, resourceGroup)
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
 		}
 
-		return fmt.Errorf("Error making Read request on EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	d.SetId(*resp.ID)
+	d.SetId(id.ID())
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		if sku := model.Sku; sku != nil {
+			d.Set("sku", string(sku.Name))
+			d.Set("capacity", sku.Capacity)
+		}
+
+		if props := model.Properties; props != nil {
+			d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
+			d.Set("kafka_enabled", props.KafkaEnabled)
+			d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
+			d.Set("zone_redundant", props.ZoneRedundant)
+			d.Set("dedicated_cluster_id", props.ClusterArmId)
+		}
+
+		tags.FlattenAndSet(d, flattenTags(model.Tags))
 	}
 
-	d.Set("sku", string(resp.Sku.Name))
-	d.Set("capacity", resp.Sku.Capacity)
-
-	keys, err := client.ListKeys(ctx, resourceGroup, name, eventHubNamespaceDefaultAuthorizationRule)
+	defaultRuleId := authorizationrulesnamespaces.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.Name, eventHubNamespaceDefaultAuthorizationRule)
+	keys, err := authorizationRulesClient.NamespacesListKeys(ctx, defaultRuleId)
 	if err != nil {
-		log.Printf("[WARN] Unable to List default keys for EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
-	} else {
-		d.Set("default_primary_connection_string_alias", keys.AliasPrimaryConnectionString)
-		d.Set("default_secondary_connection_string_alias", keys.AliasSecondaryConnectionString)
-		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
-		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
-		d.Set("default_primary_key", keys.PrimaryKey)
-		d.Set("default_secondary_key", keys.SecondaryKey)
+		log.Printf("[WARN] Unable to List default keys for %s: %+v", id, err)
+	}
+	if model := keys.Model; model != nil {
+		d.Set("default_primary_connection_string_alias", model.AliasPrimaryConnectionString)
+		d.Set("default_secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+		d.Set("default_primary_connection_string", model.PrimaryConnectionString)
+		d.Set("default_secondary_connection_string", model.SecondaryConnectionString)
+		d.Set("default_primary_key", model.PrimaryKey)
+		d.Set("default_secondary_key", model.SecondaryKey)
 	}
 
-	if props := resp.EHNamespaceProperties; props != nil {
-		d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
-		d.Set("kafka_enabled", props.KafkaEnabled)
-		d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
-		d.Set("zone_redundant", props.ZoneRedundant)
-		d.Set("dedicated_cluster_id", props.ClusterArmID)
-	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }

--- a/azurerm/internal/services/eventhub/eventhub_namespace_data_source.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_data_source.go
@@ -149,7 +149,9 @@ func EventHubNamespaceDataSourceRead(d *schema.ResourceData, meta interface{}) e
 			d.Set("dedicated_cluster_id", props.ClusterArmId)
 		}
 
-		tags.FlattenAndSet(d, flattenTags(model.Tags))
+		if err := tags.FlattenAndSet(d, flattenTags(model.Tags)); err != nil {
+			return fmt.Errorf("setting `tags`: %+v", err)
+		}
 	}
 
 	defaultRuleId := authorizationrulesnamespaces.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.Name, eventHubNamespaceDefaultAuthorizationRule)

--- a/azurerm/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
@@ -257,7 +257,7 @@ func resourceEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.ResourceDat
 	// it can take some time for the name to become available again
 	// this is mainly here	to enable updating the resource in place
 	parentNamespaceId := checknameavailabilitydisasterrecoveryconfigs.NewNamespaceID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName)
-	availabilityClient := meta.(*clients.Client).Eventhub.DisasterRecoveryNameAvailableClient
+	availabilityClient := meta.(*clients.Client).Eventhub.DisasterRecoveryNameAvailabilityClient
 	nameFreeWait := &resource.StateChangeConf{
 		Pending:    []string{"NameInUse"},
 		Target:     []string{"None"},

--- a/azurerm/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -74,60 +79,49 @@ func resourceEventHubNamespaceDisasterRecoveryConfig() *schema.Resource {
 
 func resourceEventHubNamespaceDisasterRecoveryConfigCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Eventhub.DisasterRecoveryConfigsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace Disaster Recovery Configs creation.")
 
-	name := d.Get("name").(string)
-	namespaceName := d.Get("namespace_name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
+	id := disasterrecoveryconfigs.NewDisasterRecoveryConfigID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, namespaceName, name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_eventhub_namespace_disaster_recovery_config", *existing.ID)
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_eventhub_namespace_disaster_recovery_config", id.ID())
 		}
 	}
 
-	locks.ByName(namespaceName, eventHubNamespaceResourceName)
-	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
+	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	parameters := eventhub.ArmDisasterRecovery{
-		ArmDisasterRecoveryProperties: &eventhub.ArmDisasterRecoveryProperties{
+	parameters := disasterrecoveryconfigs.ArmDisasterRecovery{
+		Properties: &disasterrecoveryconfigs.ArmDisasterRecoveryProperties{
 			PartnerNamespace: utils.String(d.Get("partner_namespace_id").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("alternate_name"); ok {
-		parameters.ArmDisasterRecoveryProperties.AlternateName = utils.String(v.(string))
+		parameters.Properties.AlternateName = utils.String(v.(string))
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
-		return fmt.Errorf("Error creating/updating EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return fmt.Errorf("Error waiting for replication to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, id); err != nil {
+		return fmt.Errorf("waiting for replication of %s: %+v", id, err)
 	}
 
-	read, err := client.Get(ctx, resourceGroup, namespaceName, name)
-	if err != nil {
-		return fmt.Errorf("Error reading EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
-	}
-
-	if read.ID == nil {
-		return fmt.Errorf("Got nil ID for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q)", name, namespaceName, resourceGroup)
-	}
-
-	d.SetId(*read.ID)
-
+	d.SetId(id.ID())
 	return resourceEventHubNamespaceDisasterRecoveryConfigRead(d, meta)
 }
 
@@ -136,46 +130,41 @@ func resourceEventHubNamespaceDisasterRecoveryConfigUpdate(d *schema.ResourceDat
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := disasterrecoveryconfigs.DisasterRecoveryConfigID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Path["disasterRecoveryConfigs"]
-	resourceGroup := id.ResourceGroup
-	namespaceName := id.Path["namespaces"]
-
-	locks.ByName(namespaceName, eventHubNamespaceResourceName)
-	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
+	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
 	if d.HasChange("partner_namespace_id") {
 		// break pairing
-		breakPair, err := client.BreakPairing(ctx, resourceGroup, namespaceName, name)
-		if breakPair.StatusCode != http.StatusOK {
-			return fmt.Errorf("Error issuing break pairing request for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+		if _, err := client.BreakPairing(ctx, *id); err != nil {
+			return fmt.Errorf("breaking the pairing for %s: %+v", *id, err)
 		}
 
-		if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutUpdate)); err != nil {
-			return fmt.Errorf("Error waiting for break pairing request to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+		if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, *id); err != nil {
+			return fmt.Errorf("waiting for the pairing to be broken for %s: %+v", *id, err)
 		}
 	}
 
-	parameters := eventhub.ArmDisasterRecovery{
-		ArmDisasterRecoveryProperties: &eventhub.ArmDisasterRecoveryProperties{
+	parameters := disasterrecoveryconfigs.ArmDisasterRecovery{
+		Properties: &disasterrecoveryconfigs.ArmDisasterRecoveryProperties{
 			PartnerNamespace: utils.String(d.Get("partner_namespace_id").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("alternate_name"); ok {
-		parameters.ArmDisasterRecoveryProperties.AlternateName = utils.String(v.(string))
+		parameters.Properties.AlternateName = utils.String(v.(string))
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
-		return fmt.Errorf("Error creating/updating EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, *id, parameters); err != nil {
+		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
-	if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return fmt.Errorf("Error waiting for replication to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, *id); err != nil {
+		return fmt.Errorf("waiting for replication after update of %s: %+v", *id, err)
 	}
 
 	return resourceEventHubNamespaceDisasterRecoveryConfigRead(d, meta)
@@ -186,31 +175,27 @@ func resourceEventHubNamespaceDisasterRecoveryConfigRead(d *schema.ResourceData,
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := disasterrecoveryconfigs.DisasterRecoveryConfigID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Path["disasterRecoveryConfigs"]
-	resourceGroup := id.ResourceGroup
-	namespaceName := id.Path["namespaces"]
-
-	resp, err := client.Get(ctx, resourceGroup, namespaceName, name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", name)
-	d.Set("namespace_name", namespaceName)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("name", id.Name)
+	d.Set("namespace_name", id.NamespaceName)
+	d.Set("resource_group_name", id.ResourceGroup)
 
-	if properties := resp.ArmDisasterRecoveryProperties; properties != nil {
-		d.Set("partner_namespace_id", properties.PartnerNamespace)
-		d.Set("alternate_name", properties.AlternateName)
+	if model := resp.Model; model != nil && model.Properties != nil {
+		d.Set("partner_namespace_id", model.Properties.PartnerNamespace)
+		d.Set("alternate_name", model.Properties.AlternateName)
 	}
 
 	return nil
@@ -221,32 +206,29 @@ func resourceEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.ResourceDat
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := disasterrecoveryconfigs.DisasterRecoveryConfigID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Path["disasterRecoveryConfigs"]
-	resourceGroup := id.ResourceGroup
-	namespaceName := id.Path["namespaces"]
+	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	locks.ByName(namespaceName, eventHubNamespaceResourceName)
-	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
-
-	breakPair, err := client.BreakPairing(ctx, resourceGroup, namespaceName, name)
-	if err != nil {
-		return fmt.Errorf("Error issuing break pairing request for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
-	}
-	if breakPair.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error breaking pairing for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if _, err := client.BreakPairing(ctx, *id); err != nil {
+		return fmt.Errorf("breaking pairing of %s: %+v", *id, err)
 	}
 
-	if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("Error waiting for break pairing request to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if err := resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, *id); err != nil {
+		return fmt.Errorf("waiting for pairing to break for %s: %+v", *id, err)
 	}
 
-	if _, err := client.Delete(ctx, resourceGroup, namespaceName, name); err != nil {
-		return fmt.Errorf("Error issuing delete request for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
+	if _, err := client.Delete(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context has no deadline")
 	}
 
 	// no future for deletion so wait for it to vanish
@@ -254,68 +236,83 @@ func resourceEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.ResourceDat
 		Pending:    []string{"200"},
 		Target:     []string{"404"},
 		MinTimeout: 30 * time.Second,
-		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Timeout:    time.Until(deadline),
 		Refresh: func() (interface{}, string, error) {
-			resp, err := client.Get(ctx, resourceGroup, namespaceName, name)
+			resp, err := client.Get(ctx, *id)
 			if err != nil {
-				if utils.ResponseWasNotFound(resp.Response) {
-					return resp, strconv.Itoa(resp.StatusCode), nil
+				if response.WasNotFound(resp.HttpResponse) {
+					return resp, strconv.Itoa(resp.HttpResponse.StatusCode), nil
 				}
-				return nil, "nil", fmt.Errorf("Error polling for the status of the EventHub Namespace Disaster Recovery Configs %q deletion (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
+				return nil, "nil", fmt.Errorf("polling to check the deletion state for %s: %+v", *id, err)
 			}
 
-			return resp, strconv.Itoa(resp.StatusCode), nil
+			return resp, strconv.Itoa(resp.HttpResponse.StatusCode), nil
 		},
 	}
 
 	if _, err := deleteWait.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting the deletion of EventHub Namespace Disaster Recovery Configs %q deletion (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
+		return fmt.Errorf("waiting the deletion of %s: %+v", *id, err)
 	}
 
 	// it can take some time for the name to become available again
-	// this is mainly here 	to enable updating the resource in place
+	// this is mainly here	to enable updating the resource in place
+	parentNamespaceId := checknameavailabilitydisasterrecoveryconfigs.NewNamespaceID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName)
+	availabilityClient := meta.(*clients.Client).Eventhub.DisasterRecoveryNameAvailableClient
 	nameFreeWait := &resource.StateChangeConf{
 		Pending:    []string{"NameInUse"},
 		Target:     []string{"None"},
 		MinTimeout: 30 * time.Second,
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Refresh: func() (interface{}, string, error) {
-			resp, err := client.CheckNameAvailability(ctx, resourceGroup, namespaceName, eventhub.CheckNameAvailabilityParameter{Name: utils.String(name)})
-			if err != nil {
-				return resp, "Error", fmt.Errorf("Error checking if the EventHub Namespace Disaster Recovery Configs %q name has been freed (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
+			input := checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityParameter{
+				Name: id.Name,
 			}
-
-			return resp, string(resp.Reason), nil
+			resp, err := availabilityClient.DisasterRecoveryConfigsCheckNameAvailability(ctx, parentNamespaceId, input)
+			if err != nil {
+				return resp, "Error", fmt.Errorf("waiting for the name of %s to become free: %v", *id, err)
+			}
+			// TODO: new crash to handle here
+			return resp, string(*resp.Model.Reason), nil
 		},
 	}
 
 	if _, err := nameFreeWait.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting the the EventHub Namespace Disaster Recovery Configs %q name to be available (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
+		return err
 	}
 
 	return nil
 }
 
-func resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx context.Context, client *eventhub.DisasterRecoveryConfigsClient, resourceGroup, namespaceName, name string, timeout time.Duration) error {
+func resourceEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx context.Context, client *disasterrecoveryconfigs.DisasterRecoveryConfigsClient, id disasterrecoveryconfigs.DisasterRecoveryConfigId) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context had no deadline")
+	}
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{string(eventhub.ProvisioningStateDRAccepted)},
 		Target:     []string{string(eventhub.ProvisioningStateDRSucceeded)},
 		MinTimeout: 30 * time.Second,
-		Timeout:    timeout,
+		Timeout:    time.Until(deadline),
 		Refresh: func() (interface{}, string, error) {
-			read, err := client.Get(ctx, resourceGroup, namespaceName, name)
+			read, err := client.Get(ctx, id)
 			if err != nil {
-				return nil, "error", fmt.Errorf("Wait read EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
+				return nil, "error", fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			if props := read.ArmDisasterRecoveryProperties; props != nil {
-				if props.ProvisioningState == eventhub.ProvisioningStateDRFailed {
-					return read, "failed", fmt.Errorf("Replication for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q) failed!", name, namespaceName, resourceGroup)
+			if model := read.Model; model != nil {
+				if props := model.Properties; props != nil {
+					if props.ProvisioningState == nil {
+						return read, "failed", fmt.Errorf("provisioningState was empty")
+					}
+
+					if *props.ProvisioningState == disasterrecoveryconfigs.ProvisioningStateDRFailed {
+						return read, "failed", fmt.Errorf("replication failed for %s: %+v", id, err)
+					}
+					return read, string(*props.ProvisioningState), nil
 				}
-				return read, string(props.ProvisioningState), nil
 			}
 
-			return read, "nil", fmt.Errorf("Waiting for replication error EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): provisioning state is nil", name, namespaceName, resourceGroup)
+			return read, "nil", fmt.Errorf("waiting for replication of %s: %+v", id, err)
 		},
 	}
 

--- a/azurerm/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -57,21 +58,17 @@ func TestAccEventHubNamespaceDisasterRecoveryConfig_update(t *testing.T) {
 }
 
 func (EventHubNamespaceDisasterRecoveryConfigResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := azure.ParseAzureResourceID(state.ID)
+	id, err := disasterrecoveryconfigs.DisasterRecoveryConfigID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	name := id.Path["disasterRecoveryConfigs"]
-	resourceGroup := id.ResourceGroup
-	namespaceName := id.Path["namespaces"]
-
-	resp, err := clients.Eventhub.DisasterRecoveryConfigsClient.Get(ctx, resourceGroup, namespaceName, name)
+	resp, err := clients.Eventhub.DisasterRecoveryConfigsClient.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving EventHub Namespace Disaster Recovery Configs %q (namespace %q / resource group: %q): %v", name, namespaceName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.ArmDisasterRecoveryProperties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceDisasterRecoveryConfigResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -7,6 +7,14 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/networkrulesets"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/namespaces"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -252,23 +260,22 @@ func resourceEventHubNamespace() *schema.Resource {
 
 func resourceEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace creation.")
 
-	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-
+	id := namespaces.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing EventHub Namespace %q (Resource Group %q): %s", name, resGroup, err)
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_eventhub_namespace", *existing.ID)
+		if existing.Model != nil {
+			return tf.ImportAsExistsError("azurerm_eventhub_namespace", id.ID())
 		}
 	}
 
@@ -279,27 +286,30 @@ func resourceEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta interfac
 	autoInflateEnabled := d.Get("auto_inflate_enabled").(bool)
 	zoneRedundant := d.Get("zone_redundant").(bool)
 
-	parameters := eventhub.EHNamespace{
+	parameters := namespaces.EHNamespace{
 		Location: &location,
-		Sku: &eventhub.Sku{
-			Name:     eventhub.SkuName(sku),
-			Tier:     eventhub.SkuTier(sku),
-			Capacity: &capacity,
+		Sku: &namespaces.Sku{
+			Name: namespaces.SkuName(sku),
+			Tier: func() *namespaces.SkuTier {
+				v := namespaces.SkuTier(sku)
+				return &v
+			}(),
+			Capacity: utils.Int64(int64(capacity)),
 		},
 		Identity: expandEventHubIdentity(d.Get("identity").([]interface{})),
-		EHNamespaceProperties: &eventhub.EHNamespaceProperties{
+		Properties: &namespaces.EHNamespaceProperties{
 			IsAutoInflateEnabled: utils.Bool(autoInflateEnabled),
 			ZoneRedundant:        utils.Bool(zoneRedundant),
 		},
-		Tags: tags.Expand(t),
+		Tags: expandTags(t),
 	}
 
 	if v := d.Get("dedicated_cluster_id").(string); v != "" {
-		parameters.EHNamespaceProperties.ClusterArmID = utils.String(v)
+		parameters.Properties.ClusterArmId = utils.String(v)
 	}
 
 	if v, ok := d.GetOk("maximum_throughput_units"); ok {
-		parameters.EHNamespaceProperties.MaximumThroughputUnits = utils.Int32(int32(v.(int)))
+		parameters.Properties.MaximumThroughputUnits = utils.Int64(int64(v.(int)))
 	}
 
 	// @favoretti: if we are downgrading from Standard to Basic SKU and namespace had both autoInflate enabled and
@@ -307,46 +317,34 @@ func resourceEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta interfac
 	//
 	// See: https://github.com/terraform-providers/terraform-provider-azurerm/issues/10244
 	//
-	if parameters.Sku.Tier == eventhub.SkuTierBasic && !autoInflateEnabled {
-		parameters.EHNamespaceProperties.MaximumThroughputUnits = utils.Int32(0)
+	if *parameters.Sku.Tier == namespaces.SkuTierBasic && !autoInflateEnabled {
+		parameters.Properties.MaximumThroughputUnits = utils.Int64(0)
 	}
 
-	future, err := client.CreateOrUpdate(ctx, resGroup, name, parameters)
-	if err != nil {
-		return err
+	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error creating eventhub namespace: %+v", err)
-	}
-
-	read, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		return err
-	}
-
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read EventHub Namespace %q (resource group %q) ID", name, resGroup)
-	}
-
-	d.SetId(*read.ID)
+	d.SetId(id.ID())
 
 	ruleSets, hasRuleSets := d.GetOk("network_rulesets")
 	if hasRuleSets {
-		rulesets := eventhub.NetworkRuleSet{
-			NetworkRuleSetProperties: expandEventHubNamespaceNetworkRuleset(ruleSets.([]interface{})),
+		rulesets := networkrulesets.NetworkRuleSet{
+			Properties: expandEventHubNamespaceNetworkRuleset(ruleSets.([]interface{})),
 		}
 
 		// cannot use network rulesets with the basic SKU
-		if parameters.Sku.Name != eventhub.Basic {
-			if _, err := client.CreateOrUpdateNetworkRuleSet(ctx, resGroup, name, rulesets); err != nil {
-				return fmt.Errorf("Error setting network ruleset properties for EventHub Namespace %q (resource group %q): %v", name, resGroup, err)
+		if parameters.Sku.Name != namespaces.SkuNameBasic {
+			ruleSetsClient := meta.(*clients.Client).Eventhub.NetworkRuleSetsClient
+			namespaceId := networkrulesets.NewNamespaceID(id.SubscriptionId, id.ResourceGroup, id.Name)
+			if _, err := ruleSetsClient.NamespacesCreateOrUpdateNetworkRuleSet(ctx, namespaceId, rulesets); err != nil {
+				return fmt.Errorf("setting network ruleset properties for %s: %+v", id, err)
 			}
 		} else {
 			// so if the user has specified the non default rule sets throw a validation error
-			if rulesets.DefaultAction != eventhub.Deny ||
-				(rulesets.IPRules != nil && len(*rulesets.IPRules) > 0) ||
-				(rulesets.VirtualNetworkRules != nil && len(*rulesets.VirtualNetworkRules) > 0) {
+			if *rulesets.Properties.DefaultAction != networkrulesets.DefaultActionDeny ||
+				(rulesets.Properties.IpRules != nil && len(*rulesets.Properties.IpRules) > 0) ||
+				(rulesets.Properties.VirtualNetworkRules != nil && len(*rulesets.Properties.VirtualNetworkRules) > 0) {
 				return fmt.Errorf("network_rulesets cannot be used when the SKU is basic")
 			}
 		}
@@ -357,67 +355,76 @@ func resourceEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta interfac
 
 func resourceEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	authorizationKeysClient := meta.(*clients.Client).Eventhub.NamespaceAuthorizationRulesClient
+	ruleSetsClient := meta.(*clients.Client).Eventhub.NetworkRuleSetsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NamespaceID(d.Id())
+	id, err := namespaces.NamespaceID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on EventHub Namespace %q: %+v", id.Name, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", resp.Name)
+	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+
+		if sku := model.Sku; sku != nil {
+			d.Set("sku", string(sku.Name))
+			d.Set("capacity", sku.Capacity)
+		}
+
+		if err := d.Set("identity", flattenEventHubIdentity(model.Identity)); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
+
+		if props := model.Properties; props != nil {
+			d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
+			d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
+			d.Set("zone_redundant", props.ZoneRedundant)
+			d.Set("dedicated_cluster_id", props.ClusterArmId)
+		}
+
+		tags.FlattenAndSet(d, flattenTags(model.Tags))
 	}
 
-	if sku := resp.Sku; sku != nil {
-		d.Set("sku", string(sku.Name))
-		d.Set("capacity", sku.Capacity)
-	}
-
-	if err := d.Set("identity", flattenEventHubIdentity(resp.Identity)); err != nil {
-		return fmt.Errorf("Error setting `identity`: %+v", err)
-	}
-
-	if props := resp.EHNamespaceProperties; props != nil {
-		d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
-		d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
-		d.Set("zone_redundant", props.ZoneRedundant)
-		d.Set("dedicated_cluster_id", props.ClusterArmID)
-	}
-
-	ruleset, err := client.GetNetworkRuleSet(ctx, id.ResourceGroup, id.Name)
+	namespaceId := networkrulesets.NewNamespaceID(id.SubscriptionId, id.ResourceGroup, id.Name)
+	ruleset, err := ruleSetsClient.NamespacesGetNetworkRuleSet(ctx, namespaceId)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on EventHub Namespace %q Network Ruleset: %+v", id.Name, err)
+		return fmt.Errorf("retrieving Network Rule Sets for %s: %+v", *id, err)
 	}
 
 	if err := d.Set("network_rulesets", flattenEventHubNamespaceNetworkRuleset(ruleset)); err != nil {
 		return fmt.Errorf("Error setting `network_ruleset` for Evenhub Namespace %s: %v", id.Name, err)
 	}
 
-	keys, err := client.ListKeys(ctx, id.ResourceGroup, id.Name, eventHubNamespaceDefaultAuthorizationRule)
+	authorizationRuleId := authorizationrulesnamespaces.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.Name, eventHubNamespaceDefaultAuthorizationRule)
+	keys, err := authorizationKeysClient.NamespacesListKeys(ctx, authorizationRuleId)
 	if err != nil {
 		log.Printf("[WARN] Unable to List default keys for EventHub Namespace %q: %+v", id.Name, err)
-	} else {
-		d.Set("default_primary_connection_string_alias", keys.AliasPrimaryConnectionString)
-		d.Set("default_secondary_connection_string_alias", keys.AliasSecondaryConnectionString)
-		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
-		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
-		d.Set("default_primary_key", keys.PrimaryKey)
-		d.Set("default_secondary_key", keys.SecondaryKey)
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	if model := keys.Model; model != nil {
+		d.Set("default_primary_connection_string_alias", model.AliasPrimaryConnectionString)
+		d.Set("default_secondary_connection_string_alias", model.AliasSecondaryConnectionString)
+		d.Set("default_primary_connection_string", model.PrimaryConnectionString)
+		d.Set("default_secondary_connection_string", model.SecondaryConnectionString)
+		d.Set("default_primary_key", model.PrimaryKey)
+		d.Set("default_secondary_key", model.SecondaryKey)
+	}
+
+	return nil
 }
 
 func resourceEventHubNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
@@ -425,65 +432,74 @@ func resourceEventHubNamespaceDelete(d *schema.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NamespaceID(d.Id())
+	id, err := namespaces.NamespaceID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	future, err := client.Delete(ctx, *id)
 	if err != nil {
-		if response.WasNotFound(future.Response()) {
+		if response.WasNotFound(future.HttpResponse) {
 			return nil
 		}
-		return fmt.Errorf("Error issuing delete request of EventHub Namespace %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
-	return waitForEventHubNamespaceToBeDeleted(ctx, client, id.ResourceGroup, id.Name, d)
+	return waitForEventHubNamespaceToBeDeleted(ctx, client, *id)
 }
 
-func waitForEventHubNamespaceToBeDeleted(ctx context.Context, client *eventhub.NamespacesClient, resourceGroup, name string, d *schema.ResourceData) error {
+func waitForEventHubNamespaceToBeDeleted(ctx context.Context, client *namespaces.NamespacesClient, id namespaces.NamespaceId) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context has no deadline")
+	}
+
 	// we can't use the Waiter here since the API returns a 200 once it's deleted which is considered a polling status code..
-	log.Printf("[DEBUG] Waiting for EventHub Namespace (%q in Resource Group %q) to be deleted", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for %s to be deleted..", id)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"200"},
 		Target:  []string{"404"},
-		Refresh: eventHubNamespaceStateStatusCodeRefreshFunc(ctx, client, resourceGroup, name),
-		Timeout: d.Timeout(schema.TimeoutDelete),
+		Refresh: eventHubNamespaceStateStatusCodeRefreshFunc(ctx, client, id),
+		Timeout: time.Until(deadline),
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for EventHub NameSpace (%q in Resource Group %q) to be deleted: %+v", name, resourceGroup, err)
+		return fmt.Errorf("waiting for %s to be deleted: %+v", id, err)
 	}
 
 	return nil
 }
 
-func eventHubNamespaceStateStatusCodeRefreshFunc(ctx context.Context, client *eventhub.NamespacesClient, resourceGroup, name string) resource.StateRefreshFunc {
+func eventHubNamespaceStateStatusCodeRefreshFunc(ctx context.Context, client *namespaces.NamespacesClient, id namespaces.NamespaceId) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.Get(ctx, resourceGroup, name)
-
-		log.Printf("Retrieving EventHub Namespace %q (Resource Group %q) returned Status %d", resourceGroup, name, res.StatusCode)
-
-		if err != nil {
-			if utils.ResponseWasNotFound(res.Response) {
-				return res, strconv.Itoa(res.StatusCode), nil
-			}
-			return nil, "", fmt.Errorf("Error polling for the status of the EventHub Namespace %q (RG: %q): %+v", name, resourceGroup, err)
+		res, err := client.Get(ctx, id)
+		if res.HttpResponse != nil {
+			log.Printf("Retrieving %s returned Status %d", id, res.HttpResponse.StatusCode)
 		}
 
-		return res, strconv.Itoa(res.StatusCode), nil
+		if err != nil {
+			if response.WasNotFound(res.HttpResponse) {
+				return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+			}
+			return nil, "", fmt.Errorf("polling for the status of %s: %+v", id, err)
+		}
+
+		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
 	}
 }
 
-func expandEventHubNamespaceNetworkRuleset(input []interface{}) *eventhub.NetworkRuleSetProperties {
+func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets.NetworkRuleSetProperties {
 	if len(input) == 0 {
 		return nil
 	}
 
 	block := input[0].(map[string]interface{})
 
-	ruleset := eventhub.NetworkRuleSetProperties{
-		DefaultAction: eventhub.DefaultAction(block["default_action"].(string)),
+	ruleset := networkrulesets.NetworkRuleSetProperties{
+		DefaultAction: func() *networkrulesets.DefaultAction {
+			v := networkrulesets.DefaultAction(block["default_action"].(string))
+			return &v
+		}(),
 	}
 
 	if v, ok := block["trusted_service_access_enabled"]; ok {
@@ -492,12 +508,12 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *eventhub.Networ
 
 	if v, ok := block["virtual_network_rule"].([]interface{}); ok {
 		if len(v) > 0 {
-			var rules []eventhub.NWRuleSetVirtualNetworkRules
+			var rules []networkrulesets.NWRuleSetVirtualNetworkRules
 			for _, r := range v {
 				rblock := r.(map[string]interface{})
-				rules = append(rules, eventhub.NWRuleSetVirtualNetworkRules{
-					Subnet: &eventhub.Subnet{
-						ID: utils.String(rblock["subnet_id"].(string)),
+				rules = append(rules, networkrulesets.NWRuleSetVirtualNetworkRules{
+					Subnet: &networkrulesets.Subnet{
+						Id: utils.String(rblock["subnet_id"].(string)),
 					},
 					IgnoreMissingVnetServiceEndpoint: utils.Bool(rblock["ignore_missing_virtual_network_service_endpoint"].(bool)),
 				})
@@ -509,34 +525,37 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *eventhub.Networ
 
 	if v, ok := block["ip_rule"].([]interface{}); ok {
 		if len(v) > 0 {
-			var rules []eventhub.NWRuleSetIPRules
+			var rules []networkrulesets.NWRuleSetIpRules
 			for _, r := range v {
 				rblock := r.(map[string]interface{})
-				rules = append(rules, eventhub.NWRuleSetIPRules{
-					IPMask: utils.String(rblock["ip_mask"].(string)),
-					Action: eventhub.NetworkRuleIPAction(rblock["action"].(string)),
+				rules = append(rules, networkrulesets.NWRuleSetIpRules{
+					IpMask: utils.String(rblock["ip_mask"].(string)),
+					Action: func() *networkrulesets.NetworkRuleIPAction {
+						v := networkrulesets.NetworkRuleIPAction(rblock["action"].(string))
+						return &v
+					}(),
 				})
 			}
 
-			ruleset.IPRules = &rules
+			ruleset.IpRules = &rules
 		}
 	}
 
 	return &ruleset
 }
 
-func flattenEventHubNamespaceNetworkRuleset(ruleset eventhub.NetworkRuleSet) []interface{} {
-	if ruleset.NetworkRuleSetProperties == nil {
+func flattenEventHubNamespaceNetworkRuleset(ruleset networkrulesets.NamespacesGetNetworkRuleSetResponse) []interface{} {
+	if ruleset.Model == nil || ruleset.Model.Properties == nil {
 		return nil
 	}
 
 	vnetBlocks := make([]interface{}, 0)
-	if vnetRules := ruleset.NetworkRuleSetProperties.VirtualNetworkRules; vnetRules != nil {
+	if vnetRules := ruleset.Model.Properties.VirtualNetworkRules; vnetRules != nil {
 		for _, vnetRule := range *vnetRules {
 			block := make(map[string]interface{})
 
 			if s := vnetRule.Subnet; s != nil {
-				if v := s.ID; v != nil {
+				if v := s.Id; v != nil {
 					block["subnet_id"] = *v
 				}
 			}
@@ -549,13 +568,18 @@ func flattenEventHubNamespaceNetworkRuleset(ruleset eventhub.NetworkRuleSet) []i
 		}
 	}
 	ipBlocks := make([]interface{}, 0)
-	if ipRules := ruleset.NetworkRuleSetProperties.IPRules; ipRules != nil {
+	if ipRules := ruleset.Model.Properties.IpRules; ipRules != nil {
 		for _, ipRule := range *ipRules {
 			block := make(map[string]interface{})
 
-			block["action"] = string(ipRule.Action)
+			action := ""
+			if ipRule.Action != nil {
+				action = string(*ipRule.Action)
+			}
 
-			if v := ipRule.IPMask; v != nil {
+			block["action"] = action
+
+			if v := ipRule.IpMask; v != nil {
 				block["ip_mask"] = *v
 			}
 
@@ -563,43 +587,53 @@ func flattenEventHubNamespaceNetworkRuleset(ruleset eventhub.NetworkRuleSet) []i
 		}
 	}
 
+	// TODO: fix this
+
 	return []interface{}{map[string]interface{}{
-		"default_action":                 string(ruleset.DefaultAction),
+		"default_action":                 string(*ruleset.Model.Properties.DefaultAction),
 		"virtual_network_rule":           vnetBlocks,
 		"ip_rule":                        ipBlocks,
-		"trusted_service_access_enabled": ruleset.TrustedServiceAccessEnabled,
+		"trusted_service_access_enabled": ruleset.Model.Properties.TrustedServiceAccessEnabled,
 	}}
 }
 
-func expandEventHubIdentity(input []interface{}) *eventhub.Identity {
+func expandEventHubIdentity(input []interface{}) *namespaces.Identity {
 	if len(input) == 0 {
 		return nil
 	}
 
 	v := input[0].(map[string]interface{})
-	return &eventhub.Identity{
-		Type: eventhub.IdentityType(v["type"].(string)),
+	return &namespaces.Identity{
+		Type: func() *namespaces.IdentityType {
+			v := namespaces.IdentityType(v["type"].(string))
+			return &v
+		}(),
 	}
 }
 
-func flattenEventHubIdentity(input *eventhub.Identity) []interface{} {
+func flattenEventHubIdentity(input *namespaces.Identity) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
 
+	identityType := ""
+	if input.Type != nil {
+		identityType = string(*input.Type)
+	}
+
 	principalID := ""
-	if input.PrincipalID != nil {
-		principalID = *input.PrincipalID
+	if input.PrincipalId != nil {
+		principalID = *input.PrincipalId
 	}
 
 	tenantID := ""
-	if input.TenantID != nil {
-		tenantID = *input.TenantID
+	if input.TenantId != nil {
+		tenantID = *input.TenantId
 	}
 
 	return []interface{}{
 		map[string]interface{}{
-			"type":         string(input.Type),
+			"type":         identityType,
 			"principal_id": principalID,
 			"tenant_id":    tenantID,
 		},

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -6,12 +6,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/namespaces"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -453,17 +454,17 @@ func TestAccEventHubNamespace_autoInfalteDisabledWithAutoInflateUnits(t *testing
 }
 
 func (EventHubNamespaceResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.NamespaceID(state.ID)
+	id, err := namespaces.NamespaceID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Eventhub.NamespacesClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Eventhub.NamespacesClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.EHNamespaceProperties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceResource) basic(data acceptance.TestData) string {

--- a/azurerm/internal/services/eventhub/eventhub_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_resource.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubs"
+
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -161,17 +164,17 @@ func resourceEventHubCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[INFO] preparing arguments for Azure ARM EventHub creation.")
 
-	id := parse.NewEventHubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
+	id := eventhubs.NewEventhubID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.NamespaceName, id.Name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 			}
 		}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return tf.ImportAsExistsError("azurerm_eventhub", id.ID())
 		}
 	}
@@ -179,8 +182,8 @@ func resourceEventHubCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 	partitionCount := int64(d.Get("partition_count").(int))
 	messageRetention := int64(d.Get("message_retention").(int))
 
-	parameters := eventhub.Model{
-		Properties: &eventhub.Properties{
+	parameters := eventhubs.Eventhub{
+		Properties: &eventhubs.EventhubProperties{
 			PartitionCount:         &partitionCount,
 			MessageRetentionInDays: &messageRetention,
 		},
@@ -190,7 +193,7 @@ func resourceEventHubCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 		parameters.Properties.CaptureDescription = expandEventHubCaptureDescription(d)
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.NamespaceName, id.Name, parameters); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {
 		return err
 	}
 
@@ -204,14 +207,14 @@ func resourceEventHubRead(d *schema.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.EventHubID(d.Id())
+	id, err := eventhubs.EventhubID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.NamespaceName, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
@@ -222,14 +225,16 @@ func resourceEventHubRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("namespace_name", id.NamespaceName)
 	d.Set("resource_group_name", id.ResourceGroup)
 
-	if props := resp.Properties; props != nil {
-		d.Set("partition_count", props.PartitionCount)
-		d.Set("message_retention", props.MessageRetentionInDays)
-		d.Set("partition_ids", props.PartitionIds)
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("partition_count", props.PartitionCount)
+			d.Set("message_retention", props.MessageRetentionInDays)
+			d.Set("partition_ids", props.PartitionIds)
 
-		captureDescription := flattenEventHubCaptureDescription(props.CaptureDescription)
-		if err := d.Set("capture_description", captureDescription); err != nil {
-			return err
+			captureDescription := flattenEventHubCaptureDescription(props.CaptureDescription)
+			if err := d.Set("capture_description", captureDescription); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -241,14 +246,14 @@ func resourceEventHubDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.EventHubID(d.Id())
+	id, err := eventhubs.EventhubID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Delete(ctx, id.ResourceGroup, id.NamespaceName, id.Name)
+	resp, err := client.Delete(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return nil
 		}
 
@@ -258,7 +263,7 @@ func resourceEventHubDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func expandEventHubCaptureDescription(d *schema.ResourceData) *eventhub.CaptureDescription {
+func expandEventHubCaptureDescription(d *schema.ResourceData) *eventhubs.CaptureDescription {
 	inputs := d.Get("capture_description").([]interface{})
 	input := inputs[0].(map[string]interface{})
 
@@ -268,11 +273,14 @@ func expandEventHubCaptureDescription(d *schema.ResourceData) *eventhub.CaptureD
 	sizeLimitInBytes := input["size_limit_in_bytes"].(int)
 	skipEmptyArchives := input["skip_empty_archives"].(bool)
 
-	captureDescription := eventhub.CaptureDescription{
-		Enabled:           utils.Bool(enabled),
-		Encoding:          eventhub.EncodingCaptureDescription(encoding),
-		IntervalInSeconds: utils.Int32(int32(intervalInSeconds)),
-		SizeLimitInBytes:  utils.Int32(int32(sizeLimitInBytes)),
+	captureDescription := eventhubs.CaptureDescription{
+		Enabled: utils.Bool(enabled),
+		Encoding: func() *eventhubs.EncodingCaptureDescription {
+			v := eventhubs.EncodingCaptureDescription(encoding)
+			return &v
+		}(),
+		IntervalInSeconds: utils.Int64(int64(intervalInSeconds)),
+		SizeLimitInBytes:  utils.Int64(int64(sizeLimitInBytes)),
 		SkipEmptyArchives: utils.Bool(skipEmptyArchives),
 	}
 
@@ -286,12 +294,12 @@ func expandEventHubCaptureDescription(d *schema.ResourceData) *eventhub.CaptureD
 			blobContainerName := destination["blob_container_name"].(string)
 			storageAccountId := destination["storage_account_id"].(string)
 
-			captureDescription.Destination = &eventhub.Destination{
+			captureDescription.Destination = &eventhubs.Destination{
 				Name: utils.String(destinationName),
-				DestinationProperties: &eventhub.DestinationProperties{
+				Properties: &eventhubs.DestinationProperties{
 					ArchiveNameFormat:        utils.String(archiveNameFormat),
 					BlobContainer:            utils.String(blobContainerName),
-					StorageAccountResourceID: utils.String(storageAccountId),
+					StorageAccountResourceId: utils.String(storageAccountId),
 				},
 			}
 		}
@@ -300,7 +308,7 @@ func expandEventHubCaptureDescription(d *schema.ResourceData) *eventhub.CaptureD
 	return &captureDescription
 }
 
-func flattenEventHubCaptureDescription(description *eventhub.CaptureDescription) []interface{} {
+func flattenEventHubCaptureDescription(description *eventhubs.CaptureDescription) []interface{} {
 	results := make([]interface{}, 0)
 
 	if description != nil {
@@ -314,7 +322,11 @@ func flattenEventHubCaptureDescription(description *eventhub.CaptureDescription)
 			output["skip_empty_archives"] = *skipEmptyArchives
 		}
 
-		output["encoding"] = string(description.Encoding)
+		encoding := ""
+		if description.Encoding != nil {
+			encoding = string(*description.Encoding)
+		}
+		output["encoding"] = encoding
 
 		if interval := description.IntervalInSeconds; interval != nil {
 			output["interval_in_seconds"] = *interval
@@ -331,14 +343,14 @@ func flattenEventHubCaptureDescription(description *eventhub.CaptureDescription)
 				destinationOutput["name"] = *name
 			}
 
-			if props := destination.DestinationProperties; props != nil {
+			if props := destination.Properties; props != nil {
 				if archiveNameFormat := props.ArchiveNameFormat; archiveNameFormat != nil {
 					destinationOutput["archive_name_format"] = *archiveNameFormat
 				}
 				if blobContainerName := props.BlobContainer; blobContainerName != nil {
 					destinationOutput["blob_container_name"] = *blobContainerName
 				}
-				if storageAccountId := props.StorageAccountResourceID; storageAccountId != nil {
+				if storageAccountId := props.StorageAccountResourceId; storageAccountId != nil {
 					destinationOutput["storage_account_id"] = *storageAccountId
 				}
 			}

--- a/azurerm/internal/services/eventhub/eventhub_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_resource_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/eventhubs"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -323,17 +323,17 @@ func TestAccEventHub_messageRetentionUpdate(t *testing.T) {
 }
 
 func (EventHubResource) Exists(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) (*bool, error) {
-	id, err := parse.EventHubID(state.ID)
+	id, err := eventhubs.EventhubID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Eventhub.EventHubsClient.Get(ctx, id.ResourceGroup, id.NamespaceName, id.Name)
+	resp, err := clients.Eventhub.EventHubsClient.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("retrieving %s: %v", id, err)
+		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (EventHubResource) basic(data acceptance.TestData, partitionCount int) string {

--- a/azurerm/internal/services/eventhub/helpers.go
+++ b/azurerm/internal/services/eventhub/helpers.go
@@ -5,41 +5,40 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 // schema
-func expandEventHubAuthorizationRuleRights(d *schema.ResourceData) *[]eventhub.AccessRights {
-	rights := make([]eventhub.AccessRights, 0)
+func expandEventHubAuthorizationRuleRights(d *schema.ResourceData) []string {
+	rights := make([]string, 0)
 
 	if d.Get("listen").(bool) {
-		rights = append(rights, eventhub.Listen)
+		rights = append(rights, "Listen")
 	}
 
 	if d.Get("send").(bool) {
-		rights = append(rights, eventhub.SendEnumValue)
+		rights = append(rights, "Send")
 	}
 
 	if d.Get("manage").(bool) {
-		rights = append(rights, eventhub.Manage)
+		rights = append(rights, "Manage")
 	}
 
-	return &rights
+	return rights
 }
 
-func flattenEventHubAuthorizationRuleRights(rights *[]eventhub.AccessRights) (listen, send, manage bool) {
+func flattenEventHubAuthorizationRuleRights(rights []string) (listen, send, manage bool) {
 	// zero (initial) value for a bool in go is false
 
 	if rights != nil {
-		for _, right := range *rights {
+		for _, right := range rights {
 			switch right {
-			case eventhub.Listen:
+			case "Listen":
 				listen = true
-			case eventhub.SendEnumValue:
+			case "Send":
 				send = true
-			case eventhub.Manage:
+			case "Manage":
 				manage = true
 			default:
 				log.Printf("[DEBUG] Unknown Authorization Rule Right '%s'", right)

--- a/azurerm/internal/services/eventhub/helpers.go
+++ b/azurerm/internal/services/eventhub/helpers.go
@@ -31,18 +31,16 @@ func expandEventHubAuthorizationRuleRights(d *schema.ResourceData) []string {
 func flattenEventHubAuthorizationRuleRights(rights []string) (listen, send, manage bool) {
 	// zero (initial) value for a bool in go is false
 
-	if rights != nil {
-		for _, right := range rights {
-			switch right {
-			case "Listen":
-				listen = true
-			case "Send":
-				send = true
-			case "Manage":
-				manage = true
-			default:
-				log.Printf("[DEBUG] Unknown Authorization Rule Right '%s'", right)
-			}
+	for _, right := range rights {
+		switch right {
+		case "Listen":
+			listen = true
+		case "Send":
+			send = true
+		case "Manage":
+			manage = true
+		default:
+			log.Printf("[DEBUG] Unknown Authorization Rule Right '%s'", right)
 		}
 	}
 

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/client.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/client.go
@@ -1,0 +1,15 @@
+package authorizationruleseventhubs
+
+import "github.com/Azure/go-autorest/autorest"
+
+type AuthorizationRulesEventHubsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewAuthorizationRulesEventHubsClientWithBaseURI(endpoint string) AuthorizationRulesEventHubsClient {
+	return AuthorizationRulesEventHubsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/constants.go
@@ -1,0 +1,8 @@
+package authorizationruleseventhubs
+
+type KeyType string
+
+const (
+	KeyTypePrimaryKey   KeyType = "PrimaryKey"
+	KeyTypeSecondaryKey KeyType = "SecondaryKey"
+)

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_authorizationrule.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_authorizationrule.go
@@ -1,0 +1,144 @@
+package authorizationruleseventhubs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type AuthorizationRuleId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	EventhubName   string
+	Name           string
+}
+
+func NewAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, eventhubName, name string) AuthorizationRuleId {
+	return AuthorizationRuleId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		EventhubName:   eventhubName,
+		Name:           name,
+	}
+}
+
+func (id AuthorizationRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Eventhub Name %q", id.EventhubName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Authorization Rule", segmentsStr)
+}
+
+func (id AuthorizationRuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/eventhubs/%s/authorizationRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
+}
+
+// AuthorizationRuleID parses a AuthorizationRule ID into an AuthorizationRuleId struct
+func AuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.EventhubName, err = id.PopSegment("eventhubs"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("authorizationRules"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// AuthorizationRuleIDInsensitively parses an AuthorizationRule ID into an AuthorizationRuleId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the AuthorizationRuleID method should be used instead for validation etc.
+func AuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'eventhubs' segment
+	eventhubsKey := "eventhubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, eventhubsKey) {
+			eventhubsKey = key
+			break
+		}
+	}
+	if resourceId.EventhubName, err = id.PopSegment(eventhubsKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'authorizationRules' segment
+	authorizationRulesKey := "authorizationRules"
+	for key := range id.Path {
+		if strings.EqualFold(key, authorizationRulesKey) {
+			authorizationRulesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(authorizationRulesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_authorizationrule_test.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_authorizationrule_test.go
@@ -1,0 +1,297 @@
+package authorizationruleseventhubs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = AuthorizationRuleId{}
+
+func TestAuthorizationRuleIDFormatter(t *testing.T) {
+	actual := NewAuthorizationRuleID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{eventHubName}", "{authorizationRuleName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestAuthorizationRuleID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/EVENTHUBS/{EVENTHUBNAME}/AUTHORIZATIONRULES/{AUTHORIZATIONRULENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AuthorizationRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.EventhubName != v.Expected.EventhubName {
+			t.Fatalf("Expected %q but got %q for EventhubName", v.Expected.EventhubName, actual.EventhubName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestAuthorizationRuleIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationrules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/EVENTHUBS/{eventHubName}/AUTHORIZATIONRULES/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/EvEnThUbS/{eventHubName}/AuThOrIzAtIoNrUlEs/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AuthorizationRuleIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.EventhubName != v.Expected.EventhubName {
+			t.Fatalf("Expected %q but got %q for EventhubName", v.Expected.EventhubName, actual.EventhubName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_eventhub.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_eventhub.go
@@ -1,0 +1,126 @@
+package authorizationruleseventhubs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type EventhubId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	Name           string
+}
+
+func NewEventhubID(subscriptionId, resourceGroup, namespaceName, name string) EventhubId {
+	return EventhubId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		Name:           name,
+	}
+}
+
+func (id EventhubId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Eventhub", segmentsStr)
+}
+
+func (id EventhubId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/eventhubs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.Name)
+}
+
+// EventhubID parses a Eventhub ID into an EventhubId struct
+func EventhubID(input string) (*EventhubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := EventhubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("eventhubs"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// EventhubIDInsensitively parses an Eventhub ID into an EventhubId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the EventhubID method should be used instead for validation etc.
+func EventhubIDInsensitively(input string) (*EventhubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := EventhubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'eventhubs' segment
+	eventhubsKey := "eventhubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, eventhubsKey) {
+			eventhubsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(eventhubsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_eventhub_test.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/id_eventhub_test.go
@@ -1,0 +1,262 @@
+package authorizationruleseventhubs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = EventhubId{}
+
+func TestEventhubIDFormatter(t *testing.T) {
+	actual := NewEventhubID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{eventHubName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestEventhubID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EventhubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/EVENTHUBS/{EVENTHUBNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EventhubID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestEventhubIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EventhubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/EVENTHUBS/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/EvEnThUbS/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EventhubIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubscreateorupdateauthorizationrule_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubscreateorupdateauthorizationrule_autorest.go
@@ -1,0 +1,65 @@
+package authorizationruleseventhubs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type EventHubsCreateOrUpdateAuthorizationRuleResponse struct {
+	HttpResponse *http.Response
+	Model        *AuthorizationRule
+}
+
+// EventHubsCreateOrUpdateAuthorizationRule ...
+func (c AuthorizationRulesEventHubsClient) EventHubsCreateOrUpdateAuthorizationRule(ctx context.Context, id AuthorizationRuleId, input AuthorizationRule) (result EventHubsCreateOrUpdateAuthorizationRuleResponse, err error) {
+	req, err := c.preparerForEventHubsCreateOrUpdateAuthorizationRule(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsCreateOrUpdateAuthorizationRule", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsCreateOrUpdateAuthorizationRule", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForEventHubsCreateOrUpdateAuthorizationRule(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsCreateOrUpdateAuthorizationRule", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForEventHubsCreateOrUpdateAuthorizationRule prepares the EventHubsCreateOrUpdateAuthorizationRule request.
+func (c AuthorizationRulesEventHubsClient) preparerForEventHubsCreateOrUpdateAuthorizationRule(ctx context.Context, id AuthorizationRuleId, input AuthorizationRule) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForEventHubsCreateOrUpdateAuthorizationRule handles the response to the EventHubsCreateOrUpdateAuthorizationRule request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesEventHubsClient) responderForEventHubsCreateOrUpdateAuthorizationRule(resp *http.Response) (result EventHubsCreateOrUpdateAuthorizationRuleResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubslistauthorizationrules_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubslistauthorizationrules_autorest.go
@@ -1,0 +1,196 @@
+package authorizationruleseventhubs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type EventHubsListAuthorizationRulesResponse struct {
+	HttpResponse *http.Response
+	Model        *[]AuthorizationRule
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (EventHubsListAuthorizationRulesResponse, error)
+}
+
+type EventHubsListAuthorizationRulesCompleteResult struct {
+	Items []AuthorizationRule
+}
+
+func (r EventHubsListAuthorizationRulesResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r EventHubsListAuthorizationRulesResponse) LoadMore(ctx context.Context) (resp EventHubsListAuthorizationRulesResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type AuthorizationRulePredicate struct {
+	// TODO: implement me
+}
+
+func (p AuthorizationRulePredicate) Matches(input AuthorizationRule) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// EventHubsListAuthorizationRules ...
+func (c AuthorizationRulesEventHubsClient) EventHubsListAuthorizationRules(ctx context.Context, id EventhubId) (resp EventHubsListAuthorizationRulesResponse, err error) {
+	req, err := c.preparerForEventHubsListAuthorizationRules(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListAuthorizationRules", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListAuthorizationRules", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForEventHubsListAuthorizationRules(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListAuthorizationRules", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// EventHubsListAuthorizationRulesCompleteMatchingPredicate retrieves all of the results into a single object
+func (c AuthorizationRulesEventHubsClient) EventHubsListAuthorizationRulesComplete(ctx context.Context, id EventhubId) (EventHubsListAuthorizationRulesCompleteResult, error) {
+	return c.EventHubsListAuthorizationRulesCompleteMatchingPredicate(ctx, id, AuthorizationRulePredicate{})
+}
+
+// EventHubsListAuthorizationRulesCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AuthorizationRulesEventHubsClient) EventHubsListAuthorizationRulesCompleteMatchingPredicate(ctx context.Context, id EventhubId, predicate AuthorizationRulePredicate) (resp EventHubsListAuthorizationRulesCompleteResult, err error) {
+	items := make([]AuthorizationRule, 0)
+
+	page, err := c.EventHubsListAuthorizationRules(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := EventHubsListAuthorizationRulesCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForEventHubsListAuthorizationRules prepares the EventHubsListAuthorizationRules request.
+func (c AuthorizationRulesEventHubsClient) preparerForEventHubsListAuthorizationRules(ctx context.Context, id EventhubId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/authorizationRules", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForEventHubsListAuthorizationRulesWithNextLink prepares the EventHubsListAuthorizationRules request with the given nextLink token.
+func (c AuthorizationRulesEventHubsClient) preparerForEventHubsListAuthorizationRulesWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForEventHubsListAuthorizationRules handles the response to the EventHubsListAuthorizationRules request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesEventHubsClient) responderForEventHubsListAuthorizationRules(resp *http.Response) (result EventHubsListAuthorizationRulesResponse, err error) {
+	type page struct {
+		Values   []AuthorizationRule `json:"value"`
+		NextLink *string             `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result EventHubsListAuthorizationRulesResponse, err error) {
+			req, err := c.preparerForEventHubsListAuthorizationRulesWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListAuthorizationRules", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListAuthorizationRules", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForEventHubsListAuthorizationRules(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListAuthorizationRules", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubslistkeys_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubslistkeys_autorest.go
@@ -1,0 +1,65 @@
+package authorizationruleseventhubs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type EventHubsListKeysResponse struct {
+	HttpResponse *http.Response
+	Model        *AccessKeys
+}
+
+// EventHubsListKeys ...
+func (c AuthorizationRulesEventHubsClient) EventHubsListKeys(ctx context.Context, id AuthorizationRuleId) (result EventHubsListKeysResponse, err error) {
+	req, err := c.preparerForEventHubsListKeys(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListKeys", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListKeys", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForEventHubsListKeys(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsListKeys", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForEventHubsListKeys prepares the EventHubsListKeys request.
+func (c AuthorizationRulesEventHubsClient) preparerForEventHubsListKeys(ctx context.Context, id AuthorizationRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listKeys", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForEventHubsListKeys handles the response to the EventHubsListKeys request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesEventHubsClient) responderForEventHubsListKeys(resp *http.Response) (result EventHubsListKeysResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubsregeneratekeys_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/method_eventhubsregeneratekeys_autorest.go
@@ -1,0 +1,66 @@
+package authorizationruleseventhubs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type EventHubsRegenerateKeysResponse struct {
+	HttpResponse *http.Response
+	Model        *AccessKeys
+}
+
+// EventHubsRegenerateKeys ...
+func (c AuthorizationRulesEventHubsClient) EventHubsRegenerateKeys(ctx context.Context, id AuthorizationRuleId, input RegenerateAccessKeyParameters) (result EventHubsRegenerateKeysResponse, err error) {
+	req, err := c.preparerForEventHubsRegenerateKeys(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsRegenerateKeys", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsRegenerateKeys", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForEventHubsRegenerateKeys(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationruleseventhubs.AuthorizationRulesEventHubsClient", "EventHubsRegenerateKeys", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForEventHubsRegenerateKeys prepares the EventHubsRegenerateKeys request.
+func (c AuthorizationRulesEventHubsClient) preparerForEventHubsRegenerateKeys(ctx context.Context, id AuthorizationRuleId, input RegenerateAccessKeyParameters) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/regenerateKeys", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForEventHubsRegenerateKeys handles the response to the EventHubsRegenerateKeys request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesEventHubsClient) responderForEventHubsRegenerateKeys(resp *http.Response) (result EventHubsRegenerateKeysResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_accesskeys.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_accesskeys.go
@@ -1,0 +1,11 @@
+package authorizationruleseventhubs
+
+type AccessKeys struct {
+	AliasPrimaryConnectionString   *string `json:"aliasPrimaryConnectionString,omitempty"`
+	AliasSecondaryConnectionString *string `json:"aliasSecondaryConnectionString,omitempty"`
+	KeyName                        *string `json:"keyName,omitempty"`
+	PrimaryConnectionString        *string `json:"primaryConnectionString,omitempty"`
+	PrimaryKey                     *string `json:"primaryKey,omitempty"`
+	SecondaryConnectionString      *string `json:"secondaryConnectionString,omitempty"`
+	SecondaryKey                   *string `json:"secondaryKey,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_authorizationrule.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_authorizationrule.go
@@ -1,0 +1,8 @@
+package authorizationruleseventhubs
+
+type AuthorizationRule struct {
+	Id         *string                      `json:"id,omitempty"`
+	Name       *string                      `json:"name,omitempty"`
+	Properties *AuthorizationRuleProperties `json:"properties,omitempty"`
+	Type       *string                      `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_authorizationruleproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_authorizationruleproperties.go
@@ -1,0 +1,5 @@
+package authorizationruleseventhubs
+
+type AuthorizationRuleProperties struct {
+	Rights []string `json:"rights"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_regenerateaccesskeyparameters.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/model_regenerateaccesskeyparameters.go
@@ -1,0 +1,6 @@
+package authorizationruleseventhubs
+
+type RegenerateAccessKeyParameters struct {
+	Key     *string `json:"key,omitempty"`
+	KeyType KeyType `json:"keyType"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/version.go
@@ -1,0 +1,9 @@
+package authorizationruleseventhubs
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/authorizationruleseventhubs/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationruleseventhubs/version.go
@@ -2,7 +2,7 @@ package authorizationruleseventhubs
 
 import "fmt"
 
-const defaultApiVersion = "2018-01-01-preview"
+const defaultApiVersion = "2017-04-01"
 
 func userAgent() string {
 	return fmt.Sprintf("pandora/authorizationruleseventhubs/%s", defaultApiVersion)

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/client.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/client.go
@@ -1,0 +1,15 @@
+package authorizationrulesnamespaces
+
+import "github.com/Azure/go-autorest/autorest"
+
+type AuthorizationRulesNamespacesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewAuthorizationRulesNamespacesClientWithBaseURI(endpoint string) AuthorizationRulesNamespacesClient {
+	return AuthorizationRulesNamespacesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/constants.go
@@ -1,0 +1,8 @@
+package authorizationrulesnamespaces
+
+type KeyType string
+
+const (
+	KeyTypePrimaryKey   KeyType = "PrimaryKey"
+	KeyTypeSecondaryKey KeyType = "SecondaryKey"
+)

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_authorizationrule.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_authorizationrule.go
@@ -1,0 +1,126 @@
+package authorizationrulesnamespaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type AuthorizationRuleId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	Name           string
+}
+
+func NewAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, name string) AuthorizationRuleId {
+	return AuthorizationRuleId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		Name:           name,
+	}
+}
+
+func (id AuthorizationRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Authorization Rule", segmentsStr)
+}
+
+func (id AuthorizationRuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/authorizationRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.Name)
+}
+
+// AuthorizationRuleID parses a AuthorizationRule ID into an AuthorizationRuleId struct
+func AuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("authorizationRules"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// AuthorizationRuleIDInsensitively parses an AuthorizationRule ID into an AuthorizationRuleId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the AuthorizationRuleID method should be used instead for validation etc.
+func AuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'authorizationRules' segment
+	authorizationRulesKey := "authorizationRules"
+	for key := range id.Path {
+		if strings.EqualFold(key, authorizationRulesKey) {
+			authorizationRulesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(authorizationRulesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_authorizationrule_test.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_authorizationrule_test.go
@@ -1,0 +1,262 @@
+package authorizationrulesnamespaces
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = AuthorizationRuleId{}
+
+func TestAuthorizationRuleIDFormatter(t *testing.T) {
+	actual := NewAuthorizationRuleID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{authorizationRuleName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestAuthorizationRuleID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/AUTHORIZATIONRULES/{AUTHORIZATIONRULENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AuthorizationRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestAuthorizationRuleIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationRules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/authorizationrules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/AUTHORIZATIONRULES/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/AuThOrIzAtIoNrUlEs/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AuthorizationRuleIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_namespace.go
@@ -1,0 +1,108 @@
+package authorizationrulesnamespaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
+}
+
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the NamespaceID method should be used instead for validation etc.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/id_namespace_test.go
@@ -1,0 +1,227 @@
+package authorizationrulesnamespaces
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacescreateorupdateauthorizationrule_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacescreateorupdateauthorizationrule_autorest.go
@@ -1,0 +1,65 @@
+package authorizationrulesnamespaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesCreateOrUpdateAuthorizationRuleResponse struct {
+	HttpResponse *http.Response
+	Model        *AuthorizationRule
+}
+
+// NamespacesCreateOrUpdateAuthorizationRule ...
+func (c AuthorizationRulesNamespacesClient) NamespacesCreateOrUpdateAuthorizationRule(ctx context.Context, id AuthorizationRuleId, input AuthorizationRule) (result NamespacesCreateOrUpdateAuthorizationRuleResponse, err error) {
+	req, err := c.preparerForNamespacesCreateOrUpdateAuthorizationRule(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesCreateOrUpdateAuthorizationRule", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesCreateOrUpdateAuthorizationRule", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesCreateOrUpdateAuthorizationRule(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesCreateOrUpdateAuthorizationRule", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesCreateOrUpdateAuthorizationRule prepares the NamespacesCreateOrUpdateAuthorizationRule request.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesCreateOrUpdateAuthorizationRule(ctx context.Context, id AuthorizationRuleId, input AuthorizationRule) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesCreateOrUpdateAuthorizationRule handles the response to the NamespacesCreateOrUpdateAuthorizationRule request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesNamespacesClient) responderForNamespacesCreateOrUpdateAuthorizationRule(resp *http.Response) (result NamespacesCreateOrUpdateAuthorizationRuleResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacesdeleteauthorizationrule_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacesdeleteauthorizationrule_autorest.go
@@ -1,0 +1,61 @@
+package authorizationrulesnamespaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesDeleteAuthorizationRuleResponse struct {
+	HttpResponse *http.Response
+}
+
+// NamespacesDeleteAuthorizationRule ...
+func (c AuthorizationRulesNamespacesClient) NamespacesDeleteAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (result NamespacesDeleteAuthorizationRuleResponse, err error) {
+	req, err := c.preparerForNamespacesDeleteAuthorizationRule(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesDeleteAuthorizationRule", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesDeleteAuthorizationRule", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesDeleteAuthorizationRule(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesDeleteAuthorizationRule", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesDeleteAuthorizationRule prepares the NamespacesDeleteAuthorizationRule request.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesDeleteAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesDeleteAuthorizationRule handles the response to the NamespacesDeleteAuthorizationRule request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesNamespacesClient) responderForNamespacesDeleteAuthorizationRule(resp *http.Response) (result NamespacesDeleteAuthorizationRuleResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacesgetauthorizationrule_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacesgetauthorizationrule_autorest.go
@@ -1,0 +1,64 @@
+package authorizationrulesnamespaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesGetAuthorizationRuleResponse struct {
+	HttpResponse *http.Response
+	Model        *AuthorizationRule
+}
+
+// NamespacesGetAuthorizationRule ...
+func (c AuthorizationRulesNamespacesClient) NamespacesGetAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (result NamespacesGetAuthorizationRuleResponse, err error) {
+	req, err := c.preparerForNamespacesGetAuthorizationRule(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesGetAuthorizationRule", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesGetAuthorizationRule", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesGetAuthorizationRule(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesGetAuthorizationRule", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesGetAuthorizationRule prepares the NamespacesGetAuthorizationRule request.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesGetAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesGetAuthorizationRule handles the response to the NamespacesGetAuthorizationRule request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesNamespacesClient) responderForNamespacesGetAuthorizationRule(resp *http.Response) (result NamespacesGetAuthorizationRuleResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespaceslistauthorizationrules_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespaceslistauthorizationrules_autorest.go
@@ -1,0 +1,196 @@
+package authorizationrulesnamespaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesListAuthorizationRulesResponse struct {
+	HttpResponse *http.Response
+	Model        *[]AuthorizationRule
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (NamespacesListAuthorizationRulesResponse, error)
+}
+
+type NamespacesListAuthorizationRulesCompleteResult struct {
+	Items []AuthorizationRule
+}
+
+func (r NamespacesListAuthorizationRulesResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r NamespacesListAuthorizationRulesResponse) LoadMore(ctx context.Context) (resp NamespacesListAuthorizationRulesResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type AuthorizationRulePredicate struct {
+	// TODO: implement me
+}
+
+func (p AuthorizationRulePredicate) Matches(input AuthorizationRule) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// NamespacesListAuthorizationRules ...
+func (c AuthorizationRulesNamespacesClient) NamespacesListAuthorizationRules(ctx context.Context, id NamespaceId) (resp NamespacesListAuthorizationRulesResponse, err error) {
+	req, err := c.preparerForNamespacesListAuthorizationRules(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListAuthorizationRules", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListAuthorizationRules", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForNamespacesListAuthorizationRules(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListAuthorizationRules", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// NamespacesListAuthorizationRulesCompleteMatchingPredicate retrieves all of the results into a single object
+func (c AuthorizationRulesNamespacesClient) NamespacesListAuthorizationRulesComplete(ctx context.Context, id NamespaceId) (NamespacesListAuthorizationRulesCompleteResult, error) {
+	return c.NamespacesListAuthorizationRulesCompleteMatchingPredicate(ctx, id, AuthorizationRulePredicate{})
+}
+
+// NamespacesListAuthorizationRulesCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AuthorizationRulesNamespacesClient) NamespacesListAuthorizationRulesCompleteMatchingPredicate(ctx context.Context, id NamespaceId, predicate AuthorizationRulePredicate) (resp NamespacesListAuthorizationRulesCompleteResult, err error) {
+	items := make([]AuthorizationRule, 0)
+
+	page, err := c.NamespacesListAuthorizationRules(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := NamespacesListAuthorizationRulesCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForNamespacesListAuthorizationRules prepares the NamespacesListAuthorizationRules request.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesListAuthorizationRules(ctx context.Context, id NamespaceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/authorizationRules", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForNamespacesListAuthorizationRulesWithNextLink prepares the NamespacesListAuthorizationRules request with the given nextLink token.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesListAuthorizationRulesWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesListAuthorizationRules handles the response to the NamespacesListAuthorizationRules request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesNamespacesClient) responderForNamespacesListAuthorizationRules(resp *http.Response) (result NamespacesListAuthorizationRulesResponse, err error) {
+	type page struct {
+		Values   []AuthorizationRule `json:"value"`
+		NextLink *string             `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result NamespacesListAuthorizationRulesResponse, err error) {
+			req, err := c.preparerForNamespacesListAuthorizationRulesWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListAuthorizationRules", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListAuthorizationRules", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForNamespacesListAuthorizationRules(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListAuthorizationRules", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespaceslistkeys_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespaceslistkeys_autorest.go
@@ -1,0 +1,65 @@
+package authorizationrulesnamespaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesListKeysResponse struct {
+	HttpResponse *http.Response
+	Model        *AccessKeys
+}
+
+// NamespacesListKeys ...
+func (c AuthorizationRulesNamespacesClient) NamespacesListKeys(ctx context.Context, id AuthorizationRuleId) (result NamespacesListKeysResponse, err error) {
+	req, err := c.preparerForNamespacesListKeys(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListKeys", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListKeys", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesListKeys(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesListKeys", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesListKeys prepares the NamespacesListKeys request.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesListKeys(ctx context.Context, id AuthorizationRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/listKeys", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesListKeys handles the response to the NamespacesListKeys request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesNamespacesClient) responderForNamespacesListKeys(resp *http.Response) (result NamespacesListKeysResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacesregeneratekeys_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/method_namespacesregeneratekeys_autorest.go
@@ -1,0 +1,66 @@
+package authorizationrulesnamespaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesRegenerateKeysResponse struct {
+	HttpResponse *http.Response
+	Model        *AccessKeys
+}
+
+// NamespacesRegenerateKeys ...
+func (c AuthorizationRulesNamespacesClient) NamespacesRegenerateKeys(ctx context.Context, id AuthorizationRuleId, input RegenerateAccessKeyParameters) (result NamespacesRegenerateKeysResponse, err error) {
+	req, err := c.preparerForNamespacesRegenerateKeys(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesRegenerateKeys", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesRegenerateKeys", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesRegenerateKeys(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "authorizationrulesnamespaces.AuthorizationRulesNamespacesClient", "NamespacesRegenerateKeys", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesRegenerateKeys prepares the NamespacesRegenerateKeys request.
+func (c AuthorizationRulesNamespacesClient) preparerForNamespacesRegenerateKeys(ctx context.Context, id AuthorizationRuleId, input RegenerateAccessKeyParameters) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/regenerateKeys", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesRegenerateKeys handles the response to the NamespacesRegenerateKeys request. The method always
+// closes the http.Response Body.
+func (c AuthorizationRulesNamespacesClient) responderForNamespacesRegenerateKeys(resp *http.Response) (result NamespacesRegenerateKeysResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_accesskeys.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_accesskeys.go
@@ -1,0 +1,11 @@
+package authorizationrulesnamespaces
+
+type AccessKeys struct {
+	AliasPrimaryConnectionString   *string `json:"aliasPrimaryConnectionString,omitempty"`
+	AliasSecondaryConnectionString *string `json:"aliasSecondaryConnectionString,omitempty"`
+	KeyName                        *string `json:"keyName,omitempty"`
+	PrimaryConnectionString        *string `json:"primaryConnectionString,omitempty"`
+	PrimaryKey                     *string `json:"primaryKey,omitempty"`
+	SecondaryConnectionString      *string `json:"secondaryConnectionString,omitempty"`
+	SecondaryKey                   *string `json:"secondaryKey,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_authorizationrule.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_authorizationrule.go
@@ -1,0 +1,8 @@
+package authorizationrulesnamespaces
+
+type AuthorizationRule struct {
+	Id         *string                      `json:"id,omitempty"`
+	Name       *string                      `json:"name,omitempty"`
+	Properties *AuthorizationRuleProperties `json:"properties,omitempty"`
+	Type       *string                      `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_authorizationruleproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_authorizationruleproperties.go
@@ -1,0 +1,5 @@
+package authorizationrulesnamespaces
+
+type AuthorizationRuleProperties struct {
+	Rights []string `json:"rights"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_regenerateaccesskeyparameters.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/model_regenerateaccesskeyparameters.go
@@ -1,0 +1,6 @@
+package authorizationrulesnamespaces
+
+type RegenerateAccessKeyParameters struct {
+	Key     *string `json:"key,omitempty"`
+	KeyType KeyType `json:"keyType"`
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/version.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/version.go
@@ -1,0 +1,9 @@
+package authorizationrulesnamespaces
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/authorizationrulesnamespaces/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/version.go
+++ b/azurerm/internal/services/eventhub/sdk/authorizationrulesnamespaces/version.go
@@ -2,7 +2,7 @@ package authorizationrulesnamespaces
 
 import "fmt"
 
-const defaultApiVersion = "2018-01-01-preview"
+const defaultApiVersion = "2017-04-01"
 
 func userAgent() string {
 	return fmt.Sprintf("pandora/authorizationrulesnamespaces/%s", defaultApiVersion)

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/client.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/client.go
@@ -1,0 +1,15 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+import "github.com/Azure/go-autorest/autorest"
+
+type CheckNameAvailabilityDisasterRecoveryConfigsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewCheckNameAvailabilityDisasterRecoveryConfigsClientWithBaseURI(endpoint string) CheckNameAvailabilityDisasterRecoveryConfigsClient {
+	return CheckNameAvailabilityDisasterRecoveryConfigsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/constants.go
@@ -1,0 +1,12 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+type UnavailableReason string
+
+const (
+	UnavailableReasonInvalidName                           UnavailableReason = "InvalidName"
+	UnavailableReasonNameInLockdown                        UnavailableReason = "NameInLockdown"
+	UnavailableReasonNameInUse                             UnavailableReason = "NameInUse"
+	UnavailableReasonNone                                  UnavailableReason = "None"
+	UnavailableReasonSubscriptionIsDisabled                UnavailableReason = "SubscriptionIsDisabled"
+	UnavailableReasonTooManyNamespaceInCurrentSubscription UnavailableReason = "TooManyNamespaceInCurrentSubscription"
+)

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/id_namespace.go
@@ -1,0 +1,108 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
+}
+
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the NamespaceID method should be used instead for validation etc.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/id_namespace_test.go
@@ -1,0 +1,227 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/method_disasterrecoveryconfigschecknameavailability_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/method_disasterrecoveryconfigschecknameavailability_autorest.go
@@ -1,0 +1,66 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DisasterRecoveryConfigsCheckNameAvailabilityResponse struct {
+	HttpResponse *http.Response
+	Model        *CheckNameAvailabilityResult
+}
+
+// DisasterRecoveryConfigsCheckNameAvailability ...
+func (c CheckNameAvailabilityDisasterRecoveryConfigsClient) DisasterRecoveryConfigsCheckNameAvailability(ctx context.Context, id NamespaceId, input CheckNameAvailabilityParameter) (result DisasterRecoveryConfigsCheckNameAvailabilityResponse, err error) {
+	req, err := c.preparerForDisasterRecoveryConfigsCheckNameAvailability(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityDisasterRecoveryConfigsClient", "DisasterRecoveryConfigsCheckNameAvailability", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityDisasterRecoveryConfigsClient", "DisasterRecoveryConfigsCheckNameAvailability", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDisasterRecoveryConfigsCheckNameAvailability(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "checknameavailabilitydisasterrecoveryconfigs.CheckNameAvailabilityDisasterRecoveryConfigsClient", "DisasterRecoveryConfigsCheckNameAvailability", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDisasterRecoveryConfigsCheckNameAvailability prepares the DisasterRecoveryConfigsCheckNameAvailability request.
+func (c CheckNameAvailabilityDisasterRecoveryConfigsClient) preparerForDisasterRecoveryConfigsCheckNameAvailability(ctx context.Context, id NamespaceId, input CheckNameAvailabilityParameter) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/disasterRecoveryConfigs/checkNameAvailability", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDisasterRecoveryConfigsCheckNameAvailability handles the response to the DisasterRecoveryConfigsCheckNameAvailability request. The method always
+// closes the http.Response Body.
+func (c CheckNameAvailabilityDisasterRecoveryConfigsClient) responderForDisasterRecoveryConfigsCheckNameAvailability(resp *http.Response) (result DisasterRecoveryConfigsCheckNameAvailabilityResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/model_checknameavailabilityparameter.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/model_checknameavailabilityparameter.go
@@ -1,0 +1,5 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+type CheckNameAvailabilityParameter struct {
+	Name string `json:"name"`
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/model_checknameavailabilityresult.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/model_checknameavailabilityresult.go
@@ -1,0 +1,7 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+type CheckNameAvailabilityResult struct {
+	Message       *string            `json:"message,omitempty"`
+	NameAvailable *bool              `json:"nameAvailable,omitempty"`
+	Reason        *UnavailableReason `json:"reason,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/version.go
@@ -1,0 +1,9 @@
+package checknameavailabilitydisasterrecoveryconfigs
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/checknameavailabilitydisasterrecoveryconfigs/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/checknameavailabilitydisasterrecoveryconfigs/version.go
@@ -2,7 +2,7 @@ package checknameavailabilitydisasterrecoveryconfigs
 
 import "fmt"
 
-const defaultApiVersion = "2018-01-01-preview"
+const defaultApiVersion = "2017-04-01"
 
 func userAgent() string {
 	return fmt.Sprintf("pandora/checknameavailabilitydisasterrecoveryconfigs/%s", defaultApiVersion)

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/client.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/client.go
@@ -1,0 +1,15 @@
+package consumergroups
+
+import "github.com/Azure/go-autorest/autorest"
+
+type ConsumerGroupsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewConsumerGroupsClientWithBaseURI(endpoint string) ConsumerGroupsClient {
+	return ConsumerGroupsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/id_consumergroup.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/id_consumergroup.go
@@ -1,0 +1,144 @@
+package consumergroups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type ConsumergroupId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	EventhubName   string
+	Name           string
+}
+
+func NewConsumergroupID(subscriptionId, resourceGroup, namespaceName, eventhubName, name string) ConsumergroupId {
+	return ConsumergroupId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		EventhubName:   eventhubName,
+		Name:           name,
+	}
+}
+
+func (id ConsumergroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Eventhub Name %q", id.EventhubName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Consumergroup", segmentsStr)
+}
+
+func (id ConsumergroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/eventhubs/%s/consumergroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
+}
+
+// ConsumergroupID parses a Consumergroup ID into an ConsumergroupId struct
+func ConsumergroupID(input string) (*ConsumergroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ConsumergroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.EventhubName, err = id.PopSegment("eventhubs"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("consumergroups"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ConsumergroupIDInsensitively parses an Consumergroup ID into an ConsumergroupId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ConsumergroupID method should be used instead for validation etc.
+func ConsumergroupIDInsensitively(input string) (*ConsumergroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ConsumergroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'eventhubs' segment
+	eventhubsKey := "eventhubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, eventhubsKey) {
+			eventhubsKey = key
+			break
+		}
+	}
+	if resourceId.EventhubName, err = id.PopSegment(eventhubsKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'consumergroups' segment
+	consumergroupsKey := "consumergroups"
+	for key := range id.Path {
+		if strings.EqualFold(key, consumergroupsKey) {
+			consumergroupsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(consumergroupsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/id_consumergroup_test.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/id_consumergroup_test.go
@@ -1,0 +1,297 @@
+package consumergroups
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ConsumergroupId{}
+
+func TestConsumergroupIDFormatter(t *testing.T) {
+	actual := NewConsumergroupID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{eventHubName}", "{consumerGroupName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestConsumergroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConsumergroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}",
+			Expected: &ConsumergroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{consumerGroupName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/EVENTHUBS/{EVENTHUBNAME}/CONSUMERGROUPS/{CONSUMERGROUPNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ConsumergroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.EventhubName != v.Expected.EventhubName {
+			t.Fatalf("Expected %q but got %q for EventhubName", v.Expected.EventhubName, actual.EventhubName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestConsumergroupIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ConsumergroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}",
+			Expected: &ConsumergroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{consumerGroupName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/consumergroups/{consumerGroupName}",
+			Expected: &ConsumergroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{consumerGroupName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/EVENTHUBS/{eventHubName}/CONSUMERGROUPS/{consumerGroupName}",
+			Expected: &ConsumergroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{consumerGroupName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/EvEnThUbS/{eventHubName}/CoNsUmErGrOuPs/{consumerGroupName}",
+			Expected: &ConsumergroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{consumerGroupName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ConsumergroupIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.EventhubName != v.Expected.EventhubName {
+			t.Fatalf("Expected %q but got %q for EventhubName", v.Expected.EventhubName, actual.EventhubName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/id_eventhub.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/id_eventhub.go
@@ -1,0 +1,126 @@
+package consumergroups
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type EventhubId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	Name           string
+}
+
+func NewEventhubID(subscriptionId, resourceGroup, namespaceName, name string) EventhubId {
+	return EventhubId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		Name:           name,
+	}
+}
+
+func (id EventhubId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Eventhub", segmentsStr)
+}
+
+func (id EventhubId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/eventhubs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.Name)
+}
+
+// EventhubID parses a Eventhub ID into an EventhubId struct
+func EventhubID(input string) (*EventhubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := EventhubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("eventhubs"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// EventhubIDInsensitively parses an Eventhub ID into an EventhubId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the EventhubID method should be used instead for validation etc.
+func EventhubIDInsensitively(input string) (*EventhubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := EventhubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'eventhubs' segment
+	eventhubsKey := "eventhubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, eventhubsKey) {
+			eventhubsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(eventhubsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/id_eventhub_test.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/id_eventhub_test.go
@@ -1,0 +1,262 @@
+package consumergroups
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = EventhubId{}
+
+func TestEventhubIDFormatter(t *testing.T) {
+	actual := NewEventhubID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{eventHubName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestEventhubID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EventhubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/EVENTHUBS/{EVENTHUBNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EventhubID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestEventhubIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EventhubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/EVENTHUBS/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/EvEnThUbS/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EventhubIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/method_createorupdate_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/method_createorupdate_autorest.go
@@ -1,0 +1,65 @@
+package consumergroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CreateOrUpdateResponse struct {
+	HttpResponse *http.Response
+	Model        *ConsumerGroup
+}
+
+// CreateOrUpdate ...
+func (c ConsumerGroupsClient) CreateOrUpdate(ctx context.Context, id ConsumergroupId, input ConsumerGroup) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c ConsumerGroupsClient) preparerForCreateOrUpdate(ctx context.Context, id ConsumergroupId, input ConsumerGroup) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c ConsumerGroupsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/method_delete_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/method_delete_autorest.go
@@ -1,0 +1,61 @@
+package consumergroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ConsumerGroupsClient) Delete(ctx context.Context, id ConsumergroupId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ConsumerGroupsClient) preparerForDelete(ctx context.Context, id ConsumergroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c ConsumerGroupsClient) responderForDelete(resp *http.Response) (result DeleteResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/method_get_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/method_get_autorest.go
@@ -1,0 +1,64 @@
+package consumergroups
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *ConsumerGroup
+}
+
+// Get ...
+func (c ConsumerGroupsClient) Get(ctx context.Context, id ConsumergroupId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ConsumerGroupsClient) preparerForGet(ctx context.Context, id ConsumergroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ConsumerGroupsClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/method_listbyeventhub_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/method_listbyeventhub_autorest.go
@@ -44,7 +44,7 @@ func DefaultListByEventHubOptions() ListByEventHubOptions {
 }
 
 func (o ListByEventHubOptions) toQueryString() map[string]interface{} {
-	out := make(map[string]interface{}, 0)
+	out := make(map[string]interface{})
 
 	if o.Skip != nil {
 		out["$skip"] = *o.Skip

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/method_listbyeventhub_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/method_listbyeventhub_autorest.go
@@ -1,0 +1,223 @@
+package consumergroups
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListByEventHubResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ConsumerGroup
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByEventHubResponse, error)
+}
+
+type ListByEventHubCompleteResult struct {
+	Items []ConsumerGroup
+}
+
+func (r ListByEventHubResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByEventHubResponse) LoadMore(ctx context.Context) (resp ListByEventHubResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type ListByEventHubOptions struct {
+	Skip *int64
+	Top  *int64
+}
+
+func DefaultListByEventHubOptions() ListByEventHubOptions {
+	return ListByEventHubOptions{}
+}
+
+func (o ListByEventHubOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{}, 0)
+
+	if o.Skip != nil {
+		out["$skip"] = *o.Skip
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+type ConsumerGroupPredicate struct {
+	// TODO: implement me
+}
+
+func (p ConsumerGroupPredicate) Matches(input ConsumerGroup) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// ListByEventHub ...
+func (c ConsumerGroupsClient) ListByEventHub(ctx context.Context, id EventhubId, options ListByEventHubOptions) (resp ListByEventHubResponse, err error) {
+	req, err := c.preparerForListByEventHub(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "ListByEventHub", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "ListByEventHub", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByEventHub(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "ListByEventHub", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListByEventHubCompleteMatchingPredicate retrieves all of the results into a single object
+func (c ConsumerGroupsClient) ListByEventHubComplete(ctx context.Context, id EventhubId, options ListByEventHubOptions) (ListByEventHubCompleteResult, error) {
+	return c.ListByEventHubCompleteMatchingPredicate(ctx, id, options, ConsumerGroupPredicate{})
+}
+
+// ListByEventHubCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ConsumerGroupsClient) ListByEventHubCompleteMatchingPredicate(ctx context.Context, id EventhubId, options ListByEventHubOptions, predicate ConsumerGroupPredicate) (resp ListByEventHubCompleteResult, err error) {
+	items := make([]ConsumerGroup, 0)
+
+	page, err := c.ListByEventHub(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByEventHubCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListByEventHub prepares the ListByEventHub request.
+func (c ConsumerGroupsClient) preparerForListByEventHub(ctx context.Context, id EventhubId, options ListByEventHubOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/consumergroups", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByEventHubWithNextLink prepares the ListByEventHub request with the given nextLink token.
+func (c ConsumerGroupsClient) preparerForListByEventHubWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByEventHub handles the response to the ListByEventHub request. The method always
+// closes the http.Response Body.
+func (c ConsumerGroupsClient) responderForListByEventHub(resp *http.Response) (result ListByEventHubResponse, err error) {
+	type page struct {
+		Values   []ConsumerGroup `json:"value"`
+		NextLink *string         `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByEventHubResponse, err error) {
+			req, err := c.preparerForListByEventHubWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "ListByEventHub", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "ListByEventHub", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByEventHub(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "consumergroups.ConsumerGroupsClient", "ListByEventHub", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/model_consumergroup.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/model_consumergroup.go
@@ -1,0 +1,8 @@
+package consumergroups
+
+type ConsumerGroup struct {
+	Id         *string                  `json:"id,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *ConsumerGroupProperties `json:"properties,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/model_consumergroupproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/model_consumergroupproperties.go
@@ -1,0 +1,31 @@
+package consumergroups
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/formatting"
+)
+
+type ConsumerGroupProperties struct {
+	CreatedAt    *string `json:"createdAt,omitempty"`
+	UpdatedAt    *string `json:"updatedAt,omitempty"`
+	UserMetadata *string `json:"userMetadata,omitempty"`
+}
+
+func (o ConsumerGroupProperties) ListCreatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o ConsumerGroupProperties) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o ConsumerGroupProperties) ListUpdatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.UpdatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o ConsumerGroupProperties) SetUpdatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.UpdatedAt = &formatted
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/version.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/version.go
@@ -1,0 +1,9 @@
+package consumergroups
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/consumergroups/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/consumergroups/version.go
+++ b/azurerm/internal/services/eventhub/sdk/consumergroups/version.go
@@ -2,7 +2,7 @@ package consumergroups
 
 import "fmt"
 
-const defaultApiVersion = "2018-01-01-preview"
+const defaultApiVersion = "2017-04-01"
 
 func userAgent() string {
 	return fmt.Sprintf("pandora/consumergroups/%s", defaultApiVersion)

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/client.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/client.go
@@ -1,0 +1,15 @@
+package disasterrecoveryconfigs
+
+import "github.com/Azure/go-autorest/autorest"
+
+type DisasterRecoveryConfigsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewDisasterRecoveryConfigsClientWithBaseURI(endpoint string) DisasterRecoveryConfigsClient {
+	return DisasterRecoveryConfigsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/constants.go
@@ -1,0 +1,17 @@
+package disasterrecoveryconfigs
+
+type ProvisioningStateDR string
+
+const (
+	ProvisioningStateDRAccepted  ProvisioningStateDR = "Accepted"
+	ProvisioningStateDRFailed    ProvisioningStateDR = "Failed"
+	ProvisioningStateDRSucceeded ProvisioningStateDR = "Succeeded"
+)
+
+type RoleDisasterRecovery string
+
+const (
+	RoleDisasterRecoveryPrimary               RoleDisasterRecovery = "Primary"
+	RoleDisasterRecoveryPrimaryNotReplicating RoleDisasterRecovery = "PrimaryNotReplicating"
+	RoleDisasterRecoverySecondary             RoleDisasterRecovery = "Secondary"
+)

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_disasterrecoveryconfig.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_disasterrecoveryconfig.go
@@ -1,0 +1,126 @@
+package disasterrecoveryconfigs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type DisasterRecoveryConfigId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	Name           string
+}
+
+func NewDisasterRecoveryConfigID(subscriptionId, resourceGroup, namespaceName, name string) DisasterRecoveryConfigId {
+	return DisasterRecoveryConfigId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		Name:           name,
+	}
+}
+
+func (id DisasterRecoveryConfigId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Disaster Recovery Config", segmentsStr)
+}
+
+func (id DisasterRecoveryConfigId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/disasterRecoveryConfigs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.Name)
+}
+
+// DisasterRecoveryConfigID parses a DisasterRecoveryConfig ID into an DisasterRecoveryConfigId struct
+func DisasterRecoveryConfigID(input string) (*DisasterRecoveryConfigId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := DisasterRecoveryConfigId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("disasterRecoveryConfigs"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// DisasterRecoveryConfigIDInsensitively parses an DisasterRecoveryConfig ID into an DisasterRecoveryConfigId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the DisasterRecoveryConfigID method should be used instead for validation etc.
+func DisasterRecoveryConfigIDInsensitively(input string) (*DisasterRecoveryConfigId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := DisasterRecoveryConfigId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'disasterRecoveryConfigs' segment
+	disasterRecoveryConfigsKey := "disasterRecoveryConfigs"
+	for key := range id.Path {
+		if strings.EqualFold(key, disasterRecoveryConfigsKey) {
+			disasterRecoveryConfigsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(disasterRecoveryConfigsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_disasterrecoveryconfig_test.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_disasterrecoveryconfig_test.go
@@ -1,0 +1,262 @@
+package disasterrecoveryconfigs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = DisasterRecoveryConfigId{}
+
+func TestDisasterRecoveryConfigIDFormatter(t *testing.T) {
+	actual := NewDisasterRecoveryConfigID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{alias}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestDisasterRecoveryConfigID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DisasterRecoveryConfigId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}",
+			Expected: &DisasterRecoveryConfigId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{alias}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/DISASTERRECOVERYCONFIGS/{ALIAS}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := DisasterRecoveryConfigID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestDisasterRecoveryConfigIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *DisasterRecoveryConfigId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterRecoveryConfigs/{alias}",
+			Expected: &DisasterRecoveryConfigId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{alias}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/disasterrecoveryconfigs/{alias}",
+			Expected: &DisasterRecoveryConfigId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{alias}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/DISASTERRECOVERYCONFIGS/{alias}",
+			Expected: &DisasterRecoveryConfigId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{alias}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/DiSaStErReCoVeRyCoNfIgS/{alias}",
+			Expected: &DisasterRecoveryConfigId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{alias}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := DisasterRecoveryConfigIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_namespace.go
@@ -1,0 +1,108 @@
+package disasterrecoveryconfigs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
+}
+
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the NamespaceID method should be used instead for validation etc.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/id_namespace_test.go
@@ -1,0 +1,227 @@
+package disasterrecoveryconfigs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_breakpairing_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_breakpairing_autorest.go
@@ -1,0 +1,63 @@
+package disasterrecoveryconfigs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type BreakPairingResponse struct {
+	HttpResponse *http.Response
+}
+
+// BreakPairing ...
+func (c DisasterRecoveryConfigsClient) BreakPairing(ctx context.Context, id DisasterRecoveryConfigId) (result BreakPairingResponse, err error) {
+	req, err := c.preparerForBreakPairing(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "BreakPairing", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "BreakPairing", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForBreakPairing(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "BreakPairing", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForBreakPairing prepares the BreakPairing request.
+func (c DisasterRecoveryConfigsClient) preparerForBreakPairing(ctx context.Context, id DisasterRecoveryConfigId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/breakPairing", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForBreakPairing handles the response to the BreakPairing request. The method always
+// closes the http.Response Body.
+func (c DisasterRecoveryConfigsClient) responderForBreakPairing(resp *http.Response) (result BreakPairingResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_createorupdate_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_createorupdate_autorest.go
@@ -1,0 +1,65 @@
+package disasterrecoveryconfigs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CreateOrUpdateResponse struct {
+	HttpResponse *http.Response
+	Model        *ArmDisasterRecovery
+}
+
+// CreateOrUpdate ...
+func (c DisasterRecoveryConfigsClient) CreateOrUpdate(ctx context.Context, id DisasterRecoveryConfigId, input ArmDisasterRecovery) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c DisasterRecoveryConfigsClient) preparerForCreateOrUpdate(ctx context.Context, id DisasterRecoveryConfigId, input ArmDisasterRecovery) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c DisasterRecoveryConfigsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_delete_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_delete_autorest.go
@@ -1,0 +1,61 @@
+package disasterrecoveryconfigs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c DisasterRecoveryConfigsClient) Delete(ctx context.Context, id DisasterRecoveryConfigId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c DisasterRecoveryConfigsClient) preparerForDelete(ctx context.Context, id DisasterRecoveryConfigId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c DisasterRecoveryConfigsClient) responderForDelete(resp *http.Response) (result DeleteResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_failover_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_failover_autorest.go
@@ -1,0 +1,63 @@
+package disasterrecoveryconfigs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type FailOverResponse struct {
+	HttpResponse *http.Response
+}
+
+// FailOver ...
+func (c DisasterRecoveryConfigsClient) FailOver(ctx context.Context, id DisasterRecoveryConfigId) (result FailOverResponse, err error) {
+	req, err := c.preparerForFailOver(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "FailOver", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "FailOver", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForFailOver(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "FailOver", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForFailOver prepares the FailOver request.
+func (c DisasterRecoveryConfigsClient) preparerForFailOver(ctx context.Context, id DisasterRecoveryConfigId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/failover", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForFailOver handles the response to the FailOver request. The method always
+// closes the http.Response Body.
+func (c DisasterRecoveryConfigsClient) responderForFailOver(resp *http.Response) (result FailOverResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_get_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_get_autorest.go
@@ -1,0 +1,64 @@
+package disasterrecoveryconfigs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *ArmDisasterRecovery
+}
+
+// Get ...
+func (c DisasterRecoveryConfigsClient) Get(ctx context.Context, id DisasterRecoveryConfigId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c DisasterRecoveryConfigsClient) preparerForGet(ctx context.Context, id DisasterRecoveryConfigId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c DisasterRecoveryConfigsClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_list_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/method_list_autorest.go
@@ -1,0 +1,196 @@
+package disasterrecoveryconfigs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ArmDisasterRecovery
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ArmDisasterRecovery
+}
+
+func (r ListResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListResponse) LoadMore(ctx context.Context) (resp ListResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type ArmDisasterRecoveryPredicate struct {
+	// TODO: implement me
+}
+
+func (p ArmDisasterRecoveryPredicate) Matches(input ArmDisasterRecovery) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// List ...
+func (c DisasterRecoveryConfigsClient) List(ctx context.Context, id NamespaceId) (resp ListResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results into a single object
+func (c DisasterRecoveryConfigsClient) ListComplete(ctx context.Context, id NamespaceId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, ArmDisasterRecoveryPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DisasterRecoveryConfigsClient) ListCompleteMatchingPredicate(ctx context.Context, id NamespaceId, predicate ArmDisasterRecoveryPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ArmDisasterRecovery, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForList prepares the List request.
+func (c DisasterRecoveryConfigsClient) preparerForList(ctx context.Context, id NamespaceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/disasterRecoveryConfigs", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c DisasterRecoveryConfigsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c DisasterRecoveryConfigsClient) responderForList(resp *http.Response) (result ListResponse, err error) {
+	type page struct {
+		Values   []ArmDisasterRecovery `json:"value"`
+		NextLink *string               `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "disasterrecoveryconfigs.DisasterRecoveryConfigsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/model_armdisasterrecovery.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/model_armdisasterrecovery.go
@@ -1,0 +1,8 @@
+package disasterrecoveryconfigs
+
+type ArmDisasterRecovery struct {
+	Id         *string                        `json:"id,omitempty"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties *ArmDisasterRecoveryProperties `json:"properties,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/model_armdisasterrecoveryproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/model_armdisasterrecoveryproperties.go
@@ -1,0 +1,9 @@
+package disasterrecoveryconfigs
+
+type ArmDisasterRecoveryProperties struct {
+	AlternateName                     *string               `json:"alternateName,omitempty"`
+	PartnerNamespace                  *string               `json:"partnerNamespace,omitempty"`
+	PendingReplicationOperationsCount *int64                `json:"pendingReplicationOperationsCount,omitempty"`
+	ProvisioningState                 *ProvisioningStateDR  `json:"provisioningState,omitempty"`
+	Role                              *RoleDisasterRecovery `json:"role,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/disasterrecoveryconfigs/version.go
@@ -1,0 +1,9 @@
+package disasterrecoveryconfigs
+
+import "fmt"
+
+const defaultApiVersion = "2017-04-01"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/disasterrecoveryconfigs/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/client.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/client.go
@@ -1,0 +1,15 @@
+package eventhubs
+
+import "github.com/Azure/go-autorest/autorest"
+
+type EventHubsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewEventHubsClientWithBaseURI(endpoint string) EventHubsClient {
+	return EventHubsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/constants.go
@@ -1,0 +1,22 @@
+package eventhubs
+
+type EncodingCaptureDescription string
+
+const (
+	EncodingCaptureDescriptionAvro        EncodingCaptureDescription = "Avro"
+	EncodingCaptureDescriptionAvroDeflate EncodingCaptureDescription = "AvroDeflate"
+)
+
+type EntityStatus string
+
+const (
+	EntityStatusActive          EntityStatus = "Active"
+	EntityStatusCreating        EntityStatus = "Creating"
+	EntityStatusDeleting        EntityStatus = "Deleting"
+	EntityStatusDisabled        EntityStatus = "Disabled"
+	EntityStatusReceiveDisabled EntityStatus = "ReceiveDisabled"
+	EntityStatusRenaming        EntityStatus = "Renaming"
+	EntityStatusRestoring       EntityStatus = "Restoring"
+	EntityStatusSendDisabled    EntityStatus = "SendDisabled"
+	EntityStatusUnknown         EntityStatus = "Unknown"
+)

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/id_authorizationrule.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/id_authorizationrule.go
@@ -1,0 +1,144 @@
+package eventhubs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type AuthorizationRuleId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	EventhubName   string
+	Name           string
+}
+
+func NewAuthorizationRuleID(subscriptionId, resourceGroup, namespaceName, eventhubName, name string) AuthorizationRuleId {
+	return AuthorizationRuleId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		EventhubName:   eventhubName,
+		Name:           name,
+	}
+}
+
+func (id AuthorizationRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Eventhub Name %q", id.EventhubName),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Authorization Rule", segmentsStr)
+}
+
+func (id AuthorizationRuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/eventhubs/%s/authorizationRules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
+}
+
+// AuthorizationRuleID parses a AuthorizationRule ID into an AuthorizationRuleId struct
+func AuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.EventhubName, err = id.PopSegment("eventhubs"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("authorizationRules"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// AuthorizationRuleIDInsensitively parses an AuthorizationRule ID into an AuthorizationRuleId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the AuthorizationRuleID method should be used instead for validation etc.
+func AuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'eventhubs' segment
+	eventhubsKey := "eventhubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, eventhubsKey) {
+			eventhubsKey = key
+			break
+		}
+	}
+	if resourceId.EventhubName, err = id.PopSegment(eventhubsKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'authorizationRules' segment
+	authorizationRulesKey := "authorizationRules"
+	for key := range id.Path {
+		if strings.EqualFold(key, authorizationRulesKey) {
+			authorizationRulesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(authorizationRulesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/id_authorizationrule_test.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/id_authorizationrule_test.go
@@ -1,0 +1,297 @@
+package eventhubs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = AuthorizationRuleId{}
+
+func TestAuthorizationRuleIDFormatter(t *testing.T) {
+	actual := NewAuthorizationRuleID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{eventHubName}", "{authorizationRuleName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestAuthorizationRuleID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/EVENTHUBS/{EVENTHUBNAME}/AUTHORIZATIONRULES/{AUTHORIZATIONRULENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AuthorizationRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.EventhubName != v.Expected.EventhubName {
+			t.Fatalf("Expected %q but got %q for EventhubName", v.Expected.EventhubName, actual.EventhubName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestAuthorizationRuleIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for EventhubName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationRules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}/authorizationrules/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/EVENTHUBS/{eventHubName}/AUTHORIZATIONRULES/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/EvEnThUbS/{eventHubName}/AuThOrIzAtIoNrUlEs/{authorizationRuleName}",
+			Expected: &AuthorizationRuleId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				EventhubName:   "{eventHubName}",
+				Name:           "{authorizationRuleName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AuthorizationRuleIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.EventhubName != v.Expected.EventhubName {
+			t.Fatalf("Expected %q but got %q for EventhubName", v.Expected.EventhubName, actual.EventhubName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/id_eventhub.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/id_eventhub.go
@@ -1,0 +1,126 @@
+package eventhubs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type EventhubId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	NamespaceName  string
+	Name           string
+}
+
+func NewEventhubID(subscriptionId, resourceGroup, namespaceName, name string) EventhubId {
+	return EventhubId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		NamespaceName:  namespaceName,
+		Name:           name,
+	}
+}
+
+func (id EventhubId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Namespace Name %q", id.NamespaceName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Eventhub", segmentsStr)
+}
+
+func (id EventhubId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s/eventhubs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.Name)
+}
+
+// EventhubID parses a Eventhub ID into an EventhubId struct
+func EventhubID(input string) (*EventhubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := EventhubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.NamespaceName, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("eventhubs"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// EventhubIDInsensitively parses an Eventhub ID into an EventhubId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the EventhubID method should be used instead for validation etc.
+func EventhubIDInsensitively(input string) (*EventhubId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := EventhubId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'eventhubs' segment
+	eventhubsKey := "eventhubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, eventhubsKey) {
+			eventhubsKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(eventhubsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/id_eventhub_test.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/id_eventhub_test.go
@@ -1,0 +1,262 @@
+package eventhubs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = EventhubId{}
+
+func TestEventhubIDFormatter(t *testing.T) {
+	actual := NewEventhubID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}", "{eventHubName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestEventhubID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EventhubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}/EVENTHUBS/{EVENTHUBNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EventhubID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestEventhubIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *EventhubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventhubs/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}/EVENTHUBS/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}/EvEnThUbS/{eventHubName}",
+			Expected: &EventhubId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				NamespaceName:  "{namespaceName}",
+				Name:           "{eventHubName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := EventhubIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/id_namespace.go
@@ -1,0 +1,108 @@
+package eventhubs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
+}
+
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the NamespaceID method should be used instead for validation etc.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/id_namespace_test.go
@@ -1,0 +1,227 @@
+package eventhubs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_createorupdate_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_createorupdate_autorest.go
@@ -1,0 +1,65 @@
+package eventhubs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type CreateOrUpdateResponse struct {
+	HttpResponse *http.Response
+	Model        *Eventhub
+}
+
+// CreateOrUpdate ...
+func (c EventHubsClient) CreateOrUpdate(ctx context.Context, id EventhubId, input Eventhub) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c EventHubsClient) preparerForCreateOrUpdate(ctx context.Context, id EventhubId, input Eventhub) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c EventHubsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_delete_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_delete_autorest.go
@@ -1,0 +1,61 @@
+package eventhubs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c EventHubsClient) Delete(ctx context.Context, id EventhubId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c EventHubsClient) preparerForDelete(ctx context.Context, id EventhubId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c EventHubsClient) responderForDelete(resp *http.Response) (result DeleteResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_deleteauthorizationrule_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_deleteauthorizationrule_autorest.go
@@ -1,0 +1,61 @@
+package eventhubs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type DeleteAuthorizationRuleResponse struct {
+	HttpResponse *http.Response
+}
+
+// DeleteAuthorizationRule ...
+func (c EventHubsClient) DeleteAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (result DeleteAuthorizationRuleResponse, err error) {
+	req, err := c.preparerForDeleteAuthorizationRule(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "DeleteAuthorizationRule", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "DeleteAuthorizationRule", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDeleteAuthorizationRule(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "DeleteAuthorizationRule", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDeleteAuthorizationRule prepares the DeleteAuthorizationRule request.
+func (c EventHubsClient) preparerForDeleteAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDeleteAuthorizationRule handles the response to the DeleteAuthorizationRule request. The method always
+// closes the http.Response Body.
+func (c EventHubsClient) responderForDeleteAuthorizationRule(resp *http.Response) (result DeleteAuthorizationRuleResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusNoContent),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_get_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_get_autorest.go
@@ -1,0 +1,64 @@
+package eventhubs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *Eventhub
+}
+
+// Get ...
+func (c EventHubsClient) Get(ctx context.Context, id EventhubId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c EventHubsClient) preparerForGet(ctx context.Context, id EventhubId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c EventHubsClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_getauthorizationrule_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_getauthorizationrule_autorest.go
@@ -1,0 +1,64 @@
+package eventhubs
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetAuthorizationRuleResponse struct {
+	HttpResponse *http.Response
+	Model        *AuthorizationRule
+}
+
+// GetAuthorizationRule ...
+func (c EventHubsClient) GetAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (result GetAuthorizationRuleResponse, err error) {
+	req, err := c.preparerForGetAuthorizationRule(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "GetAuthorizationRule", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "GetAuthorizationRule", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGetAuthorizationRule(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "GetAuthorizationRule", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGetAuthorizationRule prepares the GetAuthorizationRule request.
+func (c EventHubsClient) preparerForGetAuthorizationRule(ctx context.Context, id AuthorizationRuleId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGetAuthorizationRule handles the response to the GetAuthorizationRule request. The method always
+// closes the http.Response Body.
+func (c EventHubsClient) responderForGetAuthorizationRule(resp *http.Response) (result GetAuthorizationRuleResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_listbynamespace_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_listbynamespace_autorest.go
@@ -44,7 +44,7 @@ func DefaultListByNamespaceOptions() ListByNamespaceOptions {
 }
 
 func (o ListByNamespaceOptions) toQueryString() map[string]interface{} {
-	out := make(map[string]interface{}, 0)
+	out := make(map[string]interface{})
 
 	if o.Skip != nil {
 		out["$skip"] = *o.Skip

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/method_listbynamespace_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/method_listbynamespace_autorest.go
@@ -1,0 +1,223 @@
+package eventhubs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListByNamespaceResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Eventhub
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByNamespaceResponse, error)
+}
+
+type ListByNamespaceCompleteResult struct {
+	Items []Eventhub
+}
+
+func (r ListByNamespaceResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByNamespaceResponse) LoadMore(ctx context.Context) (resp ListByNamespaceResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type ListByNamespaceOptions struct {
+	Skip *int64
+	Top  *int64
+}
+
+func DefaultListByNamespaceOptions() ListByNamespaceOptions {
+	return ListByNamespaceOptions{}
+}
+
+func (o ListByNamespaceOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{}, 0)
+
+	if o.Skip != nil {
+		out["$skip"] = *o.Skip
+	}
+
+	if o.Top != nil {
+		out["$top"] = *o.Top
+	}
+
+	return out
+}
+
+type EventhubPredicate struct {
+	// TODO: implement me
+}
+
+func (p EventhubPredicate) Matches(input Eventhub) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// ListByNamespace ...
+func (c EventHubsClient) ListByNamespace(ctx context.Context, id NamespaceId, options ListByNamespaceOptions) (resp ListByNamespaceResponse, err error) {
+	req, err := c.preparerForListByNamespace(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "ListByNamespace", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "ListByNamespace", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByNamespace(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "ListByNamespace", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListByNamespaceCompleteMatchingPredicate retrieves all of the results into a single object
+func (c EventHubsClient) ListByNamespaceComplete(ctx context.Context, id NamespaceId, options ListByNamespaceOptions) (ListByNamespaceCompleteResult, error) {
+	return c.ListByNamespaceCompleteMatchingPredicate(ctx, id, options, EventhubPredicate{})
+}
+
+// ListByNamespaceCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c EventHubsClient) ListByNamespaceCompleteMatchingPredicate(ctx context.Context, id NamespaceId, options ListByNamespaceOptions, predicate EventhubPredicate) (resp ListByNamespaceCompleteResult, err error) {
+	items := make([]Eventhub, 0)
+
+	page, err := c.ListByNamespace(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByNamespaceCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListByNamespace prepares the ListByNamespace request.
+func (c EventHubsClient) preparerForListByNamespace(ctx context.Context, id NamespaceId, options ListByNamespaceOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/eventhubs", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByNamespaceWithNextLink prepares the ListByNamespace request with the given nextLink token.
+func (c EventHubsClient) preparerForListByNamespaceWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByNamespace handles the response to the ListByNamespace request. The method always
+// closes the http.Response Body.
+func (c EventHubsClient) responderForListByNamespace(resp *http.Response) (result ListByNamespaceResponse, err error) {
+	type page struct {
+		Values   []Eventhub `json:"value"`
+		NextLink *string    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByNamespaceResponse, err error) {
+			req, err := c.preparerForListByNamespaceWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "ListByNamespace", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "ListByNamespace", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByNamespace(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "eventhubs.EventHubsClient", "ListByNamespace", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_authorizationrule.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_authorizationrule.go
@@ -1,0 +1,8 @@
+package eventhubs
+
+type AuthorizationRule struct {
+	Id         *string                      `json:"id,omitempty"`
+	Name       *string                      `json:"name,omitempty"`
+	Properties *AuthorizationRuleProperties `json:"properties,omitempty"`
+	Type       *string                      `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_authorizationruleproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_authorizationruleproperties.go
@@ -1,0 +1,5 @@
+package eventhubs
+
+type AuthorizationRuleProperties struct {
+	Rights []string `json:"rights"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_capturedescription.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_capturedescription.go
@@ -1,0 +1,10 @@
+package eventhubs
+
+type CaptureDescription struct {
+	Destination       *Destination                `json:"destination,omitempty"`
+	Enabled           *bool                       `json:"enabled,omitempty"`
+	Encoding          *EncodingCaptureDescription `json:"encoding,omitempty"`
+	IntervalInSeconds *int64                      `json:"intervalInSeconds,omitempty"`
+	SizeLimitInBytes  *int64                      `json:"sizeLimitInBytes,omitempty"`
+	SkipEmptyArchives *bool                       `json:"skipEmptyArchives,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_destination.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_destination.go
@@ -1,0 +1,6 @@
+package eventhubs
+
+type Destination struct {
+	Name       *string                `json:"name,omitempty"`
+	Properties *DestinationProperties `json:"properties,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_destinationproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_destinationproperties.go
@@ -1,0 +1,7 @@
+package eventhubs
+
+type DestinationProperties struct {
+	ArchiveNameFormat        *string `json:"archiveNameFormat,omitempty"`
+	BlobContainer            *string `json:"blobContainer,omitempty"`
+	StorageAccountResourceId *string `json:"storageAccountResourceId,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_eventhub.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_eventhub.go
@@ -1,0 +1,8 @@
+package eventhubs
+
+type Eventhub struct {
+	Id         *string             `json:"id,omitempty"`
+	Name       *string             `json:"name,omitempty"`
+	Properties *EventhubProperties `json:"properties,omitempty"`
+	Type       *string             `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/model_eventhubproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/model_eventhubproperties.go
@@ -1,0 +1,35 @@
+package eventhubs
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/formatting"
+)
+
+type EventhubProperties struct {
+	CaptureDescription     *CaptureDescription `json:"captureDescription,omitempty"`
+	CreatedAt              *string             `json:"createdAt,omitempty"`
+	MessageRetentionInDays *int64              `json:"messageRetentionInDays,omitempty"`
+	PartitionCount         *int64              `json:"partitionCount,omitempty"`
+	PartitionIds           *[]string           `json:"partitionIds,omitempty"`
+	Status                 *EntityStatus       `json:"status,omitempty"`
+	UpdatedAt              *string             `json:"updatedAt,omitempty"`
+}
+
+func (o EventhubProperties) ListCreatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o EventhubProperties) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o EventhubProperties) ListUpdatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.UpdatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o EventhubProperties) SetUpdatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.UpdatedAt = &formatted
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/version.go
@@ -1,0 +1,9 @@
+package eventhubs
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/eventhubs/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubs/version.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubs/version.go
@@ -2,7 +2,7 @@ package eventhubs
 
 import "fmt"
 
-const defaultApiVersion = "2018-01-01-preview"
+const defaultApiVersion = "2017-04-01"
 
 func userAgent() string {
 	return fmt.Sprintf("pandora/eventhubs/%s", defaultApiVersion)

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/client.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/client.go
@@ -1,0 +1,15 @@
+package eventhubsclusters
+
+import "github.com/Azure/go-autorest/autorest"
+
+type EventHubsClustersClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewEventHubsClustersClientWithBaseURI(endpoint string) EventHubsClustersClient {
+	return EventHubsClustersClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/constants.go
@@ -1,0 +1,7 @@
+package eventhubsclusters
+
+type ClusterSkuName string
+
+const (
+	ClusterSkuNameDedicated ClusterSkuName = "Dedicated"
+)

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_cluster.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_cluster.go
@@ -1,0 +1,108 @@
+package eventhubsclusters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type ClusterId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewClusterID(subscriptionId, resourceGroup, name string) ClusterId {
+	return ClusterId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id ClusterId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Cluster", segmentsStr)
+}
+
+func (id ClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/clusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// ClusterID parses a Cluster ID into an ClusterId struct
+func ClusterID(input string) (*ClusterId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ClusterId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("clusters"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ClusterIDInsensitively parses an Cluster ID into an ClusterId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ClusterID method should be used instead for validation etc.
+func ClusterIDInsensitively(input string) (*ClusterId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ClusterId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'clusters' segment
+	clustersKey := "clusters"
+	for key := range id.Path {
+		if strings.EqualFold(key, clustersKey) {
+			clustersKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(clustersKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_cluster_test.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_cluster_test.go
@@ -1,0 +1,227 @@
+package eventhubsclusters
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ClusterId{}
+
+func TestClusterIDFormatter(t *testing.T) {
+	actual := NewClusterID("{subscriptionId}", "{resourceGroupName}", "{clusterName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestClusterID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ClusterId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}",
+			Expected: &ClusterId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{clusterName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/CLUSTERS/{CLUSTERNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ClusterID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestClusterIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ClusterId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}",
+			Expected: &ClusterId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{clusterName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/clusters/{clusterName}",
+			Expected: &ClusterId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{clusterName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/CLUSTERS/{clusterName}",
+			Expected: &ClusterId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{clusterName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/ClUsTeRs/{clusterName}",
+			Expected: &ClusterId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{clusterName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ClusterIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_resourcegroup.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_resourcegroup.go
@@ -1,0 +1,89 @@
+package eventhubsclusters
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type ResourceGroupId struct {
+	SubscriptionId string
+	ResourceGroup  string
+}
+
+func NewResourceGroupID(subscriptionId, resourceGroup string) ResourceGroupId {
+	return ResourceGroupId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+	}
+}
+
+func (id ResourceGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Resource Group", segmentsStr)
+}
+
+func (id ResourceGroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup)
+}
+
+// ResourceGroupID parses a ResourceGroup ID into an ResourceGroupId struct
+func ResourceGroupID(input string) (*ResourceGroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ResourceGroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ResourceGroupIDInsensitively parses an ResourceGroup ID into an ResourceGroupId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ResourceGroupID method should be used instead for validation etc.
+func ResourceGroupIDInsensitively(input string) (*ResourceGroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ResourceGroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_resourcegroup_test.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/id_resourcegroup_test.go
@@ -1,0 +1,192 @@
+package eventhubsclusters
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ResourceGroupId{}
+
+func TestResourceGroupIDFormatter(t *testing.T) {
+	actual := NewResourceGroupID("{subscriptionId}", "{resourceGroupName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestResourceGroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ResourceGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}
+
+func TestResourceGroupIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ResourceGroupIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clusterscreateorupdate_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clusterscreateorupdate_autorest.go
@@ -1,0 +1,75 @@
+package eventhubsclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type ClustersCreateOrUpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// ClustersCreateOrUpdate ...
+func (c EventHubsClustersClient) ClustersCreateOrUpdate(ctx context.Context, id ClusterId, input Cluster) (result ClustersCreateOrUpdateResponse, err error) {
+	req, err := c.preparerForClustersCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersCreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForClustersCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersCreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ClustersCreateOrUpdateThenPoll performs ClustersCreateOrUpdate then polls until it's completed
+func (c EventHubsClustersClient) ClustersCreateOrUpdateThenPoll(ctx context.Context, id ClusterId, input Cluster) error {
+	result, err := c.ClustersCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ClustersCreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after ClustersCreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForClustersCreateOrUpdate prepares the ClustersCreateOrUpdate request.
+func (c EventHubsClustersClient) preparerForClustersCreateOrUpdate(ctx context.Context, id ClusterId, input Cluster) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForClustersCreateOrUpdate sends the ClustersCreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c EventHubsClustersClient) senderForClustersCreateOrUpdate(ctx context.Context, req *http.Request) (future ClustersCreateOrUpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clustersdelete_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clustersdelete_autorest.go
@@ -1,0 +1,73 @@
+package eventhubsclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type ClustersDeleteResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// ClustersDelete ...
+func (c EventHubsClustersClient) ClustersDelete(ctx context.Context, id ClusterId) (result ClustersDeleteResponse, err error) {
+	req, err := c.preparerForClustersDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForClustersDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ClustersDeleteThenPoll performs ClustersDelete then polls until it's completed
+func (c EventHubsClustersClient) ClustersDeleteThenPoll(ctx context.Context, id ClusterId) error {
+	result, err := c.ClustersDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ClustersDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after ClustersDelete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForClustersDelete prepares the ClustersDelete request.
+func (c EventHubsClustersClient) preparerForClustersDelete(ctx context.Context, id ClusterId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForClustersDelete sends the ClustersDelete request. The method will close the
+// http.Response Body if it receives an error.
+func (c EventHubsClustersClient) senderForClustersDelete(ctx context.Context, req *http.Request) (future ClustersDeleteResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clustersget_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clustersget_autorest.go
@@ -1,0 +1,64 @@
+package eventhubsclusters
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ClustersGetResponse struct {
+	HttpResponse *http.Response
+	Model        *Cluster
+}
+
+// ClustersGet ...
+func (c EventHubsClustersClient) ClustersGet(ctx context.Context, id ClusterId) (result ClustersGetResponse, err error) {
+	req, err := c.preparerForClustersGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForClustersGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForClustersGet prepares the ClustersGet request.
+func (c EventHubsClustersClient) preparerForClustersGet(ctx context.Context, id ClusterId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForClustersGet handles the response to the ClustersGet request. The method always
+// closes the http.Response Body.
+func (c EventHubsClustersClient) responderForClustersGet(resp *http.Response) (result ClustersGetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clusterslistbyresourcegroup_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clusterslistbyresourcegroup_autorest.go
@@ -1,0 +1,196 @@
+package eventhubsclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ClustersListByResourceGroupResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Cluster
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ClustersListByResourceGroupResponse, error)
+}
+
+type ClustersListByResourceGroupCompleteResult struct {
+	Items []Cluster
+}
+
+func (r ClustersListByResourceGroupResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ClustersListByResourceGroupResponse) LoadMore(ctx context.Context) (resp ClustersListByResourceGroupResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type ClusterPredicate struct {
+	// TODO: implement me
+}
+
+func (p ClusterPredicate) Matches(input Cluster) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// ClustersListByResourceGroup ...
+func (c EventHubsClustersClient) ClustersListByResourceGroup(ctx context.Context, id ResourceGroupId) (resp ClustersListByResourceGroupResponse, err error) {
+	req, err := c.preparerForClustersListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForClustersListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ClustersListByResourceGroupCompleteMatchingPredicate retrieves all of the results into a single object
+func (c EventHubsClustersClient) ClustersListByResourceGroupComplete(ctx context.Context, id ResourceGroupId) (ClustersListByResourceGroupCompleteResult, error) {
+	return c.ClustersListByResourceGroupCompleteMatchingPredicate(ctx, id, ClusterPredicate{})
+}
+
+// ClustersListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c EventHubsClustersClient) ClustersListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id ResourceGroupId, predicate ClusterPredicate) (resp ClustersListByResourceGroupCompleteResult, err error) {
+	items := make([]Cluster, 0)
+
+	page, err := c.ClustersListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ClustersListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForClustersListByResourceGroup prepares the ClustersListByResourceGroup request.
+func (c EventHubsClustersClient) preparerForClustersListByResourceGroup(ctx context.Context, id ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.EventHub/clusters", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForClustersListByResourceGroupWithNextLink prepares the ClustersListByResourceGroup request with the given nextLink token.
+func (c EventHubsClustersClient) preparerForClustersListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForClustersListByResourceGroup handles the response to the ClustersListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c EventHubsClustersClient) responderForClustersListByResourceGroup(resp *http.Response) (result ClustersListByResourceGroupResponse, err error) {
+	type page struct {
+		Values   []Cluster `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ClustersListByResourceGroupResponse, err error) {
+			req, err := c.preparerForClustersListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForClustersListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clustersupdate_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/method_clustersupdate_autorest.go
@@ -1,0 +1,75 @@
+package eventhubsclusters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type ClustersUpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// ClustersUpdate ...
+func (c EventHubsClustersClient) ClustersUpdate(ctx context.Context, id ClusterId, input Cluster) (result ClustersUpdateResponse, err error) {
+	req, err := c.preparerForClustersUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForClustersUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "eventhubsclusters.EventHubsClustersClient", "ClustersUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ClustersUpdateThenPoll performs ClustersUpdate then polls until it's completed
+func (c EventHubsClustersClient) ClustersUpdateThenPoll(ctx context.Context, id ClusterId, input Cluster) error {
+	result, err := c.ClustersUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ClustersUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after ClustersUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForClustersUpdate prepares the ClustersUpdate request.
+func (c EventHubsClustersClient) preparerForClustersUpdate(ctx context.Context, id ClusterId, input Cluster) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForClustersUpdate sends the ClustersUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c EventHubsClustersClient) senderForClustersUpdate(ctx context.Context, req *http.Request) (future ClustersUpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/model_cluster.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/model_cluster.go
@@ -1,0 +1,11 @@
+package eventhubsclusters
+
+type Cluster struct {
+	Id         *string            `json:"id,omitempty"`
+	Location   *string            `json:"location,omitempty"`
+	Name       *string            `json:"name,omitempty"`
+	Properties *ClusterProperties `json:"properties,omitempty"`
+	Sku        *ClusterSku        `json:"sku,omitempty"`
+	Tags       *map[string]string `json:"tags,omitempty"`
+	Type       *string            `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/model_clusterproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/model_clusterproperties.go
@@ -1,0 +1,8 @@
+package eventhubsclusters
+
+type ClusterProperties struct {
+	CreatedAt *string `json:"createdAt,omitempty"`
+	MetricId  *string `json:"metricId,omitempty"`
+	Status    *string `json:"status,omitempty"`
+	UpdatedAt *string `json:"updatedAt,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/model_clustersku.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/model_clustersku.go
@@ -1,0 +1,6 @@
+package eventhubsclusters
+
+type ClusterSku struct {
+	Capacity *int64         `json:"capacity,omitempty"`
+	Name     ClusterSkuName `json:"name"`
+}

--- a/azurerm/internal/services/eventhub/sdk/eventhubsclusters/version.go
+++ b/azurerm/internal/services/eventhub/sdk/eventhubsclusters/version.go
@@ -1,0 +1,9 @@
+package eventhubsclusters
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/eventhubsclusters/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/client.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/client.go
@@ -1,0 +1,15 @@
+package namespaces
+
+import "github.com/Azure/go-autorest/autorest"
+
+type NamespacesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewNamespacesClientWithBaseURI(endpoint string) NamespacesClient {
+	return NamespacesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/constants.go
@@ -1,0 +1,27 @@
+package namespaces
+
+type IdentityType string
+
+const (
+	IdentityTypeSystemAssigned IdentityType = "SystemAssigned"
+)
+
+type KeySource string
+
+const (
+	KeySourceMicrosoftKeyVault KeySource = "Microsoft.KeyVault"
+)
+
+type SkuName string
+
+const (
+	SkuNameBasic    SkuName = "Basic"
+	SkuNameStandard SkuName = "Standard"
+)
+
+type SkuTier string
+
+const (
+	SkuTierBasic    SkuTier = "Basic"
+	SkuTierStandard SkuTier = "Standard"
+)

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace.go
@@ -1,0 +1,108 @@
+package namespaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
+}
+
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the NamespaceID method should be used instead for validation etc.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace_test.go
@@ -1,0 +1,227 @@
+package namespaces
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup.go
@@ -1,0 +1,89 @@
+package namespaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type ResourceGroupId struct {
+	SubscriptionId string
+	ResourceGroup  string
+}
+
+func NewResourceGroupID(subscriptionId, resourceGroup string) ResourceGroupId {
+	return ResourceGroupId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+	}
+}
+
+func (id ResourceGroupId) String() string {
+	segments := []string{
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Resource Group", segmentsStr)
+}
+
+func (id ResourceGroupId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup)
+}
+
+// ResourceGroupID parses a ResourceGroup ID into an ResourceGroupId struct
+func ResourceGroupID(input string) (*ResourceGroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ResourceGroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// ResourceGroupIDInsensitively parses an ResourceGroup ID into an ResourceGroupId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the ResourceGroupID method should be used instead for validation etc.
+func ResourceGroupIDInsensitively(input string) (*ResourceGroupId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ResourceGroupId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup_test.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup_test.go
@@ -1,0 +1,192 @@
+package namespaces
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ResourceGroupId{}
+
+func TestResourceGroupIDFormatter(t *testing.T) {
+	actual := NewResourceGroupID("{subscriptionId}", "{resourceGroupName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestResourceGroupID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ResourceGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}
+
+func TestResourceGroupIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceGroupId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+			Expected: &ResourceGroupId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ResourceGroupIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_createorupdate_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_createorupdate_autorest.go
@@ -1,0 +1,75 @@
+package namespaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type CreateOrUpdateResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c NamespacesClient) CreateOrUpdate(ctx context.Context, id NamespaceId, input EHNamespace) (result CreateOrUpdateResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c NamespacesClient) CreateOrUpdateThenPoll(ctx context.Context, id NamespaceId, input EHNamespace) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c NamespacesClient) preparerForCreateOrUpdate(ctx context.Context, id NamespaceId, input EHNamespace) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c NamespacesClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_delete_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_delete_autorest.go
@@ -1,0 +1,73 @@
+package namespaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+type DeleteResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c NamespacesClient) Delete(ctx context.Context, id NamespaceId) (result DeleteResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c NamespacesClient) DeleteThenPoll(ctx context.Context, id NamespaceId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c NamespacesClient) preparerForDelete(ctx context.Context, id NamespaceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c NamespacesClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+	future.Poller, err = polling.NewLongRunningPollerFromResponse(ctx, resp, c.Client)
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_get_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_get_autorest.go
@@ -1,0 +1,64 @@
+package namespaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+	Model        *EHNamespace
+}
+
+// Get ...
+func (c NamespacesClient) Get(ctx context.Context, id NamespaceId) (result GetResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c NamespacesClient) preparerForGet(ctx context.Context, id NamespaceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c NamespacesClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_listbyresourcegroup_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_listbyresourcegroup_autorest.go
@@ -1,0 +1,196 @@
+package namespaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type ListByResourceGroupResponse struct {
+	HttpResponse *http.Response
+	Model        *[]EHNamespace
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByResourceGroupResponse, error)
+}
+
+type ListByResourceGroupCompleteResult struct {
+	Items []EHNamespace
+}
+
+func (r ListByResourceGroupResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByResourceGroupResponse) LoadMore(ctx context.Context) (resp ListByResourceGroupResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type EHNamespacePredicate struct {
+	// TODO: implement me
+}
+
+func (p EHNamespacePredicate) Matches(input EHNamespace) bool {
+	// TODO: implement me
+	// if p.Name != nil && input.Name != *p.Name {
+	// 	return false
+	// }
+
+	return true
+}
+
+// ListByResourceGroup ...
+func (c NamespacesClient) ListByResourceGroup(ctx context.Context, id ResourceGroupId) (resp ListByResourceGroupResponse, err error) {
+	req, err := c.preparerForListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "ListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "ListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "ListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results into a single object
+func (c NamespacesClient) ListByResourceGroupComplete(ctx context.Context, id ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, EHNamespacePredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c NamespacesClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id ResourceGroupId, predicate EHNamespacePredicate) (resp ListByResourceGroupCompleteResult, err error) {
+	items := make([]EHNamespace, 0)
+
+	page, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}
+
+// preparerForListByResourceGroup prepares the ListByResourceGroup request.
+func (c NamespacesClient) preparerForListByResourceGroup(ctx context.Context, id ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.EventHub/namespaces", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByResourceGroupWithNextLink prepares the ListByResourceGroup request with the given nextLink token.
+func (c NamespacesClient) preparerForListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByResourceGroup handles the response to the ListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c NamespacesClient) responderForListByResourceGroup(resp *http.Response) (result ListByResourceGroupResponse, err error) {
+	type page struct {
+		Values   []EHNamespace `json:"value"`
+		NextLink *string       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByResourceGroupResponse, err error) {
+			req, err := c.preparerForListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "ListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "ListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "ListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_update_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_update_autorest.go
@@ -1,0 +1,65 @@
+package namespaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type UpdateResponse struct {
+	HttpResponse *http.Response
+	Model        *EHNamespace
+}
+
+// Update ...
+func (c NamespacesClient) Update(ctx context.Context, id NamespaceId, input EHNamespace) (result UpdateResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "namespaces.NamespacesClient", "Update", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdate prepares the Update request.
+func (c NamespacesClient) preparerForUpdate(ctx context.Context, id NamespaceId, input EHNamespace) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdate handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (c NamespacesClient) responderForUpdate(resp *http.Response) (result UpdateResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK, http.StatusCreated),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespace.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespace.go
@@ -1,0 +1,12 @@
+package namespaces
+
+type EHNamespace struct {
+	Id         *string                `json:"id,omitempty"`
+	Identity   *Identity              `json:"identity,omitempty"`
+	Location   *string                `json:"location,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *EHNamespaceProperties `json:"properties,omitempty"`
+	Sku        *Sku                   `json:"sku,omitempty"`
+	Tags       *map[string]string     `json:"tags,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespaceproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespaceproperties.go
@@ -1,0 +1,39 @@
+package namespaces
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/formatting"
+)
+
+type EHNamespaceProperties struct {
+	ClusterArmId           *string     `json:"clusterArmId,omitempty"`
+	CreatedAt              *string     `json:"createdAt,omitempty"`
+	Encryption             *Encryption `json:"encryption,omitempty"`
+	IsAutoInflateEnabled   *bool       `json:"isAutoInflateEnabled,omitempty"`
+	KafkaEnabled           *bool       `json:"kafkaEnabled,omitempty"`
+	MaximumThroughputUnits *int64      `json:"maximumThroughputUnits,omitempty"`
+	MetricId               *string     `json:"metricId,omitempty"`
+	ProvisioningState      *string     `json:"provisioningState,omitempty"`
+	ServiceBusEndpoint     *string     `json:"serviceBusEndpoint,omitempty"`
+	UpdatedAt              *string     `json:"updatedAt,omitempty"`
+	ZoneRedundant          *bool       `json:"zoneRedundant,omitempty"`
+}
+
+func (o EHNamespaceProperties) ListCreatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o EHNamespaceProperties) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o EHNamespaceProperties) ListUpdatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.UpdatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o EHNamespaceProperties) SetUpdatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.UpdatedAt = &formatted
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_encryption.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_encryption.go
@@ -1,0 +1,6 @@
+package namespaces
+
+type Encryption struct {
+	KeySource          *KeySource            `json:"keySource,omitempty"`
+	KeyVaultProperties *[]KeyVaultProperties `json:"keyVaultProperties,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_identity.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_identity.go
@@ -1,0 +1,7 @@
+package namespaces
+
+type Identity struct {
+	PrincipalId *string       `json:"principalId,omitempty"`
+	TenantId    *string       `json:"tenantId,omitempty"`
+	Type        *IdentityType `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_keyvaultproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_keyvaultproperties.go
@@ -1,0 +1,7 @@
+package namespaces
+
+type KeyVaultProperties struct {
+	KeyName     *string `json:"keyName,omitempty"`
+	KeyVaultUri *string `json:"keyVaultUri,omitempty"`
+	KeyVersion  *string `json:"keyVersion,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_sku.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_sku.go
@@ -1,0 +1,7 @@
+package namespaces
+
+type Sku struct {
+	Capacity *int64   `json:"capacity,omitempty"`
+	Name     SkuName  `json:"name"`
+	Tier     *SkuTier `json:"tier,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/version.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/version.go
@@ -1,0 +1,9 @@
+package namespaces
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/namespaces/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/client.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/client.go
@@ -1,0 +1,15 @@
+package networkrulesets
+
+import "github.com/Azure/go-autorest/autorest"
+
+type NetworkRuleSetsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewNetworkRuleSetsClientWithBaseURI(endpoint string) NetworkRuleSetsClient {
+	return NetworkRuleSetsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/constants.go
@@ -1,0 +1,14 @@
+package networkrulesets
+
+type DefaultAction string
+
+const (
+	DefaultActionAllow DefaultAction = "Allow"
+	DefaultActionDeny  DefaultAction = "Deny"
+)
+
+type NetworkRuleIPAction string
+
+const (
+	NetworkRuleIPActionAllow NetworkRuleIPAction = "Allow"
+)

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/id_namespace.go
@@ -1,0 +1,108 @@
+package networkrulesets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type NamespaceId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Name           string
+}
+
+func NewNamespaceID(subscriptionId, resourceGroup, name string) NamespaceId {
+	return NamespaceId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Name:           name,
+	}
+}
+
+func (id NamespaceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Namespace", segmentsStr)
+}
+
+func (id NamespaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.EventHub/namespaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
+}
+
+// NamespaceID parses a Namespace ID into an NamespaceId struct
+func NamespaceID(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Name, err = id.PopSegment("namespaces"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting to a consistent casing,
+// the NamespaceID method should be used instead for validation etc.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/id_namespace_test.go
@@ -1,0 +1,227 @@
+package networkrulesets
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = NamespaceId{}
+
+func TestNamespaceIDFormatter(t *testing.T) {
+	actual := NewNamespaceID("{subscriptionId}", "{resourceGroupName}", "{namespaceName}").ID()
+	expected := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestNamespaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/{SUBSCRIPTIONID}/RESOURCEGROUPS/{RESOURCEGROUPNAME}/PROVIDERS/MICROSOFT.EVENTHUB/NAMESPACES/{NAMESPACENAME}",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NAMESPACES/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/NaMeSpAcEs/{namespaceName}",
+			Expected: &NamespaceId{
+				SubscriptionId: "{subscriptionId}",
+				ResourceGroup:  "{resourceGroupName}",
+				Name:           "{namespaceName}",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/method_namespacescreateorupdatenetworkruleset_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/method_namespacescreateorupdatenetworkruleset_autorest.go
@@ -1,0 +1,66 @@
+package networkrulesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesCreateOrUpdateNetworkRuleSetResponse struct {
+	HttpResponse *http.Response
+	Model        *NetworkRuleSet
+}
+
+// NamespacesCreateOrUpdateNetworkRuleSet ...
+func (c NetworkRuleSetsClient) NamespacesCreateOrUpdateNetworkRuleSet(ctx context.Context, id NamespaceId, input NetworkRuleSet) (result NamespacesCreateOrUpdateNetworkRuleSetResponse, err error) {
+	req, err := c.preparerForNamespacesCreateOrUpdateNetworkRuleSet(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "networkrulesets.NetworkRuleSetsClient", "NamespacesCreateOrUpdateNetworkRuleSet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "networkrulesets.NetworkRuleSetsClient", "NamespacesCreateOrUpdateNetworkRuleSet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesCreateOrUpdateNetworkRuleSet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "networkrulesets.NetworkRuleSetsClient", "NamespacesCreateOrUpdateNetworkRuleSet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesCreateOrUpdateNetworkRuleSet prepares the NamespacesCreateOrUpdateNetworkRuleSet request.
+func (c NetworkRuleSetsClient) preparerForNamespacesCreateOrUpdateNetworkRuleSet(ctx context.Context, id NamespaceId, input NetworkRuleSet) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/networkRuleSets/default", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesCreateOrUpdateNetworkRuleSet handles the response to the NamespacesCreateOrUpdateNetworkRuleSet request. The method always
+// closes the http.Response Body.
+func (c NetworkRuleSetsClient) responderForNamespacesCreateOrUpdateNetworkRuleSet(resp *http.Response) (result NamespacesCreateOrUpdateNetworkRuleSetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/method_namespacesgetnetworkruleset_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/method_namespacesgetnetworkruleset_autorest.go
@@ -1,0 +1,65 @@
+package networkrulesets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+type NamespacesGetNetworkRuleSetResponse struct {
+	HttpResponse *http.Response
+	Model        *NetworkRuleSet
+}
+
+// NamespacesGetNetworkRuleSet ...
+func (c NetworkRuleSetsClient) NamespacesGetNetworkRuleSet(ctx context.Context, id NamespaceId) (result NamespacesGetNetworkRuleSetResponse, err error) {
+	req, err := c.preparerForNamespacesGetNetworkRuleSet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "networkrulesets.NetworkRuleSetsClient", "NamespacesGetNetworkRuleSet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "networkrulesets.NetworkRuleSetsClient", "NamespacesGetNetworkRuleSet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForNamespacesGetNetworkRuleSet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "networkrulesets.NetworkRuleSetsClient", "NamespacesGetNetworkRuleSet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForNamespacesGetNetworkRuleSet prepares the NamespacesGetNetworkRuleSet request.
+func (c NetworkRuleSetsClient) preparerForNamespacesGetNetworkRuleSet(ctx context.Context, id NamespaceId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/networkRuleSets/default", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForNamespacesGetNetworkRuleSet handles the response to the NamespacesGetNetworkRuleSet request. The method always
+// closes the http.Response Body.
+func (c NetworkRuleSetsClient) responderForNamespacesGetNetworkRuleSet(resp *http.Response) (result NamespacesGetNetworkRuleSetResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	return
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/model_networkruleset.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/model_networkruleset.go
@@ -1,0 +1,8 @@
+package networkrulesets
+
+type NetworkRuleSet struct {
+	Id         *string                   `json:"id,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *NetworkRuleSetProperties `json:"properties,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/model_networkrulesetproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/model_networkrulesetproperties.go
@@ -1,0 +1,8 @@
+package networkrulesets
+
+type NetworkRuleSetProperties struct {
+	DefaultAction               *DefaultAction                  `json:"defaultAction,omitempty"`
+	IpRules                     *[]NWRuleSetIpRules             `json:"ipRules,omitempty"`
+	TrustedServiceAccessEnabled *bool                           `json:"trustedServiceAccessEnabled,omitempty"`
+	VirtualNetworkRules         *[]NWRuleSetVirtualNetworkRules `json:"virtualNetworkRules,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/model_nwrulesetiprules.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/model_nwrulesetiprules.go
@@ -1,0 +1,6 @@
+package networkrulesets
+
+type NWRuleSetIpRules struct {
+	Action *NetworkRuleIPAction `json:"action,omitempty"`
+	IpMask *string              `json:"ipMask,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/model_nwrulesetvirtualnetworkrules.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/model_nwrulesetvirtualnetworkrules.go
@@ -1,0 +1,6 @@
+package networkrulesets
+
+type NWRuleSetVirtualNetworkRules struct {
+	IgnoreMissingVnetServiceEndpoint *bool   `json:"ignoreMissingVnetServiceEndpoint,omitempty"`
+	Subnet                           *Subnet `json:"subnet,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/model_subnet.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/model_subnet.go
@@ -1,0 +1,5 @@
+package networkrulesets
+
+type Subnet struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/networkrulesets/version.go
+++ b/azurerm/internal/services/eventhub/sdk/networkrulesets/version.go
@@ -1,0 +1,9 @@
+package networkrulesets
+
+import "fmt"
+
+const defaultApiVersion = "2018-01-01-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("pandora/networkrulesets/%s", defaultApiVersion)
+}

--- a/azurerm/internal/services/eventhub/transition.go
+++ b/azurerm/internal/services/eventhub/transition.go
@@ -1,0 +1,21 @@
+package eventhub
+
+func expandTags(input map[string]interface{}) *map[string]string {
+	output := make(map[string]string)
+	for k, v := range input {
+		output[k] = v.(string)
+	}
+	return &output
+}
+
+func flattenTags(input *map[string]string) map[string]*string {
+	output := make(map[string]*string)
+
+	if input != nil {
+		for k, v := range *input {
+			output[k] = &v
+		}
+	}
+
+	return output
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.2
-	github.com/hashicorp/go-azure-helpers v0.16.2
+	github.com/hashicorp/go-azure-helpers v0.16.3
 	github.com/hashicorp/go-getter v1.5.3
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-plugin v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/hashicorp/go-azure-helpers v0.10.0/go.mod h1:YuAtHxm2v74s+IjQwUG88dHB
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.16.2 h1:Rr1q+6bkSHbzWqa2EeqaY7u3SOYAgbeOlYlMH8saEHY=
 github.com/hashicorp/go-azure-helpers v0.16.2/go.mod h1:kR7+sTDEb9TOp/O80ss1UEJg1t4/BHLD/U8wHLS4BGQ=
+github.com/hashicorp/go-azure-helpers v0.16.3 h1:zzlT0looBZpG301Rbrxw+yRjGPb90m2ZvERSQq68+pc=
+github.com/hashicorp/go-azure-helpers v0.16.3/go.mod h1:kR7+sTDEb9TOp/O80ss1UEJg1t4/BHLD/U8wHLS4BGQ=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.10.0/go.mod h1:YuAtHxm2v74s+IjQwUG88dHBJPd5jL+cXr5BGVzSKhE=
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
-github.com/hashicorp/go-azure-helpers v0.16.2 h1:Rr1q+6bkSHbzWqa2EeqaY7u3SOYAgbeOlYlMH8saEHY=
-github.com/hashicorp/go-azure-helpers v0.16.2/go.mod h1:kR7+sTDEb9TOp/O80ss1UEJg1t4/BHLD/U8wHLS4BGQ=
 github.com/hashicorp/go-azure-helpers v0.16.3 h1:zzlT0looBZpG301Rbrxw+yRjGPb90m2ZvERSQq68+pc=
 github.com/hashicorp/go-azure-helpers v0.16.3/go.mod h1:kR7+sTDEb9TOp/O80ss1UEJg1t4/BHLD/U8wHLS4BGQ=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/vendor/github.com/hashicorp/go-azure-helpers/polling/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/polling/poller.go
@@ -9,6 +9,9 @@ import (
 )
 
 type LongRunningPoller struct {
+	// HttpResponse is the latest HTTP Response
+	HttpResponse *http.Response
+
 	future *azure.Future
 	ctx    context.Context
 	client autorest.Client
@@ -30,5 +33,7 @@ func NewLongRunningPollerFromResponse(ctx context.Context, resp *http.Response, 
 
 // PollUntilDone polls until this Long Running Poller is completed
 func (fw *LongRunningPoller) PollUntilDone() error {
-	return fw.future.WaitForCompletionRef(fw.ctx, fw.client)
+	err := fw.future.WaitForCompletionRef(fw.ctx, fw.client)
+	fw.HttpResponse = fw.future.Response()
+	return err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -263,7 +263,7 @@ github.com/google/uuid
 github.com/googleapis/gax-go/v2
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.16.2
+# github.com/hashicorp/go-azure-helpers v0.16.3
 ## explicit
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/formatting


### PR DESCRIPTION
Similar to #11959, this PR refactors the `eventhub` package atop a Go SDK generated from [the Azure Rest API Specs](https://github.com/Azure/azure-rest-api-specs) - providing an SDK similar to (and using the same foundation as) [the Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go) with some Terraform specifics built-in.