### PR TITLE
fix spelling of compatibility in GitHub workflows

### DIFF
--- a/.github/workflows/thirty-two-bit.yaml
+++ b/.github/workflows/thirty-two-bit.yaml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/**'
 
 jobs:
-  compatability-32bit-test:
+  compatibility-32bit-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
fix spelling mistake: compatability -> compatibility.