### PR TITLE
identity - support `SystemAssignedUserAssigned`

### DIFF
--- a/azurerm/internal/identity/schema.go
+++ b/azurerm/internal/identity/schema.go
@@ -5,13 +5,11 @@ import (
 )
 
 const (
-	none           = "None"
-	systemAssigned = "SystemAssigned"
-	userAssigned   = "UserAssigned"
+	none                       = "None"
+	systemAssigned             = "SystemAssigned"
+	userAssigned               = "UserAssigned"
+	systemAssignedUserAssigned = "SystemAssigned, UserAssigned"
 )
-
-// TODO: support SystemAssigned, UserAssigned
-// const systemAssignedUserAssigned = "SystemAssigned, UserAssigned"
 
 type ExpandedConfig struct {
 	// Type is the type of User Assigned Identity, either `None`, `SystemAssigned`, `UserAssigned`

--- a/azurerm/internal/identity/system_assigned_user_assigned.go
+++ b/azurerm/internal/identity/system_assigned_user_assigned.go
@@ -1,0 +1,123 @@
+package identity
+
+import (
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var _ Identity = SystemAssignedUserAssigned{}
+
+type SystemAssignedUserAssigned struct{}
+
+func (s SystemAssignedUserAssigned) Expand(input []interface{}) (*ExpandedConfig, error) {
+	if len(input) == 0 || input[0] == nil {
+		return &ExpandedConfig{
+			Type: none,
+		}, nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	config := &ExpandedConfig{
+		Type:                    v["type"].(string),
+		UserAssignedIdentityIds: utils.ExpandStringSlice(v["identity_ids"].([]interface{})),
+	}
+
+	if identityIds := v["identity_ids"].([]interface{}); len(identityIds) != 0 {
+		config.UserAssignedIdentityIds = utils.ExpandStringSlice(identityIds)
+	}
+
+	return config, nil
+}
+
+func (s SystemAssignedUserAssigned) Flatten(input *ExpandedConfig) []interface{} {
+	if input == nil || input.Type == none {
+		return []interface{}{}
+	}
+
+	coalesce := func(input *string) string {
+		if input == nil {
+			return ""
+		}
+
+		return *input
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":         input.Type,
+			"identity_ids": utils.FlattenStringSlice(input.UserAssignedIdentityIds),
+			"principal_id": coalesce(input.PrincipalId),
+			"tenant_id":    coalesce(input.TenantId),
+		},
+	}
+}
+
+func (s SystemAssignedUserAssigned) Schema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"type": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						userAssigned,
+						systemAssigned,
+						systemAssignedUserAssigned,
+					}, false),
+				},
+				"identity_ids": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.NoZeroValues,
+					},
+				},
+				"principal_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func (s SystemAssignedUserAssigned) SchemaDataSource() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"type": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"identity_ids": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+				"principal_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"tenant_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -173,7 +173,7 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 				ValidateFunc: azValidate.ISO8601DurationBetween("PT15M", "PT2H"),
 			},
 
-			"identity": virtualMachineIdentitySchema(),
+			"identity": virtualMachineIdentity{}.Schema(),
 
 			"license_type": {
 				Type:     pluginsdk.TypeString,

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -2,13 +2,13 @@ package compute
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/identity"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-12-01/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	msiparse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/parse"
-	msivalidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/msi/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
@@ -68,110 +68,50 @@ func flattenVirtualMachineAdditionalCapabilities(input *compute.AdditionalCapabi
 }
 
 func virtualMachineIdentitySchema() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				"type": {
-					Type:     pluginsdk.TypeString,
-					Required: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(compute.ResourceIdentityTypeSystemAssigned),
-						string(compute.ResourceIdentityTypeUserAssigned),
-						string(compute.ResourceIdentityTypeSystemAssignedUserAssigned),
-					}, false),
-				},
-
-				"identity_ids": {
-					Type:     pluginsdk.TypeSet,
-					Optional: true,
-					Elem: &pluginsdk.Schema{
-						Type:         pluginsdk.TypeString,
-						ValidateFunc: msivalidate.UserAssignedIdentityID,
-					},
-				},
-
-				"principal_id": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
-				},
-
-				"tenant_id": {
-					Type:     pluginsdk.TypeString,
-					Computed: true,
-				},
-			},
-		},
-	}
+	return identity.SystemAssignedUserAssigned{}.Schema()
 }
 
 func expandVirtualMachineIdentity(input []interface{}) (*compute.VirtualMachineIdentity, error) {
-	if len(input) == 0 {
-		// TODO: Does this want to be this, or nil?
-		return &compute.VirtualMachineIdentity{
-			Type: compute.ResourceIdentityTypeNone,
-		}, nil
+	config, err := identity.SystemAssignedUserAssigned{}.Expand(input)
+	if err != nil {
+		return nil, err
 	}
 
-	raw := input[0].(map[string]interface{})
-
-	identity := compute.VirtualMachineIdentity{
-		Type: compute.ResourceIdentityType(raw["type"].(string)),
-	}
-
-	identityIdsRaw := raw["identity_ids"].(*pluginsdk.Set).List()
-	identityIds := make(map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue)
-	for _, v := range identityIdsRaw {
-		identityIds[v.(string)] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
-	}
-
-	if len(identityIds) > 0 {
-		if identity.Type != compute.ResourceIdentityTypeUserAssigned && identity.Type != compute.ResourceIdentityTypeSystemAssignedUserAssigned {
-			return nil, fmt.Errorf("`identity_ids` can only be specified when `type` includes `UserAssigned`")
+	var identityIds map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue
+	if config.UserAssignedIdentityIds != nil {
+		identityIds = map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
+		for _, id := range *config.UserAssignedIdentityIds {
+			identityIds[id] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
 		}
-
-		identity.UserAssignedIdentities = identityIds
 	}
 
-	return &identity, nil
+	return &compute.VirtualMachineIdentity{
+		Type:                   compute.ResourceIdentityType(config.Type),
+		UserAssignedIdentities: identityIds,
+	}, nil
 }
 
 func flattenVirtualMachineIdentity(input *compute.VirtualMachineIdentity) ([]interface{}, error) {
-	if input == nil || input.Type == compute.ResourceIdentityTypeNone {
-		return []interface{}{}, nil
-	}
+	var config *identity.ExpandedConfig
 
-	identityIds := make([]string, 0)
-	if input.UserAssignedIdentities != nil {
-		for key := range input.UserAssignedIdentities {
-			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(key)
+	if input != nil {
+		var identityIds []string
+		for id := range input.UserAssignedIdentities {
+			parsedId, err := msiparse.UserAssignedIdentityIDInsensitively(id)
 			if err != nil {
 				return nil, err
 			}
 			identityIds = append(identityIds, parsedId.ID())
 		}
-	}
 
-	principalId := ""
-	if input.PrincipalID != nil {
-		principalId = *input.PrincipalID
+		config = &identity.ExpandedConfig{
+			Type:                    string(input.Type),
+			PrincipalId:             input.PrincipalID,
+			TenantId:                input.TenantID,
+			UserAssignedIdentityIds: &identityIds,
+		}
 	}
-
-	tenantId := ""
-	if input.TenantID != nil {
-		tenantId = *input.TenantID
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"type":         string(input.Type),
-			"identity_ids": identityIds,
-			"principal_id": principalId,
-			"tenant_id":    tenantId,
-		},
-	}, nil
+	return identity.SystemAssignedUserAssigned{}.Flatten(config), nil
 }
 
 func expandVirtualMachineNetworkInterfaceIDs(input []interface{}) []compute.NetworkInterfaceReference {

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -15,6 +15,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+type virtualMachineIdentity = identity.SystemAssignedUserAssigned
+
 func virtualMachineAdditionalCapabilitiesSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -67,12 +69,8 @@ func flattenVirtualMachineAdditionalCapabilities(input *compute.AdditionalCapabi
 	}
 }
 
-func virtualMachineIdentitySchema() *pluginsdk.Schema {
-	return identity.SystemAssignedUserAssigned{}.Schema()
-}
-
 func expandVirtualMachineIdentity(input []interface{}) (*compute.VirtualMachineIdentity, error) {
-	config, err := identity.SystemAssignedUserAssigned{}.Expand(input)
+	config, err := virtualMachineIdentity{}.Expand(input)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +109,7 @@ func flattenVirtualMachineIdentity(input *compute.VirtualMachineIdentity) ([]int
 			UserAssignedIdentityIds: &identityIds,
 		}
 	}
-	return identity.SystemAssignedUserAssigned{}.Flatten(config), nil
+	return virtualMachineIdentity{}.Flatten(config), nil
 }
 
 func expandVirtualMachineNetworkInterfaceIDs(input []interface{}) []compute.NetworkInterfaceReference {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -174,7 +174,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				ValidateFunc: azValidate.ISO8601DurationBetween("PT15M", "PT2H"),
 			},
 
-			"identity": virtualMachineIdentitySchema(),
+			"identity": virtualMachineIdentity{}.Schema(),
 
 			"license_type": {
 				Type:     pluginsdk.TypeString,


### PR DESCRIPTION
Identity supports `SystemAssignedUserAssigned` variant. Also adopt the linux/windows vm to approve.

## Test

```shell
💢 TF_ACC=1 go test -v -timeout=8h ./azurerm/internal/services/compute -run="TestAccLinuxVirtualMachine_identityUpdate"
2021/06/16 17:29:41 [DEBUG] not using binary driver name, it's no longer needed
2021/06/16 17:29:41 [DEBUG] not using binary driver name, it's no longer needed
=== RUN   TestAccLinuxVirtualMachine_identityUpdate
=== PAUSE TestAccLinuxVirtualMachine_identityUpdate
=== CONT  TestAccLinuxVirtualMachine_identityUpdate
--- PASS: TestAccLinuxVirtualMachine_identityUpdate (1044.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute     1045.006s
```