### PR TITLE
Migrate most GitHub HashiBot behaviors to GitHub Actions

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -1,0 +1,4 @@
+bug:
+  - 'panic:'
+crash:
+  - 'panic:'

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - go.mod
+  - go.sum
+  - vendor/**/*
+documentation:
+  - website/**/*

--- a/.github/workflows/issue-comment-created.yaml
+++ b/.github/workflows/issue-comment-created.yaml
@@ -1,0 +1,15 @@
+name: Issue Comment Created Triage
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_comment_triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            stale
+            waiting-reply

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -1,0 +1,15 @@
+name: Issue Opened Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  issue_triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: github/issue-labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,12 @@
+name: "Pull Request Triage"
+
+on: [pull_request_target]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        configuration-path: .github/labeler-pull-request-triage.yml
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -11,3 +11,33 @@ queued_behavior "release_commenter" "releases" {
     ```
   EOF
 }
+
+behavior "pull_request_size_labeler" "size" {
+    label_prefix = "size/"
+    label_map = {
+        "size/XS" = {
+            from = 0
+            to = 30
+        }
+        "size/S" = {
+            from = 31
+            to = 60
+        }
+        "size/M" = {
+            from = 61
+            to = 150
+        }
+        "size/L" = {
+            from = 151
+            to = 300
+        }
+        "size/XL" = {
+            from = 301
+            to = 1000
+        }
+        "size/XXL" = {
+            from = 1001
+            to = 0
+        }
+    }
+}


### PR DESCRIPTION
Reference: https://github.com/terraform-providers/.hashibot/blob/master/.hashibot.hcl

The `terraform-providers` organization-level configuration for these behaviors will be removed after this repository change. The `pull_request_size_labeler` and `release_commenter` behaviors will be handled in later changes.