### PR TITLE
azurerm_application_gateway  - correctly poopulat the `identity` block

### DIFF
--- a/azurerm/internal/identity/user_assigned.go
+++ b/azurerm/internal/identity/user_assigned.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 var _ Identity = UserAssigned{}
@@ -16,8 +17,11 @@ func (u UserAssigned) Expand(input []interface{}) (*ExpandedConfig, error) {
 		}, nil
 	}
 
+	v := input[0].(map[string]interface{})
+
 	return &ExpandedConfig{
-		Type: systemAssigned,
+		Type:                    userAssigned,
+		UserAssignedIdentityIds: utils.ExpandStringSlice(v["identity_ids"].([]interface{})),
 	}, nil
 }
 
@@ -26,19 +30,10 @@ func (u UserAssigned) Flatten(input *ExpandedConfig) []interface{} {
 		return []interface{}{}
 	}
 
-	coalesce := func(input *string) string {
-		if input == nil {
-			return ""
-		}
-
-		return *input
-	}
-
 	return []interface{}{
 		map[string]interface{}{
 			"type":         input.Type,
-			"principal_id": coalesce(input.PrincipalId),
-			"tenant_id":    coalesce(input.TenantId),
+			"identity_ids": utils.FlattenStringSlice(input.UserAssignedIdentityIds),
 		},
 	}
 }

--- a/azurerm/internal/identity/user_assigned.go
+++ b/azurerm/internal/identity/user_assigned.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	msivalidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -21,7 +22,7 @@ func (u UserAssigned) Expand(input []interface{}) (*ExpandedConfig, error) {
 
 	return &ExpandedConfig{
 		Type:                    userAssigned,
-		UserAssignedIdentityIds: utils.ExpandStringSlice(v["identity_ids"].([]interface{})),
+		UserAssignedIdentityIds: utils.ExpandStringSlice(v["identity_ids"].(*pluginsdk.Set).List()),
 	}, nil
 }
 
@@ -53,11 +54,11 @@ func (u UserAssigned) Schema() *pluginsdk.Schema {
 					}, false),
 				},
 				"identity_ids": {
-					Type:     pluginsdk.TypeList,
+					Type:     pluginsdk.TypeSet,
 					Required: true,
 					Elem: &pluginsdk.Schema{
 						Type:         pluginsdk.TypeString,
-						ValidateFunc: validation.NoZeroValues,
+						ValidateFunc: msivalidate.UserAssignedIdentityID,
 					},
 				},
 			},

--- a/azurerm/internal/services/network/application_gateway_data_source.go
+++ b/azurerm/internal/services/network/application_gateway_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	msiparse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
+
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-11-01/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -63,7 +65,10 @@ func dataSourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{
 
 	d.Set("location", location.NormalizeNilable(resp.Location))
 
-	identity := flattenApplicationGatewayDataSourceIdentity(resp.Identity)
+	identity, err := flattenApplicationGatewayDataSourceIdentity(resp.Identity)
+	if err != nil {
+		return err
+	}
 	flattenedIdentity := applicationGatewayDataSourceIdentity{}.Flatten(identity)
 	if err = d.Set("identity", flattenedIdentity); err != nil {
 		return err
@@ -72,17 +77,21 @@ func dataSourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 
-func flattenApplicationGatewayDataSourceIdentity(input *network.ManagedServiceIdentity) *identity.ExpandedConfig {
+func flattenApplicationGatewayDataSourceIdentity(input *network.ManagedServiceIdentity) (*identity.ExpandedConfig, error) {
 	var config *identity.ExpandedConfig
 	if input != nil {
 		identityIds := make([]string, 0, len(input.UserAssignedIdentities))
 		for id := range input.UserAssignedIdentities {
-			identityIds = append(identityIds, id)
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(id)
+			if err != nil {
+				return nil, err
+			}
+			identityIds = append(identityIds, parsedId.ID())
 		}
 		config = &identity.ExpandedConfig{
 			Type:                    string(input.Type),
 			UserAssignedIdentityIds: &identityIds,
 		}
 	}
-	return config
+	return config, nil
 }

--- a/azurerm/internal/services/network/application_gateway_data_source.go
+++ b/azurerm/internal/services/network/application_gateway_data_source.go
@@ -75,10 +75,13 @@ func dataSourceApplicationGatewayRead(d *pluginsdk.ResourceData, meta interface{
 func flattenApplicationGatewayDataSourceIdentity(input *network.ManagedServiceIdentity) *identity.ExpandedConfig {
 	var config *identity.ExpandedConfig
 	if input != nil {
+		identityIds := make([]string, 0, len(input.UserAssignedIdentities))
+		for id := range input.UserAssignedIdentities {
+			identityIds = append(identityIds, id)
+		}
 		config = &identity.ExpandedConfig{
-			Type:        string(input.Type),
-			PrincipalId: input.PrincipalID,
-			TenantId:    input.TenantID,
+			Type:                    string(input.Type),
+			UserAssignedIdentityIds: &identityIds,
 		}
 	}
 	return config

--- a/azurerm/internal/services/network/application_gateway_data_source_test.go
+++ b/azurerm/internal/services/network/application_gateway_data_source_test.go
@@ -25,6 +25,21 @@ func TestAccDataSourceAppGateway_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAppGateway_userAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_application_gateway", "test")
+	r := AppGatewayDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.userAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").Exists(),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+			),
+		},
+	})
+}
+
 func (AppGatewayDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -34,4 +49,15 @@ data "azurerm_application_gateway" "test" {
   name                = azurerm_application_gateway.test.name
 }
 `, ApplicationGatewayResource{}.basic(data))
+}
+
+func (AppGatewayDataSource) userAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_application_gateway" "test" {
+  resource_group_name = azurerm_application_gateway.test.resource_group_name
+  name                = azurerm_application_gateway.test.name
+}
+`, ApplicationGatewayResource{}.UserDefinedIdentity(data))
 }


### PR DESCRIPTION
This PR fixes the helper flatten/expand functionality of the userAssigned identity in the `identity` package. Meanwhile, also fixes the only place that the prior errorneous user assigned identity is used, namely the `azurerm_application_gateway` data source.

## Test Result

```bash
💤 TF_ACC=1 go test -v -timeout=8h ./azurerm/internal/services/network -run="TestAccDataSourceAppGateway_userAssignedIdentity"


2021/06/16 14:52:23 [DEBUG] not using binary driver name, it's no longer needed
2021/06/16 14:52:24 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccDataSourceAppGateway_userAssignedIdentity
=== PAUSE TestAccDataSourceAppGateway_userAssignedIdentity
=== CONT  TestAccDataSourceAppGateway_userAssignedIdentity
--- PASS: TestAccDataSourceAppGateway_userAssignedIdentity (996.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network     996.907s
```