### PR TITLE
Fix synapse workspace managed-vnet

### DIFF
--- a/azurerm/internal/services/synapse/synapse_workspace_resource.go
+++ b/azurerm/internal/services/synapse/synapse_workspace_resource.go
@@ -264,7 +264,7 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	managedVirtualNetwork := ""
 	if d.Get("managed_virtual_network_enabled").(bool) {
-		managedVirtualNetwork = "default"
+		managedVirtualNetwork = "true"
 	}
 
 	workspaceInfo := synapse.Workspace{


### PR DESCRIPTION
Fix Synapse workspace enabling managed virtual network configuration.
Synapse workspace managed virtual network default value is `disabled` 