### PR TITLE
"azurerm_data_factory_linked_service_data_lake_storage_gen2" - supports property "storage_account_key"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
@@ -62,8 +62,8 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2() *pluginsdk.Resource {
 				Type:          pluginsdk.TypeBool,
 				Optional:      true,
 				Default:       false,
-				ConflictsWith: []string{"service_principal_key", "service_principal_id"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "use_managed_identity"},
+				ConflictsWith: []string{"service_principal_key", "service_principal_id", "storage_account_key"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
 			},
 
 			"service_principal_id": {
@@ -71,8 +71,8 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2() *pluginsdk.Resource {
 				Optional:      true,
 				ValidateFunc:  validation.IsUUID,
 				RequiredWith:  []string{"service_principal_key"},
-				ConflictsWith: []string{"use_managed_identity"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "use_managed_identity"},
+				ConflictsWith: []string{"storage_account_key", "use_managed_identity"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
 			},
 
 			"service_principal_key": {
@@ -80,14 +80,23 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2() *pluginsdk.Resource {
 				Optional:      true,
 				ValidateFunc:  validation.StringIsNotEmpty,
 				RequiredWith:  []string{"service_principal_id"},
-				ConflictsWith: []string{"use_managed_identity"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "use_managed_identity"},
+				ConflictsWith: []string{"storage_account_key", "use_managed_identity"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
+			},
+
+			"storage_account_key": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"service_principal_id", "service_principal_key", "use_managed_identity"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
 			},
 
 			"tenant": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  validation.StringIsNotEmpty,
+				RequiredWith:  []string{"service_principal_id"},
+				ConflictsWith: []string{"storage_account_key", "use_managed_identity"},
 			},
 
 			"description": {
@@ -155,8 +164,15 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2CreateUpdate(d *pluginsd
 
 	if d.Get("use_managed_identity").(bool) {
 		datalakeStorageGen2Properties = &datafactory.AzureBlobFSLinkedServiceTypeProperties{
-			URL:    utils.String(d.Get("url").(string)),
-			Tenant: utils.String(d.Get("tenant").(string)),
+			URL: utils.String(d.Get("url").(string)),
+		}
+	} else if v, ok := d.GetOk("storage_account_key"); ok {
+		datalakeStorageGen2Properties = &datafactory.AzureBlobFSLinkedServiceTypeProperties{
+			URL: utils.String(d.Get("url").(string)),
+			AccountKey: datafactory.SecureString{
+				Value: utils.String(v.(string)),
+				Type:  datafactory.TypeTypeSecureString,
+			},
 		}
 	} else {
 		secureString := datafactory.SecureString{
@@ -253,9 +269,6 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2Read(d *pluginsdk.Resour
 
 	if dataLakeStorageGen2.ServicePrincipalID != nil {
 		d.Set("service_principal_id", dataLakeStorageGen2.ServicePrincipalID)
-		d.Set("use_managed_identity", false)
-	} else {
-		d.Set("use_managed_identity", true)
 	}
 
 	if dataLakeStorageGen2.URL != nil {

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
@@ -166,11 +166,11 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "test" {
-  name                  = "acctestDataLake%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  data_factory_name     = azurerm_data_factory.test.name
-  url                   = azurerm_storage_account.test.primary_dfs_endpoint
-  storage_account_key   = azurerm_storage_account.test.primary_access_key
+  name                = "acctestDataLake%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  url                 = azurerm_storage_account.test.primary_dfs_endpoint
+  storage_account_key = azurerm_storage_account.test.primary_access_key
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger)
 }

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource_test.go
@@ -27,7 +27,22 @@ func TestAccDataFactoryLinkedServiceDataLakeStorageGen2_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("service_principal_key"),
+		data.ImportStep("service_principal_key", "use_managed_identity"),
+	})
+}
+
+func TestAccDataFactoryLinkedServiceDataLakeStorageGen2_accountKeyAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_data_lake_storage_gen2", "test")
+	r := LinkedServiceDataLakeStorageGen2Resource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.accountKeyAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("storage_account_key", "use_managed_identity"),
 	})
 }
 
@@ -42,7 +57,7 @@ func TestAccDataFactoryLinkedServiceDataLakeStorageGen2_managed_id(t *testing.T)
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("use_managed_identity"),
 	})
 }
 
@@ -71,7 +86,7 @@ func TestAccDataFactoryLinkedServiceDataLakeStorageGen2_update(t *testing.T) {
 				check.That(data.ResourceName).Key("description").HasValue("test description 2"),
 			),
 		},
-		data.ImportStep("service_principal_key"),
+		data.ImportStep("service_principal_key", "use_managed_identity"),
 	})
 }
 
@@ -118,10 +133,46 @@ resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "test" {
   data_factory_name     = azurerm_data_factory.test.name
   service_principal_id  = data.azurerm_client_config.current.client_id
   service_principal_key = "testkey"
-  tenant                = "11111111-1111-1111-1111-111111111111"
   url                   = "https://test.azure.com"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServiceDataLakeStorageGen2Resource) accountKeyAuth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "testaccsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  is_hns_enabled           = true
+  allow_blob_public_access = true
+}
+
+resource "azurerm_data_factory_linked_service_data_lake_storage_gen2" "test" {
+  name                  = "acctestDataLake%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  data_factory_name     = azurerm_data_factory.test.name
+  url                   = azurerm_storage_account.test.primary_dfs_endpoint
+  storage_account_key   = azurerm_storage_account.test.primary_access_key
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger)
 }
 
 func (LinkedServiceDataLakeStorageGen2Resource) managed_id(data acceptance.TestData) string {

--- a/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
+++ b/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
@@ -73,7 +73,11 @@ The following supported arguments are specific to Data Lake Storage Gen2 Linked 
 
 ~> **NOTE** If `service_principal_id` is used, `service_principal_key` is also required.
 
+* `storage_account_key` - (Optional) The Storage Account Key in which to authenticate against the Azure Data Lake Storage Gen2 account.
+
 * `tenant` - (Required) The tenant id or name in which to authenticate against the Azure Data Lake Storage Gen2 account.
+
+~> **NOTE** Users should specify one of the three authentication way: storage account key, service principal, managed identity.
 
 ## Attributes Reference
 


### PR DESCRIPTION
this linked service supports three authentication: storage_account_key, service principal, managed identity

this PR add supports for storage_account_key authentication.

Besides, according to https://docs.microsoft.com/en-us/azure/data-factory/connector-azure-data-lake-storage#linked-service-properties.

`url`, `accountKey` is required when using Account key authentication. `accountKey` not returned in response.
`url`, `servicePrincipalId`, `servicePrincipalCredential`, `tenant`  is required when using service principal authentication
`url` is needed when using msi authentication.

So I added some limitation for `tenant` schema.
because `accountKey` is not returned in response, in the read function, it's hard to know whether users are using Account key authentication or msi authentication. So I removed the `d.set("use_use_managed_identity", xxx)`.

![image](https://user-images.githubusercontent.com/2786738/121328245-bcf50500-c946-11eb-90b1-05e4f8e54e46.png)
