### PR TITLE
Fix `azurerm_application_insights_smart_detection_rule` to support/configure all rules

### DIFF
--- a/azurerm/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
@@ -39,7 +39,6 @@ func resourceApplicationInsightsSmartDetectionRule() *pluginsdk.Resource {
 					/*
 						Acceptable values referred from link below. Cleaner to use the internal name of the rule directly instead of translating UI name to internal name in the code.
 						This will also be simpler to maintain going forward as more rules get added (and when rule names don't match word to word)
-						For backwards compatibility, we can use a flag temporarily to allow UI name.
 
 						https://docs.microsoft.com/en-us/azure/azure-monitor/app/proactive-arm-config#smart-detection-rule-names
 						Azure portal rule name	Internal name
@@ -81,11 +80,6 @@ func resourceApplicationInsightsSmartDetectionRule() *pluginsdk.Resource {
 				Optional: true,
 				Default:  true,
 			},
-			"use_internal_rule_names": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 
 			"send_emails_to_subscription_owners": {
 				Type:     pluginsdk.TypeBool,
@@ -109,12 +103,6 @@ func resourceApplicationInsightsSmartDetectionRuleUpdate(d *pluginsdk.ResourceDa
 
 	log.Printf("[INFO] preparing arguments for AzureRM Application Insights Samrt Detection Rule update.")
 	name := d.Get("name").(string)
-	if !(d.Get("use_internal_rule_names").(bool)) {
-		// if not use_internal_name, then convert the rule name from UI name to internal name
-		// The Smart Detection Rule name from the UI doesn't match what the API accepts.
-		// We'll have the user submit what the name looks like in the UI and trim it behind the scenes to match what the API accepts
-		name = strings.ToLower(strings.Join(strings.Split(name, " "), ""))
-	}
 	appInsightsID := d.Get("application_insights_id").(string)
 
 	id, err := parse.ComponentID(appInsightsID)
@@ -210,6 +198,7 @@ func resourceApplicationInsightsSmartDetectionRuleDelete(d *pluginsdk.ResourceDa
 	return nil
 }
 
+// Update: We should move towards using internal rule name. The below comment will be obsolete soon.
 // The Smart Detection Rule name from the UI doesn't match what the API accepts.
 // This Diff checks that the name UI name matches the API name when spaces are removed
 func smartDetectionRuleNameDiff(_, old string, new string, _ *pluginsdk.ResourceData) bool {

--- a/azurerm/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/applicationinsights/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -32,39 +31,9 @@ func resourceApplicationInsightsSmartDetectionRule() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					/*
-						Acceptable values referred from link below. Cleaner to use the internal name of the rule directly instead of translating UI name to internal name in the code.
-						This will also be simpler to maintain going forward as more rules get added (and when rule names don't match word to word)
-
-						https://docs.microsoft.com/en-us/azure/azure-monitor/app/proactive-arm-config#smart-detection-rule-names
-						Azure portal rule name	Internal name
-						---------------------- <> ---------------
-						Slow page load time	slowpageloadtime
-						Slow server response time	slowserverresponsetime
-						Long dependency duration	longdependencyduration
-						Degradation in server response time	degradationinserverresponsetime
-						Degradation in dependency duration	degradationindependencyduration
-						Degradation in trace severity ratio (preview)	extension_traceseveritydetector
-						Abnormal rise in exception volume (preview)	extension_exceptionchangeextension
-						Potential memory leak detected (preview)	extension_memoryleakextension
-						Potential security issue detected (preview)	extension_securityextensionspackage
-						Abnormal rise in daily data volume (preview)	extension_billingdatavolumedailyspikeextension
-					*/
-					"slowpageloadtime",
-					"slowserverresponsetime",
-					"longdependencyduration",
-					"degradationinserverresponsetime",
-					"degradationindependencyduration",
-					"extension_traceseveritydetector",
-					"extension_exceptionchangeextension",
-					"extension_memoryleakextension",
-					"extension_securityextensionspackage",
-					"extension_billingdatavolumedailyspikeextension",
-				}, false),
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
 				DiffSuppressFunc: smartDetectionRuleNameDiff,
 			},
 
@@ -102,7 +71,7 @@ func resourceApplicationInsightsSmartDetectionRuleUpdate(d *pluginsdk.ResourceDa
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for AzureRM Application Insights Samrt Detection Rule update.")
-	name := d.Get("name").(string)
+	name := strings.Join(strings.Split(strings.ToLower(d.Get("name").(string)), " "), "")
 	appInsightsID := d.Get("application_insights_id").(string)
 
 	id, err := parse.ComponentID(appInsightsID)

--- a/azurerm/internal/services/applicationinsights/application_insights_smart_detection_rule_resource_test.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_smart_detection_rule_resource_test.go
@@ -86,6 +86,34 @@ func TestAccApplicationInsightsSmartDetectionRule_longDependencyDuration(t *test
 	})
 }
 
+func TestAccApplicationInsightsSmartDetectionRule_degradationinserverresponsetime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_smart_detection_rule", "test")
+	r := AppInsightsSmartDetectionRule{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.degradationinserverresponsetime(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAccApplicationInsightsSmartDetectionRule_degradationindependencyduration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_smart_detection_rule", "test")
+	r := AppInsightsSmartDetectionRule{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.degradationindependencyduration(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (t AppInsightsSmartDetectionRule) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SmartDetectionRuleID(state.Attributes["id"])
 	if err != nil {
@@ -119,7 +147,7 @@ resource "azurerm_application_insights" "test" {
 }
 
 resource "azurerm_application_insights_smart_detection_rule" "test" {
-  name                    = "Slow page load time"
+  name                    = "slowpageloadtime"
   application_insights_id = azurerm_application_insights.test.id
   enabled                 = false
 }
@@ -145,7 +173,7 @@ resource "azurerm_application_insights" "test" {
 }
 
 resource "azurerm_application_insights_smart_detection_rule" "test" {
-  name                    = "Slow page load time"
+  name                    = "slowpageloadtime"
   application_insights_id = azurerm_application_insights.test.id
   enabled                 = false
 
@@ -174,13 +202,13 @@ resource "azurerm_application_insights" "test" {
 }
 
 resource "azurerm_application_insights_smart_detection_rule" "test" {
-  name                    = "Slow page load time"
+  name                    = "slowpageloadtime"
   application_insights_id = azurerm_application_insights.test.id
   enabled                 = false
 }
 
 resource "azurerm_application_insights_smart_detection_rule" "test2" {
-  name                    = "Slow server response time"
+  name                    = "slowserverresponsetime"
   application_insights_id = azurerm_application_insights.test.id
   enabled                 = false
 }
@@ -206,7 +234,59 @@ resource "azurerm_application_insights" "test" {
 }
 
 resource "azurerm_application_insights_smart_detection_rule" "test" {
-  name                    = "Long dependency duration"
+  name                    = "longdependencyduration"
+  application_insights_id = azurerm_application_insights.test.id
+  enabled                 = false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (AppInsightsSmartDetectionRule) degradationinserverresponsetime(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_smart_detection_rule" "test" {
+  name                    = "degradationinserverresponsetime"
+  application_insights_id = azurerm_application_insights.test.id
+  enabled                 = false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (AppInsightsSmartDetectionRule) degradationindependencyduration(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_smart_detection_rule" "test" {
+  name                    = "degradationindependencyduration"
   application_insights_id = azurerm_application_insights.test.id
   enabled                 = false
 }

--- a/website/docs/r/application_insights_smart_detection_rule.html.markdown
+++ b/website/docs/r/application_insights_smart_detection_rule.html.markdown
@@ -25,10 +25,17 @@ resource "azurerm_application_insights" "example" {
   application_type    = "web"
 }
 
-resource "azurerm_application_insights_smart_detection_rule" "example" {
-  name                    = "Slow server response time"
+resource "azurerm_application_insights_smart_detection_rule" "example_rule_1" {
+  name                    = "slowserverresponsetime"
   application_insights_id = azurerm_application_insights.example.id
   enabled                 = false
+}
+
+resource "azurerm_application_insights_smart_detection_rule" "example_rule_2" {
+  name                               = "degradationindependencyduration"
+  application_insights_id            = azurerm_application_insights.example.id
+  enabled                            = true
+  send_emails_to_subscription_owners = false
 }
 ```
 
@@ -36,8 +43,7 @@ resource "azurerm_application_insights_smart_detection_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Application Insights Smart Detection Rule. Valid values include `Slow page load time`, `Slow server response time`, 
-`Long dependency duration`.  Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Application Insights Smart Detection Rule. This rule name should refer to the internal rule name specified in the azure docs [here](https://docs.microsoft.com/en-us/azure/azure-monitor/app/proactive-arm-config#smart-detection-rule-names). Changing this forces a new resource to be created.
 
 * `application_insights_id` - (Required) The ID of the Application Insights component on which the Smart Detection Rule operates. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Addresses the issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/11999  

In the smart detection resource, there is currently a validation(which has become a restriction) – that accepts only a set of rule names – that is hindering support for new rules as and when they become available.  This also requires us to update our code every time a rule name is added/updated/deleted by microsoft. 

To simplify this, I propose to remove this restriction so that users can reference [microsoft docs](https://docs.microsoft.com/en-us/azure/azure-monitor/app/proactive-arm-config#smart-detection-rule-names) and pass the internal rule name as required. This will also decouple our code from Microsoft's updates to old/new rules/names. 