### PR TITLE
`monitor_autoscale_setting.html.markdown` - mark `rule` block optional

### DIFF
--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -293,7 +293,7 @@ A `profile` block supports the following:
 
 * `capacity` - (Required) A `capacity` block as defined below.
 
-* `rule` - (Required) One or more (up to 10) `rule` blocks as defined below.
+* `rule` - (Optional) One or more (up to 10) `rule` blocks as defined below.
 
 * `fixed_date` - (Optional) A `fixed_date` block as defined below. This cannot be specified if a `recurrence` block is specified.
 


### PR DESCRIPTION
The `rule` block in `monitor_autoscale_setting` is marked as optional in the code, but the documentation says otherwise. Fixing documentation to indicate that the rule block is optional. 

https://github.com/terraform-providers/terraform-provider-azurerm/blob/96dd941637212efeb9ef17c2f5f569e9503872ac/azurerm/internal/services/monitor/monitor_autoscale_setting_resource.go#L102

Fixes #3870