### PR TITLE
Support azurerm_resource_groups data source

### DIFF
--- a/azurerm/internal/services/resource/data_source_resource_groups.go
+++ b/azurerm/internal/services/resource/data_source_resource_groups.go
@@ -1,0 +1,108 @@
+package resource
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+)
+
+func dataSourceResourceGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceResourceGroupsRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"location": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subscription_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": tags.SchemaDataSource(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceResourceGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*clients.Client)
+	rgClient := armClient.Resource.GroupsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	// ListComplete returns an iterator struct
+	top := int32(0)
+	results, err := rgClient.ListComplete(ctx, "", &top)
+	if err != nil {
+		return fmt.Errorf("listing subscriptions: %+v", err)
+	}
+
+	// iterate across each subscriptions and append them to slice
+	resource_groups := make([]map[string]interface{}, 0)
+	for results.NotDone() {
+		val := results.Value()
+
+		rg := make(map[string]interface{})
+
+		if v := val.ID; v != nil {
+			rg["id"] = *v
+		}
+		if v := val.Name; v != nil {
+			rg["name"] = *v
+		}
+		if v := val.Type; v != nil {
+			rg["type"] = *v
+		}
+		if v := val.Location; v != nil {
+			rg["location"] = *v
+		}
+
+		if err = results.Next(); err != nil {
+			return fmt.Errorf("going to next subscriptions value: %+v", err)
+		}
+
+		rg["tags"] = tags.Flatten(val.Tags)
+
+		resource_groups = append(resource_groups, rg)
+	}
+
+	d.SetId("resource_groups-" + armClient.Account.TenantId)
+	if err = d.Set("resource_groups", resource_groups); err != nil {
+		return fmt.Errorf("setting `resource_groups`: %+v", err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/resource/data_source_resource_groups_test.go
+++ b/azurerm/internal/services/resource/data_source_resource_groups_test.go
@@ -1,0 +1,36 @@
+package resource_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type ResourceGroupsDataSource struct{}
+
+func TestAccDataSourceResourceGroups_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_resource_groups", "current")
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: ResourceGroupsDataSource{}.basic(),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("resource_groups.0.id").Exists(),
+				check.That(data.ResourceName).Key("resource_groups.0.subscription_id").Exists(),
+				check.That(data.ResourceName).Key("resource_groups.0.tenant_id").Exists(),
+			),
+		},
+	})
+}
+
+func (d ResourceGroupsDataSource) basic() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_resource_groups" "current" {}
+`
+}


### PR DESCRIPTION
- [ ] Support for `tenant_id` and `subscription_id` has to be added
- [ ] Tests should be run once
- [ ] data source has to be registered