### PR TITLE
Fix backup_policy_vm documentation

### DIFF
--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -133,7 +133,7 @@ The `retention_yearly` block supports:
 
 * `weeks` - (Required) The weeks of the month to retain backups of. Must be one of `First`, `Second`, `Third`, `Fourth`, `Last`.
 
-* `months` - (Required) The months of the year to retain backups of. Must be one of `January`, `February`, `March`, `April`, `May`, `June`, `July`, `Augest`, `September`, `October`, `November` and `December`.
+* `months` - (Required) The months of the year to retain backups of. Must be one of `January`, `February`, `March`, `April`, `May`, `June`, `July`, `August`, `September`, `October`, `November` and `December`.
 
 ---
 


### PR DESCRIPTION
Fix for #12269 

There is a small error in the documentation of the resource `azurerm_backup_policy_vm` for the writing of the month "August".