### PR TITLE
`azurerm_subnet_network_security_group_association` fix potential deadlock when using multiple association resources.

### DIFF
--- a/azurerm/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/azurerm/internal/services/network/subnet_network_security_group_association_resource.go
@@ -76,11 +76,11 @@ func resourceSubnetNetworkSecurityGroupAssociationCreate(d *pluginsdk.ResourceDa
 	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
 	resourceGroup := parsedSubnetId.ResourceGroup
 
-	locks.ByName(subnetName, SubnetResourceName)
-	defer locks.UnlockByName(subnetName, SubnetResourceName)
-
 	locks.ByName(virtualNetworkName, VirtualNetworkResourceName)
 	defer locks.UnlockByName(virtualNetworkName, VirtualNetworkResourceName)
+
+	locks.ByName(subnetName, SubnetResourceName)
+	defer locks.UnlockByName(subnetName, SubnetResourceName)
 
 	subnet, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {


### PR DESCRIPTION
Fixes #2489

When creating a NSG association the lock order {subnet lock -> VNet lock} conflicts with other resources for example [subnet_nat_gateway_association](https://github.com/terraform-providers/terraform-provider-azurerm/blob/7577022de289609f8cd9f3bdc59ed003f9f42bb2/azurerm/internal/services/network/subnet_nat_gateway_association_resource.go#L77) where the lock order is directly the opposite.

This leads to deadlock when multiple associations are created in parallel.


