### PR TITLE
`data.azurerm_synapse_workspace`: Add `identity` attribute

### DIFF
--- a/azurerm/internal/services/synapse/synapse_workspace_data_source.go
+++ b/azurerm/internal/services/synapse/synapse_workspace_data_source.go
@@ -41,6 +41,29 @@ func dataSourceSynapseWorkspace() *pluginsdk.Resource {
 				},
 			},
 
+			"identity": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"principal_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"tenant_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -71,6 +94,9 @@ func dataSourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{})
 	d.Set("location", location.NormalizeNilable(resp.Location))
 	if props := resp.WorkspaceProperties; props != nil {
 		d.Set("connectivity_endpoints", utils.FlattenMapStringPtrString(props.ConnectivityEndpoints))
+	}
+	if err := d.Set("identity", flattenArmWorkspaceManagedIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
 	}
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/internal/services/synapse/synapse_workspace_data_source_test.go
+++ b/azurerm/internal/services/synapse/synapse_workspace_data_source_test.go
@@ -20,6 +20,8 @@ func TestAccDataSourceSynapseWorkspace_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
 				check.That(data.ResourceName).Key("connectivity_endpoints.%").Exists(),
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
 			),
 		},
 	})

--- a/website/docs/d/synapse_workspace.html.markdown
+++ b/website/docs/d/synapse_workspace.html.markdown
@@ -43,6 +43,18 @@ the following Attributes are exported:
 
 * `tags` - A mapping of tags assigned to the resource.
 
+* `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this Synapse Workspace.
+
+---
+
+The `identity` block exports the following:
+
+* `type` - The Identity Type for the Service Principal associated with the Managed Service Identity of this Synapse Workspace.
+
+* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this Synapse Workspace.
+
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this Synapse Workspace.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
Adding `identity` attribute to the azurerm_synapse_workspace data source. That's useful when Azure Synapse identity needs permissions for multiple storage accounts managed by different Terraform configurations. Currently, Azure Synapse supports only System Assigned identity which is known only after workspace is created.

Usage sample:
```HCL
# Get reference to the workspace
data "azurerm_synapse_workspace" "ws" {
  name                = "existing"
  resource_group_name = "example-resource-group"
}

# Allow the workspace read from storage accounts
resource "azurerm_role_assignment" "account_readers" {
  for_each             = data.azurerm_storage_account.data
  scope                = each.value.id
  role_definition_name = "Storage Blob Data Reader"
  principal_id         = data.azurerm_synapse_workspace.ws.identity[0].principal_id
}

```