### PR TITLE
Align docs and schema for `azurerm_data_factory_linked_service_data_lake_storage_gen2`

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
@@ -62,41 +62,42 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2() *pluginsdk.Resource {
 				Type:          pluginsdk.TypeBool,
 				Optional:      true,
 				Default:       false,
-				ConflictsWith: []string{"service_principal_key", "service_principal_id", "storage_account_key"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
+				ConflictsWith: []string{"service_principal_key", "service_principal_id", "storage_account_key", "tenant"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "tenant", "storage_account_key", "use_managed_identity"},
 			},
 
 			"service_principal_id": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
 				ValidateFunc:  validation.IsUUID,
-				RequiredWith:  []string{"service_principal_key"},
+				RequiredWith:  []string{"service_principal_key", "tenant"},
 				ConflictsWith: []string{"storage_account_key", "use_managed_identity"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "tenant", "storage_account_key", "use_managed_identity"},
 			},
 
 			"service_principal_key": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
 				ValidateFunc:  validation.StringIsNotEmpty,
-				RequiredWith:  []string{"service_principal_id"},
+				RequiredWith:  []string{"service_principal_id", "tenant"},
 				ConflictsWith: []string{"storage_account_key", "use_managed_identity"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "tenant", "storage_account_key", "use_managed_identity"},
 			},
 
 			"storage_account_key": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"service_principal_id", "service_principal_key", "use_managed_identity"},
-				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "storage_account_key", "use_managed_identity"},
+				ConflictsWith: []string{"service_principal_id", "service_principal_key", "use_managed_identity", "tenant"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "tenant", "storage_account_key", "use_managed_identity"},
 			},
 
 			"tenant": {
 				Type:          pluginsdk.TypeString,
 				Optional:      true,
 				ValidateFunc:  validation.StringIsNotEmpty,
-				RequiredWith:  []string{"service_principal_id"},
+				RequiredWith:  []string{"service_principal_id", "service_principal_key},
 				ConflictsWith: []string{"storage_account_key", "use_managed_identity"},
+				AtLeastOneOf:  []string{"service_principal_key", "service_principal_id", "tenant", "storage_account_key", "use_managed_identity"},
 			},
 
 			"description": {

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_data_lake_storage_gen2_resource.go
@@ -270,6 +270,7 @@ func resourceDataFactoryLinkedServiceDataLakeStorageGen2Read(d *pluginsdk.Resour
 
 	if dataLakeStorageGen2.ServicePrincipalID != nil {
 		d.Set("service_principal_id", dataLakeStorageGen2.ServicePrincipalID)
+		d.Set("use_managed_identity", false)
 	}
 
 	if dataLakeStorageGen2.URL != nil {

--- a/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
+++ b/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
@@ -65,19 +65,19 @@ The following supported arguments are specific to Data Lake Storage Gen2 Linked 
 
 * `url` - (Required) The endpoint for the Azure Data Lake Storage Gen2 service.
 
-* `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure Data Lake Storage Gen2 account. Incompatible with `service_principal_id` and `service_principal_key`  
+~> **NOTE** Users should specify only one of the following three authentication strategies: storage account key, managed identity, service principal.
 
-* `service_principal_id` - (Optional) The service principal id in which to authenticate against the Azure Data Lake Storage Gen2 account.
+* `storage_account_key` - (Optional) The Storage Account Key with which to authenticate against the Azure Data Lake Storage Gen2 account.  Incompatible with `service_principal_id`, `service_principal_key`, `tenant` and `use_managed_identity`.
 
-* `service_principal_key` - (Optional) The service principal key in which to authenticate against the Azure Data Lake Storage Gen2 account.
+* `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure Data Lake Storage Gen2 account. Incompatible with `service_principal_id`, `service_principal_key`, `tenant` and `storage_account_key`.
 
-~> **NOTE** If `service_principal_id` is used, `service_principal_key` is also required.
+* `service_principal_id` - (Optional) The service principal id with which to authenticate against the Azure Data Lake Storage Gen2 account.  Incompatible with `storage_account_key` and `use_managed_identity`.
 
-* `storage_account_key` - (Optional) The Storage Account Key in which to authenticate against the Azure Data Lake Storage Gen2 account.
+* `service_principal_key` - (Optional) The service principal key with which to authenticate against the Azure Data Lake Storage Gen2 account.
 
-* `tenant` - (Required) The tenant id or name in which to authenticate against the Azure Data Lake Storage Gen2 account.
+* `tenant` - (Optional) The tenant id or name in which the service principal exists to authenticate against the Azure Data Lake Storage Gen2 account.
 
-~> **NOTE** Users should specify one of the three authentication way: storage account key, service principal, managed identity.
+~> **NOTE** If `service_principal_id` is used, `service_principal_key` and `tenant` are also required.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Updated dependencies in the schema to match the Azure API docs
Updated website docs to match the schema in Azure API docs
Reinstated a recently-removed setting based on the above - please review this one carefully!

@favoretti I am not knowledgeable enough to determine if the tests might now need to be changed to match the changed schema; I hope you can help with this.

Thanks for letting me contribute.