### PR TITLE
Add sensitive to instrumentation_key docs

### DIFF
--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -68,7 +68,7 @@ The following attributes are exported:
 
 * `app_id` - The App ID associated with this Application Insights component.
 
-* `instrumentation_key` - The Instrumentation Key for this Application Insights component.
+* `instrumentation_key` - The Instrumentation Key for this Application Insights component. (Sensitive)
 
 * `connection_string` - The Connection String for this Application Insights component. (Sensitive)
 


### PR DESCRIPTION
instrumentation_key is marked sensitive in the code (https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/internal/services/applicationinsights/application_insights_resource.go#L119), add this to the documentation.