### PR TITLE
`azurerm_role_assignment`: Fix assignments to resources

### DIFF
--- a/azurerm/helpers/azure/resourceid.go
+++ b/azurerm/helpers/azure/resourceid.go
@@ -11,10 +11,11 @@ import (
 // level fields, and other key-value pairs available via a map in the
 // Path field.
 type ResourceID struct {
-	SubscriptionID string
-	ResourceGroup  string
-	Provider       string
-	Path           map[string]string
+	SubscriptionID    string
+	ResourceGroup     string
+	Provider          string
+	SecondaryProvider string
+	Path              map[string]string
 }
 
 // ParseAzureResourceID converts a long-form Azure Resource Manager ID
@@ -90,6 +91,11 @@ func ParseAzureResourceID(id string) (*ResourceID, error) {
 
 	if provider != "" {
 		idObj.Provider = provider
+	}
+
+	if secondaryProvider := componentMap["providers"]; secondaryProvider != "" {
+		idObj.SecondaryProvider = secondaryProvider
+		delete(componentMap, "providers")
 	}
 
 	return idObj, nil

--- a/azurerm/helpers/azure/resourceid_test.go
+++ b/azurerm/helpers/azure/resourceid_test.go
@@ -148,6 +148,20 @@ func TestParseAzureResourceID(t *testing.T) {
 			false,
 		},
 		{
+			"/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/example-resources/providers/Microsoft.Storage/storageAccounts/nameStorageAccount/providers/Microsoft.Authorization/roleAssignments/22222222-2222-2222-2222-222222222222",
+			&azure.ResourceID{
+				SubscriptionID:    "11111111-1111-1111-1111-111111111111",
+				ResourceGroup:     "example-resources",
+				Provider:          "Microsoft.Storage",
+				SecondaryProvider: "Microsoft.Authorization",
+				Path: map[string]string{
+					"storageAccounts": "nameStorageAccount",
+					"roleAssignments": "22222222-2222-2222-2222-222222222222",
+				},
+			},
+			false,
+		},
+		{
 			// missing resource group
 			"/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.ApiManagement/service/service1/subscriptions/22222222-2222-2222-2222-222222222222",
 			&azure.ResourceID{

--- a/azurerm/internal/services/authorization/parse/role_assignment.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment.go
@@ -8,14 +8,16 @@ import (
 )
 
 type RoleAssignmentId struct {
-	SubscriptionID  string
-	ResourceGroup   string
-	ManagementGroup string
-	Name            string
-	TenantId        string
+	SubscriptionID   string
+	ResourceGroup    string
+	ManagementGroup  string
+	ResourceScope    string
+	ResourceProvider string
+	Name             string
+	TenantId         string
 }
 
-func NewRoleAssignmentID(subscriptionId, resourceGroup, managementGroup, name, tenantId string) (*RoleAssignmentId, error) {
+func NewRoleAssignmentID(subscriptionId, resourceGroup, resourceProvider, resourceScope, managementGroup, name, tenantId string) (*RoleAssignmentId, error) {
 	if subscriptionId == "" && resourceGroup == "" && managementGroup == "" {
 		return nil, fmt.Errorf("one of subscriptionId, resourceGroup, or managementGroup must be provided")
 	}
@@ -33,17 +35,24 @@ func NewRoleAssignmentID(subscriptionId, resourceGroup, managementGroup, name, t
 	}
 
 	return &RoleAssignmentId{
-		SubscriptionID:  subscriptionId,
-		ResourceGroup:   resourceGroup,
-		ManagementGroup: managementGroup,
-		Name:            name,
-		TenantId:        tenantId,
+		SubscriptionID:   subscriptionId,
+		ResourceGroup:    resourceGroup,
+		ResourceProvider: resourceProvider,
+		ResourceScope:    resourceScope,
+		ManagementGroup:  managementGroup,
+		Name:             name,
+		TenantId:         tenantId,
 	}, nil
 }
 
 // in general case, the id format does not change
 // for cross tenant scenario, add the tenantId info
 func (id RoleAssignmentId) AzureResourceID() string {
+	if id.ResourceScope != "" {
+		fmtString := "/subscriptions/%s/resourceGroups/%s/providers/%s/%s/providers/Microsoft.Authorization/roleAssignments/%s"
+		return fmt.Sprintf(fmtString, id.SubscriptionID, id.ResourceGroup, id.ResourceProvider, id.ResourceScope, id.Name)
+	}
+
 	if id.ManagementGroup != "" {
 		fmtString := "/providers/Microsoft.Management/managementGroups/%s/providers/Microsoft.Authorization/roleAssignments/%s"
 		return fmt.Sprintf(fmtString, id.ManagementGroup, id.Name)
@@ -90,6 +99,17 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 		}
 		roleAssignmentId.SubscriptionID = id.SubscriptionID
 		roleAssignmentId.ResourceGroup = id.ResourceGroup
+		if id.Provider != "Microsoft.Authorization" && id.Provider != "" {
+			roleAssignmentId.ResourceProvider = id.Provider
+			// logic to save resource scope
+			result := strings.Split(input, "/")
+			for k, v := range result {
+				if v == id.Provider && len(result) >= k+1 {
+					roleAssignmentId.ResourceScope = fmt.Sprintf("%s/%s", result[k+1], result[k+2])
+				}
+			}
+		}
+
 		if roleAssignmentId.Name, err = id.PopSegment("roleAssignments"); err != nil {
 			return nil, err
 		}

--- a/azurerm/internal/services/authorization/parse/role_assignment.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment.go
@@ -102,11 +102,9 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 		if id.Provider != "Microsoft.Authorization" && id.Provider != "" {
 			roleAssignmentId.ResourceProvider = id.Provider
 			// logic to save resource scope
-			result := strings.Split(input, "/")
-			for k, v := range result {
-				if v == id.Provider && len(result) >= k+1 {
-					roleAssignmentId.ResourceScope = fmt.Sprintf("%s/%s", result[k+1], result[k+2])
-				}
+			result := strings.Split(input, "/providers/")
+			if len(result) == 3 {
+				roleAssignmentId.ResourceScope = strings.TrimPrefix(result[1], fmt.Sprintf("%s/", id.Provider))
 			}
 		}
 

--- a/azurerm/internal/services/authorization/parse/role_assignment_test.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment_test.go
@@ -208,6 +208,18 @@ func TestRoleAssignmentID(t *testing.T) {
 				TenantId:         "34567812-3456-7653-6742-345678901234",
 			},
 		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.AppPlatform/Spring/spring1/apps/app1/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121|34567812-3456-7653-6742-345678901234",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:   "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:    "group1",
+				ResourceProvider: "Microsoft.AppPlatform",
+				ResourceScope:    "Spring/spring1/apps/app1",
+				ManagementGroup:  "",
+				Name:             "23456781-2349-8764-5631-234567890121",
+				TenantId:         "34567812-3456-7653-6742-345678901234",
+			},
+		},
 	}
 
 	for _, v := range testData {
@@ -231,15 +243,23 @@ func TestRoleAssignmentID(t *testing.T) {
 		}
 
 		if actual.SubscriptionID != v.Expected.SubscriptionID {
-			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.SubscriptionID, actual.SubscriptionID)
+			t.Fatalf("Expected %q but got %q for Role Assignment Subscription ID", v.Expected.SubscriptionID, actual.SubscriptionID)
 		}
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.ResourceGroup, actual.ResourceGroup)
+			t.Fatalf("Expected %q but got %q for Role Assignment Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+
+		if actual.ResourceProvider != v.Expected.ResourceProvider {
+			t.Fatalf("Expected %q but got %q for Role Assignment Resource Provider", v.Expected.ResourceProvider, actual.ResourceProvider)
+		}
+
+		if actual.ResourceScope != v.Expected.ResourceScope {
+			t.Fatalf("Expected %q but got %q for Role Assignment Resource Scope", v.Expected.ResourceScope, actual.ResourceScope)
 		}
 
 		if actual.ManagementGroup != v.Expected.ManagementGroup {
-			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.ManagementGroup, actual.ManagementGroup)
+			t.Fatalf("Expected %q but got %q for Role Assignment Management Group", v.Expected.ManagementGroup, actual.ManagementGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/authorization/parse/role_assignment_test.go
+++ b/azurerm/internal/services/authorization/parse/role_assignment_test.go
@@ -10,16 +10,19 @@ var _ resourceid.Formatter = RoleAssignmentId{}
 
 func TestRoleAssignmentIDFormatter(t *testing.T) {
 	testData := []struct {
-		SubscriptionId  string
-		ResourceGroup   string
-		ManagementGroup string
-		Name            string
-		TenantId        string
-		Expected        string
+		SubscriptionId   string
+		ResourceGroup    string
+		ResourceProvider string
+		ResourceScope    string
+		ManagementGroup  string
+		Name             string
+		TenantId         string
+		Expected         string
 	}{
 		{
 			SubscriptionId:  "",
 			ResourceGroup:   "",
+			ResourceScope:   "",
 			ManagementGroup: "",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "",
@@ -27,6 +30,7 @@ func TestRoleAssignmentIDFormatter(t *testing.T) {
 		{
 			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
 			ResourceGroup:   "group1",
+			ResourceScope:   "",
 			ManagementGroup: "managementGroup1",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "",
@@ -34,6 +38,7 @@ func TestRoleAssignmentIDFormatter(t *testing.T) {
 		{
 			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
 			ResourceGroup:   "",
+			ResourceScope:   "",
 			ManagementGroup: "managementGroup1",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "",
@@ -41,6 +46,7 @@ func TestRoleAssignmentIDFormatter(t *testing.T) {
 		{
 			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
 			ResourceGroup:   "",
+			ResourceScope:   "",
 			ManagementGroup: "",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "",
@@ -49,6 +55,7 @@ func TestRoleAssignmentIDFormatter(t *testing.T) {
 		{
 			SubscriptionId:  "12345678-1234-9876-4563-123456789012",
 			ResourceGroup:   "group1",
+			ResourceScope:   "",
 			ManagementGroup: "",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "",
@@ -57,6 +64,7 @@ func TestRoleAssignmentIDFormatter(t *testing.T) {
 		{
 			SubscriptionId:  "",
 			ResourceGroup:   "",
+			ResourceScope:   "",
 			ManagementGroup: "12345678-1234-9876-4563-123456789012",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "",
@@ -65,15 +73,26 @@ func TestRoleAssignmentIDFormatter(t *testing.T) {
 		{
 			SubscriptionId:  "",
 			ResourceGroup:   "",
+			ResourceScope:   "",
 			ManagementGroup: "12345678-1234-9876-4563-123456789012",
 			Name:            "23456781-2349-8764-5631-234567890121",
 			TenantId:        "34567812-3456-7653-6742-345678901234",
 			Expected:        "/providers/Microsoft.Management/managementGroups/12345678-1234-9876-4563-123456789012/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121|34567812-3456-7653-6742-345678901234",
 		},
+		{
+			SubscriptionId:   "12345678-1234-9876-4563-123456789012",
+			ResourceGroup:    "group1",
+			ResourceProvider: "Microsoft.Storage",
+			ResourceScope:    "storageAccounts/nameStorageAccount",
+			ManagementGroup:  "",
+			Name:             "23456781-2349-8764-5631-234567890121",
+			TenantId:         "34567812-3456-7653-6742-345678901234",
+			Expected:         "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/nameStorageAccount/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121|34567812-3456-7653-6742-345678901234",
+		},
 	}
 	for _, v := range testData {
 		t.Logf("testing %+v", v)
-		actual, err := NewRoleAssignmentID(v.SubscriptionId, v.ResourceGroup, v.ManagementGroup, v.Name, v.TenantId)
+		actual, err := NewRoleAssignmentID(v.SubscriptionId, v.ResourceGroup, v.ResourceProvider, v.ResourceScope, v.ManagementGroup, v.Name, v.TenantId)
 		if err != nil {
 			if v.Expected == "" {
 				continue
@@ -140,6 +159,7 @@ func TestRoleAssignmentID(t *testing.T) {
 			Expected: &RoleAssignmentId{
 				SubscriptionID:  "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:   "",
+				ResourceScope:   "",
 				ManagementGroup: "",
 				Name:            "23456781-2349-8764-5631-234567890121",
 			},
@@ -174,6 +194,18 @@ func TestRoleAssignmentID(t *testing.T) {
 				ManagementGroup: "managementGroup1",
 				Name:            "23456781-2349-8764-5631-234567890121",
 				TenantId:        "34567812-3456-7653-6742-345678901234",
+			},
+		},
+		{
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/nameStorageAccount/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121|34567812-3456-7653-6742-345678901234",
+			Expected: &RoleAssignmentId{
+				SubscriptionID:   "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:    "group1",
+				ResourceProvider: "Microsoft.Storage",
+				ResourceScope:    "storageAccounts/nameStorageAccount",
+				ManagementGroup:  "",
+				Name:             "23456781-2349-8764-5631-234567890121",
+				TenantId:         "34567812-3456-7653-6742-345678901234",
 			},
 		},
 	}


### PR DESCRIPTION
Fixes  #12074 
Fixes  #12060 
Fixes  #12057
Fixes #12079
Fixes #12078
Fixes #12087

Related to/similar for [go-azure-helpers](https://github.com/hashicorp/go-azure-helpers): [this PR](https://github.com/hashicorp/go-azure-helpers/pull/79)

Done:
- [x] Reproduce the problem :)
```
❯ make acctests SERVICE='authorization' TESTARGS='-run=TestAccRoleAssignment_resourceScoped'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/authorization -run=TestAccRoleAssignment_resourceScoped -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/06/05 16:11:49 [DEBUG] not using binary driver name, it's no longer needed
2021/06/05 16:11:50 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccRoleAssignment_resourceScoped
=== PAUSE TestAccRoleAssignment_resourceScoped
=== CONT  TestAccRoleAssignment_resourceScoped
    testing.go:620: Step 1/2 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to azurerm_role_assignment.test, provider
        "provider[\"registry.terraform.io/hashicorp/azurerm\"]" produced an
        unexpected new value: Root resource was present, but now absent.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccRoleAssignment_resourceScoped (136.30s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/authorization 139.640s
FAIL
make: *** [acctests] Error 1
```
- [x] Diagnose the problem:
  - Previously the ID was saved raw and without transformation/checks. Because the roleAssignmentID parser doesn't contain a resource/scope part, it wasn't saved and therefore not (able to be) regenerated correctly based on saved parameters: `/subscriptions/<subscription>/resourceGroups/<resource_group>/providers/Microsoft.Storage/storageAccounts/<storage_account_name>/providers/Microsoft.Authorization/roleAssignments/<UUID>` became `/subscriptions/<subscription>/resourceGroups/<resource_group>/providers/Microsoft.Authorization/roleAssignments/<UUID>`

- [x] Implement the fix
```
❯ make acctests SERVICE='authorization' TESTARGS='-run=TestAccRoleAssignment_resourceScoped'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/authorization -run=TestAccRoleAssignment_resourceScoped -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
2021/06/06 08:41:44 [DEBUG] not using binary driver name, it's no longer needed
2021/06/06 08:41:45 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccRoleAssignment_resourceScoped
=== PAUSE TestAccRoleAssignment_resourceScoped
=== CONT  TestAccRoleAssignment_resourceScoped
--- PASS: TestAccRoleAssignment_resourceScoped (191.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/authorization       195.451s
```

- [x] Clean up
  - Fix the unit tests of other resources by providing a general `id.SecondaryProvider`, which solved the problems for the resources which have multiple provider entries in their IDs