### PR TITLE
Add support for status property of azurerm_eventhub

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_resource.go
@@ -147,6 +147,7 @@ func resourceEventHub() *pluginsdk.Resource {
 			"status": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
+				Default:  string(eventhubs.EntityStatusActive),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(eventhubs.EntityStatusActive),
 					string(eventhubs.EntityStatusCreating),

--- a/azurerm/internal/services/eventhub/eventhub_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_resource.go
@@ -150,14 +150,8 @@ func resourceEventHub() *pluginsdk.Resource {
 				Default:  string(eventhubs.EntityStatusActive),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(eventhubs.EntityStatusActive),
-					string(eventhubs.EntityStatusCreating),
-					string(eventhubs.EntityStatusDeleting),
 					string(eventhubs.EntityStatusDisabled),
-					string(eventhubs.EntityStatusReceiveDisabled),
-					string(eventhubs.EntityStatusRenaming),
-					string(eventhubs.EntityStatusRestoring),
 					string(eventhubs.EntityStatusSendDisabled),
-					string(eventhubs.EntityStatusUnknown),
 				}, false),
 			},
 

--- a/azurerm/internal/services/eventhub/eventhub_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_resource.go
@@ -190,17 +190,14 @@ func resourceEventHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	partitionCount := int64(d.Get("partition_count").(int))
 	messageRetention := int64(d.Get("message_retention").(int))
+	eventhubStatus := eventhubs.EntityStatus(d.Get("status").(string))
 
 	parameters := eventhubs.Eventhub{
 		Properties: &eventhubs.EventhubProperties{
 			PartitionCount:         &partitionCount,
 			MessageRetentionInDays: &messageRetention,
+			Status:                 &eventhubStatus,
 		},
-	}
-
-	if v, ok := d.GetOk("status"); ok {
-		eventhubStatus := eventhubs.EntityStatus(v.(string))
-		parameters.Properties.Status = &eventhubStatus
 	}
 
 	if _, ok := d.GetOk("capture_description"); ok {
@@ -244,10 +241,7 @@ func resourceEventHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("partition_count", props.PartitionCount)
 			d.Set("message_retention", props.MessageRetentionInDays)
 			d.Set("partition_ids", props.PartitionIds)
-
-			if eventhubStatus := props.Status; eventhubStatus != nil {
-				d.Set("status", eventhubStatus)
-			}
+			d.Set("status", props.Status)
 
 			captureDescription := flattenEventHubCaptureDescription(props.CaptureDescription)
 			if err := d.Set("capture_description", captureDescription); err != nil {

--- a/azurerm/internal/services/eventhub/eventhub_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_resource.go
@@ -241,7 +241,7 @@ func resourceEventHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("partition_count", props.PartitionCount)
 			d.Set("message_retention", props.MessageRetentionInDays)
 			d.Set("partition_ids", props.PartitionIds)
-			d.Set("status", props.Status)
+			d.Set("status", string(*props.Status))
 
 			captureDescription := flattenEventHubCaptureDescription(props.CaptureDescription)
 			if err := d.Set("capture_description", captureDescription); err != nil {

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `capture_description` - (Optional) A `capture_description` block as defined below.
 
-* `status` - (Optional) Specifies the status of the Event Hub resource. Possible values are `Active`, `Creating`, `Deleting`, `Disabled`, `ReceiveDisabled`, `Renaming`, `Restoring`, `SendDisabled` and `Unknown`. Defaults to `Active`.
+* `status` - (Optional) Specifies the status of the Event Hub resource. Possible values are `Active`, `Disabled` and `SendDisabled`. Defaults to `Active`.
 
 ---
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `capture_description` - (Optional) A `capture_description` block as defined below.
 
-* `status` - (Optional) Specifies the status of the Event Hub resource.
+* `status` - (Optional) Specifies the status of the Event Hub resource. Possible values are `Active`, `Creating`, `Deleting`, `Disabled`, `ReceiveDisabled`, `Renaming`, `Restoring`, `SendDisabled` and `Unknown`. Defaults to `Active`.
 
 ---
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub"
 description: |-
-  Manages a Event Hubs as a nested resource within an Event Hubs namespace.
+Manages a Event Hubs as a nested resource within an Event Hubs namespace.
 ---
 
 # azurerm_eventhub
@@ -58,6 +58,8 @@ The following arguments are supported:
 ~> **Note:** When using a dedicated Event Hubs cluster, maximum value of `message_retention` is 90 days. When using a shared parent EventHub Namespace, maximum value is 7 days; or 1 day when using a Basic SKU for the shared parent EventHub Namespace.
 
 * `capture_description` - (Optional) A `capture_description` block as defined below.
+
+* `status` - (Optional) Specifies the status of the Event Hub resource.
 
 ---
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub"
 description: |-
-Manages a Event Hubs as a nested resource within an Event Hubs namespace.
+  Manages a Event Hubs as a nested resource within an Event Hubs namespace.
 ---
 
 # azurerm_eventhub


### PR DESCRIPTION
Currently azurerm_eventhub doesn't support to set event hub status. So I submitted this PR to implement it.

--- PASS: TestAccEventHub_standard (306.97s)
--- PASS: TestAccEventHub_basic (370.29s)
--- PASS: TestAccEventHub_requiresImport (396.79s)
--- PASS: TestAccEventHub_basicOnePartition (415.47s)
--- PASS: TestAccEventHub_eventhubStatus (426.89s)
--- PASS: TestAccEventHub_messageRetentionUpdate (433.99s)
--- PASS: TestAccEventHub_captureDescription (437.25s)
--- PASS: TestAccEventHub_partitionCountUpdate (500.02s)
--- PASS: TestAccEventHub_captureDescriptionDisabled (529.67s)

API spec:
https://github.com/Azure/azure-rest-api-specs/blob/916568aafe943c0be88e7f845d38de5f189d4b68/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2021-01-01-preview/eventhubs.json#L310

