### PR TITLE
`role_definition.html.markdown` - Swap description for `id` and `role_definition_id` 

### DIFF
--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -67,9 +67,9 @@ A `permissions` block as the following properties:
 
 The following attributes are exported:
 
-* `id` - The Role Definition ID.
+* `id` - This ID is specific to Terraform - and is of the format `{roleDefinitionId}|{scope}`.
 
-* `role_definition_id` - This ID is specific to Terraform - and is of the format `{roleDefinitionId}|{scope}`.
+* `role_definition_id` - The Role Definition ID.
 
 * `role_definition_resource_id` - The Azure Resource Manager ID for the resource.
 


### PR DESCRIPTION
When outputting the resource ID, theses descriptions are the wrong way round.