### PR TITLE
Add support for multiple auth types for azurerm_vpn_server_configuration

### DIFF
--- a/azurerm/internal/services/network/vpn_server_configuration_resource.go
+++ b/azurerm/internal/services/network/vpn_server_configuration_resource.go
@@ -56,11 +56,6 @@ func resourceVPNServerConfiguration() *pluginsdk.Resource {
 						string(network.VpnAuthenticationTypeRadius),
 					}, false),
 				},
-
-				// StatusCode=400 -- Original Error: Code="MultipleVpnAuthenticationTypesNotSupprtedOnVpnServerConfiguration"
-				// Message="VpnServerConfiguration XXX/acctestrg-191125124621329676 supports single VpnAuthenticationType at a time.
-				// Customer has specified 3 number of VpnAuthenticationTypes."
-				MaxItems: 1,
 			},
 
 			// Optional

--- a/azurerm/internal/services/network/vpn_server_configuration_resource_test.go
+++ b/azurerm/internal/services/network/vpn_server_configuration_resource_test.go
@@ -174,6 +174,21 @@ func TestAccVPNServerConfiguration_tags(t *testing.T) {
 	})
 }
 
+func TestAccVPNServerConfiguration_multipleAuthTypes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_server_configuration", "test")
+	r := VPNServerConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleAuthTypes(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VPNServerConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VpnServerConfigurationID(state.ID)
 	if err != nil {
@@ -515,6 +530,53 @@ EOF
 
   tags = {
     Hello = "World"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VPNServerConfigurationResource) multipleAuthTypes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_vpn_server_configuration" "test" {
+  name                     = "acctestVPNSC-%d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  vpn_authentication_types = ["AAD", "Certificate"]
+
+  azure_active_directory_authentication {
+    audience = "00000000-abcd-abcd-abcd-999999999999"
+    issuer   = "https://sts.windows.net/${data.azurerm_subscription.current.tenant_id}/"
+    tenant   = "https://login.microsoftonline.com/${data.azurerm_subscription.current.tenant_id}"
+  }
+
+  client_root_certificate {
+    name             = "DigiCert-Federated-ID-Root-CA"
+    public_cert_data = <<EOF
+MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+EOF
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/website/docs/r/vpn_server_configuration.html.markdown
+++ b/website/docs/r/vpn_server_configuration.html.markdown
@@ -62,9 +62,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure location where this VPN Server Configuration should be created. Changing this forces a new resource to be created.
 
-* `vpn_authentication_types` - (Required) A list of one of more Authentication Types applicable for this VPN Server Configuration. Possible values are `AAD` (Azure Active Directory), `Certificate` and `Radius`.
-
--> **NOTE:** At this time a maximum of one VPN Authentication Types can be specified.
+* `vpn_authentication_types` - (Required) A list of Authentication Types applicable for this VPN Server Configuration. Possible values are `AAD` (Azure Active Directory), `Certificate` and `Radius`.
 
 ---
 


### PR DESCRIPTION
After checked with service team, VPN Server Configuration API has supported multiple vpn auth types since Network 2020-11-01. So I submitted this PR to implement it.

--- PASS: TestAccVPNServerConfiguration_azureAD (229.42s)
--- PASS: TestAccVPNServerConfiguration_tags (232.57s)
--- PASS: TestAccVPNServerConfiguration_radius (234.45s)
--- PASS: TestAccVPNServerConfiguration_multipleAuthTypes (235.55s)
--- PASS: TestAccVPNServerConfiguration_requiresImport (267.10s)
--- PASS: TestAccVPNServerConfiguration_certificate (327.32s)
--- PASS: TestAccVPNServerConfiguration_multipleAuth (426.25s)
--- PASS: TestAccVPNServerConfiguration_multipleRadius (620.00s)
