### PR TITLE
Add missing advanced filtering operators for Event Grid subscriptions

### DIFF
--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -1026,10 +1026,10 @@ func expandAdvancedFilter(operatorType string, config map[string]interface{}) (e
 	case "is_null_or_undefined":
 		return eventgrid.IsNullOrUndefinedAdvancedFilter{Key: &k, OperatorType: eventgrid.OperatorTypeIsNullOrUndefined}, nil
 	case "number_in_range":
-		v := utils.ExpandFloatRangeSlice(config["values"].([][]interface{}))
+		v := utils.ExpandFloatRangeSlice(config["values"].([]interface{}))
 		return eventgrid.NumberInRangeAdvancedFilter{Key: &k, OperatorType: eventgrid.OperatorTypeNumberInRange, Values: v}, nil
 	case "number_not_in_range":
-		v := utils.ExpandFloatRangeSlice(config["values"].([][]interface{}))
+		v := utils.ExpandFloatRangeSlice(config["values"].([]interface{}))
 		return eventgrid.NumberNotInRangeAdvancedFilter{Key: &k, OperatorType: eventgrid.OperatorTypeNumberNotInRange, Values: v}, nil
 	default:
 		return nil, fmt.Errorf("Invalid `advanced_filter` operator_type %q used", operatorType)
@@ -1306,7 +1306,7 @@ func flattenEventGridEventSubscriptionAdvancedFilter(input *eventgrid.EventSubsc
 			"number_in":                     numberIn,
 			"number_not_in":                 numberNotIn,
 			"number_in_range":               numberInRange,
-			"number_not_in_rang":            numberNotInRange,
+			"number_not_in_range":           numberNotInRange,
 			"string_begins_with":            stringBeginsWith,
 			"string_not_begins_with":        stringNotBeginsWith,
 			"string_ends_with":              stringEndsWith,

--- a/azurerm/internal/services/eventgrid/event_subscription.go
+++ b/azurerm/internal/services/eventgrid/event_subscription.go
@@ -650,7 +650,6 @@ func eventSubscriptionSchemaAdvancedFilter() *pluginsdk.Schema {
 								MaxItems: 25,
 								Elem: &pluginsdk.Schema{
 									Type:     pluginsdk.TypeList,
-									Required: true,
 									MinItems: 2,
 									MaxItems: 2,
 									Elem: &pluginsdk.Schema{
@@ -678,7 +677,6 @@ func eventSubscriptionSchemaAdvancedFilter() *pluginsdk.Schema {
 								MaxItems: 25,
 								Elem: &pluginsdk.Schema{
 									Type:     pluginsdk.TypeList,
-									Required: true,
 									MinItems: 2,
 									MaxItems: 2,
 									Elem: &pluginsdk.Schema{
@@ -1266,19 +1264,19 @@ func flattenEventGridEventSubscriptionAdvancedFilter(input *eventgrid.EventSubsc
 			stringBeginsWith = append(stringBeginsWith, flattenValues(f.Key, &v))
 		case eventgrid.StringNotBeginsWithAdvancedFilter:
 			v := utils.FlattenStringSlice(f.Values)
-			stringNotBeginsWith = append(stringBeginsWith, flattenValues(f.Key, &v))
+			stringNotBeginsWith = append(stringNotBeginsWith, flattenValues(f.Key, &v))
 		case eventgrid.StringEndsWithAdvancedFilter:
 			v := utils.FlattenStringSlice(f.Values)
 			stringEndsWith = append(stringEndsWith, flattenValues(f.Key, &v))
 		case eventgrid.StringNotEndsWithAdvancedFilter:
 			v := utils.FlattenStringSlice(f.Values)
-			stringNotEndsWith = append(stringEndsWith, flattenValues(f.Key, &v))
+			stringNotEndsWith = append(stringNotEndsWith, flattenValues(f.Key, &v))
 		case eventgrid.StringContainsAdvancedFilter:
 			v := utils.FlattenStringSlice(f.Values)
 			stringContains = append(stringContains, flattenValues(f.Key, &v))
 		case eventgrid.StringNotContainsAdvancedFilter:
 			v := utils.FlattenStringSlice(f.Values)
-			stringNotContains = append(stringContains, flattenValues(f.Key, &v))
+			stringNotContains = append(stringNotContains, flattenValues(f.Key, &v))
 		case eventgrid.StringInAdvancedFilter:
 			v := utils.FlattenStringSlice(f.Values)
 			stringIn = append(stringIn, flattenValues(f.Key, &v))

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -44,6 +44,8 @@ func resourceEventGridEventSubscription() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(eventSubscriptionCustomizeDiffAdvancedFilter),
+
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.EventSubscriptionID(id)
 			return err

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -157,7 +157,7 @@ func TestAccEventGridEventSubscription_filter(t *testing.T) {
 }
 
 func TestAccEventGridEventSubscription_advancedFilter(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_eventgrid_event_subscription", "test")
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_event_subscription", "test1")
 	r := EventGridEventSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -165,42 +165,7 @@ func TestAccEventGridEventSubscription_advancedFilter(t *testing.T) {
 			Config: r.advancedFilter(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.value").HasValue("true"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.value").HasValue("1"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.value").HasValue("42"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.value").HasValue("42.1"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.value").HasValue("2"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("0"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("5"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.values.0").HasValue("[0, 1]"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.values.0").HasValue("[5, 13]"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("foo"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("bar"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.values.0").HasValue("lorem"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.values.0").HasValue("ipsum"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("application"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.key").HasValue("data.contentType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.values.0").HasValue("text"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("Block"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("Page"),
-				check.That(data.ResourceName).Key("advanced_filter.0.is_not_null.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.is_null_or_undefined.0.key").HasValue("subject"),
+				check.That("azurerm_eventgrid_event_subscription.test2").ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -216,43 +181,6 @@ func TestAccEventGridEventSubscription_advancedFilterMaxItems(t *testing.T) {
 			Config: r.advancedFilterMaxItems(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.value").HasValue("true"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.value").HasValue("2"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.value").HasValue("3"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.value").HasValue("4"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.value").HasValue("5"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("6"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.1").HasValue("7"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.2").HasValue("8"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("9"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.1").HasValue("10"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.2").HasValue("11"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("12"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.1").HasValue("13"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.2").HasValue("14"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("15"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.1").HasValue("16"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.2").HasValue("17"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("18"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.1").HasValue("19"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.2").HasValue("20"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("21"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.1").HasValue("22"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.2").HasValue("23"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("24"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.1").HasValue("25"),
 			),
 		},
 		data.ImportStep(),
@@ -280,12 +208,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "acctestacc%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -297,7 +225,7 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_queue" "test" {
-  name                 = "mysamplequeue-%d"
+  name                 = "mysamplequeue-%[1]d"
   storage_account_name = azurerm_storage_account.test.name
 }
 
@@ -318,7 +246,7 @@ resource "azurerm_storage_blob" "test" {
 }
 
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name  = "acctesteg-%d"
+  name  = "acctesteg-%[1]d"
   scope = azurerm_resource_group.test.id
 
   storage_queue_endpoint {
@@ -338,7 +266,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
 
   labels = ["test", "test1", "test2"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (EventGridEventSubscriptionResource) requiresImport(data acceptance.TestData) string {
@@ -360,12 +288,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "acctestacc%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -377,7 +305,7 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_queue" "test" {
-  name                 = "mysamplequeue-%d"
+  name                 = "mysamplequeue-%[1]d"
   storage_account_name = azurerm_storage_account.test.name
 }
 
@@ -398,7 +326,7 @@ resource "azurerm_storage_blob" "test" {
 }
 
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name  = "acctest-eg-%d"
+  name  = "acctest-eg-%[1]d"
   scope = azurerm_resource_group.test.id
 
   storage_queue_endpoint {
@@ -424,7 +352,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
   included_event_types = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
   labels               = ["test4", "test5", "test6"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (EventGridEventSubscriptionResource) eventHubID(data acceptance.TestData) string {
@@ -434,19 +362,19 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_eventhub_namespace" "test" {
-  name                = "acctesteventhubnamespace-%d"
+  name                = "acctesteventhubnamespace-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Basic"
 }
 
 resource "azurerm_eventhub" "test" {
-  name                = "acctesteventhub-%d"
+  name                = "acctesteventhub-%[1]d"
   namespace_name      = azurerm_eventhub_namespace.test.name
   resource_group_name = azurerm_resource_group.test.name
   partition_count     = 2
@@ -454,13 +382,13 @@ resource "azurerm_eventhub" "test" {
 }
 
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name                  = "acctest-eg-%d"
+  name                  = "acctest-eg-%[1]d"
   scope                 = azurerm_resource_group.test.id
   event_delivery_schema = "CloudEventSchemaV1_0"
 
   eventhub_endpoint_id = azurerm_eventhub.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (EventGridEventSubscriptionResource) serviceBusQueueID(data acceptance.TestData) string {
@@ -469,29 +397,29 @@ provider "azurerm" {
   features {}
 }
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_servicebus_namespace" "example" {
-  name                = "acctestservicebusnamespace-%d"
+  name                = "acctestservicebusnamespace-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Basic"
 }
 resource "azurerm_servicebus_queue" "test" {
-  name                = "acctestservicebusqueue-%d"
+  name                = "acctestservicebusqueue-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   namespace_name      = azurerm_servicebus_namespace.example.name
   enable_partitioning = true
 }
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name                          = "acctest-eg-%d"
+  name                          = "acctest-eg-%[1]d"
   scope                         = azurerm_resource_group.test.id
   event_delivery_schema         = "CloudEventSchemaV1_0"
   service_bus_queue_endpoint_id = azurerm_servicebus_queue.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (EventGridEventSubscriptionResource) serviceBusTopicID(data acceptance.TestData) string {
@@ -500,28 +428,28 @@ provider "azurerm" {
   features {}
 }
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 resource "azurerm_servicebus_namespace" "example" {
-  name                = "acctestservicebusnamespace-%d"
+  name                = "acctestservicebusnamespace-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 }
 resource "azurerm_servicebus_topic" "test" {
-  name                = "acctestservicebustopic-%d"
+  name                = "acctestservicebustopic-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   namespace_name      = azurerm_servicebus_namespace.example.name
   enable_partitioning = true
 }
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name                          = "acctest-eg-%d"
+  name                          = "acctest-eg-%[1]d"
   scope                         = azurerm_resource_group.test.id
   event_delivery_schema         = "CloudEventSchemaV1_0"
   service_bus_topic_endpoint_id = azurerm_servicebus_topic.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (EventGridEventSubscriptionResource) filter(data acceptance.TestData) string {
@@ -531,12 +459,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "acctestacc%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -548,12 +476,12 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_queue" "test" {
-  name                 = "mysamplequeue-%d"
+  name                 = "mysamplequeue-%[1]d"
   storage_account_name = azurerm_storage_account.test.name
 }
 
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name  = "acctest-eg-%d"
+  name  = "acctest-eg-%[1]d"
   scope = azurerm_resource_group.test.id
 
   storage_queue_endpoint {
@@ -568,7 +496,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     subject_ends_with   = ".jpg"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (EventGridEventSubscriptionResource) advancedFilter(data acceptance.TestData) string {
@@ -578,12 +506,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "acctestacc%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -595,12 +523,12 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_queue" "test" {
-  name                 = "mysamplequeue-%d"
+  name                 = "mysamplequeue-%[1]d"
   storage_account_name = azurerm_storage_account.test.name
 }
 
-resource "azurerm_eventgrid_event_subscription" "test" {
-  name  = "acctesteg-%d"
+resource "azurerm_eventgrid_event_subscription" "test1" {
+  name  = "acctesteg-%[1]d-1"
   scope = azurerm_storage_account.test.id
 
   storage_queue_endpoint {
@@ -649,6 +577,19 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "subject"
       values = ["foo"]
     }
+  }
+}
+
+resource "azurerm_eventgrid_event_subscription" "test2" {
+  name  = "acctesteg-%[1]d-2"
+  scope = azurerm_storage_account.test.id
+
+  storage_queue_endpoint {
+    storage_account_id = azurerm_storage_account.test.id
+    queue_name         = azurerm_storage_queue.test.name
+  }
+
+  advanced_filter {
     string_ends_with {
       key    = "subject"
       values = ["bar"]
@@ -684,9 +625,8 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key = "subject"
     }
   }
-
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (EventGridEventSubscriptionResource) advancedFilterMaxItems(data acceptance.TestData) string {
@@ -696,12 +636,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-eg-%d"
-  location = "%s"
+  name     = "acctestRG-eg-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "acctestacc%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -713,12 +653,12 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_queue" "test" {
-  name                 = "mysamplequeue-%d"
+  name                 = "mysamplequeue-%[1]d"
   storage_account_name = azurerm_storage_account.test.name
 }
 
 resource "azurerm_eventgrid_event_subscription" "test" {
-  name  = "acctesteg-%d"
+  name  = "acctesteg-%[1]d"
   scope = azurerm_storage_account.test.id
 
   storage_queue_endpoint {
@@ -778,5 +718,5 @@ resource "azurerm_eventgrid_event_subscription" "test" {
   }
 
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -637,7 +637,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "data.contentLength"
       values = [5, 8, 13, 21, 34]
     }
-	number_in_range {
+    number_in_range {
       key    = "data.contentLength"
       values = [[0, 1], [2, 3]]
     }
@@ -653,7 +653,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "subject"
       values = ["bar"]
     }
-	string_not_begins_with {
+    string_not_begins_with {
       key    = "subject"
       values = ["lorem"]
     }
@@ -665,7 +665,7 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "data.contentType"
       values = ["application", "octet-stream"]
     }
-	string_not_contains {
+    string_not_contains {
       key    = "data.contentType"
       values = ["text"]
     }
@@ -677,11 +677,11 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "data.blobType"
       values = ["Page"]
     }
-	is_not_null {
-      key    = "subject"
+    is_not_null {
+      key = "subject"
     }
-	is_null_or_undefined {
-      key    = "subject"
+    is_null_or_undefined {
+      key = "subject"
     }
   }
 

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -183,8 +183,14 @@ func TestAccEventGridEventSubscription_advancedFilter(t *testing.T) {
 				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("foo"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("bar"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.values.0").HasValue("lorem"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.values.0").HasValue("ipsum"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("application"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.key").HasValue("data.contentType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.values.0").HasValue("text"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("Block"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
@@ -633,9 +639,21 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "subject"
       values = ["bar"]
     }
+	string_not_begins_with {
+      key    = "subject"
+      values = ["lorem"]
+    }
+    string_not_ends_with {
+      key    = "subject"
+      values = ["ipsum"]
+    }
     string_contains {
       key    = "data.contentType"
       values = ["application", "octet-stream"]
+    }
+	string_not_contains {
+      key    = "data.contentType"
+      values = ["text"]
     }
     string_in {
       key    = "data.blobType"

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource_test.go
@@ -179,6 +179,10 @@ func TestAccEventGridEventSubscription_advancedFilter(t *testing.T) {
 				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("0"),
 				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
 				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("5"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.values.0").HasValue("[0, 1]"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.values.0").HasValue("[5, 13]"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("foo"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
@@ -195,6 +199,8 @@ func TestAccEventGridEventSubscription_advancedFilter(t *testing.T) {
 				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("Block"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("Page"),
+				check.That(data.ResourceName).Key("advanced_filter.0.is_not_null.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.is_null_or_undefined.0.key").HasValue("subject"),
 			),
 		},
 		data.ImportStep(),
@@ -631,6 +637,14 @@ resource "azurerm_eventgrid_event_subscription" "test" {
       key    = "data.contentLength"
       values = [5, 8, 13, 21, 34]
     }
+	number_in_range {
+      key    = "data.contentLength"
+      values = [[0, 1], [2, 3]]
+    }
+    number_not_in_range {
+      key    = "data.contentLength"
+      values = [[5, 13], [21, 34]]
+    }
     string_begins_with {
       key    = "subject"
       values = ["foo"]
@@ -662,6 +676,12 @@ resource "azurerm_eventgrid_event_subscription" "test" {
     string_not_in {
       key    = "data.blobType"
       values = ["Page"]
+    }
+	is_not_null {
+      key    = "subject"
+    }
+	is_null_or_undefined {
+      key    = "subject"
     }
   }
 

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
@@ -179,16 +179,28 @@ func TestAccEventGridSystemTopicEventSubscription_advancedFilter(t *testing.T) {
 				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("0"),
 				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
 				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("5"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.values.0").HasValue("[0, 1]"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.key").HasValue("data.contentLength"),
+				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.values.0").HasValue("[5, 13]"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("foo"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("bar"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.values.0").HasValue("lorem"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.values.0").HasValue("ipsum"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("application"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.key").HasValue("data.contentType"),
+				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.values.0").HasValue("text"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("Block"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
 				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("Page"),
+				check.That(data.ResourceName).Key("advanced_filter.0.is_not_null.0.key").HasValue("subject"),
+				check.That(data.ResourceName).Key("advanced_filter.0.is_null_or_undefined.0.key").HasValue("subject"),
 			),
 		},
 		data.ImportStep(),
@@ -699,6 +711,14 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
       key    = "data.contentLength"
       values = [5, 8, 13, 21, 34]
     }
+    number_in_range {
+      key    = "data.contentLength"
+      values = [[0, 1], [2, 3]]
+    }
+    number_not_in_range {
+      key    = "data.contentLength"
+      values = [[5, 13], [21, 34]]
+    }
     string_begins_with {
       key    = "subject"
       values = ["foo"]
@@ -706,6 +726,18 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
     string_ends_with {
       key    = "subject"
       values = ["bar"]
+    }
+    string_not_begins_with {
+      key    = "subject"
+      values = ["lorem"]
+    }
+    string_not_ends_with {
+      key    = "subject"
+      values = ["ipsum"]
+    }
+    string_not_contains {
+      key    = "data.contentType"
+      values = ["text"]
     }
     string_contains {
       key    = "data.contentType"
@@ -718,6 +750,12 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
     string_not_in {
       key    = "data.blobType"
       values = ["Page"]
+    }
+    is_not_null {
+      key = "subject"
+    }
+    is_null_or_undefined {
+      key = "subject"
     }
   }
 

--- a/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_system_topic_event_subscription_resource_test.go
@@ -157,7 +157,7 @@ func TestAccEventGridSystemTopicEventSubscription_filter(t *testing.T) {
 }
 
 func TestAccEventGridSystemTopicEventSubscription_advancedFilter(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_eventgrid_system_topic_event_subscription", "test")
+	data := acceptance.BuildTestData(t, "azurerm_eventgrid_system_topic_event_subscription", "test1")
 	r := EventGridSystemTopicEventSubscriptionResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -165,42 +165,7 @@ func TestAccEventGridSystemTopicEventSubscription_advancedFilter(t *testing.T) {
 			Config: r.advancedFilter(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.value").HasValue("true"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.value").HasValue("1"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.value").HasValue("42"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.value").HasValue("42.1"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.value").HasValue("2"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("0"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("5"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in_range.0.values.0").HasValue("[0, 1]"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in_range.0.values.0").HasValue("[5, 13]"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("foo"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("bar"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_begins_with.0.values.0").HasValue("lorem"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_ends_with.0.values.0").HasValue("ipsum"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("application"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.key").HasValue("data.contentType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_contains.0.values.0").HasValue("text"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("Block"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("Page"),
-				check.That(data.ResourceName).Key("advanced_filter.0.is_not_null.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.is_null_or_undefined.0.key").HasValue("subject"),
+				check.That("azurerm_eventgrid_system_topic_event_subscription.test2").ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -216,43 +181,6 @@ func TestAccEventGridSystemTopicEventSubscription_advancedFilterMaxItems(t *test
 			Config: r.advancedFilterMaxItems(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.bool_equals.0.value").HasValue("true"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than.0.value").HasValue("2"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_greater_than_or_equals.0.value").HasValue("3"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than.0.value").HasValue("4"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.key").HasValue("data.metadataVersion"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_less_than_or_equals.0.value").HasValue("5"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.0").HasValue("6"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.1").HasValue("7"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_in.0.values.2").HasValue("8"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.key").HasValue("data.contentLength"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.0").HasValue("9"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.1").HasValue("10"),
-				check.That(data.ResourceName).Key("advanced_filter.0.number_not_in.0.values.2").HasValue("11"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.0").HasValue("12"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.1").HasValue("13"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_begins_with.0.values.2").HasValue("14"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.key").HasValue("subject"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.0").HasValue("15"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.1").HasValue("16"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_ends_with.0.values.2").HasValue("17"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.key").HasValue("data.contentType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.0").HasValue("18"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.1").HasValue("19"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_contains.0.values.2").HasValue("20"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.0").HasValue("21"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.1").HasValue("22"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_in.0.values.2").HasValue("23"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.key").HasValue("data.blobType"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.0").HasValue("24"),
-				check.That(data.ResourceName).Key("advanced_filter.0.string_not_in.0.values.1").HasValue("25"),
 			),
 		},
 		data.ImportStep(),
@@ -672,8 +600,8 @@ resource "azurerm_eventgrid_system_topic" "test" {
   topic_type             = "Microsoft.Resources.ResourceGroups"
 }
 
-resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
-  name                = "acctesteg-%[1]d"
+resource "azurerm_eventgrid_system_topic_event_subscription" "test1" {
+  name                = "acctesteg-%[1]d-1"
   system_topic        = azurerm_eventgrid_system_topic.test.name
   resource_group_name = azurerm_resource_group.test.name
 
@@ -723,6 +651,20 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
       key    = "subject"
       values = ["foo"]
     }
+  }
+}
+
+resource "azurerm_eventgrid_system_topic_event_subscription" "test2" {
+  name                = "acctesteg-%[1]d-2"
+  system_topic        = azurerm_eventgrid_system_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  storage_queue_endpoint {
+    storage_account_id = azurerm_storage_account.test.id
+    queue_name         = azurerm_storage_queue.test.name
+  }
+
+  advanced_filter {
     string_ends_with {
       key    = "subject"
       values = ["bar"]
@@ -758,7 +700,6 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "test" {
       key = "subject"
     }
   }
-
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -22,6 +22,16 @@ func ExpandFloatSlice(input []interface{}) *[]float64 {
 	return &result
 }
 
+func ExpandFloatRangeSlice(input [][]interface{}) *[][]float64 {
+	result := make([][]float64, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, *ExpandFloatSlice(item))
+		}
+	}
+	return &result
+}
+
 func ExpandMapStringPtrString(input map[string]interface{}) map[string]*string {
 	result := make(map[string]*string)
 	for k, v := range input {
@@ -54,6 +64,16 @@ func FlattenFloatSlice(input *[]float64) []interface{} {
 	if input != nil {
 		for _, item := range *input {
 			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func FlattenFloatRangeSlice(input *[][]float64) [][]interface{} {
+	result := make([][]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, FlattenFloatSlice(&item))
 		}
 	}
 	return result

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -22,11 +22,11 @@ func ExpandFloatSlice(input []interface{}) *[]float64 {
 	return &result
 }
 
-func ExpandFloatRangeSlice(input [][]interface{}) *[][]float64 {
+func ExpandFloatRangeSlice(input []interface{}) *[][]float64 {
 	result := make([][]float64, 0)
 	for _, item := range input {
 		if item != nil {
-			result = append(result, *ExpandFloatSlice(item))
+			result = append(result, *ExpandFloatSlice(item.([]interface{})))
 		}
 	}
 	return &result

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -175,9 +175,9 @@ Each nested block consists of a key and a value(s) element.
 
 * `key` - (Required) Specifies the field within the event data that you want to use for filtering. Type of the field can be a number, boolean, or string.
 
-* `value` - (Required) Specifies a single value to compare to when using a single value operator. 
+* `value` - (Required) Specifies a single value to compare to when using a single value operator.
 
-**OR** 
+**OR**
 
 * `values` - (Required) Specifies an array of values to compare to when using a multiple values operator.
 

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -159,8 +159,11 @@ A `advanced_filter` supports the following nested blocks:
 * `number_in` - Compares a value of an event using multiple floating point numbers.
 * `number_not_in` - Compares a value of an event using multiple floating point numbers.
 * `string_begins_with` - Compares a value of an event using multiple string values.
+* `string_not_begins_with` - Compares a value of an event using multiple string values.
 * `string_ends_with` - Compares a value of an event using multiple string values.
+* `string_not_ends_with` - Compares a value of an event using multiple string values.
 * `string_contains` - Compares a value of an event using multiple string values.
+* `string_not_contains` - Compares a value of an event using multiple string values.
 * `string_in` - Compares a value of an event using multiple string values.
 * `string_not_in` - Compares a value of an event using multiple string values.
 

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -158,6 +158,8 @@ A `advanced_filter` supports the following nested blocks:
 * `number_less_than_or_equals` - Compares a value of an event using a single floating point number.
 * `number_in` - Compares a value of an event using multiple floating point numbers.
 * `number_not_in` - Compares a value of an event using multiple floating point numbers.
+* `number_in_range` - Compares a value of an event using multiple floating point number ranges.
+* `number_not_in_range` - Compares a value of an event using multiple floating point number ranges.
 * `string_begins_with` - Compares a value of an event using multiple string values.
 * `string_not_begins_with` - Compares a value of an event using multiple string values.
 * `string_ends_with` - Compares a value of an event using multiple string values.
@@ -166,6 +168,8 @@ A `advanced_filter` supports the following nested blocks:
 * `string_not_contains` - Compares a value of an event using multiple string values.
 * `string_in` - Compares a value of an event using multiple string values.
 * `string_not_in` - Compares a value of an event using multiple string values.
+* `is_not_null` - Evaluates if a value of an event isn't NULL or undefined.
+* `is_null_or_undefined` - Evaluates if a value of an event is NULL or undefined.
 
 Each nested block consists of a key and a value(s) element.
 

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -152,19 +152,26 @@ A `advanced_filter` supports the following nested blocks:
 * `number_less_than_or_equals` - Compares a value of an event using a single floating point number.
 * `number_in` - Compares a value of an event using multiple floating point numbers.
 * `number_not_in` - Compares a value of an event using multiple floating point numbers.
+* `number_in_range` - Compares a value of an event using multiple floating point number ranges.
+* `number_not_in_range` - Compares a value of an event using multiple floating point number ranges.
 * `string_begins_with` - Compares a value of an event using multiple string values.
+* `string_not_begins_with` - Compares a value of an event using multiple string values.
 * `string_ends_with` - Compares a value of an event using multiple string values.
+* `string_not_ends_with` - Compares a value of an event using multiple string values.
 * `string_contains` - Compares a value of an event using multiple string values.
+* `string_not_contains` - Compares a value of an event using multiple string values.
 * `string_in` - Compares a value of an event using multiple string values.
 * `string_not_in` - Compares a value of an event using multiple string values.
+* `is_not_null` - Evaluates if a value of an event isn't NULL or undefined.
+* `is_null_or_undefined` - Evaluates if a value of an event is NULL or undefined.
 
 Each nested block consists of a key and a value(s) element.
 
 * `key` - (Required) Specifies the field within the event data that you want to use for filtering. Type of the field can be a number, boolean, or string.
 
-* `value` - (Required) Specifies a single value to compare to when using a single value operator. 
+* `value` - (Required) Specifies a single value to compare to when using a single value operator.
 
-**OR** 
+**OR**
 
 * `values` - (Required) Specifies an array of values to compare to when using a multiple values operator.
 
@@ -188,7 +195,7 @@ A `retry_policy` supports the following:
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported: 
+In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the EventGrid System Topic.
 


### PR DESCRIPTION
Currently the azurerm_eventgrid_event_subscription does not implement all supported advanced filters from Event Grid subscriptions. 
This PR is intended to add the missing `NumberInRage`, `NumberNotInRange`, `StringNotBeginsWith`, `StringNotEndsWith`, `StringNotContains`, `IsNotNull` and `IsNullOrUndefined` filtering operators.

Fixes #12162