### PR TITLE
linting: ignoring the RetryError funcs for the moment

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_schema_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_schema_resource.go
@@ -102,7 +102,7 @@ func resourceApiManagementApiSchemaCreateUpdate(d *pluginsdk.ResourceData, meta 
 		return fmt.Errorf("creating or updating API Schema %q (API Management Service %q / API %q / Resource Group %q): %s", schemaID, serviceName, apiName, resourceGroup, err)
 	}
 
-	err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError { //lintignore:R006
 		resp, err := client.Get(ctx, resourceGroup, serviceName, apiName, schemaID)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {

--- a/azurerm/internal/services/apimanagement/api_management_api_schema_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_schema_resource.go
@@ -102,7 +102,8 @@ func resourceApiManagementApiSchemaCreateUpdate(d *pluginsdk.ResourceData, meta 
 		return fmt.Errorf("creating or updating API Schema %q (API Management Service %q / API %q / Resource Group %q): %s", schemaID, serviceName, apiName, resourceGroup, err)
 	}
 
-	err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError { //lintignore:R006
+	//lintignore:R006
+	err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		resp, err := client.Get(ctx, resourceGroup, serviceName, apiName, schemaID)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {

--- a/azurerm/internal/services/authorization/role_assignment_resource.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource.go
@@ -307,7 +307,7 @@ func resourceArmRoleAssignmentDelete(d *pluginsdk.ResourceData, meta interface{}
 	return nil
 }
 
-func retryRoleAssignmentsClient(d *pluginsdk.ResourceData, scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}, tenantId string) func() *pluginsdk.RetryError {
+func retryRoleAssignmentsClient(d *pluginsdk.ResourceData, scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}, tenantId string) func() *pluginsdk.RetryError { //lintignore:R006
 	return func() *pluginsdk.RetryError {
 		roleAssignmentsClient := meta.(*clients.Client).Authorization.RoleAssignmentsClient
 		ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)

--- a/azurerm/internal/services/authorization/role_assignment_resource.go
+++ b/azurerm/internal/services/authorization/role_assignment_resource.go
@@ -307,7 +307,8 @@ func resourceArmRoleAssignmentDelete(d *pluginsdk.ResourceData, meta interface{}
 	return nil
 }
 
-func retryRoleAssignmentsClient(d *pluginsdk.ResourceData, scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}, tenantId string) func() *pluginsdk.RetryError { //lintignore:R006
+//lintignore:R006
+func retryRoleAssignmentsClient(d *pluginsdk.ResourceData, scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}, tenantId string) func() *pluginsdk.RetryError {
 	return func() *pluginsdk.RetryError {
 		roleAssignmentsClient := meta.(*clients.Client).Authorization.RoleAssignmentsClient
 		ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -99,7 +99,7 @@ func resourceEventHubAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceData, me
 		},
 	}
 
-	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError { //lintignore:R006
 		localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
 		if _, err := authorizationRulesClient.EventHubsCreateOrUpdateAuthorizationRule(ctx, localId, parameters); err != nil {
 			return pluginsdk.NonRetryableError(fmt.Errorf("creating %s: %+v", id, err))

--- a/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -99,7 +99,8 @@ func resourceEventHubAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceData, me
 		},
 	}
 
-	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError { //lintignore:R006
+	//lintignore:R006
+	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		localId := authorizationruleseventhubs.NewAuthorizationRuleID(id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.EventhubName, id.Name)
 		if _, err := authorizationRulesClient.EventHubsCreateOrUpdateAuthorizationRule(ctx, localId, parameters); err != nil {
 			return pluginsdk.NonRetryableError(fmt.Errorf("creating %s: %+v", id, err))

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -146,7 +146,8 @@ func resourceEventHubClusterDelete(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	// The EventHub Cluster can't be deleted until four hours after creation so we'll keep retrying until it can be deleted.
-	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutDelete), func() *pluginsdk.RetryError { //lintignore:R006
+	//lintignore:R006
+	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutDelete), func() *pluginsdk.RetryError {
 		future, err := client.ClustersDelete(ctx, *id)
 		if err != nil {
 			if response.WasNotFound(future.HttpResponse) {

--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -146,7 +146,7 @@ func resourceEventHubClusterDelete(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	// The EventHub Cluster can't be deleted until four hours after creation so we'll keep retrying until it can be deleted.
-	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutDelete), func() *pluginsdk.RetryError {
+	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutDelete), func() *pluginsdk.RetryError { //lintignore:R006
 		future, err := client.ClustersDelete(ctx, *id)
 		if err != nil {
 			if response.WasNotFound(future.HttpResponse) {

--- a/azurerm/internal/services/keyvault/internal.go
+++ b/azurerm/internal/services/keyvault/internal.go
@@ -68,7 +68,7 @@ func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPur
 	}
 
 	log.Printf("[DEBUG] Purging %s..", description)
-	err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError {
+	err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError { //lintignore:R006
 		_, err := helper.PurgeNestedItem(ctx)
 		if err == nil {
 			return nil

--- a/azurerm/internal/services/keyvault/internal.go
+++ b/azurerm/internal/services/keyvault/internal.go
@@ -68,7 +68,8 @@ func deleteAndOptionallyPurge(ctx context.Context, description string, shouldPur
 	}
 
 	log.Printf("[DEBUG] Purging %s..", description)
-	err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError { //lintignore:R006
+	//lintignore:R006
+	err := pluginsdk.Retry(time.Until(timeout), func() *pluginsdk.RetryError {
 		_, err := helper.PurgeNestedItem(ctx)
 		if err == nil {
 			return nil

--- a/azurerm/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
+++ b/azurerm/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
@@ -90,6 +90,7 @@ func resourceArmMaintenanceAssignmentDedicatedHostCreate(d *pluginsdk.ResourceDa
 	}
 
 	// It may take a few minutes after starting a VM for it to become available to assign to a configuration
+	//lintignore:R006
 	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdateParent(ctx, dedicatedHostId.ResourceGroup, "Microsoft.Compute", "hostGroups", dedicatedHostId.HostGroupName, "hosts", dedicatedHostId.HostName, assignmentName, assignment); err != nil {
 			if strings.Contains(err.Error(), "It may take a few minutes after starting a VM for it to become available to assign to a configuration") {

--- a/azurerm/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/azurerm/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -90,6 +90,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 	}
 
 	// It may take a few minutes after starting a VM for it to become available to assign to a configuration
+	//lintignore:R006
 	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdate(ctx, virtualMachineId.ResourceGroup, "Microsoft.Compute", "virtualMachines", virtualMachineId.Name, assignmentName, assignment); err != nil {
 			if strings.Contains(err.Error(), "It may take a few minutes after starting a VM for it to become available to assign to a configuration") {

--- a/azurerm/internal/services/network/virtual_network_peering_resource.go
+++ b/azurerm/internal/services/network/virtual_network_peering_resource.go
@@ -219,7 +219,8 @@ func getVirtualNetworkPeeringProperties(d *pluginsdk.ResourceData) *network.Virt
 	}
 }
 
-func retryVnetPeeringsClientCreateUpdate(d *pluginsdk.ResourceData, resGroup string, vnetName string, name string, peer network.VirtualNetworkPeering, meta interface{}) func() *pluginsdk.RetryError { //lintignore:R006
+//lintignore:R006
+func retryVnetPeeringsClientCreateUpdate(d *pluginsdk.ResourceData, resGroup string, vnetName string, name string, peer network.VirtualNetworkPeering, meta interface{}) func() *pluginsdk.RetryError {
 	return func() *pluginsdk.RetryError {
 		vnetPeeringsClient := meta.(*clients.Client).Network.VnetPeeringsClient
 		ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/azurerm/internal/services/network/virtual_network_peering_resource.go
+++ b/azurerm/internal/services/network/virtual_network_peering_resource.go
@@ -219,7 +219,7 @@ func getVirtualNetworkPeeringProperties(d *pluginsdk.ResourceData) *network.Virt
 	}
 }
 
-func retryVnetPeeringsClientCreateUpdate(d *pluginsdk.ResourceData, resGroup string, vnetName string, name string, peer network.VirtualNetworkPeering, meta interface{}) func() *pluginsdk.RetryError {
+func retryVnetPeeringsClientCreateUpdate(d *pluginsdk.ResourceData, resGroup string, vnetName string, name string, peer network.VirtualNetworkPeering, meta interface{}) func() *pluginsdk.RetryError { //lintignore:R006
 	return func() *pluginsdk.RetryError {
 		vnetPeeringsClient := meta.(*clients.Client).Network.VnetPeeringsClient
 		ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)

--- a/azurerm/internal/services/web/function_app_host_keys_data_source.go
+++ b/azurerm/internal/services/web/function_app_host_keys_data_source.go
@@ -76,7 +76,8 @@ func dataSourceFunctionAppHostKeysRead(d *pluginsdk.ResourceData, meta interface
 	}
 	d.SetId(*functionSettings.ID)
 
-	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError { //lintignore:R006
+	//lintignore:R006
+	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		res, err := client.ListHostKeys(ctx, resourceGroup, name)
 		if err != nil {
 			if utils.ResponseWasNotFound(res.Response) {

--- a/azurerm/internal/services/web/function_app_host_keys_data_source.go
+++ b/azurerm/internal/services/web/function_app_host_keys_data_source.go
@@ -76,7 +76,7 @@ func dataSourceFunctionAppHostKeysRead(d *pluginsdk.ResourceData, meta interface
 	}
 	d.SetId(*functionSettings.ID)
 
-	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError { //lintignore:R006
 		res, err := client.ListHostKeys(ctx, resourceGroup, name)
 		if err != nil {
 			if utils.ResponseWasNotFound(res.Response) {


### PR DESCRIPTION
These are valid, but due to the alias the linter is incorrectly highlighting these as invalid - so we can safely ignore these for now.