### PR TITLE
"azurerm_kusto_cluster_customer_managed_key" - supports property "user_identity"

### DIFF
--- a/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -13,6 +13,7 @@ import (
 	keyVaultValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/kusto/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/kusto/validate"
+	msiValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -61,6 +62,12 @@ func resourceKustoClusterCustomerManagedKey() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"user_identity": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: msiValidate.UserAssignedIdentityID,
 			},
 		},
 	}
@@ -143,6 +150,10 @@ func resourceKustoClusterCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceDat
 		},
 	}
 
+	if v, ok := d.GetOk("user_identity"); ok {
+		props.ClusterProperties.KeyVaultProperties.UserIdentity = utils.String(v.(string))
+	}
+
 	future, err := clusterClient.Update(ctx, clusterID.ResourceGroup, clusterID.Name, props)
 	if err != nil {
 		return fmt.Errorf("Error updating Customer Managed Key for Kusto Cluster %q (Resource Group %q): %+v", clusterID.Name, clusterID.ResourceGroup, err)
@@ -192,6 +203,7 @@ func resourceKustoClusterCustomerManagedKeyRead(d *pluginsdk.ResourceData, meta 
 	keyName := ""
 	keyVaultURI := ""
 	keyVersion := ""
+	userIdentity := ""
 	if props != nil {
 		if props.KeyName != nil {
 			keyName = *props.KeyName
@@ -201,6 +213,9 @@ func resourceKustoClusterCustomerManagedKeyRead(d *pluginsdk.ResourceData, meta 
 		}
 		if props.KeyVersion != nil {
 			keyVersion = *props.KeyVersion
+		}
+		if props.UserIdentity != nil {
+			userIdentity = *props.UserIdentity
 		}
 	}
 
@@ -218,7 +233,7 @@ func resourceKustoClusterCustomerManagedKeyRead(d *pluginsdk.ResourceData, meta 
 	d.Set("key_vault_id", keyVaultID)
 	d.Set("key_name", keyName)
 	d.Set("key_version", keyVersion)
-
+	d.Set("user_identity", userIdentity)
 	return nil
 }
 

--- a/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -65,7 +65,7 @@ func resourceKustoClusterCustomerManagedKey() *pluginsdk.Resource {
 			},
 
 			"user_identity": {
-				Type:         schema.TypeString,
+				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: msiValidate.UserAssignedIdentityID,
 			},

--- a/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -86,6 +88,21 @@ func TestAccKustoClusterCustomerManagedKey_updateKey(t *testing.T) {
 	})
 }
 
+func TestAccKustoClusterCustomerManagedKey_userIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster_customer_managed_key", "test")
+	r := KustoClusterCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.userIdentity(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KustoClusterCustomerManagedKeyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ClusterID(state.ID)
 	if err != nil {
@@ -157,6 +174,101 @@ resource "azurerm_kusto_cluster_customer_managed_key" "test" {
   key_version  = azurerm_key_vault_key.second.version
 }
 `, template)
+}
+
+func (KustoClusterCustomerManagedKeyResource) userIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  soft_delete_enabled      = true
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "cluster" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  key_permissions = ["get", "unwrapkey", "wrapkey"]
+}
+
+resource "azurerm_key_vault_access_policy" "client" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "create",
+    "delete",
+    "get",
+    "list",
+    "purge",
+    "recover",
+  ]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "test"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.client,
+    azurerm_key_vault_access_policy.cluster,
+  ]
+}
+
+resource "azurerm_kusto_cluster_customer_managed_key" "test" {
+  cluster_id    = azurerm_kusto_cluster.test.id
+  key_vault_id  = azurerm_key_vault.test.id
+  key_name      = azurerm_key_vault_key.test.name
+  key_version   = azurerm_key_vault_key.test.version
+  user_identity = azurerm_user_assigned_identity.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString)
 }
 
 func (KustoClusterCustomerManagedKeyResource) template(data acceptance.TestData) string {

--- a/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
@@ -94,6 +94,8 @@ The following arguments are supported:
 
 * `key_version` - (Required) The version of Key Vault Key.
 
+* `user_identity` - (Optional) The user assigned identity that has access to the Key Vault Key. If not specified, system assigned identity will be used.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2786738/121311841-616f4b00-c937-11eb-9418-62156827c4ff.png)

supports user assigned identity