### PR TITLE
r/azurerm_api_management_api_subscription: support for `api_id`

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -64,10 +64,19 @@ func resourceApiManagementSubscription() *pluginsdk.Resource {
 
 			// TODO this now sets the scope property - either a scope block needs adding or additional properties `api_id` and maybe `all_apis`
 			"product_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.ProductID,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.ProductID,
+				ConflictsWith: []string{"api_id"},
+			},
+
+			"api_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validate.ApiID,
+				ConflictsWith: []string{"product_id"},
 			},
 
 			"state": {
@@ -138,14 +147,24 @@ func resourceApiManagementSubscriptionCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	displayName := d.Get("display_name").(string)
-	productId := d.Get("product_id").(string)
+	productId, productSet := d.GetOk("product_id")
+	apiId, apiSet := d.GetOk("api_id")
 	state := d.Get("state").(string)
 	allowTracing := d.Get("allow_tracing").(bool)
+
+	var scope string
+	if productSet {
+		scope = productId.(string)
+	} else if apiSet {
+		scope = apiId.(string)
+	} else {
+		scope = "all_apis"
+	}
 
 	params := apimanagement.SubscriptionCreateParameters{
 		SubscriptionCreateParameterProperties: &apimanagement.SubscriptionCreateParameterProperties{
 			DisplayName:  utils.String(displayName),
-			Scope:        utils.String(productId),
+			Scope:        utils.String(scope),
 			State:        apimanagement.SubscriptionState(state),
 			AllowTracing: utils.Bool(allowTracing),
 		},
@@ -207,14 +226,22 @@ func resourceApiManagementSubscriptionRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("display_name", props.DisplayName)
 		d.Set("state", string(props.State))
 		productId := ""
+		apiId := ""
 		if *props.Scope != "" {
+			// the scope is either a product or api id or "all_apis" constant
 			parseId, err := parse.ProductID(*props.Scope)
-			if err != nil {
-				return fmt.Errorf("parsing product id %q: %+v", *props.Scope, err)
+			if err == nil {
+				productId = parseId.ID()
+			} else {
+				parsedApiId, err := parse.ApiID(*props.Scope)
+				if err != nil {
+					return fmt.Errorf("parsing scope into product/ api id %q: %+v", *props.Scope, err)
+				}
+				apiId = parsedApiId.ID()
 			}
-			productId = parseId.ID()
 		}
 		d.Set("product_id", productId)
+		d.Set("api_id", apiId)
 		d.Set("user_id", props.OwnerID)
 		d.Set("allow_tracing", props.AllowTracing)
 	}

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -62,7 +62,6 @@ func resourceApiManagementSubscription() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			// TODO this now sets the scope property - either a scope block needs adding or additional properties `api_id` and maybe `all_apis`
 			"product_id": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -153,11 +153,12 @@ func resourceApiManagementSubscriptionCreateUpdate(d *pluginsdk.ResourceData, me
 	allowTracing := d.Get("allow_tracing").(bool)
 
 	var scope string
-	if productSet {
+	switch {
+	case productSet:
 		scope = productId.(string)
-	} else if apiSet {
+	case apiSet:
 		scope = apiId.(string)
-	} else {
+	default:
 		scope = "all_apis"
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -256,9 +256,9 @@ func (ApiManagementSubscriptionResource) withApiId(data acceptance.TestData) str
 %s
 
 resource "azurerm_api_management_api" "test" {
-  name                  = "TestApi"
-  resource_group_name   = azurerm_api_management.test.resource_group_name
-  api_management_name   = azurerm_api_management.test.name
+  name                = "TestApi"
+  resource_group_name = azurerm_api_management.test.resource_group_name
+  api_management_name = azurerm_api_management.test.name
   revision            = "1"
   protocols           = ["https"]
   display_name        = "Test API"

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -141,6 +141,24 @@ func TestAccApiManagementSubscription_withoutUser(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementSubscription_withApiId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
+	r := ApiManagementSubscriptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withApiId(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("api_id").Exists(),
+				check.That(data.ResourceName).Key("product_id").HasValue(""),
+				check.That(data.ResourceName).Key("user_id").HasValue(""),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ApiManagementSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SubscriptionID(state.ID)
 	if err != nil {
@@ -230,6 +248,31 @@ resource "azurerm_api_management_subscription" "test" {
   allow_tracing       = false
 }
 `, r.template(data))
+}
+
+func (ApiManagementSubscriptionResource) withApiId(data acceptance.TestData) string {
+	template := ApiManagementSubscriptionResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                  = "Test Api"
+  resource_group_name   = azurerm_api_management.test.resource_group_name
+  api_management_name   = azurerm_api_management.test.name
+  revision            = "1"
+  protocols           = ["https"]
+  display_name        = "Test API"
+  path                = "test"
+}
+
+resource "azurerm_api_management_subscription" "test" {
+  resource_group_name = azurerm_api_management.test.resource_group_name
+  api_management_name = azurerm_api_management.test.name
+  user_id             = azurerm_api_management_user.test.id
+  api_id              = azurerm_api_management_api.test.id
+  display_name        = "Butter Parser API Enterprise Edition"
+}
+`, template)
 }
 
 func (ApiManagementSubscriptionResource) template(data acceptance.TestData) string {

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -256,7 +256,7 @@ func (ApiManagementSubscriptionResource) withApiId(data acceptance.TestData) str
 %s
 
 resource "azurerm_api_management_api" "test" {
-  name                  = "Test Api"
+  name                  = "TestApi"
   resource_group_name   = azurerm_api_management.test.resource_group_name
   api_management_name   = azurerm_api_management.test.name
   revision            = "1"
@@ -268,7 +268,6 @@ resource "azurerm_api_management_api" "test" {
 resource "azurerm_api_management_subscription" "test" {
   resource_group_name = azurerm_api_management.test.resource_group_name
   api_management_name = azurerm_api_management.test.name
-  user_id             = azurerm_api_management_user.test.id
   api_id              = azurerm_api_management_api.test.id
   display_name        = "Butter Parser API Enterprise Edition"
 }

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -51,9 +51,15 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new resource to be created.
 
-* `product_id` - (Required) The ID of the Product which should be assigned to this Subscription. Changing this forces a new resource to be created.
+* `product_id` - (Optional) The ID of the Product which should be assigned to this Subscription. Changing this forces a new resource to be created.
+
+-> **Info:** Only one of `product_id` and `api_id` can be set. If both are missing `all_apis` scope is used for the subscription.
 
 * `user_id` - (Optional) The ID of the User which should be assigned to this Subscription. Changing this forces a new resource to be created.
+
+* `api_id` - (Optional) The ID of the API which should be assigned to this Subscription. Changing this forces a new resource to be created.
+
+-> **Info:** Only one of `product_id` and `api_id` can be set. If both are missing `all_apis` scope is used for the subscription.
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/12016 .

Enables the configuration of subscriptions per API. 

The test passed:
```
make testacc TEST='./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go' TESTARGS='-run=TestAccApiManagementSubscription_withApiId' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go -v -run=TestAccApiManagementSubscription_withApiId -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/06/01 13:25:25 [DEBUG] not using binary driver name, it's no longer needed
2021/06/01 13:25:26 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccApiManagementSubscription_withApiId
=== PAUSE TestAccApiManagementSubscription_withApiId
=== CONT  TestAccApiManagementSubscription_withApiId
--- PASS: TestAccApiManagementSubscription_withApiId (2670.30s)
PASS
ok      command-line-arguments  2672.300s
```

The `scope` attribute must be parsed to check if the scope is for a product, an api or for all apis. Probably the code can be  better for the differentiation.

At the moment I assume the subscription is for all apis if neither product nor api id are configured.