### PR TITLE
fix error creating zone-redundant ip in central us euap

### DIFF
--- a/azurerm/internal/services/network/public_ip_prefix_resource.go
+++ b/azurerm/internal/services/network/public_ip_prefix_resource.go
@@ -136,7 +136,7 @@ func resourcePublicIpPrefixCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	prefixLength := d.Get("prefix_length").(int)
 	t := d.Get("tags").(map[string]interface{})
 
-	zones := &[]string{"1", "2", "3"}
+	zones := &[]string{"1", "2"}
 	// TODO - Remove in 3.0
 	if deprecatedZonesRaw, ok := d.GetOk("zones"); ok {
 		deprecatedZones := azure.ExpandZones(deprecatedZonesRaw.([]interface{}))
@@ -150,7 +150,7 @@ func resourcePublicIpPrefixCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		case "1", "2", "3":
 			zones = &[]string{availabilityZones.(string)}
 		case "Zone-Redundant":
-			zones = &[]string{"1", "2", "3"}
+			zones = &[]string{"1", "2"}
 		case "No-Zone":
 			zones = &[]string{}
 		}

--- a/azurerm/internal/services/network/public_ip_resource.go
+++ b/azurerm/internal/services/network/public_ip_resource.go
@@ -195,7 +195,7 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	sku := d.Get("sku").(string)
 	t := d.Get("tags").(map[string]interface{})
 	// Default to Zone-Redundant - Legacy behaviour TODO - Switch to `No-Zone` in 3.0 to match service?
-	zones := &[]string{"1", "2", "3"}
+	zones := &[]string{"1", "2"}
 	zonesSet := false
 	// TODO - Remove in 3.0
 	if deprecatedZonesRaw, ok := d.GetOk("zones"); ok {
@@ -212,7 +212,7 @@ func resourcePublicIpCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		case "1", "2", "3":
 			zones = &[]string{availabilityZones.(string)}
 		case "Zone-Redundant":
-			zones = &[]string{"1", "2", "3"}
+			zones = &[]string{"1", "2"}
 		case "No-Zone":
 			zones = &[]string{}
 		}


### PR DESCRIPTION
The constant [1,2,3] is used to create zone-redundant resource, however, in location Central US EUAP, the available zones are [1,2], then it will throw an exception like the following
```
error: Code="InvalidAvailabilityZone" Message="The zone(s) '3' for 
resource 'Microsoft.Network/publicIPAddresses/acctestpublicip-henglu-02' is not supported. The supported zones for location 'centraluseuap' are '1,2'
```

It can be easily fixed by using [1,2], it can create zone-redundant resources in Central US EUAP and other locations.