### PR TITLE
New resource: azurerm_eventhub_namespace_customer_managed_key

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
@@ -1,0 +1,245 @@
+package eventhub
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/namespaces"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/validate"
+	keyVaultParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
+	keyVaultValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceEventHubNamespaceCustomerManagedKey() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceEventHubNamespaceCustomerManagedKeyCreateUpdate,
+		Read:   resourceEventHubNamespaceCustomerManagedKeyRead,
+		Update: resourceEventHubNamespaceCustomerManagedKeyCreateUpdate,
+		Delete: resourceEventHubNamespaceCustomerManagedKeyDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.DefaultImporter(),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"eventhub_namespace_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NamespaceID,
+			},
+
+			"key_vault_key_ids": {
+				Type:     pluginsdk.TypeSet,
+				Required: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
+				},
+			},
+		},
+	}
+}
+
+func resourceEventHubNamespaceCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := namespaces.NamespaceID(d.Get("eventhub_namespace_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, "azurerm_eventhub_namespace")
+	defer locks.UnlockByName(id.Name, "azurerm_eventhub_namespace")
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	if d.IsNewResource() {
+		if resp.Model.Properties != nil && resp.Model.Properties.Encryption != nil {
+			return tf.ImportAsExistsError("azurerm_eventhub_namespace_customer_managed_key", id.ID())
+		}
+	}
+
+	namespace := resp.Model
+
+	keySource := namespaces.KeySourceMicrosoftKeyVault
+	namespace.Properties.Encryption = &namespaces.Encryption{
+		KeySource: &keySource,
+	}
+
+	keyVaultProps, err := expandEventHubNamespaceKeyVaultKeyIds(d.Get("key_vault_key_ids").(*pluginsdk.Set).List())
+	if err != nil {
+		return err
+	}
+	namespace.Properties.Encryption.KeyVaultProperties = keyVaultProps
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *namespace); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", *id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceEventHubNamespaceCustomerManagedKeyRead(d, meta)
+}
+
+func resourceEventHubNamespaceCustomerManagedKeyRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := namespaces.NamespaceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+	if resp.Model.Properties == nil && resp.Model.Properties.Encryption == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("eventhub_namespace_id", id.ID())
+
+	if props := resp.Model.Properties; props != nil {
+		keyVaultKeyIds, err := flattenEventHubNamespaceKeyVaultKeyIds(props.Encryption)
+		if err != nil {
+			return err
+		}
+
+		d.Set("key_vault_key_ids", keyVaultKeyIds)
+	}
+
+	return nil
+}
+
+func resourceEventHubNamespaceCustomerManagedKeyDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Eventhub.NamespacesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := namespaces.NamespaceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, "azurerm_eventhub_namespace")
+	defer locks.UnlockByName(id.Name, "azurerm_eventhub_namespace")
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	// Since this isn't a real object and it cannot be disabled once Customer Managed Key at rest has been enabled
+	// And it must keep at least one key once Customer Managed Key is enabled
+	// So for the delete operation, it has to recreate the EventHub Namespace with disabled Customer Managed Key
+	future, err := client.Delete(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(future.HttpResponse) {
+			return nil
+		}
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	if err := waitForEventHubNamespaceToBeDeleted(ctx, client, *id); err != nil {
+		return err
+	}
+
+	namespace := resp.Model
+	namespace.Properties.Encryption = nil
+
+	if err = client.CreateOrUpdateThenPoll(ctx, *id, *namespace); err != nil {
+		return fmt.Errorf("removing %s: %+v", *id, err)
+	}
+
+	return nil
+}
+
+func expandEventHubNamespaceKeyVaultKeyIds(input []interface{}) (*[]namespaces.KeyVaultProperties, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	results := make([]namespaces.KeyVaultProperties, 0)
+
+	for _, item := range input {
+		keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(item.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, namespaces.KeyVaultProperties{
+			KeyName:     utils.String(keyId.Name),
+			KeyVaultUri: utils.String(keyId.KeyVaultBaseUrl),
+			KeyVersion:  utils.String(keyId.Version),
+		})
+	}
+
+	return &results, nil
+}
+
+func flattenEventHubNamespaceKeyVaultKeyIds(input *namespaces.Encryption) ([]interface{}, error) {
+	results := make([]interface{}, 0)
+	if input == nil || input.KeyVaultProperties == nil {
+		return results, nil
+	}
+
+	for _, item := range *input.KeyVaultProperties {
+		var keyName string
+		if item.KeyName != nil {
+			keyName = *item.KeyName
+		}
+
+		var keyVaultUri string
+		if item.KeyVaultUri != nil {
+			keyVaultUri = *item.KeyVaultUri
+		}
+
+		var keyVersion string
+		if item.KeyVersion != nil {
+			keyVersion = *item.KeyVersion
+		}
+
+		keyVaultKeyId, err := keyVaultParse.NewNestedItemID(keyVaultUri, "keys", keyName, keyVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, keyVaultKeyId.ID())
+	}
+
+	return results, nil
+}

--- a/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
@@ -1,0 +1,260 @@
+package eventhub_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/eventhub/sdk/namespaces"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type EventHubNamespaceCustomerManagedKeyResource struct {
+}
+
+func TestAccEventHubNamespaceCustomerManagedKey_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace_customer_managed_key", "test")
+	r := EventHubNamespaceCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccEventHubNamespaceCustomerManagedKey_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace_customer_managed_key", "test")
+	r := EventHubNamespaceCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccEventHubNamespaceCustomerManagedKey_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace_customer_managed_key", "test")
+	r := EventHubNamespaceCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccEventHubNamespaceCustomerManagedKey_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace_customer_managed_key", "test")
+	r := EventHubNamespaceCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r EventHubNamespaceCustomerManagedKeyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := namespaces.NamespaceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Eventhub.NamespacesClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+	if resp.Model == nil {
+		return nil, fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	if resp.Model.Properties == nil || resp.Model.Properties.Encryption == nil {
+		return utils.Bool(false), nil
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r EventHubNamespaceCustomerManagedKeyResource) requiresImport(data acceptance.TestData) string {
+	template := EventHubNamespaceCustomerManagedKeyResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_eventhub_namespace_customer_managed_key" "import" {
+  eventhub_namespace_id = azurerm_eventhub_namespace_customer_managed_key.test.eventhub_namespace_id
+  key_vault_key_ids     = azurerm_eventhub_namespace_customer_managed_key.test.key_vault_key_ids
+}
+`, template)
+}
+
+func (r EventHubNamespaceCustomerManagedKeyResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_eventhub_namespace_customer_managed_key" "test" {
+  eventhub_namespace_id = azurerm_eventhub_namespace.test.id
+  key_vault_key_ids     = [azurerm_key_vault_key.test.id]
+}
+`, r.template(data))
+}
+
+func (r EventHubNamespaceCustomerManagedKeyResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "acctestkvkey2%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+  ]
+}
+
+resource "azurerm_eventhub_namespace_customer_managed_key" "test" {
+  eventhub_namespace_id = azurerm_eventhub_namespace.test.id
+  key_vault_key_ids     = [azurerm_key_vault_key.test2.id]
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r EventHubNamespaceCustomerManagedKeyResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "acctestkvkey2%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+  ]
+}
+
+resource "azurerm_eventhub_namespace_customer_managed_key" "test" {
+  eventhub_namespace_id = azurerm_eventhub_namespace.test.id
+  key_vault_key_ids     = [azurerm_key_vault_key.test.id, azurerm_key_vault_key.test2.id]
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r EventHubNamespaceCustomerManagedKeyResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-namespacecmk-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_cluster" "test" {
+  name                = "acctest-cluster-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku_name            = "Dedicated_1"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                 = "acctest-namespace-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  sku                  = "Standard"
+  dedicated_cluster_id = azurerm_eventhub_cluster.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  soft_delete_enabled      = true
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_eventhub_namespace.test.identity.0.tenant_id
+  object_id    = azurerm_eventhub_namespace.test.identity.0.principal_id
+
+  key_permissions = ["get", "unwrapkey", "wrapkey"]
+}
+
+resource "azurerm_key_vault_access_policy" "test2" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "create",
+    "delete",
+    "get",
+    "list",
+    "purge",
+    "recover",
+  ]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkvkey%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString)
+}

--- a/azurerm/internal/services/eventhub/registration.go
+++ b/azurerm/internal/services/eventhub/registration.go
@@ -37,6 +37,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_eventhub_authorization_rule":                 resourceEventHubAuthorizationRule(),
 		"azurerm_eventhub_cluster":                            resourceEventHubCluster(),
 		"azurerm_eventhub_namespace_authorization_rule":       resourceEventHubNamespaceAuthorizationRule(),
+		"azurerm_eventhub_namespace_customer_managed_key":     resourceEventHubNamespaceCustomerManagedKey(),
 		"azurerm_eventhub_namespace_disaster_recovery_config": resourceEventHubNamespaceDisasterRecoveryConfig(),
 		"azurerm_eventhub_namespace":                          resourceEventHubNamespace(),
 		"azurerm_eventhub":                                    resourceEventHub(),

--- a/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
@@ -1,0 +1,158 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_eventhub_namespace_customer_managed_key"
+description: |-
+  Manages a Customer Managed Key for a EventHub Namespace.
+---
+
+# azurerm_eventhub_namespace_customer_managed_key
+
+Manages a Customer Managed Key for a EventHub Namespace.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_eventhub_cluster" "example" {
+  name                = "example-cluster"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku_name            = "Dedicated_1"
+}
+
+resource "azurerm_eventhub_namespace" "example" {
+  name                 = "example-namespace"
+  location             = azurerm_resource_group.example.location
+  resource_group_name  = azurerm_resource_group.example.name
+  sku                  = "Standard"
+  dedicated_cluster_id = azurerm_eventhub_cluster.example.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "example" {
+  name                       = "example-kv"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get",
+      "List",
+      "Update",
+      "Create",
+      "Import",
+      "Delete",
+      "Recover",
+      "Backup",
+      "Restore"
+    ]
+
+    secret_permissions = [
+      "Get",
+      "List",
+      "Set",
+      "Delete",
+      "Recover",
+      "Backup",
+      "Restore"
+    ]
+
+    certificate_permissions = [
+      "Get",
+      "List",
+      "Update",
+      "Create",
+      "Import",
+      "Delete",
+      "Recover",
+      "Backup",
+      "Restore",
+      "ManageContacts",
+      "ManageIssuers",
+      "GetIssuers",
+      "ListIssuers",
+      "SetIssuers",
+      "DeleteIssuers"
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_eventhub_namespace.example.identity.0.tenant_id
+    object_id = azurerm_eventhub_namespace.example.identity.0.principal_id
+
+    key_permissions = [
+      "get",
+      "unwrapKey",
+      "wrapKey",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "example" {
+  name         = "example-key"
+  key_vault_id = azurerm_key_vault.example.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_eventhub_namespace_customer_managed_key" "example" {
+  eventhub_namespace_id = azurerm_eventhub_namespace.example.id
+  key_vault_key_ids     = [azurerm_key_vault_key.example.id]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `eventhub_namespace_id` - (Required) The ID of the EventHub Namespace. Changing this forces a new resource to be created.
+
+* `key_vault_key_ids` - (Required) The list of keys of Key Vault.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the EventHub Namespace.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the EventHub Namespace Customer Managed Key.
+* `read` - (Defaults to 5 minutes) Used when retrieving the EventHub Namespace Customer Managed Key.
+* `update` - (Defaults to 30 minutes) Used when updating the EventHub Namespace Customer Managed Key.
+* `delete` - (Defaults to 30 minutes) Used when deleting the EventHub Namespace Customer Managed Key.
+
+## Import
+
+Customer Managed Keys for a EventHub Namespace can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_eventhub_namespace_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1
+```


### PR DESCRIPTION
Currently, The EventHub Namespace resource doesn't support to enable customer-managed key encryption. So I submitted this PR to implement it.

The encryption property only can be set on an existing resource.

--- PASS: TestAccEventHubNamespaceCustomerManagedKey_basic (15164.75s)
--- PASS: TestAccEventHubNamespaceCustomerManagedKey_complete (15168.92s)
--- PASS: TestAccEventHubNamespaceCustomerManagedKey_update (15377.69s)
--- PASS: TestAccEventHubNamespaceCustomerManagedKey_requiresImport (15387.40s)

API Reference:
https://github.com/Azure/azure-rest-api-specs/blob/d3a5ab585146ee8ee09f43eb0948c45daacd36f7/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2021-01-01-preview/namespaces-preview.json#L662