### PR TITLE
docs: fix allowed values by moving them to name

### DIFF
--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -141,11 +141,11 @@ A `notification` block supports the following:
 
 A `dimension` block supports the following:
 
-* `name` - (Required) The name of the column to use for the filter. The allowed values are
+* `name` - (Required) The name of the column to use for the filter. The allowed values are `ChargeType`, `Frequency`, `InvoiceId`, `Meter`, `MeterCategory`, `MeterSubCategory`, `PartNumber`, `PricingModel`, `Product`, `ProductOrderId`, `ProductOrderName`, `PublisherType`, `ReservationId`, `ReservationName`, `ResourceGroupName`, `ResourceGuid`, `ResourceId`, `ResourceLocation`, `ResourceType`, `ServiceFamily`, `ServiceName`, `UnitOfMeasure`.
 
 * `operator` - (Optional) The operator to use for comparison. The allowed values are `In`.
 
-* `values` - (Required) Specifies a list of values for the column. The allowed values are `ChargeType`, `Frequency`, `InvoiceId`, `Meter`, `MeterCategory`, `MeterSubCategory`, `PartNumber`, `PricingModel`, `Product`, `ProductOrderId`, `ProductOrderName`, `PublisherType`, `ReservationId`, `ReservationName`, `ResourceGroupName`, `ResourceGuid`, `ResourceId`, `ResourceLocation`, `ResourceType`, `ServiceFamily`, `ServiceName`, `UnitOfMeasure`.
+* `values` - (Required) Specifies a list of values for the column.
 
 ---
 

--- a/website/docs/r/consumption_budget_subscription.html.markdown
+++ b/website/docs/r/consumption_budget_subscription.html.markdown
@@ -143,11 +143,11 @@ A `notification` block supports the following:
 
 A `dimension` block supports the following:
 
-* `name` - (Required) The name of the column to use for the filter. The allowed values are 
+* `name` - (Required) The name of the column to use for the filter. The allowed values are `ChargeType`, `Frequency`, `InvoiceId`, `Meter`, `MeterCategory`, `MeterSubCategory`, `PartNumber`, `PricingModel`, `Product`, `ProductOrderId`, `ProductOrderName`, `PublisherType`, `ReservationId`, `ReservationName`, `ResourceGroupName`, `ResourceGuid`, `ResourceId`, `ResourceLocation`, `ResourceType`, `ServiceFamily`, `ServiceName`, `UnitOfMeasure`.
 
 * `operator` - (Optional) The operator to use for comparison. The allowed values are `In`.
 
-* `values` - (Required) Specifies a list of values for the column. The allowed values are `ChargeType`, `Frequency`, `InvoiceId`, `Meter`, `MeterCategory`, `MeterSubCategory`, `PartNumber`, `PricingModel`, `Product`, `ProductOrderId`, `ProductOrderName`, `PublisherType`, `ReservationId`, `ReservationName`, `ResourceGroupName`, `ResourceGuid`, `ResourceId`, `ResourceLocation`, `ResourceType`, `ServiceFamily`, `ServiceName`, `UnitOfMeasure`.
+* `values` - (Required) Specifies a list of values for the column.
 
 ---
 


### PR DESCRIPTION
shift the allowed values list to `name` since `name` selects the key to filter.

This aligns with the example provided and what is shown on the Azure Portal. In addition, this is tested and the result is shown below:

![image](https://user-images.githubusercontent.com/31919569/121294081-5b6d7000-c91f-11eb-9235-9eb736c94a99.png)
