### PR TITLE
#12249 - Private Link Service force replacement on load balancer id change

### DIFF
--- a/azurerm/internal/services/network/private_link_service_resource.go
+++ b/azurerm/internal/services/network/private_link_service_resource.go
@@ -122,6 +122,7 @@ func resourcePrivateLinkService() *pluginsdk.Resource {
 			"load_balancer_frontend_ip_configuration_ids": {
 				Type:     pluginsdk.TypeSet,
 				Required: true,
+				ForceNew: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
 					ValidateFunc: azure.ValidateResourceID,


### PR DESCRIPTION
Issue is described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/12249

Azure does not support changing a load balancer ID on an existing resource.
Resource needs to be recreated to update this value.

I have tested this locally and confirmed the desired result:
```
 # azurerm_private_link_service.example must be replaced
-/+ resource "azurerm_private_link_service" "example" {
      ~ alias                                       = "example-privatelink.removed.westeurope.azure.privatelinkservice" -> (known after apply)
      - enable_proxy_protocol                       = false -> null
      ~ id                                          = "/subscriptions/removed/resourceGroups/example-resources/providers/Microsoft.Network/privateLinkServices/example-privatelink" -> (known after apply)
      ~ load_balancer_frontend_ip_configuration_ids = [ # forces replacement
          - "/subscriptions/removed/resourceGroups/example-resources/providers/Microsoft.Network/loadBalancers/1-example-lb/frontendIPConfigurations/1-example-api",
          + "/subscriptions/removed/resourceGroups/example-resources/providers/Microsoft.Network/loadBalancers/2-example-lb/frontendIPConfigurations/2-example-api",
        ]
        name                                        = "example-privatelink"
      - tags                                        = {} -> null
        # (4 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
 ```