### PR TITLE
Fix markdown bullet rendered as header

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -546,6 +546,7 @@ A `rewrite_rule` block supports the following:
 * `response_header_configuration` - (Optional) One or more `response_header_configuration` blocks as defined above.
 
 * `url` - (Optional) One `url` block as defined above
+
 ---
 
 A `condition` block supports the following:


### PR DESCRIPTION
Due to the lack of space between the unordered list element `url` and the `---` horizontal line separator, the bullet was rendered as a header in application gateways documentation.

![Screen Shot 2021-05-30 at 14 31 19](https://user-images.githubusercontent.com/34400837/120116140-a388d780-c154-11eb-8257-e29d19d8278e.png)

Adding a space fixes the rendering.