### PR TITLE
`azurerm_stream_analytics_job` - add supports for `identity`

### DIFF
--- a/azurerm/internal/services/streamanalytics/stream_analytics_job_data_source.go
+++ b/azurerm/internal/services/streamanalytics/stream_analytics_job_data_source.go
@@ -59,6 +59,27 @@ func dataSourceArmStreamAnalyticsJob() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"identity": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"type": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"principal_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"output_error_policy": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -100,6 +121,9 @@ func dataSourceArmStreamAnalyticsJobRead(d *pluginsdk.ResourceData, meta interfa
 	d.Set("resource_group_name", resourceGroup)
 	if resp.Location != nil {
 		d.Set("location", azure.NormalizeLocation(*resp.Location))
+	}
+	if err := d.Set("identity", flattenStreamAnalyticsJobIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("setting `identity`: %v", err)
 	}
 
 	if props := resp.StreamingJobProperties; props != nil {

--- a/azurerm/internal/services/streamanalytics/stream_analytics_job_data_source_test.go
+++ b/azurerm/internal/services/streamanalytics/stream_analytics_job_data_source_test.go
@@ -25,8 +25,37 @@ func TestAccDataSourceStreamAnalyticsJob_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceStreamAnalyticsJob_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_stream_analytics_job", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StreamAnalyticsJobDataSource{}.identity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("job_id").Exists(),
+				check.That(data.ResourceName).Key("streaming_units").Exists(),
+				check.That(data.ResourceName).Key("transformation_query").Exists(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
+			),
+		},
+	})
+}
+
 func (d StreamAnalyticsJobDataSource) basic(data acceptance.TestData) string {
 	config := StreamAnalyticsJobResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_stream_analytics_job" "test" {
+  name                = azurerm_stream_analytics_job.test.name
+  resource_group_name = azurerm_stream_analytics_job.test.resource_group_name
+}
+`, config)
+}
+
+func (d StreamAnalyticsJobDataSource) identity(data acceptance.TestData) string {
+	config := StreamAnalyticsJobResource{}.identity(data)
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/d/stream_analytics_job.html.markdown
+++ b/website/docs/d/stream_analytics_job.html.markdown
@@ -48,12 +48,23 @@ output "job_id" {
 
 * `location` - The Azure location where the Stream Analytics Job exists.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `output_error_policy` - The policy which should be applied to events which arrive at the output and cannot be written to the external storage due to being malformed (such as missing column values, column values of wrong type or size). 
 
 * `streaming_units` - The number of streaming units that the streaming job uses.
 
 * `transformation_query` - The query that will be run in the streaming job, [written in Stream Analytics Query Language (SAQL)](https://msdn.microsoft.com/library/azure/dn834998).
 
+---
+
+An `identity` block exports the following:
+
+* `type` - The type of identity used for the Stream Analytics Job.
+  
+* `principal_id` - The ID of the Principal (Client) in Azure Active Directory.
+
+* `tenant_id` - The ID of the Azure Active Directory Tenant.
 
 ## Timeouts
 

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 * `events_out_of_order_policy` - (Optional) Specifies the policy which should be applied to events which arrive out of order in the input event stream. Possible values are `Adjust` and `Drop`.  Default is `Adjust`.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `output_error_policy` - (Optional) Specifies the policy which should be applied to events which arrive at the output and cannot be written to the external storage due to being malformed (such as missing column values, column values of wrong type or size). Possible values are `Drop` and `Stop`.  Default is `Drop`.
 
 * `streaming_units` - (Required) Specifies the number of streaming units that the streaming job uses. Supported values are `1`, `3`, `6` and multiples of `6` up to `120`.
@@ -73,6 +75,12 @@ The following arguments are supported:
 
 * `tags` - A mapping of tags assigned to the resource.
 
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The type of identity used for the Stream Analytics Job. Possible values are `SystemAssigned`.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
@@ -80,6 +88,16 @@ The following attributes are exported in addition to the arguments listed above:
 * `id` - The ID of the Stream Analytics Job.
 
 * `job_id` - The Job ID assigned by the Stream Analytics Job.
+  
+* `identity` - (Optional) An `identity` block as defined below.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The ID of the Principal (Client) in Azure Active Directory.
+
+* `tenant_id` - The ID of the Azure Active Directory Tenant.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #12096 

## Test Result

```shell
💢 TF_ACC=1 go test -v -timeout=8h ./azurerm/internal/services/streamanalytics -run="TestAccStreamAnalyticsJob_identity|TestAccDataSourceStreamAnalyticsJob_identity"
2021/06/11 12:23:47 [DEBUG] not using binary driver name, it's no longer needed
2021/06/11 12:23:47 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataSourceStreamAnalyticsJob_identity
=== PAUSE TestAccDataSourceStreamAnalyticsJob_identity
=== RUN   TestAccStreamAnalyticsJob_identity
=== PAUSE TestAccStreamAnalyticsJob_identity
=== CONT  TestAccDataSourceStreamAnalyticsJob_identity
=== CONT  TestAccStreamAnalyticsJob_identity
--- PASS: TestAccDataSourceStreamAnalyticsJob_identity (167.98s)
--- PASS: TestAccStreamAnalyticsJob_identity (176.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/streamanalytics     177.064s
```