### PR TITLE
`azurerm_kubernetes_cluster`: Support update of `azure_rbac_enabled`

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_auth_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_auth_resource_test.go
@@ -305,6 +305,7 @@ func testAccKubernetesCluster_roleBasedAccessControlAADManagedChange(t *testing.
 				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.#").HasValue("1"),
 				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.tenant_id").Exists(),
 				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.managed").Exists(),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.azure_rbac_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("kube_admin_config.#").HasValue("1"),
 				check.That(data.ResourceName).Key("kube_admin_config_raw").Exists(),
 				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
@@ -337,6 +338,24 @@ func testAccKubernetesCluster_roleBasedAccessControlAzure(t *testing.T) {
 	clientData := data.Client()
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleBasedAccessControlAADManagedConfig(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_based_access_control.#").HasValue("1"),
+				check.That(data.ResourceName).Key("role_based_access_control.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.#").HasValue("1"),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.tenant_id").Exists(),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.managed").Exists(),
+				check.That(data.ResourceName).Key("role_based_access_control.0.azure_active_directory.0.azure_rbac_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("kube_admin_config.#").HasValue("1"),
+				check.That(data.ResourceName).Key("kube_admin_config_raw").Exists(),
+				check.That(data.ResourceName).Key("default_node_pool.0.node_count").HasValue("1"),
+			),
+		},
+		data.ImportStep(
+			"role_based_access_control.0.azure_active_directory.0.server_app_secret",
+		),
 		{
 			Config: r.roleBasedAccessControlAzureConfig(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -746,8 +765,9 @@ resource "azurerm_kubernetes_cluster" "test" {
     enabled = true
 
     azure_active_directory {
-      tenant_id = var.tenant_id
-      managed   = true
+      tenant_id          = var.tenant_id
+      managed            = true
+      azure_rbac_enabled = false
     }
   }
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -592,9 +592,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 									"azure_rbac_enabled": {
 										Type:     pluginsdk.TypeBool,
 										Optional: true,
-										// ForceNew can be removed after GA:
-										// https://docs.microsoft.com/en-us/azure/aks/manage-azure-rbac#limitations
-										ForceNew: true,
 									},
 
 									"admin_group_object_ids": {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -269,7 +269,7 @@ When `managed` is set to `true` the following properties can be specified:
 
 * `admin_group_object_ids` - (Optional) A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster.
 
-* `azure_rbac_enabled` - (Optional) Is Role Based Access Control based on Azure AD enabled? Changing this forces a new resource to be created.
+* `azure_rbac_enabled` - (Optional) Is Role Based Access Control based on Azure AD enabled?
 
 ~> **Note:** Azure AD based RBAC is in Public Preview - more information and details on how to opt into the Preview [can be found in this article](https://docs.microsoft.com/en-us/azure/aks/manage-azure-rbac).
 


### PR DESCRIPTION
Remove ForceNew from `azure_rbac_enabled` as feature is GA.

## Acceptance Tests
```bash
❯ make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_roleBasedAccessControlAzure'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/containers -run=TestAccKubernetesCluster_roleBasedAccessControlAzure -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/06/01 12:51:01 [DEBUG] not using binary driver name, it's no longer needed
2021/06/01 12:51:03 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccKubernetesCluster_roleBasedAccessControlAzure
=== PAUSE TestAccKubernetesCluster_roleBasedAccessControlAzure
=== CONT  TestAccKubernetesCluster_roleBasedAccessControlAzure
--- PASS: TestAccKubernetesCluster_roleBasedAccessControlAzure (1354.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers     1358.813s
```