### PR TITLE
New datasource: `azurerm_key_vault_secrets`

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -550,6 +550,7 @@ resource "azurerm_key_vault" "test" {
     secret_permissions = [
       "Get",
       "Delete",
+      "List",
       "Purge",
       "Recover",
       "Set",

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -73,7 +73,10 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 					return err
 				}
 				names = append(names, *name)
-				secretList.NextWithContext(ctx)
+				err = secretList.NextWithContext(ctx)
+				if err != nil {
+					return fmt.Errorf("listing secrets on Azure KeyVault %q: %+v", *keyVaultId, err)
+				}
 			}
 		}
 	}

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -69,7 +69,7 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error making Read request on Azure KeyVault %q: %+v", *keyVaultId, err)
 		}
 	} else {
-		secretList, err = client.GetSecretsComplete(ctx, *keyVaultBaseUri, utils.Int32(2147483646))
+		secretList, err = client.GetSecretsComplete(ctx, *keyVaultBaseUri, utils.Int32(10000))
 		if err != nil {
 			return fmt.Errorf("Error making Read request on Azure KeyVault %q: %+v", *keyVaultId, err)
 		}

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -1,0 +1,103 @@
+package keyvault
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
+	keyVaultValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceKeyVaultSecrets() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceKeyVaultSecretsRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"key_vault_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: keyVaultValidate.VaultID,
+			},
+
+			"max_results": {
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				Default:  25,
+			},
+
+			"all": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	keyVaultsClient := meta.(*clients.Client).KeyVault
+	client := meta.(*clients.Client).KeyVault.ManagementClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	maxResults := d.Get("max_results").(int)
+	keyVaultId, err := parse.VaultID(d.Get("key_vault_id").(string))
+	if err != nil {
+		return err
+	}
+
+	keyVaultBaseUri, err := keyVaultsClient.BaseUriForKeyVault(ctx, *keyVaultId)
+	if err != nil {
+		return fmt.Errorf("fetching base vault url from id %q: %+v", *keyVaultId, err)
+	}
+
+	// we always want to get the latest version
+	resp, err := client.GetSecrets(ctx, *keyVaultBaseUri, utils.Int32(int32(maxResults)))
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure KeyVault %q: %+v", *keyVaultId, err)
+	}
+
+	d.SetId(keyVaultId.ID())
+
+	var all []string
+
+	if resp.Response().Value != nil {
+		for _, v := range *resp.Response().Value {
+			name, err := parseNameFromSecretUrl(*v.ID)
+			if err != nil {
+				return err
+			}
+			all = append(all, *name)
+		}
+	}
+
+	d.Set("all", all)
+	d.Set("key_vault_id", keyVaultId.ID())
+
+	return nil
+}
+
+func parseNameFromSecretUrl(input string) (*string, error) {
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, err
+	}
+	// https://favoretti-keyvault.vault.azure.net/secrets/secret-name
+	segments := strings.Split(uri.Path, "/")
+	if len(segments) != 3 {
+		return nil, fmt.Errorf("expected a Path in the format `/secrets/secret-name` but got %q", uri.Path)
+	}
+	return &segments[2], nil
+}

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -35,7 +35,7 @@ func dataSourceKeyVaultSecrets() *pluginsdk.Resource {
 				Default:  25,
 			},
 
-			"all": {
+			"names": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
@@ -71,7 +71,7 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 
 	d.SetId(keyVaultId.ID())
 
-	var all []string
+	var names []string
 
 	if resp.Response().Value != nil {
 		for _, v := range *resp.Response().Value {
@@ -79,11 +79,11 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 			if err != nil {
 				return err
 			}
-			all = append(all, *name)
+			names = append(names, *name)
 		}
 	}
 
-	d.Set("all", all)
+	d.Set("names", names)
 	d.Set("key_vault_id", keyVaultId.ID())
 
 	return nil

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -69,7 +69,7 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error making Read request on Azure KeyVault %q: %+v", *keyVaultId, err)
 		}
 	} else {
-		secretList, err = client.GetSecretsComplete(ctx, *keyVaultBaseUri, utils.Int32(2147483647))
+		secretList, err = client.GetSecretsComplete(ctx, *keyVaultBaseUri, utils.Int32(2147483646))
 		if err != nil {
 			return fmt.Errorf("Error making Read request on Azure KeyVault %q: %+v", *keyVaultId, err)
 		}

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
@@ -1,0 +1,38 @@
+package keyvault_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type KeyVaultSecretsDataSource struct {
+}
+
+func TestAccDataSourceKeyVaultSecrets_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_secrets", "test")
+	r := KeyVaultSecretsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("all.#").HasValue("1"),
+			),
+		},
+	})
+}
+
+func (KeyVaultSecretsDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_secrets" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  depends_on = [azurerm_key_vault_secret.test]
+}
+`, KeyVaultSecretResource{}.basic(data))
+}

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
@@ -19,7 +19,21 @@ func TestAccDataSourceKeyVaultSecrets_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("names.#").HasValue("1"),
+				check.That(data.ResourceName).Key("names.#").HasValue("31"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKeyVaultSecrets_maxResults(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_secrets", "test")
+	r := KeyVaultSecretsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.maxresults(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("names.#").HasValue("10"),
 			),
 		},
 	})
@@ -29,10 +43,37 @@ func (KeyVaultSecretsDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
+resource "azurerm_key_vault_secret" "test2" {
+  count        = 30
+  name         = "secret-${count.index}"
+  value        = "rick-and-morty"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
 data "azurerm_key_vault_secrets" "test" {
   key_vault_id = azurerm_key_vault.test.id
 
-  depends_on = [azurerm_key_vault_secret.test]
+  depends_on = [azurerm_key_vault_secret.test, azurerm_key_vault_secret.test2]
+}
+`, KeyVaultSecretResource{}.basic(data))
+}
+
+func (KeyVaultSecretsDataSource) maxresults(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_secret" "test2" {
+  count        = 30
+  name         = "secret-${count.index}"
+  value        = "rick-and-morty"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+data "azurerm_key_vault_secrets" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+  max_results  = 10
+
+  depends_on = [azurerm_key_vault_secret.test, azurerm_key_vault_secret.test2]
 }
 `, KeyVaultSecretResource{}.basic(data))
 }

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceKeyVaultSecrets_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("all.#").HasValue("1"),
+				check.That(data.ResourceName).Key("names.#").HasValue("1"),
 			),
 		},
 	})

--- a/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_secrets_data_source_test.go
@@ -25,20 +25,6 @@ func TestAccDataSourceKeyVaultSecrets_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceKeyVaultSecrets_maxResults(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_secrets", "test")
-	r := KeyVaultSecretsDataSource{}
-
-	data.DataSourceTest(t, []acceptance.TestStep{
-		{
-			Config: r.maxresults(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("names.#").HasValue("10"),
-			),
-		},
-	})
-}
-
 func (KeyVaultSecretsDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -52,26 +38,6 @@ resource "azurerm_key_vault_secret" "test2" {
 
 data "azurerm_key_vault_secrets" "test" {
   key_vault_id = azurerm_key_vault.test.id
-
-  depends_on = [azurerm_key_vault_secret.test, azurerm_key_vault_secret.test2]
-}
-`, KeyVaultSecretResource{}.basic(data))
-}
-
-func (KeyVaultSecretsDataSource) maxresults(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_key_vault_secret" "test2" {
-  count        = 30
-  name         = "secret-${count.index}"
-  value        = "rick-and-morty"
-  key_vault_id = azurerm_key_vault.test.id
-}
-
-data "azurerm_key_vault_secrets" "test" {
-  key_vault_id = azurerm_key_vault.test.id
-  max_results  = 10
 
   depends_on = [azurerm_key_vault_secret.test, azurerm_key_vault_secret.test2]
 }

--- a/azurerm/internal/services/keyvault/registration.go
+++ b/azurerm/internal/services/keyvault/registration.go
@@ -28,6 +28,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_key_vault_key":                              dataSourceKeyVaultKey(),
 		"azurerm_key_vault_managed_hardware_security_module": dataSourceKeyVaultManagedHardwareSecurityModule(),
 		"azurerm_key_vault_secret":                           dataSourceKeyVaultSecret(),
+		"azurerm_key_vault_secrets":                          dataSourceKeyVaultSecrets(),
 		"azurerm_key_vault":                                  dataSourceKeyVault(),
 	}
 }

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -17,8 +17,8 @@ data "azurerm_key_vault_secrets" "example" {
   key_vault_id = data.azurerm_key_vault.existing.id
 }
 
-data "azurerm_key_vault_secret" "this" {
-  for_each = data.azurerm_key_vault_secrets.example.all
+data "azurerm_key_vault_secret" "example" {
+  for_each = data.azurerm_key_vault_secrets.example.names
   name     = each.key
 }
 
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `all` - List containing names of secrets that exist in this Key Vault.
+* `names` - List containing names of secrets that exist in this Key Vault.
 * `key_vault_id` - The Key Vault ID.
 
 ## Timeouts

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `key_vault_id` - Specifies the ID of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource.
 
-* `max_results` - Maximum amount of secrets to fetch from the Key Vault. Defaults to `25`.
+* `max_results` - Maximum amount of secrets to fetch from the Key Vault.
 
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -18,7 +18,7 @@ data "azurerm_key_vault_secrets" "example" {
 }
 
 data "azurerm_key_vault_secret" "this" {
-  for_each = data.azurerm_key_vault_secrets.these.all
+  for_each = data.azurerm_key_vault_secrets.example.all
   name     = each.key
 }
 

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_secrets"
+description: |-
+  Gets a list of secret names from an existing Key Vault Secret.
+---
+
+# Data Source: azurerm_key_vault_secrets
+
+Use this data source to retrieve a list of secret names from an existing Key Vault Secret.
+
+## Example Usage
+
+```hcl
+data "azurerm_key_vault_secrets" "example" {
+  key_vault_id = data.azurerm_key_vault.existing.id
+}
+
+data "azurerm_key_vault_secret" "this" {
+  for_each = data.azurerm_key_vault_secrets.these.all
+  name = each.key
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key_vault_id` - Specifies the ID of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource.
+
+* `max_results` - Maximum amount of secrets to fetch from the Key Vault. Defaults to `25`.
+
+**NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `all` - List containing names of secrets that exist in this Key Vault.
+* `key_vault_id` - The Key Vault ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Secret.

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -30,8 +30,6 @@ The following arguments are supported:
 
 * `key_vault_id` - Specifies the ID of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource.
 
-* `max_results` - Maximum amount of secrets to fetch from the Key Vault.
-
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_key_vault_secrets" "example" {
 
 data "azurerm_key_vault_secret" "this" {
   for_each = data.azurerm_key_vault_secrets.these.all
-  name = each.key
+  name     = each.key
 }
 
 ```


### PR DESCRIPTION
TODO:
- [x] Add docs

Fixes #12146

```
2021/06/09 17:27:37 [DEBUG] not using binary driver name, it's no longer needed
2021/06/09 17:27:38 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataSourceKeyVaultSecrets_basic
=== PAUSE TestAccDataSourceKeyVaultSecrets_basic
=== CONT  TestAccDataSourceKeyVaultSecrets_basic
--- PASS: TestAccDataSourceKeyVaultSecrets_basic (351.90s)
PASS
```