### PR TITLE
Add support for the categories property of azurerm_security_center_assessment_metadata

### DIFF
--- a/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
@@ -63,7 +63,6 @@ func resourceArmSecurityCenterAssessmentMetadata() *pluginsdk.Resource {
 			"categories": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
-				Default:  string(security.Unknown),
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
@@ -72,7 +71,6 @@ func resourceArmSecurityCenterAssessmentMetadata() *pluginsdk.Resource {
 						string(security.IdentityAndAccess),
 						string(security.IoT),
 						string(security.Networking),
-						string(security.Unknown),
 					}, false),
 				},
 			},
@@ -229,7 +227,9 @@ func resourceArmSecurityCenterAssessmentMetadataRead(d *pluginsdk.ResourceData, 
 		categories := make([]string, 0)
 		if props.Categories != nil {
 			for _, item := range *props.Categories {
-				categories = append(categories, string(item))
+				if string(item) != "Unknown" {
+					categories = append(categories, string(item))
+				}
 			}
 		}
 		d.Set("categories", utils.FlattenStringSlice(&categories))

--- a/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
@@ -63,6 +63,7 @@ func resourceArmSecurityCenterAssessmentMetadata() *pluginsdk.Resource {
 			"categories": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
+				Default:  string(security.Unknown),
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
@@ -71,6 +72,7 @@ func resourceArmSecurityCenterAssessmentMetadata() *pluginsdk.Resource {
 						string(security.IdentityAndAccess),
 						string(security.IoT),
 						string(security.Networking),
+						string(security.Unknown),
 					}, false),
 				},
 			},

--- a/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
@@ -60,12 +60,17 @@ func resourceArmSecurityCenterAssessmentMetadata() *pluginsdk.Resource {
 				}, false),
 			},
 
+			// API would return `Unknown` when `categories` isn't set.
+			// After synced with service team, they confirmed will add `Unknown` as possible value to this property and it will be published as a new version of this API.
+			// https://github.com/Azure/azure-rest-api-specs/issues/14918
 			"categories": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
+						"Unknown",
 						string(security.Compute),
 						string(security.Data),
 						string(security.IdentityAndAccess),
@@ -227,12 +232,7 @@ func resourceArmSecurityCenterAssessmentMetadataRead(d *pluginsdk.ResourceData, 
 		categories := make([]string, 0)
 		if props.Categories != nil {
 			for _, item := range *props.Categories {
-				// API would return `Unknown` when `categories` isn't set.
-				// After synced with service team, they confirmed it's an issue and will fix it in the new version.
-				// https://github.com/Azure/azure-rest-api-specs/issues/14918
-				if string(item) != "Unknown" {
-					categories = append(categories, string(item))
-				}
+				categories = append(categories, string(item))
 			}
 		}
 		d.Set("categories", utils.FlattenStringSlice(&categories))

--- a/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource.go
@@ -227,6 +227,9 @@ func resourceArmSecurityCenterAssessmentMetadataRead(d *pluginsdk.ResourceData, 
 		categories := make([]string, 0)
 		if props.Categories != nil {
 			for _, item := range *props.Categories {
+				// API would return `Unknown` when `categories` isn't set.
+				// After synced with service team, they confirmed it's an issue and will fix it in the new version.
+				// https://github.com/Azure/azure-rest-api-specs/issues/14918
 				if string(item) != "Unknown" {
 					categories = append(categories, string(item))
 				}

--- a/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource_test.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_metadata_resource_test.go
@@ -67,6 +67,21 @@ func TestAccSecurityCenterAssessmentMetadata_update(t *testing.T) {
 	})
 }
 
+func TestAccSecurityCenterAssessmentMetadata_categories(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_assessment_metadata", "test")
+	r := SecurityCenterAssessmentMetadataResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.categories(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r SecurityCenterAssessmentMetadataResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	assessmentMetadataClient := client.SecurityCenter.AssessmentsMetadataClient
 	id, err := parse.AssessmentMetadataID(state.ID)
@@ -132,6 +147,21 @@ resource "azurerm_security_center_assessment_metadata" "test" {
   remediation_description = "Updated Test Remediation Description"
   threats                 = ["DataExfiltration", "DataSpillage"]
   user_impact             = "Moderate"
+}
+`
+}
+
+func (r SecurityCenterAssessmentMetadataResource) categories() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_security_center_assessment_metadata" "test" {
+  display_name = "Test Display Name"
+  severity     = "Medium"
+  description  = "Test Description"
+  categories   = ["Data"]
 }
 `
 }

--- a/website/docs/r/security_center_assessment_metadata.html.markdown
+++ b/website/docs/r/security_center_assessment_metadata.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 ---
 
-* `categories` - (Optional) A list of the categories of resource that is at risk when the Security Center Assessment is unhealthy. Possible values are `Compute`, `Data`, `IdentityAndAccess`, `IoT` and `Networking`.
+* `categories` - (Optional) A list of the categories of resource that is at risk when the Security Center Assessment is unhealthy. Possible values are `Unknown`, `Compute`, `Data`, `IdentityAndAccess`, `IoT` and `Networking`.
 
 * `implementation_effort` - (Optional) The implementation effort which is used to remediate the Security Center Assessment. Possible values are `Low`, `Moderate` and `High`.
 

--- a/website/docs/r/security_center_assessment_metadata.html.markdown
+++ b/website/docs/r/security_center_assessment_metadata.html.markdown
@@ -34,6 +34,8 @@ The following arguments are supported:
 
 ---
 
+* `categories` - (Optional) A list of the categories of resource that is at risk when the Security Center Assessment is unhealthy. Possible values are `Compute`, `Data`, `IdentityAndAccess`, `IoT` and `Networking`.
+
 * `implementation_effort` - (Optional) The implementation effort which is used to remediate the Security Center Assessment. Possible values are `Low`, `Moderate` and `High`.
 
 * `remediation_description` - (Optional) The description which is used to mitigate the security issue.


### PR DESCRIPTION
Currently, azurerm_security_center_assessment_metadata cannot set the categories of resource that is at risk when the Security Center Assessment is unhealthy. So submitted this PR to support it.

--- PASS: TestAccSecurityCenterAssessmentMetadata_complete (164.20s)
--- PASS: TestAccSecurityCenterAssessmentMetadata_basic (165.24s)
--- PASS: TestAccSecurityCenterAssessmentMetadata_categories (166.01s)
--- PASS: TestAccSecurityCenterAssessmentMetadata_update (270.68s)
