### PR TITLE
`kubernetes_cluster`: Support for `gateway_name` for Application Gateway add-on

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -175,6 +175,11 @@ func schemaKubernetesAddOnProfiles() *pluginsdk.Schema {
 								ConflictsWith: []string{"addon_profile.0.ingress_application_gateway.0.subnet_cidr", "addon_profile.0.ingress_application_gateway.0.subnet_id"},
 								ValidateFunc:  applicationGatewayValidate.ApplicationGatewayID,
 							},
+							"gateway_name": {
+								Type:         pluginsdk.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
 							"subnet_cidr": {
 								Type:          pluginsdk.TypeString,
 								Optional:      true,
@@ -319,6 +324,10 @@ func expandKubernetesAddOnProfiles(input []interface{}, env azure.Environment) (
 			config["applicationGatewayId"] = utils.String(gatewayId.(string))
 		}
 
+		if gatewayName, ok := value["gateway_name"]; ok && gatewayName != "" {
+			config["applicationGatewayName"] = utils.String(gatewayName.(string))
+		}
+
 		if subnetCIDR, ok := value["subnet_cidr"]; ok && subnetCIDR != "" {
 			config["subnetCIDR"] = utils.String(subnetCIDR.(string))
 		}
@@ -461,6 +470,11 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 			gatewayId = *v
 		}
 
+		gatewayName := ""
+		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "applicationGatewayName"); v != nil {
+			gatewayName = *v
+		}
+
 		effectiveGatewayId := ""
 		if v := kubernetesAddonProfilelocateInConfig(ingressApplicationGateway.Config, "effectiveApplicationGatewayId"); v != nil {
 			effectiveGatewayId = *v
@@ -481,6 +495,7 @@ func flattenKubernetesAddOnProfiles(profile map[string]*containerservice.Managed
 		ingressApplicationGateways = append(ingressApplicationGateways, map[string]interface{}{
 			"enabled":                              enabled,
 			"gateway_id":                           gatewayId,
+			"gateway_name":                         gatewayName,
 			"effective_gateway_id":                 effectiveGatewayId,
 			"subnet_cidr":                          subnetCIDR,
 			"subnet_id":                            subnetId,

--- a/azurerm/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -301,6 +301,7 @@ func testAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR(t
 			Config: r.addonProfileIngressApplicationGatewaySubnetCIDRConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_name").Exists(),
 				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
 				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.subnet_cidr").HasValue(addOnAppGatewaySubnetCIDR),
 			),
@@ -332,6 +333,7 @@ func testAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId(t *
 			Config: r.addonProfileIngressApplicationGatewaySubnetIdConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.gateway_name").Exists(),
 				check.That(data.ResourceName).Key("addon_profile.0.ingress_application_gateway.0.effective_gateway_id").Exists(),
 			),
 		},
@@ -968,8 +970,9 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   addon_profile {
     ingress_application_gateway {
-      enabled     = true
-      subnet_cidr = "%s"
+      enabled      = true
+      gateway_name = "acctestgwn%d"
+      subnet_cidr  = "%s"
     }
     kube_dashboard {
       enabled = false
@@ -980,7 +983,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, addOnAppGatewaySubnetCIDR)
 }
 
 func (KubernetesClusterResource) addonProfileIngressApplicationGatewayDisabledConfig(data acceptance.TestData) string {
@@ -1077,8 +1080,9 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   addon_profile {
     ingress_application_gateway {
-      enabled   = true
-      subnet_id = azurerm_subnet.test.id
+      enabled      = true
+      gateway_name = "acctestgwn%d"
+      subnet_id    = azurerm_subnet.test.id
     }
     kube_dashboard {
       enabled = false
@@ -1089,5 +1093,5 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -452,7 +452,7 @@ An `ingress_application_gateway` block supports the following:
 
 * `gateway_id` - (Optional) The ID of the Application Gateway to integrate with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-existing) page for further details.
 
-* `gateway_name` - (Optional) The name to be used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.
+* `gateway_name` - (Optional) The name of the Application Gateway to be used or created in the Nodepool Resource Group, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.
 
 * `subnet_cidr` - (Optional) The subnet CIDR to be used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -452,6 +452,8 @@ An `ingress_application_gateway` block supports the following:
 
 * `gateway_id` - (Optional) The ID of the Application Gateway to integrate with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-existing) page for further details.
 
+* `gateway_name` - (Optional) The name to be used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.
+
 * `subnet_cidr` - (Optional) The subnet CIDR to be used to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.
 
 * `subnet_id` - (Optional) The ID of the subnet on which to create an Application Gateway, which in turn will be integrated with the ingress controller of this Kubernetes Cluster. See [this](https://docs.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new) page for further details.


### PR DESCRIPTION
fixes #11357

# Acceptance Tests:
```
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR (1046.55s)
--- PASS: TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetId (1065.66s)
```