### PR TITLE
Fix: azurerm_lb zones should accept multiple

### DIFF
--- a/azurerm/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/azurerm/internal/services/loadbalancer/loadbalancer_resource.go
@@ -156,7 +156,7 @@ func resourceArmLoadBalancer() *pluginsdk.Resource {
 							Set: pluginsdk.HashString,
 						},
 
-						"zones": azure.SchemaSingleZone(),
+						"zones": azure.SchemaMultipleZones(),
 
 						"id": {
 							Type:     pluginsdk.TypeString,


### PR DESCRIPTION
Addresses https://github.com/terraform-providers/terraform-provider-azurerm/issues/12215

Azure LBs changed the behaviour for zonal redundancy (https://azure.microsoft.com/en-gb/updates/zone-behavior-change/), with that change zonal-redundant LBs are now configured by declaring `zones = ["1", "2", "3"]` (which is currently not allow).

This PR changes the schema to allow declaring more than one AZ for `azurerm_lb`(`Single` -> `Multiple`).