### PR TITLE
fix panic when split empty string

### DIFF
--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -1608,7 +1608,9 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 
 		documents := make([]string, 0)
 		for _, document := range input {
-			documents = append(documents, document.(string))
+			if document != nil {
+				documents = append(documents, document.(string))
+			}
 		}
 
 		siteConfig.DefaultDocuments = &documents


### PR DESCRIPTION
To address issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/11584
The cause is that input like `split(",", "")` will generate an array contains a nil like `[<Nil>]`. 