### PR TITLE
`azurerm_lb` - fix zone behaviour bug introduced in recent API upgrade

### DIFF
--- a/azurerm/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_resource.go
@@ -109,8 +109,6 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 						"private_ip_address_version": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							// this property should only be applied for frontendIpConfigurations which reference a subnet
-							//Default:  string(network.IPVersionIPv4),
 							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(network.IPVersionIPv4),

--- a/azurerm/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_resource.go
@@ -397,6 +397,7 @@ func expandAzureRmLoadBalancerFrontendIpConfigurations(d *pluginsdk.ResourceData
 		}
 
 		name := data["name"].(string)
+		// TODO - get zone list for each location by Resource API, instead of hardcode
 		zones := &[]string{"1", "2"}
 		zonesSet := false
 		// TODO - Remove in 3.0

--- a/azurerm/internal/services/loadbalancer/loadbalancer_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_resource_test.go
@@ -165,6 +165,36 @@ func TestAccAzureRMLoadBalancer_privateIP(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLoadBalancer_ZoneRedundant(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_lb", "test")
+	r := LoadBalancer{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.availability_zone(data, "Zone-Redundant"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMLoadBalancer_NoZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_lb", "test")
+	r := LoadBalancer{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.availability_zone(data, "No-Zone"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LoadBalancer) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	loadBalancerName := state.Attributes["name"]
 	resourceGroup := state.Attributes["resource_group_name"]
@@ -496,4 +526,47 @@ resource "azurerm_lb" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LoadBalancer) availability_zone(data acceptance.TestData, zone string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-lb-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctestlb-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                          = "Internal"
+    private_ip_address_allocation = "Static"
+    private_ip_address_version    = "IPv4"
+    private_ip_address            = "10.0.2.7"
+    subnet_id                     = azurerm_subnet.test.id
+    availability_zone             = "%s"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, zone)
 }

--- a/azurerm/internal/services/loadbalancer/loadbalancer_resource_test.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_resource_test.go
@@ -195,6 +195,21 @@ func TestAccAzureRMLoadBalancer_NoZone(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLoadBalancer_SingleZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_lb", "test")
+	r := LoadBalancer{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.availability_zone(data, "1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LoadBalancer) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	loadBalancerName := state.Attributes["name"]
 	resourceGroup := state.Attributes["resource_group_name"]

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -53,7 +53,8 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the frontend ip configuration.
 * `availability_zone` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Defaults to `Zone-Redundant`.
-  
+  `Zone-Redundant` will specify multiple zones in a region with Availability Zones and create a zone-redundant resource.
+
 -> **Please Note**: Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Load Balancer that do not specify a zone are zone redundant by default.
 
 * `subnet_id` - The ID of the Subnet which should be associated with the IP Configuration.

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -53,9 +53,13 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the frontend ip configuration.
 * `availability_zone` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Defaults to `Zone-Redundant`.
-  `Zone-Redundant` will specify multiple zones in a region with Availability Zones and create a zone-redundant resource.
+ `No-Zones` - A `non-zonal` resource will be created and the resource will not be replicated or distributed to any Availability Zones.
 
--> **Please Note**: Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Load Balancer that do not specify a zone are zone redundant by default.
+ `1`, `2` or `3` (e.g. single Availability Zone) - A `zonal` resource will be created and will be replicate or distribute to a single specific Availability Zone. 
+
+ `Zone-Redundant` - A `zone-redundant` resource will be created and will replicate or distribute the resource across all three Availability Zones automatically.
+
+-> **NOTE:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Load Balancer that do not specify a zone are zone redundant by default.
 
 * `subnet_id` - The ID of the Subnet which should be associated with the IP Configuration.
 * `private_ip_address` - (Optional) Private IP Address to assign to the Load Balancer. The last one and first four IPs in any range are reserved and cannot be manually assigned.

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -52,15 +52,16 @@ The following arguments are supported:
 `frontend_ip_configuration` supports the following:
 
 * `name` - (Required) Specifies the name of the frontend ip configuration.
+* `availability_zone` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in. Possible values are `Zone-Redundant`, `1`, `2`, `3`, and `No-Zone`. Defaults to `Zone-Redundant`.
+  
+-> **Please Note**: Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Load Balancer that do not specify a zone are zone redundant by default.
+
 * `subnet_id` - The ID of the Subnet which should be associated with the IP Configuration.
 * `private_ip_address` - (Optional) Private IP Address to assign to the Load Balancer. The last one and first four IPs in any range are reserved and cannot be manually assigned.
 * `private_ip_address_allocation` - (Optional) The allocation method for the Private IP Address used by this Load Balancer. Possible values as `Dynamic` and `Static`.
 * `private_ip_address_version` - The version of IP that the Private IP Address is. Possible values are `IPv4` or `IPv6`.
 * `public_ip_address_id` - (Optional) The ID of a Public IP Address which should be associated with the Load Balancer.
 * `public_ip_prefix_id` - (Optional) The ID of a Public IP Prefix which should be associated with the Load Balancer. Public IP Prefix can only be used with outbound rules.
-* `zones` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in.
-
--> **Please Note**: Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-availability-zones) and [in select regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) at this time. Standard SKU Load Balancer that do not specify a zone are zone redundant by default.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR fixed 2 issues.
1. For users who use azurerm 2.62.x, there'll be a [breaking change]( https://azure.microsoft.com/en-us/updates/zone-behavior-change/) when they update azurerm to latest version. This is fix is similar with [the fix for public ip resource](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/internal/services/network/public_ip_resource.go#L64).


2. For users who updates to azurerm 2.63.0, resources will be deployed as `no-zone` by default and there's no way to set it as `zone-redundant`.

After this fix, 2.62.x users can update azurerm smoothly. But users who ever used 2.63.0, if they want to use a `zone-redundant` resource, they have modify config and add the following line.
```
availability_zone = "Zone-Redundant"
```


The tests are listed as the following.
```

=== RUN   TestAccAzureRMLoadBalancer_basic
=== PAUSE TestAccAzureRMLoadBalancer_basic
=== CONT  TestAccAzureRMLoadBalancer_basic
--- PASS: TestAccAzureRMLoadBalancer_basic (245.14s)
=== RUN   TestAccAzureRMLoadBalancer_requiresImport
=== PAUSE TestAccAzureRMLoadBalancer_requiresImport
=== CONT  TestAccAzureRMLoadBalancer_requiresImport
--- PASS: TestAccAzureRMLoadBalancer_requiresImport (239.84s)
=== RUN   TestAccAzureRMLoadBalancer_standard
=== PAUSE TestAccAzureRMLoadBalancer_standard
=== CONT  TestAccAzureRMLoadBalancer_standard
--- PASS: TestAccAzureRMLoadBalancer_standard (178.31s)
=== RUN   TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix
=== PAUSE TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix
=== CONT  TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix (223.97s)
=== RUN   TestAccAzureRMLoadBalancer_frontEndConfig
=== PAUSE TestAccAzureRMLoadBalancer_frontEndConfig
=== CONT  TestAccAzureRMLoadBalancer_frontEndConfig
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfig (488.93s)
=== RUN   TestAccAzureRMLoadBalancer_tags
=== PAUSE TestAccAzureRMLoadBalancer_tags
=== CONT  TestAccAzureRMLoadBalancer_tags
--- PASS: TestAccAzureRMLoadBalancer_tags (312.32s)
=== RUN   TestAccAzureRMLoadBalancer_emptyPrivateIP
=== PAUSE TestAccAzureRMLoadBalancer_emptyPrivateIP
=== CONT  TestAccAzureRMLoadBalancer_emptyPrivateIP
--- PASS: TestAccAzureRMLoadBalancer_emptyPrivateIP (311.15s)
=== RUN   TestAccAzureRMLoadBalancer_privateIP
=== PAUSE TestAccAzureRMLoadBalancer_privateIP
=== CONT  TestAccAzureRMLoadBalancer_privateIP
--- PASS: TestAccAzureRMLoadBalancer_privateIP (259.72s)
=== RUN   TestAccAzureRMLoadBalancer_ZoneRedundant
=== PAUSE TestAccAzureRMLoadBalancer_ZoneRedundant
=== CONT  TestAccAzureRMLoadBalancer_ZoneRedundant
--- PASS: TestAccAzureRMLoadBalancer_ZoneRedundant (242.98s)
=== RUN   TestAccAzureRMLoadBalancer_NoZone
=== PAUSE TestAccAzureRMLoadBalancer_NoZone
=== CONT  TestAccAzureRMLoadBalancer_NoZone
--- PASS: TestAccAzureRMLoadBalancer_NoZone (245.47s)
=== RUN   TestAccAzureRMLoadBalancer_SingleZone
=== PAUSE TestAccAzureRMLoadBalancer_SingleZone
=== CONT  TestAccAzureRMLoadBalancer_SingleZone
--- PASS: TestAccAzureRMLoadBalancer_SingleZone (251.52s)
PASS


```

(fixes #12215)