### PR TITLE
azurerm_app_service_environment - support for `internal_ip_address`, `service_ip_address`, `outbound_ip_addresses`

### DIFF
--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -92,7 +92,13 @@ A `cluster_setting` block supports the following:
 
 * `id` - The ID of the App Service Environment.
 
+* `internal_ip_address` - IP address of internal load balancer of the App Service Environment.
+
 * `location` - The location where the App Service Environment exists.
+
+* `outbound_ip_addresses` - List of outbound IP addresses of the App Service Environment.
+
+* `service_ip_address` - IP address of service endpoint of the App Service Environment.
 
 ## Timeouts
 


### PR DESCRIPTION
#8179

Return the VipInfo for the ASE on create.  This is required for configuration of external Azure resources (e.g. App Gateway WAF).  Using the data provider will cause failures if the resource doesn't exist.  This is the preferred solution.