### PR TITLE
eventhub: updating the `namespace` SDK to use API Version `2021-01-01-preview`

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
@@ -58,7 +58,7 @@ func resourceEventHubNamespaceCustomerManagedKeyCreateUpdate(d *pluginsdk.Resour
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := namespaces.NamespaceID(d.Get("eventhub_namespace_id").(string))
+	id, err := namespaces.ParseNamespaceID(d.Get("eventhub_namespace_id").(string))
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func resourceEventHubNamespaceCustomerManagedKeyRead(d *pluginsdk.ResourceData, 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := namespaces.NamespaceID(d.Id())
+	id, err := namespaces.ParseNamespaceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func resourceEventHubNamespaceCustomerManagedKeyDelete(d *pluginsdk.ResourceData
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := namespaces.NamespaceID(d.Id())
+	id, err := namespaces.ParseNamespaceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
@@ -84,7 +84,7 @@ func TestAccEventHubNamespaceCustomerManagedKey_update(t *testing.T) {
 }
 
 func (r EventHubNamespaceCustomerManagedKeyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := namespaces.NamespaceID(state.ID)
+	id, err := namespaces.ParseNamespaceID(state.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -355,7 +355,7 @@ func resourceEventHubNamespaceRead(d *pluginsdk.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := namespaces.NamespaceID(d.Id())
+	id, err := namespaces.ParseNamespaceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -429,7 +429,7 @@ func resourceEventHubNamespaceDelete(d *pluginsdk.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := namespaces.NamespaceID(d.Id())
+	id, err := namespaces.ParseNamespaceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -601,8 +601,8 @@ func expandEventHubIdentity(input []interface{}) *namespaces.Identity {
 
 	v := input[0].(map[string]interface{})
 	return &namespaces.Identity{
-		Type: func() *namespaces.IdentityType {
-			v := namespaces.IdentityType(v["type"].(string))
+		Type: func() *namespaces.ManagedServiceIdentityType {
+			v := namespaces.ManagedServiceIdentityType(v["type"].(string))
 			return &v
 		}(),
 	}

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -455,7 +455,7 @@ func TestAccEventHubNamespace_autoInfalteDisabledWithAutoInflateUnits(t *testing
 }
 
 func (EventHubNamespaceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := namespaces.NamespaceID(state.ID)
+	id, err := namespaces.ParseNamespaceID(state.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/constants.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/constants.go
@@ -1,9 +1,23 @@
 package namespaces
 
-type IdentityType string
+type CreatedByType string
 
 const (
-	IdentityTypeSystemAssigned IdentityType = "SystemAssigned"
+	CreatedByTypeApplication     CreatedByType = "Application"
+	CreatedByTypeKey             CreatedByType = "Key"
+	CreatedByTypeManagedIdentity CreatedByType = "ManagedIdentity"
+	CreatedByTypeUser            CreatedByType = "User"
+)
+
+type EndPointProvisioningState string
+
+const (
+	EndPointProvisioningStateCanceled  EndPointProvisioningState = "Canceled"
+	EndPointProvisioningStateCreating  EndPointProvisioningState = "Creating"
+	EndPointProvisioningStateDeleting  EndPointProvisioningState = "Deleting"
+	EndPointProvisioningStateFailed    EndPointProvisioningState = "Failed"
+	EndPointProvisioningStateSucceeded EndPointProvisioningState = "Succeeded"
+	EndPointProvisioningStateUpdating  EndPointProvisioningState = "Updating"
 )
 
 type KeySource string
@@ -12,10 +26,29 @@ const (
 	KeySourceMicrosoftKeyVault KeySource = "Microsoft.KeyVault"
 )
 
+type ManagedServiceIdentityType string
+
+const (
+	ManagedServiceIdentityTypeNone                       ManagedServiceIdentityType = "None"
+	ManagedServiceIdentityTypeSystemAssigned             ManagedServiceIdentityType = "SystemAssigned"
+	ManagedServiceIdentityTypeSystemAssignedUserAssigned ManagedServiceIdentityType = "SystemAssigned, UserAssigned"
+	ManagedServiceIdentityTypeUserAssigned               ManagedServiceIdentityType = "UserAssigned"
+)
+
+type PrivateLinkConnectionStatus string
+
+const (
+	PrivateLinkConnectionStatusApproved     PrivateLinkConnectionStatus = "Approved"
+	PrivateLinkConnectionStatusDisconnected PrivateLinkConnectionStatus = "Disconnected"
+	PrivateLinkConnectionStatusPending      PrivateLinkConnectionStatus = "Pending"
+	PrivateLinkConnectionStatusRejected     PrivateLinkConnectionStatus = "Rejected"
+)
+
 type SkuName string
 
 const (
 	SkuNameBasic    SkuName = "Basic"
+	SkuNamePremium  SkuName = "Premium"
 	SkuNameStandard SkuName = "Standard"
 )
 
@@ -23,5 +56,6 @@ type SkuTier string
 
 const (
 	SkuTierBasic    SkuTier = "Basic"
+	SkuTierPremium  SkuTier = "Premium"
 	SkuTierStandard SkuTier = "Standard"
 )

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace.go
@@ -35,8 +35,8 @@ func (id NamespaceId) ID() string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Name)
 }
 
-// NamespaceID parses a Namespace ID into an NamespaceId struct
-func NamespaceID(input string) (*NamespaceId, error) {
+// ParseNamespaceID parses a Namespace ID into an NamespaceId struct
+func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
@@ -66,10 +66,10 @@ func NamespaceID(input string) (*NamespaceId, error) {
 	return &resourceId, nil
 }
 
-// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// ParseNamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
 // This should only be used to parse an ID for rewriting to a consistent casing,
-// the NamespaceID method should be used instead for validation etc.
-func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+// the ParseNamespaceID method should be used instead for validation etc.
+func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace_test.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_namespace_test.go
@@ -16,7 +16,7 @@ func TestNamespaceIDFormatter(t *testing.T) {
 	}
 }
 
-func TestNamespaceID(t *testing.T) {
+func TestParseNamespaceID(t *testing.T) {
 	testData := []struct {
 		Input    string
 		Error    bool
@@ -85,7 +85,7 @@ func TestNamespaceID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := NamespaceID(v.Input)
+		actual, err := ParseNamespaceID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue
@@ -109,7 +109,7 @@ func TestNamespaceID(t *testing.T) {
 	}
 }
 
-func TestNamespaceIDInsensitively(t *testing.T) {
+func TestParseNamespaceIDInsensitively(t *testing.T) {
 	testData := []struct {
 		Input    string
 		Error    bool
@@ -202,7 +202,7 @@ func TestNamespaceIDInsensitively(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := NamespaceIDInsensitively(v.Input)
+		actual, err := ParseNamespaceIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup.go
@@ -32,8 +32,8 @@ func (id ResourceGroupId) ID() string {
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup)
 }
 
-// ResourceGroupID parses a ResourceGroup ID into an ResourceGroupId struct
-func ResourceGroupID(input string) (*ResourceGroupId, error) {
+// ParseResourceGroupID parses a ResourceGroup ID into an ResourceGroupId struct
+func ParseResourceGroupID(input string) (*ResourceGroupId, error) {
 	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
@@ -59,10 +59,10 @@ func ResourceGroupID(input string) (*ResourceGroupId, error) {
 	return &resourceId, nil
 }
 
-// ResourceGroupIDInsensitively parses an ResourceGroup ID into an ResourceGroupId struct, insensitively
+// ParseResourceGroupIDInsensitively parses an ResourceGroup ID into an ResourceGroupId struct, insensitively
 // This should only be used to parse an ID for rewriting to a consistent casing,
-// the ResourceGroupID method should be used instead for validation etc.
-func ResourceGroupIDInsensitively(input string) (*ResourceGroupId, error) {
+// the ParseResourceGroupID method should be used instead for validation etc.
+func ParseResourceGroupIDInsensitively(input string) (*ResourceGroupId, error) {
 	id, err := resourceids.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup_test.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/id_resourcegroup_test.go
@@ -16,7 +16,7 @@ func TestResourceGroupIDFormatter(t *testing.T) {
 	}
 }
 
-func TestResourceGroupID(t *testing.T) {
+func TestParseResourceGroupID(t *testing.T) {
 	testData := []struct {
 		Input    string
 		Error    bool
@@ -72,7 +72,7 @@ func TestResourceGroupID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := ResourceGroupID(v.Input)
+		actual, err := ParseResourceGroupID(v.Input)
 		if err != nil {
 			if v.Error {
 				continue
@@ -93,7 +93,7 @@ func TestResourceGroupID(t *testing.T) {
 	}
 }
 
-func TestResourceGroupIDInsensitively(t *testing.T) {
+func TestParseResourceGroupIDInsensitively(t *testing.T) {
 	testData := []struct {
 		Input    string
 		Error    bool
@@ -170,7 +170,7 @@ func TestResourceGroupIDInsensitively(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
-		actual, err := ResourceGroupIDInsensitively(v.Input)
+		actual, err := ParseResourceGroupIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_get_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_get_autorest.go
@@ -56,7 +56,7 @@ func (c NamespacesClient) preparerForGet(ctx context.Context, id NamespaceId) (*
 func (c NamespacesClient) responderForGet(resp *http.Response) (result GetResponse, err error) {
 	err = autorest.Respond(
 		resp,
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Model),
 		autorest.ByClosing())
 	result.HttpResponse = resp

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_update_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_update_autorest.go
@@ -57,7 +57,7 @@ func (c NamespacesClient) preparerForUpdate(ctx context.Context, id NamespaceId,
 func (c NamespacesClient) responderForUpdate(resp *http.Response) (result UpdateResponse, err error) {
 	err = autorest.Respond(
 		resp,
-		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusOK, http.StatusCreated),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result.Model),
 		autorest.ByClosing())
 	result.HttpResponse = resp

--- a/azurerm/internal/services/eventhub/sdk/namespaces/method_update_autorest.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/method_update_autorest.go
@@ -57,7 +57,7 @@ func (c NamespacesClient) preparerForUpdate(ctx context.Context, id NamespaceId,
 func (c NamespacesClient) responderForUpdate(resp *http.Response) (result UpdateResponse, err error) {
 	err = autorest.Respond(
 		resp,
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusCreated, http.StatusOK),
 		autorest.ByUnmarshallingJSON(&result.Model),
 		autorest.ByClosing())
 	result.HttpResponse = resp

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_connectionstate.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_connectionstate.go
@@ -1,0 +1,6 @@
+package namespaces
+
+type ConnectionState struct {
+	Description *string                      `json:"description,omitempty"`
+	Status      *PrivateLinkConnectionStatus `json:"status,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespace.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespace.go
@@ -7,6 +7,7 @@ type EHNamespace struct {
 	Name       *string                `json:"name,omitempty"`
 	Properties *EHNamespaceProperties `json:"properties,omitempty"`
 	Sku        *Sku                   `json:"sku,omitempty"`
+	SystemData *SystemData            `json:"systemData,omitempty"`
 	Tags       *map[string]string     `json:"tags,omitempty"`
 	Type       *string                `json:"type,omitempty"`
 }

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespaceproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_ehnamespaceproperties.go
@@ -7,17 +7,19 @@ import (
 )
 
 type EHNamespaceProperties struct {
-	ClusterArmId           *string     `json:"clusterArmId,omitempty"`
-	CreatedAt              *string     `json:"createdAt,omitempty"`
-	Encryption             *Encryption `json:"encryption,omitempty"`
-	IsAutoInflateEnabled   *bool       `json:"isAutoInflateEnabled,omitempty"`
-	KafkaEnabled           *bool       `json:"kafkaEnabled,omitempty"`
-	MaximumThroughputUnits *int64      `json:"maximumThroughputUnits,omitempty"`
-	MetricId               *string     `json:"metricId,omitempty"`
-	ProvisioningState      *string     `json:"provisioningState,omitempty"`
-	ServiceBusEndpoint     *string     `json:"serviceBusEndpoint,omitempty"`
-	UpdatedAt              *string     `json:"updatedAt,omitempty"`
-	ZoneRedundant          *bool       `json:"zoneRedundant,omitempty"`
+	ClusterArmId               *string                      `json:"clusterArmId,omitempty"`
+	CreatedAt                  *string                      `json:"createdAt,omitempty"`
+	Encryption                 *Encryption                  `json:"encryption,omitempty"`
+	IsAutoInflateEnabled       *bool                        `json:"isAutoInflateEnabled,omitempty"`
+	KafkaEnabled               *bool                        `json:"kafkaEnabled,omitempty"`
+	MaximumThroughputUnits     *int64                       `json:"maximumThroughputUnits,omitempty"`
+	MetricId                   *string                      `json:"metricId,omitempty"`
+	PrivateEndpointConnections *[]PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
+	ProvisioningState          *string                      `json:"provisioningState,omitempty"`
+	ServiceBusEndpoint         *string                      `json:"serviceBusEndpoint,omitempty"`
+	Status                     *string                      `json:"status,omitempty"`
+	UpdatedAt                  *string                      `json:"updatedAt,omitempty"`
+	ZoneRedundant              *bool                        `json:"zoneRedundant,omitempty"`
 }
 
 func (o EHNamespaceProperties) ListCreatedAtAsTime() (*time.Time, error) {

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_encryption.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_encryption.go
@@ -1,6 +1,7 @@
 package namespaces
 
 type Encryption struct {
-	KeySource          *KeySource            `json:"keySource,omitempty"`
-	KeyVaultProperties *[]KeyVaultProperties `json:"keyVaultProperties,omitempty"`
+	KeySource                       *KeySource            `json:"keySource,omitempty"`
+	KeyVaultProperties              *[]KeyVaultProperties `json:"keyVaultProperties,omitempty"`
+	RequireInfrastructureEncryption *bool                 `json:"requireInfrastructureEncryption,omitempty"`
 }

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_identity.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_identity.go
@@ -1,7 +1,8 @@
 package namespaces
 
 type Identity struct {
-	PrincipalId *string       `json:"principalId,omitempty"`
-	TenantId    *string       `json:"tenantId,omitempty"`
-	Type        *IdentityType `json:"type,omitempty"`
+	PrincipalId            *string                         `json:"principalId,omitempty"`
+	TenantId               *string                         `json:"tenantId,omitempty"`
+	Type                   *ManagedServiceIdentityType     `json:"type,omitempty"`
+	UserAssignedIdentities *UserAssignedIdentityProperties `json:"userAssignedIdentities,omitempty"`
 }

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_keyvaultproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_keyvaultproperties.go
@@ -1,7 +1,8 @@
 package namespaces
 
 type KeyVaultProperties struct {
-	KeyName     *string `json:"keyName,omitempty"`
-	KeyVaultUri *string `json:"keyVaultUri,omitempty"`
-	KeyVersion  *string `json:"keyVersion,omitempty"`
+	Identity    *UserAssignedIdentityProperties `json:"identity,omitempty"`
+	KeyName     *string                         `json:"keyName,omitempty"`
+	KeyVaultUri *string                         `json:"keyVaultUri,omitempty"`
+	KeyVersion  *string                         `json:"keyVersion,omitempty"`
 }

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_privateendpoint.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_privateendpoint.go
@@ -1,0 +1,5 @@
+package namespaces
+
+type PrivateEndpoint struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_privateendpointconnection.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_privateendpointconnection.go
@@ -1,0 +1,9 @@
+package namespaces
+
+type PrivateEndpointConnection struct {
+	Id         *string                              `json:"id,omitempty"`
+	Name       *string                              `json:"name,omitempty"`
+	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	SystemData *SystemData                          `json:"systemData,omitempty"`
+	Type       *string                              `json:"type,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_privateendpointconnectionproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_privateendpointconnectionproperties.go
@@ -1,0 +1,7 @@
+package namespaces
+
+type PrivateEndpointConnectionProperties struct {
+	PrivateEndpoint                   *PrivateEndpoint           `json:"privateEndpoint,omitempty"`
+	PrivateLinkServiceConnectionState *ConnectionState           `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *EndPointProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_systemdata.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_systemdata.go
@@ -1,0 +1,34 @@
+package namespaces
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/formatting"
+)
+
+type SystemData struct {
+	CreatedAt          *string        `json:"createdAt,omitempty"`
+	CreatedBy          *string        `json:"createdBy,omitempty"`
+	CreatedByType      *CreatedByType `json:"createdByType,omitempty"`
+	LastModifiedAt     *string        `json:"lastModifiedAt,omitempty"`
+	LastModifiedBy     *string        `json:"lastModifiedBy,omitempty"`
+	LastModifiedByType *CreatedByType `json:"lastModifiedByType,omitempty"`
+}
+
+func (o SystemData) ListCreatedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.CreatedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o SystemData) SetCreatedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedAt = &formatted
+}
+
+func (o SystemData) ListLastModifiedAtAsTime() (*time.Time, error) {
+	return formatting.ParseAsDateFormat(o.LastModifiedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o SystemData) SetLastModifiedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastModifiedAt = &formatted
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/model_userassignedidentityproperties.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/model_userassignedidentityproperties.go
@@ -1,0 +1,5 @@
+package namespaces
+
+type UserAssignedIdentityProperties struct {
+	UserAssignedIdentity *string `json:"userAssignedIdentity,omitempty"`
+}

--- a/azurerm/internal/services/eventhub/sdk/namespaces/version.go
+++ b/azurerm/internal/services/eventhub/sdk/namespaces/version.go
@@ -2,7 +2,7 @@ package namespaces
 
 import "fmt"
 
-const defaultApiVersion = "2018-01-01-preview"
+const defaultApiVersion = "2021-01-01-preview"
 
 func userAgent() string {
 	return fmt.Sprintf("pandora/namespaces/%s", defaultApiVersion)


### PR DESCRIPTION
This PR updates the `namespace` SDK to use API Version `2021-01-01-preview` - required to support encryption 