### PR TITLE
`azurerm_monitor_metric_alert`: Support `StartsWith` dimension operator

### DIFF
--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
@@ -122,6 +122,7 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 										ValidateFunc: validation.StringInSlice([]string{
 											"Include",
 											"Exclude",
+											"StartsWith",
 										}, false),
 									},
 									"values": {

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -146,7 +146,7 @@ A `application_insights_web_test_location_availability_criteria` block supports 
 A `dimension` block supports the following:
 
 * `name` - (Required) One of the dimension names.
-* `operator` - (Required) The dimension operator. Possible values are `Include` and `Exclude`.
+* `operator` - (Required) The dimension operator. Possible values are `Include`, `Exclude` and `StartsWith`.
 * `values` - (Required) The list of dimension values.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes #12175