### PR TITLE
add resource "azurerm_data_protection_backup_instance_postgresql"

### DIFF
--- a/azurerm/internal/services/dataprotection/client/client.go
+++ b/azurerm/internal/services/dataprotection/client/client.go
@@ -6,14 +6,24 @@ import (
 )
 
 type Client struct {
-	BackupVaultClient *dataprotection.BackupVaultsClient
+	BackupVaultClient    *dataprotection.BackupVaultsClient
+	BackupPolicyClient   *dataprotection.BackupPoliciesClient
+	BackupInstanceClient *dataprotection.BackupInstancesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
 	backupVaultClient := dataprotection.NewBackupVaultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&backupVaultClient.Client, o.ResourceManagerAuthorizer)
 
+	backupPolicyClient := dataprotection.NewBackupPoliciesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&backupPolicyClient.Client, o.ResourceManagerAuthorizer)
+
+	backupInstanceClient := dataprotection.NewBackupInstancesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&backupInstanceClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
-		BackupVaultClient: &backupVaultClient,
+		BackupVaultClient:    &backupVaultClient,
+		BackupPolicyClient:   &backupPolicyClient,
+		BackupInstanceClient: &backupInstanceClient,
 	}
 }

--- a/azurerm/internal/services/dataprotection/data_protection_backup_instance_postgresql_resource.go
+++ b/azurerm/internal/services/dataprotection/data_protection_backup_instance_postgresql_resource.go
@@ -1,0 +1,199 @@
+package dataprotection
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/legacysdk/dataprotection"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/validate"
+	postgresParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/parse"
+	postgresValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDataProtectionBackupInstancePostgreSql() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDataProtectionBackupInstancePostgreSqlCreateUpdate,
+		Read:   resourceDataProtectionBackupInstancePostgreSqlRead,
+		Update: resourceDataProtectionBackupInstancePostgreSqlCreateUpdate,
+		Delete: resourceDataProtectionBackupInstancePostgreSqlDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BackupInstanceID(id)
+			return err
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": location.Schema(),
+
+			"vault_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"database_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: postgresValidate.DatabaseID,
+			},
+
+			"policy_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.BackupPolicyID,
+			},
+		},
+	}
+}
+func resourceDataProtectionBackupInstancePostgreSqlCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).DataProtection.BackupInstanceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	vaultName := d.Get("vault_name").(string)
+
+	id := parse.NewBackupInstanceID(subscriptionId, resourceGroup, vaultName, name)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for existing DataProtection BackupInstance (%q): %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_data_protection_backup_instance_postgresql", id.ID())
+		}
+	}
+
+	databaseId, _ := postgresParse.DatabaseID(d.Get("database_id").(string))
+	location := location.Normalize(d.Get("location").(string))
+	serverId := postgresParse.NewServerID(databaseId.SubscriptionId, databaseId.ResourceGroup, databaseId.ServerName)
+	policyId, _ := parse.BackupPolicyID(d.Get("policy_id").(string))
+
+	parameters := dataprotection.BackupInstanceResource{
+		Properties: &dataprotection.BackupInstance{
+			DataSourceInfo: &dataprotection.Datasource{
+				DatasourceType:   utils.String("Microsoft.DBforPostgreSQL/servers/databases"),
+				ObjectType:       utils.String("Datasource"),
+				ResourceID:       utils.String(databaseId.ID()),
+				ResourceLocation: utils.String(location),
+				ResourceName:     utils.String(databaseId.Name),
+				ResourceType:     utils.String("Microsoft.DBforPostgreSQL/servers/databases"),
+				ResourceURI:      utils.String(""),
+			},
+			DataSourceSetInfo: &dataprotection.DatasourceSet{
+				DatasourceType:   utils.String("Microsoft.DBForPostgreSQL/servers"),
+				ObjectType:       utils.String("DatasourceSet"),
+				ResourceID:       utils.String(serverId.ID()),
+				ResourceLocation: utils.String(location),
+				ResourceName:     utils.String(serverId.Name),
+				ResourceType:     utils.String("Microsoft.DBForPostgreSQL/servers"),
+				ResourceURI:      utils.String(""),
+			},
+			FriendlyName: utils.String(id.Name),
+			PolicyInfo: &dataprotection.PolicyInfo{
+				PolicyID: utils.String(policyId.ID()),
+			},
+		},
+	}
+	future, err := client.CreateOrUpdate(ctx, id.BackupVaultName, id.ResourceGroup, id.Name, parameters)
+	if err != nil {
+		return fmt.Errorf("creating/updating DataProtection BackupInstance (%q): %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for creation/update of the DataProtection BackupInstance (%q): %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceDataProtectionBackupInstancePostgreSqlRead(d, meta)
+}
+
+func resourceDataProtectionBackupInstancePostgreSqlRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataProtection.BackupInstanceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BackupInstanceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] dataprotection %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving DataProtection BackupInstance (%q): %+v", id, err)
+	}
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("vault_name", id.BackupVaultName)
+	if props := resp.Properties; props != nil {
+		if props.DataSourceInfo != nil {
+			d.Set("database_id", props.DataSourceInfo.ResourceID)
+			d.Set("location", props.DataSourceInfo.ResourceLocation)
+		}
+		if props.PolicyInfo != nil {
+			d.Set("policy_id", props.PolicyInfo.PolicyID)
+		}
+	}
+	return nil
+}
+
+func resourceDataProtectionBackupInstancePostgreSqlDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataProtection.BackupInstanceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BackupInstanceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if response.WasNotFound(future.Response()) {
+			return nil
+		}
+		return fmt.Errorf("deleting DataProtection BackupInstance (%q): %+v", id, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of the DataProtection BackupInstance (%q): %+v", id.Name, err)
+	}
+	return nil
+}

--- a/azurerm/internal/services/dataprotection/data_protection_backup_instance_postgresql_resource_test.go
+++ b/azurerm/internal/services/dataprotection/data_protection_backup_instance_postgresql_resource_test.go
@@ -1,0 +1,223 @@
+package dataprotection_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type DataProtectionBackupInstancePostgreSqlResource struct{}
+
+func TestAccDataProtectionBackupInstancePostgreSql_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_postgresql", "test")
+	r := DataProtectionBackupInstancePostgreSqlResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataProtectionBackupInstancePostgreSql_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_postgresql", "test")
+	r := DataProtectionBackupInstancePostgreSqlResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccDataProtectionBackupInstancePostgreSql_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_postgresql", "test")
+	r := DataProtectionBackupInstancePostgreSqlResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataProtectionBackupInstancePostgreSql_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_instance_postgresql", "test")
+	r := DataProtectionBackupInstancePostgreSqlResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r DataProtectionBackupInstancePostgreSqlResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.BackupInstanceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.DataProtection.BackupInstanceClient.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving DataProtection BackupInstance (%q): %+v", id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r DataProtectionBackupInstancePostgreSqlResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-dataprotection-%d"
+  location = "%s"
+}
+
+resource "azurerm_postgresql_server" "test" {
+  name                = "acctest-postgresql-server-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "B_Gen5_2"
+
+  storage_mb                   = 5120
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  auto_grow_enabled            = true
+
+  administrator_login          = "psqladminun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "9.5"
+  ssl_enforcement_enabled      = true
+}
+
+resource "azurerm_postgresql_database" "test" {
+  name                = "acctest-postgresql-database-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  server_name         = azurerm_postgresql_server.test.name
+  charset             = "UTF8"
+  collation           = "English_United States.1252"
+}
+
+resource "azurerm_data_protection_backup_vault" "test" {
+  name                = "acctest-dataprotection-vault-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_data_protection_backup_policy_postgresql" "test" {
+  name                = "acctest-dp-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vault_name          = azurerm_data_protection_backup_vault.test.name
+  backup_rules {
+    name                     = "default"
+    repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]
+  }
+  default_retention_duration = "P4M"
+}
+
+resource "azurerm_data_protection_backup_policy_postgresql" "another" {
+  name                = "acctest-dp-second-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vault_name          = azurerm_data_protection_backup_vault.test.name
+  backup_rules {
+    name                     = "default"
+    repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]
+  }
+  default_retention_duration = "P3M"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r DataProtectionBackupInstancePostgreSqlResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_instance_postgresql" "test" {
+  name                = "acctest-dbi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  vault_name          = azurerm_data_protection_backup_vault.test.name
+  database_id         = azurerm_postgresql_database.test.id
+  policy_id           = azurerm_data_protection_backup_policy_postgresql.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupInstancePostgreSqlResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_instance_postgresql" "import" {
+  name                = azurerm_data_protection_backup_instance_postgresql.test.name
+  resource_group_name = azurerm_data_protection_backup_instance_postgresql.test.resource_group_name
+  location            = azurerm_resource_group.test.location
+  vault_name          = azurerm_data_protection_backup_instance_postgresql.test.vault_name
+  database_id         = azurerm_postgresql_database.test.id
+  policy_id           = azurerm_data_protection_backup_policy_postgresql.test.id
+}
+`, config)
+}
+
+func (r DataProtectionBackupInstancePostgreSqlResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_instance_postgresql" "test" {
+  name                = "acctest-dbi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  vault_name          = azurerm_data_protection_backup_vault.test.name
+  database_id         = azurerm_postgresql_database.test.id
+  policy_id           = azurerm_data_protection_backup_policy_postgresql.another.id
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/dataprotection/parse/backup_instance.go
+++ b/azurerm/internal/services/dataprotection/parse/backup_instance.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type BackupInstanceId struct {
+	SubscriptionId  string
+	ResourceGroup   string
+	BackupVaultName string
+	Name            string
+}
+
+func NewBackupInstanceID(subscriptionId, resourceGroup, backupVaultName, name string) BackupInstanceId {
+	return BackupInstanceId{
+		SubscriptionId:  subscriptionId,
+		ResourceGroup:   resourceGroup,
+		BackupVaultName: backupVaultName,
+		Name:            name,
+	}
+}
+
+func (id BackupInstanceId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Backup Vault Name %q", id.BackupVaultName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Backup Instance", segmentsStr)
+}
+
+func (id BackupInstanceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DataProtection/backupVaults/%s/backupInstances/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BackupVaultName, id.Name)
+}
+
+// BackupInstanceID parses a BackupInstance ID into an BackupInstanceId struct
+func BackupInstanceID(input string) (*BackupInstanceId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := BackupInstanceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.BackupVaultName, err = id.PopSegment("backupVaults"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("backupInstances"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/dataprotection/parse/backup_instance_test.go
+++ b/azurerm/internal/services/dataprotection/parse/backup_instance_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = BackupInstanceId{}
+
+func TestBackupInstanceIDFormatter(t *testing.T) {
+	actual := NewBackupInstanceID("12345678-1234-9876-4563-123456789012", "resourceGroup1", "vault1", "backupInstance1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/backupInstance1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestBackupInstanceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *BackupInstanceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/",
+			Error: true,
+		},
+
+		{
+			// missing value for BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/backupInstance1",
+			Expected: &BackupInstanceId{
+				SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:   "resourceGroup1",
+				BackupVaultName: "vault1",
+				Name:            "backupInstance1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESOURCEGROUP1/PROVIDERS/MICROSOFT.DATAPROTECTION/BACKUPVAULTS/VAULT1/BACKUPINSTANCES/BACKUPINSTANCE1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := BackupInstanceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.BackupVaultName != v.Expected.BackupVaultName {
+			t.Fatalf("Expected %q but got %q for BackupVaultName", v.Expected.BackupVaultName, actual.BackupVaultName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/dataprotection/parse/backup_policy.go
+++ b/azurerm/internal/services/dataprotection/parse/backup_policy.go
@@ -1,0 +1,75 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type BackupPolicyId struct {
+	SubscriptionId  string
+	ResourceGroup   string
+	BackupVaultName string
+	Name            string
+}
+
+func NewBackupPolicyID(subscriptionId, resourceGroup, backupVaultName, name string) BackupPolicyId {
+	return BackupPolicyId{
+		SubscriptionId:  subscriptionId,
+		ResourceGroup:   resourceGroup,
+		BackupVaultName: backupVaultName,
+		Name:            name,
+	}
+}
+
+func (id BackupPolicyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Name %q", id.Name),
+		fmt.Sprintf("Backup Vault Name %q", id.BackupVaultName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Backup Policy", segmentsStr)
+}
+
+func (id BackupPolicyId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DataProtection/backupVaults/%s/backupPolicies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.BackupVaultName, id.Name)
+}
+
+// BackupPolicyID parses a BackupPolicy ID into an BackupPolicyId struct
+func BackupPolicyID(input string) (*BackupPolicyId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := BackupPolicyId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.BackupVaultName, err = id.PopSegment("backupVaults"); err != nil {
+		return nil, err
+	}
+	if resourceId.Name, err = id.PopSegment("backupPolicies"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/dataprotection/parse/backup_policy_test.go
+++ b/azurerm/internal/services/dataprotection/parse/backup_policy_test.go
@@ -1,0 +1,128 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
+)
+
+var _ resourceid.Formatter = BackupPolicyId{}
+
+func TestBackupPolicyIDFormatter(t *testing.T) {
+	actual := NewBackupPolicyID("12345678-1234-9876-4563-123456789012", "resourceGroup1", "vault1", "backupPolicy1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/backupPolicy1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestBackupPolicyID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *BackupPolicyId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/",
+			Error: true,
+		},
+
+		{
+			// missing value for BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/backupPolicy1",
+			Expected: &BackupPolicyId{
+				SubscriptionId:  "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:   "resourceGroup1",
+				BackupVaultName: "vault1",
+				Name:            "backupPolicy1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESOURCEGROUP1/PROVIDERS/MICROSOFT.DATAPROTECTION/BACKUPVAULTS/VAULT1/BACKUPPOLICIES/BACKUPPOLICY1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := BackupPolicyID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.BackupVaultName != v.Expected.BackupVaultName {
+			t.Fatalf("Expected %q but got %q for BackupVaultName", v.Expected.BackupVaultName, actual.BackupVaultName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/dataprotection/registration.go
+++ b/azurerm/internal/services/dataprotection/registration.go
@@ -24,6 +24,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_data_protection_backup_vault": resourceDataProtectionBackupVault(),
+		"azurerm_data_protection_backup_vault":               resourceDataProtectionBackupVault(),
+		"azurerm_data_protection_backup_instance_postgresql": resourceDataProtectionBackupInstancePostgreSql(),
 	}
 }

--- a/azurerm/internal/services/dataprotection/resourceids.go
+++ b/azurerm/internal/services/dataprotection/resourceids.go
@@ -1,3 +1,5 @@
 package dataprotection
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BackupVault -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BackupPolicy -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/backupPolicy1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=BackupInstance -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/backupInstance1

--- a/azurerm/internal/services/dataprotection/validate/backup_instance_id.go
+++ b/azurerm/internal/services/dataprotection/validate/backup_instance_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
+)
+
+func BackupInstanceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.BackupInstanceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/dataprotection/validate/backup_instance_id_test.go
+++ b/azurerm/internal/services/dataprotection/validate/backup_instance_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestBackupInstanceID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/",
+			Valid: false,
+		},
+
+		{
+			// missing value for BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/backupInstance1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESOURCEGROUP1/PROVIDERS/MICROSOFT.DATAPROTECTION/BACKUPVAULTS/VAULT1/BACKUPINSTANCES/BACKUPINSTANCE1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := BackupInstanceID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/azurerm/internal/services/dataprotection/validate/backup_policy_id.go
+++ b/azurerm/internal/services/dataprotection/validate/backup_policy_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
+)
+
+func BackupPolicyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.BackupPolicyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/azurerm/internal/services/dataprotection/validate/backup_policy_id_test.go
+++ b/azurerm/internal/services/dataprotection/validate/backup_policy_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestBackupPolicyID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/",
+			Valid: false,
+		},
+
+		{
+			// missing value for BackupVaultName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/",
+			Valid: false,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/backupPolicy1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESOURCEGROUP1/PROVIDERS/MICROSOFT.DATAPROTECTION/BACKUPVAULTS/VAULT1/BACKUPPOLICIES/BACKUPPOLICY1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := BackupPolicyID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/data_protection_backup_instance_postgresql.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_postgresql.html.markdown
@@ -1,0 +1,117 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_protection_backup_instance_postgresql"
+description: |-
+  Manages a Backup Instance Postgre Sql.
+---
+
+# azurerm_data_protection_backup_instance_postgresql
+
+Manages a Backup Instance Postgre Sql.
+
+-> **Note**: Before using this resource, there are some prerequisite permissions for configure backup and restore. See more details from https://docs.microsoft.com/en-us/azure/backup/backup-azure-database-postgresql#prerequisite-permissions-for-configure-backup-and-restore.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_postgresql_server" "example" {
+  name                = "example-postgresql-server"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  sku_name = "B_Gen5_2"
+
+  storage_mb                   = 5120
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  auto_grow_enabled            = true
+
+  administrator_login          = "psqladminun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "9.5"
+  ssl_enforcement_enabled      = true
+}
+
+resource "azurerm_postgresql_database" "example" {
+  name                = "example-postgresql-database"
+  resource_group_name = azurerm_resource_group.example.name
+  server_name         = azurerm_postgresql_server.example.name
+  charset             = "UTF8"
+  collation           = "English_United States.1252"
+}
+
+resource "azurerm_data_protection_backup_vault" "example" {
+  name                = "example-backup-vault"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+}
+
+resource "azurerm_data_protection_backup_policy_postgresql" "example" {
+  name                = "example-backup-policy"
+  resource_group_name = azurerm_resource_group.rg.name
+  vault_name          = azurerm_data_protection_backup_vault.example.name
+
+  backup_rules {
+    name                     = "backup"
+    repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]
+  }
+  default_retention_duration = "P4M"
+}
+
+resource "azurerm_data_protection_backup_instance_postgresql" "example" {
+  name                = "example-backup-instance"
+  resource_group_name = azurerm_resource_group.rg.name
+  vault_name          = azurerm_data_protection_backup_vault.example.name
+
+  database_id       = azurerm_postgresql_database.example.id
+  database_location = azurerm_resource_group.rg.location
+  policy_id         = azurerm_data_protection_backup_policy_postgresql.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Backup Instance Postgre Sql. Changing this forces a new Backup Instance Postgre Sql to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Backup Instance Postgre Sql should exist. Changing this forces a new Backup Instance Postgre Sql to be created.
+
+* `vault_name` - (Required) The name of the Backup Vault where the Backup Instance Postgre Sql should exist.. Changing this forces a new Backup Instance Postgre Sql to be created.
+
+* `database_id` - (Required) The ID of the source database. Changing this forces a new Backup Instance Postgre Sql to be created.
+
+* `database_location` - (Required) The location of the source database. Changing this forces a new Backup Instance Postgre Sql to be created.
+
+* `policy_id` - (Required) The ID of the Backup Policy.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Backup Instance Postgre Sql.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Backup Instance Postgre Sql.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Instance Postgre Sql.
+* `update` - (Defaults to 30 minutes) Used when updating the Backup Instance Postgre Sql.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Backup Instance Postgre Sql.
+
+## Import
+
+Backup Instance Postgre Sqls can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_protection_backup_instance_postgresql.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DataProtection/backupVaults/vault1/backupInstances/backupInstance1
+```


### PR DESCRIPTION
The tests are listed as follows.

```
=== RUN   TestAccDataProtectionBackupInstancePostgreSql_basic
=== PAUSE TestAccDataProtectionBackupInstancePostgreSql_basic
=== CONT  TestAccDataProtectionBackupInstancePostgreSql_basic
--- PASS: TestAccDataProtectionBackupInstancePostgreSql_basic (501.75s)
=== RUN   TestAccDataProtectionBackupInstancePostgreSql_requiresImport
=== PAUSE TestAccDataProtectionBackupInstancePostgreSql_requiresImport
=== CONT  TestAccDataProtectionBackupInstancePostgreSql_requiresImport
--- PASS: TestAccDataProtectionBackupInstancePostgreSql_requiresImport (577.23s)
=== RUN   TestAccDataProtectionBackupInstancePostgreSql_complete
=== PAUSE TestAccDataProtectionBackupInstancePostgreSql_complete
=== CONT  TestAccDataProtectionBackupInstancePostgreSql_complete
--- PASS: TestAccDataProtectionBackupInstancePostgreSql_complete (490.25s)
=== RUN   TestAccDataProtectionBackupInstancePostgreSql_update
=== PAUSE TestAccDataProtectionBackupInstancePostgreSql_update
=== CONT  TestAccDataProtectionBackupInstancePostgreSql_update
--- PASS: TestAccDataProtectionBackupInstancePostgreSql_update (731.34s)

```