### PR TITLE
new resource "azurerm_data_factory_linked_custom_service"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource.go
@@ -56,9 +56,9 @@ func resourceDataFactoryLinkedCustomService() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
-			"type_property_json": {
+			"type_properties_json": {
 				Type:             pluginsdk.TypeString,
-				Optional:         true,
+				Required:         true,
 				StateFunc:        utils.NormalizeJson,
 				DiffSuppressFunc: suppressJsonOrderingDifference,
 			},
@@ -148,11 +148,9 @@ func resourceDataFactoryLinkedCustomServiceCreateUpdate(d *pluginsdk.ResourceDat
 		"connectVia": expandDataFactoryLinkedServiceIntegrationRuntimeV2(d.Get("integration_runtime").([]interface{})),
 	}
 
-	if v, ok := d.GetOk("type_property_json"); ok {
-		jsonData := fmt.Sprintf(`{ "typeProperties": %s }`, v.(string))
-		if err = json.Unmarshal([]byte(jsonData), &props); err != nil {
-			return err
-		}
+	jsonDataStr := fmt.Sprintf(`{ "typeProperties": %s }`, d.Get("type_properties_json").(string))
+	if err = json.Unmarshal([]byte(jsonDataStr), &props); err != nil {
+		return err
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource.go
@@ -1,0 +1,337 @@
+package datafactory
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDataFactoryLinkedCustomService() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceDataFactoryLinkedCustomServiceCreateUpdate,
+		Read:   resourceDataFactoryLinkedCustomServiceRead,
+		Update: resourceDataFactoryLinkedCustomServiceCreateUpdate,
+		Delete: resourceDataFactoryLinkedCustomServiceDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.LinkedServiceID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.LinkedServiceDatasetName,
+			},
+
+			"data_factory_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataFactoryID,
+			},
+
+			"type": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type_property_json": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				StateFunc:        utils.NormalizeJson,
+				DiffSuppressFunc: suppressJsonOrderingDifference,
+			},
+
+			"description": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"integration_runtime": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"parameters": {
+							Type:     pluginsdk.TypeMap,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"parameters": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"annotations": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"additional_properties": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceDataFactoryLinkedCustomServiceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	dataFactoryId, err := parse.DataFactoryID(d.Get("data_factory_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := parse.NewLinkedServiceID(subscriptionId, dataFactoryId.ResourceGroup, dataFactoryId.FactoryName, d.Get("name").(string))
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_data_factory_linked_custom_service", id.ID())
+		}
+	}
+
+	props := map[string]interface{}{
+		"type":       d.Get("type").(string),
+		"connectVia": expandDataFactoryLinkedServiceIntegrationRuntimeV2(d.Get("integration_runtime").([]interface{})),
+	}
+
+	if v, ok := d.GetOk("type_property_json"); ok {
+		jsonData := fmt.Sprintf(`{ "typeProperties": %s }`, v.(string))
+		if err = json.Unmarshal([]byte(jsonData), &props); err != nil {
+			return err
+		}
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		props["description"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		props["parameters"] = expandDataFactoryParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		props["annotations"] = v.([]interface{})
+	}
+
+	additionalProperties := d.Get("additional_properties").(map[string]interface{})
+	for k, v := range additionalProperties {
+		props[k] = v
+	}
+
+	jsonData, err := json.Marshal(map[string]interface{}{
+		"properties": props,
+	})
+	if err != nil {
+		return err
+	}
+
+	linkedService := &datafactory.LinkedServiceResource{}
+	if err := linkedService.UnmarshalJSON(jsonData); err != nil {
+		return err
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.FactoryName, id.Name, *linkedService, ""); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceDataFactoryLinkedCustomServiceRead(d, meta)
+}
+
+func resourceDataFactoryLinkedCustomServiceRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LinkedServiceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("data_factory_id", parse.NewDataFactoryID(subscriptionId, id.ResourceGroup, id.FactoryName).ID())
+
+	byteArr, err := json.Marshal(resp.Properties)
+	if err != nil {
+		return err
+	}
+
+	var m map[string]*json.RawMessage
+	if err = json.Unmarshal(byteArr, &m); err != nil {
+		return err
+	}
+
+	description := ""
+	if v, ok := m["description"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &description); err != nil {
+			return err
+		}
+		delete(m, "description")
+	}
+	d.Set("description", description)
+
+	t := ""
+	if v, ok := m["type"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &t); err != nil {
+			return err
+		}
+		delete(m, "type")
+	}
+	d.Set("type", t)
+
+	annotations := make([]interface{}, 0)
+	if v, ok := m["annotations"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &annotations); err != nil {
+			return err
+		}
+		delete(m, "annotations")
+	}
+	d.Set("annotations", annotations)
+
+	parameters := make(map[string]*datafactory.ParameterSpecification)
+	if v, ok := m["parameters"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &parameters); err != nil {
+			return err
+		}
+		delete(m, "parameters")
+	}
+	if err := d.Set("parameters", flattenDataFactoryParameters(parameters)); err != nil {
+		return fmt.Errorf("setting `parameters`: %+v", err)
+	}
+
+	var integrationRuntime *datafactory.IntegrationRuntimeReference
+	if v, ok := m["connectVia"]; ok && v != nil {
+		integrationRuntime = &datafactory.IntegrationRuntimeReference{}
+		if err := json.Unmarshal(*v, &integrationRuntime); err != nil {
+			return err
+		}
+		delete(m, "connectVia")
+	}
+	if err := d.Set("integration_runtime", flattenDataFactoryLinkedServiceIntegrationRuntimeV2(integrationRuntime)); err != nil {
+		return fmt.Errorf("setting `integration_runtime`: %+v", err)
+	}
+
+	delete(m, "typeProperties")
+
+	additionalProperties := make(map[string]interface{})
+	for k, v := range m {
+		additionalProperties[k] = v
+	}
+	d.Set("additional_properties", additionalProperties)
+
+	return nil
+}
+
+func resourceDataFactoryLinkedCustomServiceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LinkedServiceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.FactoryName, id.Name); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	return nil
+}
+
+func expandDataFactoryLinkedServiceIntegrationRuntimeV2(input []interface{}) *datafactory.IntegrationRuntimeReference {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+	return &datafactory.IntegrationRuntimeReference{
+		ReferenceName: utils.String(v["name"].(string)),
+		Type:          utils.String("IntegrationRuntimeReference"),
+		Parameters:    v["parameters"].(map[string]interface{}),
+	}
+}
+
+func flattenDataFactoryLinkedServiceIntegrationRuntimeV2(input *datafactory.IntegrationRuntimeReference) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	name := ""
+	if input.ReferenceName != nil {
+		name = *input.ReferenceName
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":       name,
+			"parameters": input.Parameters,
+		},
+	}
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource_test.go
@@ -27,7 +27,7 @@ func TestAccDataFactoryLinkedCustomService_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 	})
 }
 
@@ -57,7 +57,7 @@ func TestAccDataFactoryLinkedCustomService_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 	})
 }
 
@@ -72,21 +72,21 @@ func TestAccDataFactoryLinkedCustomService_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 	})
 }
 
@@ -101,7 +101,7 @@ func TestAccDataFactoryLinkedCustomService_web(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 	})
 }
 
@@ -116,7 +116,7 @@ func TestAccDataFactoryLinkedCustomService_search(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("type_property_json"),
+		data.ImportStep("type_properties_json"),
 	})
 }
 
@@ -139,10 +139,10 @@ func (r LinkedCustomServiceResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_data_factory_linked_custom_service" "test" {
-  name               = "acctestls%d"
-  data_factory_id    = azurerm_data_factory.test.id
-  type               = "AzureBlobStorage"
-  type_property_json = <<JSON
+  name                 = "acctestls%d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureBlobStorage"
+  type_properties_json = <<JSON
 {
   "connectionString": "${azurerm_storage_account.test.primary_connection_string}"
 }
@@ -156,10 +156,10 @@ func (r LinkedCustomServiceResource) requiresImport(data acceptance.TestData) st
 %s
 
 resource "azurerm_data_factory_linked_custom_service" "import" {
-  name               = azurerm_data_factory_linked_custom_service.test.name
-  data_factory_id    = azurerm_data_factory_linked_custom_service.test.data_factory_id
-  type               = azurerm_data_factory_linked_custom_service.test.type
-  type_property_json = azurerm_data_factory_linked_custom_service.test.type_property_json
+  name                 = azurerm_data_factory_linked_custom_service.test.name
+  data_factory_id      = azurerm_data_factory_linked_custom_service.test.data_factory_id
+  type                 = azurerm_data_factory_linked_custom_service.test.type
+  type_properties_json = azurerm_data_factory_linked_custom_service.test.type_properties_json
 }
 `, r.basic(data))
 }
@@ -169,11 +169,11 @@ func (r LinkedCustomServiceResource) complete(data acceptance.TestData) string {
 %s
 
 resource "azurerm_data_factory_linked_custom_service" "test" {
-  name               = "acctestls%d"
-  data_factory_id    = azurerm_data_factory.test.id
-  type               = "AzureBlobStorage"
-  description        = "test description"
-  type_property_json = <<JSON
+  name                 = "acctestls%d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureBlobStorage"
+  description          = "test description"
+  type_properties_json = <<JSON
 {
   "connectionString":"${azurerm_storage_account.test.primary_connection_string}"
 }
@@ -221,10 +221,10 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_linked_custom_service" "test" {
-  name               = "acctestls%d"
-  data_factory_id    = azurerm_data_factory.test.id
-  type               = "Web"
-  type_property_json = <<JSON
+  name                 = "acctestls%d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "Web"
+  type_properties_json = <<JSON
 {
   "authenticationType": "Anonymous",
   "url": "http://www.bing.com"
@@ -259,10 +259,10 @@ resource "azurerm_search_service" "test" {
 }
 
 resource "azurerm_data_factory_linked_custom_service" "test" {
-  name               = "acctestls%d"
-  data_factory_id    = azurerm_data_factory.test.id
-  type               = "AzureSearch"
-  type_property_json = <<JSON
+  name                 = "acctestls%d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureSearch"
+  type_properties_json = <<JSON
 {
   "url": "https://${azurerm_search_service.test.name}.search.windows.net",
   "key": {

--- a/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_custom_service_resource_test.go
@@ -1,0 +1,320 @@
+package datafactory_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type LinkedCustomServiceResource struct {
+}
+
+func TestAccDataFactoryLinkedCustomService_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_custom_service", "test")
+	r := LinkedCustomServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+	})
+}
+
+func TestAccDataFactoryLinkedCustomService_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_custom_service", "test")
+	r := LinkedCustomServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccDataFactoryLinkedCustomService_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_custom_service", "test")
+	r := LinkedCustomServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+	})
+}
+
+func TestAccDataFactoryLinkedCustomService_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_custom_service", "test")
+	r := LinkedCustomServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+	})
+}
+
+func TestAccDataFactoryLinkedCustomService_web(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_custom_service", "test")
+	r := LinkedCustomServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.web(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+	})
+}
+
+func TestAccDataFactoryLinkedCustomService_search(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_custom_service", "test")
+	r := LinkedCustomServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.search(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("type_property_json"),
+	})
+}
+
+func (t LinkedCustomServiceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.LinkedServiceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.DataFactory.LinkedServiceClient.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r LinkedCustomServiceResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name               = "acctestls%d"
+  data_factory_id    = azurerm_data_factory.test.id
+  type               = "AzureBlobStorage"
+  type_property_json = <<JSON
+{
+  "connectionString": "${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinkedCustomServiceResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_linked_custom_service" "import" {
+  name               = azurerm_data_factory_linked_custom_service.test.name
+  data_factory_id    = azurerm_data_factory_linked_custom_service.test.data_factory_id
+  type               = azurerm_data_factory_linked_custom_service.test.type
+  type_property_json = azurerm_data_factory_linked_custom_service.test.type_property_json
+}
+`, r.basic(data))
+}
+
+func (r LinkedCustomServiceResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name               = "acctestls%d"
+  data_factory_id    = azurerm_data_factory.test.id
+  type               = "AzureBlobStorage"
+  description        = "test description"
+  type_property_json = <<JSON
+{
+  "connectionString":"${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+
+  integration_runtime {
+    name = azurerm_data_factory_integration_runtime_managed.test.name
+    parameters = {
+      "Key" : "value"
+    }
+  }
+
+  parameters = {
+    "foo" : "bar"
+    "Env" : "Test"
+  }
+
+  annotations = [
+    "test1",
+    "test2",
+    "test3"
+  ]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinkedCustomServiceResource) web(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name               = "acctestls%d"
+  data_factory_id    = azurerm_data_factory.test.id
+  type               = "Web"
+  type_property_json = <<JSON
+{
+  "authenticationType": "Anonymous",
+  "url": "http://www.bing.com"
+}
+JSON
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r LinkedCustomServiceResource) search(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_search_service" "test" {
+  name                = "acctestsearchservice%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name               = "acctestls%d"
+  data_factory_id    = azurerm_data_factory.test.id
+  type               = "AzureSearch"
+  type_property_json = <<JSON
+{
+  "url": "https://${azurerm_search_service.test.name}.search.windows.net",
+  "key": {
+    "type": "SecureString",
+    "value": "${azurerm_search_service.test.primary_key}"
+  }
+}
+JSON
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedCustomServiceResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_data_factory_integration_runtime_managed" "test" {
+  name                = "acctest-irm%d"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  node_size                        = "Standard_D8_v3"
+  number_of_nodes                  = 2
+  max_parallel_executions_per_node = 8
+  edition                          = "Standard"
+  license_type                     = "LicenseIncluded"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger)
+}

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -43,6 +43,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_data_factory_integration_runtime_azure":             resourceDataFactoryIntegrationRuntimeAzure(),
 		"azurerm_data_factory_integration_runtime_azure_ssis":        resourceDataFactoryIntegrationRuntimeAzureSsis(),
 		"azurerm_data_factory_integration_runtime_self_hosted":       resourceDataFactoryIntegrationRuntimeSelfHosted(),
+		"azurerm_data_factory_linked_custom_service":                 resourceDataFactoryLinkedCustomService(),
 		"azurerm_data_factory_linked_service_azure_blob_storage":     resourceDataFactoryLinkedServiceAzureBlobStorage(),
 		"azurerm_data_factory_linked_service_azure_databricks":       resourceDataFactoryLinkedServiceAzureDatabricks(),
 		"azurerm_data_factory_linked_service_azure_file_storage":     resourceDataFactoryLinkedServiceAzureFileStorage(),

--- a/website/docs/r/data_factory_linked_custom_service.html.markdown
+++ b/website/docs/r/data_factory_linked_custom_service.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_linked_custom_service"
 description: |-
-  Manages a Linked Service (connection) between a resource and Azure Data Factory. This is a generic resource that supports all different Linked Service Type.
+  Manages a Linked Service (connection) between a resource and Azure Data Factory. This is a generic resource that supports all different Linked Service Types.
 ---
 
 # azurerm_data_factory_linked_custom_service
 
-Manages a Linked Service (connection) between a resource and Azure Data Factory. This is a generic resource that supports all different Linked Service Type.
+Manages a Linked Service (connection) between a resource and Azure Data Factory. This is a generic resource that supports all different Linked Service Types.
 
 ## Example Usage
 
@@ -37,11 +37,11 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_data_factory_linked_custom_service" "example" {
-  name               = "example"
-  data_factory_id    = azurerm_data_factory.example.id
-  type               = "AzureBlobStorage"
-  description        = "test description"
-  type_property_json = <<JSON
+  name                 = "example"
+  data_factory_id      = azurerm_data_factory.example.id
+  type                 = "AzureBlobStorage"
+  description          = "test description"
+  type_properties_json = <<JSON
 {
   "connectionString":"${azurerm_storage_account.test.primary_connection_string}"
 }
@@ -62,14 +62,13 @@ JSON
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data
-  factory. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data factory. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
 
 * `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
 * `type` - (Required) The type of data stores that will be connected to Data Factory. For full list of supported data stores, please refer to [Azure Data Factory connector](https://docs.microsoft.com/en-us/azure/data-factory/connector-overview).
 
-* `type_property_json` - (Optional) A JSON object that contains the properties of the Data Factory Linked Service.
+* `type_properties_json` - (Required) A JSON object that contains the properties of the Data Factory Linked Service.
 
 * `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service.
 

--- a/website/docs/r/data_factory_linked_custom_service.html.markdown
+++ b/website/docs/r/data_factory_linked_custom_service.html.markdown
@@ -1,0 +1,113 @@
+---
+subcategory: "Data Factory"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_factory_linked_custom_service"
+description: |-
+  Manages a Linked Service (connection) between a resource and Azure Data Factory. This is a generic resource that supports all different Linked Service Type.
+---
+
+# azurerm_data_factory_linked_custom_service
+
+Manages a Linked Service (connection) between a resource and Azure Data Factory. This is a generic resource that supports all different Linked Service Type.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_data_factory" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "example"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_data_factory_linked_custom_service" "example" {
+  name               = "example"
+  data_factory_id    = azurerm_data_factory.example.id
+  type               = "AzureBlobStorage"
+  description        = "test description"
+  type_property_json = <<JSON
+{
+  "connectionString":"${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+
+  parameters = {
+    "foo" : "bar"
+    "Env" : "Test"
+  }
+
+  annotations = [
+    "test1",
+    "test2",
+    "test3"
+  ]
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data
+  factory. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+
+* `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
+
+* `type` - (Required) The type of data stores that will be connected to Data Factory. For full list of supported data stores, please refer to [Azure Data Factory connector](https://docs.microsoft.com/en-us/azure/data-factory/connector-overview).
+
+* `type_property_json` - (Optional) A JSON object that contains the properties of the Data Factory Linked Service.
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service.
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service.
+
+* `description` - (Optional) The description for the Data Factory Linked Service.
+
+* `integration_runtime` - (Optional) An `integration_runtime` block as defined below.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
+
+---
+
+An `integration_runtime` supports the following:
+
+* `name` - (Required) The integration runtime reference to associate with the Data Factory Linked Service.
+
+* `parameters` - (Optional) A map of parameters to associate with the integration runtime.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Data Factory Linked Service.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Linked Service.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Linked Service.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Linked Service.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Linked Service.
+
+## Import
+
+Data Factory Linked Service's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_factory_linked_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+```


### PR DESCRIPTION
fix #9860
fix #9431

a generic resource for data factory linked service. Users could use a json string and construct a specific type linked service.
the same with azure cli implementation https://docs.microsoft.com/en-us/cli/azure/datafactory/linked-service?view=azure-cli-latest#az_datafactory_linked_service_create

there are some sensitive properties in `property_json` not returned in the response, so not set it in read function and no `supressDiff` func.

![image](https://user-images.githubusercontent.com/2786738/122171539-68a3d500-ceb2-11eb-825f-0459d8cc20a4.png)
