### PR TITLE
Policy Definition Groups Update on when changed

### DIFF
--- a/azurerm/internal/services/policy/policy_set_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_set_definition_resource.go
@@ -620,7 +620,7 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitionsUpdate(d *pluginsdk.Resour
 			PolicyDefinitionID:          utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_definition_id", i)).(string)),
 			Parameters:                  parameters,
 			PolicyDefinitionReferenceID: utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.reference_id", i)).(string)),
-			GroupNames:                  utils.ExpandStringSlice(i["policy_group_names"].(*pluginsdk.Set).List()),
+			GroupNames:                  utils.ExpandStringSlice(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_group_names", i)).(*pluginsdk.Set).List()),
 		})
 	}
 

--- a/azurerm/internal/services/policy/policy_set_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_set_definition_resource.go
@@ -620,6 +620,7 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitionsUpdate(d *pluginsdk.Resour
 			PolicyDefinitionID:          utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_definition_id", i)).(string)),
 			Parameters:                  parameters,
 			PolicyDefinitionReferenceID: utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.reference_id", i)).(string)),
+			GroupNames:                  utils.ExpandStringSlice(i["policy_group_names"].(*pluginsdk.Set).List()),
 		})
 	}
 

--- a/azurerm/internal/services/policy/policy_set_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_set_definition_resource.go
@@ -428,6 +428,10 @@ func resourceArmPolicySetDefinitionUpdate(d *pluginsdk.ResourceData, meta interf
 		}
 	}
 
+	if d.HasChange("policy_definition_group") {
+		existing.SetDefinitionProperties.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(d.Get("policy_definition_group").(*pluginsdk.Set).List())
+	}
+
 	if d.HasChange("policy_definitions") {
 		var policyDefinitions []policy.DefinitionReference
 		err := json.Unmarshal([]byte(d.Get("policy_definitions").(string)), &policyDefinitions)
@@ -620,7 +624,6 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitionsUpdate(d *pluginsdk.Resour
 			PolicyDefinitionID:          utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_definition_id", i)).(string)),
 			Parameters:                  parameters,
 			PolicyDefinitionReferenceID: utils.String(d.Get(fmt.Sprintf("policy_definition_reference.%d.reference_id", i)).(string)),
-			GroupNames:                  utils.ExpandStringSlice(d.Get(fmt.Sprintf("policy_definition_reference.%d.policy_group_names", i)).(*pluginsdk.Set).List()),
 		})
 	}
 


### PR DESCRIPTION
As part of issue #10155 , I believe I have fixed the error that @fgarcia-cnb reports [here](https://github.com/terraform-providers/terraform-provider-azurerm/issues/10155#issuecomment-783590373). 

Whilst the plan and apply still looks similar to this:

```hcl
      - policy_definition_group {
          - name = "INFRA-TEST-Initiative3-test-group1" -> null
        }
      - policy_definition_group {
          - name = "INFRA-TEST-Initiative3-test-group2" -> null
        }
      + policy_definition_group {
          + name = "INFRA-TEST-Initiative3-test-group3"
        }
      + policy_definition_group {
          + name = "INFRA-TEST-Initiative3-test-group1"
        }
      + policy_definition_group {
          + name = "INFRA-TEST-Initiative3-test-group2"
        }
```

Terraform does actually plan and apply the changes and commit them to state now on an update.