### PR TITLE
Migrate GitHub HashiBot release_commenter behavior to GitHub Actions

### DIFF
--- a/.github/workflows/milestone-closed.yaml
+++ b/.github/workflows/milestone-closed.yaml
@@ -1,0 +1,20 @@
+name: Closed Milestones
+
+on:
+  milestone:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  Comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bflad/action-milestone-comment@v1
+        with:
+          body: |
+            This functionality has been released in [${{ github.event.milestone.title }} of the Terraform Provider](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).  Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.
+
+            For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,17 +1,3 @@
-queued_behavior "release_commenter" "releases" {
-  repo_prefix = "terraform-provider-"
-
-  message = <<-EOF
-    This has been released in [version ${var.release_version} of the provider](${var.changelog_link}). Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading. As an example:
-    ```hcl
-    provider "${var.project_name}" {
-        version = "~> ${var.release_version}"
-    }
-    # ... other configuration ...
-    ```
-  EOF
-}
-
 behavior "pull_request_size_labeler" "size" {
     label_prefix = "size/"
     label_map = {


### PR DESCRIPTION
GitHub HashiBot is in the process of being decommissioned in preference of GitHub Actions.