### PR TITLE
9785 - prepare_encryption and infrastructure_encryption_enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ ENHANCEMENTS:
 * dependencies: updating to `v0.11.19` of `github.com/Azure/go-autorest/autorest` [GH-12209]
 * dependencies: updating to `v0.9.14` of `github.com/Azure/go-autorest/autorest/adal` [GH-12209]
 * dependencies: updating the embedded SDK for Eventhub Namespaces to use API Version `2021-01-01-preview` [GH-12290]
-* `azurerm_databricks_workspace` - support for `infrastructure_encryption_enabled` and `prepare_encryption` ([#9785](https://github.com/terraform-providers/terraform-provider-azurerm/issues/9785))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * dependencies: updating to `v0.11.19` of `github.com/Azure/go-autorest/autorest` [GH-12209]
 * dependencies: updating to `v0.9.14` of `github.com/Azure/go-autorest/autorest/adal` [GH-12209]
 * dependencies: updating the embedded SDK for Eventhub Namespaces to use API Version `2021-01-01-preview` [GH-12290]
+* `azurerm_databricks_workspace` - support for `infrastructure_encryption_enabled` and `prepare_encryption` ([#9785](https://github.com/terraform-providers/terraform-provider-azurerm/issues/9785))
 
 BUG FIXES:
 

--- a/azurerm/internal/services/databricks/databricks_workspace_resource.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource.go
@@ -84,7 +84,7 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 							ForceNew: true,
 							Optional: true,
 							AtLeastOneOf: []string{"custom_parameters.0.no_public_ip", "custom_parameters.0.public_subnet_name",
-								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id",
+								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id", "custom_parameters.0.prepare_encryption", "custom_parameters.0.infrastructure_encryption_enabled",
 							},
 						},
 
@@ -93,7 +93,7 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 							ForceNew: true,
 							Optional: true,
 							AtLeastOneOf: []string{"custom_parameters.0.no_public_ip", "custom_parameters.0.public_subnet_name",
-								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id",
+								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id", "custom_parameters.0.prepare_encryption", "custom_parameters.0.infrastructure_encryption_enabled",
 							},
 						},
 
@@ -102,7 +102,7 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 							ForceNew: true,
 							Optional: true,
 							AtLeastOneOf: []string{"custom_parameters.0.no_public_ip", "custom_parameters.0.public_subnet_name",
-								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id",
+								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id", "custom_parameters.0.prepare_encryption", "custom_parameters.0.infrastructure_encryption_enabled",
 							},
 						},
 
@@ -112,7 +112,25 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 							Optional:     true,
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 							AtLeastOneOf: []string{"custom_parameters.0.no_public_ip", "custom_parameters.0.public_subnet_name",
-								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id",
+								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id", "custom_parameters.0.prepare_encryption", "custom_parameters.0.infrastructure_encryption_enabled",
+							},
+						},
+
+						"prepare_encryption": {
+							Type:     pluginsdk.TypeBool,
+							ForceNew: true,
+							Optional: true,
+							AtLeastOneOf: []string{"custom_parameters.0.no_public_ip", "custom_parameters.0.public_subnet_name",
+								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id", "custom_parameters.0.prepare_encryption", "custom_parameters.0.infrastructure_encryption_enabled",
+							},
+						},
+
+						"infrastructure_encryption_enabled": {
+							Type:     pluginsdk.TypeBool,
+							ForceNew: true,
+							Optional: true,
+							AtLeastOneOf: []string{"custom_parameters.0.no_public_ip", "custom_parameters.0.public_subnet_name",
+								"custom_parameters.0.private_subnet_name", "custom_parameters.0.virtual_network_id", "custom_parameters.0.prepare_encryption", "custom_parameters.0.infrastructure_encryption_enabled",
 							},
 						},
 					},
@@ -341,6 +359,18 @@ func flattenWorkspaceCustomParameters(p *databricks.WorkspaceCustomParameters) [
 		}
 	}
 
+	if v := p.PrepareEncryption; v != nil {
+		if v.Value != nil {
+			parameters["prepare_encryption"] = *v.Value
+		}
+	}
+
+	if v := p.RequireInfrastructureEncryption; v != nil {
+		if v.Value != nil {
+			parameters["infrastructure_encryption_enabled"] = *v.Value
+		}
+	}
+
 	return []interface{}{parameters}
 }
 
@@ -372,6 +402,18 @@ func expandWorkspaceCustomParameters(input []interface{}) *databricks.WorkspaceC
 
 	if v := config["virtual_network_id"].(string); v != "" {
 		parameters.CustomVirtualNetworkID = &databricks.WorkspaceCustomStringParameter{
+			Value: &v,
+		}
+	}
+
+	if v, ok := config["prepare_encryption"].(bool); ok {
+		parameters.PrepareEncryption = &databricks.WorkspaceCustomBooleanParameter{
+			Value: &v,
+		}
+	}
+
+	if v, ok := config["infrastructure_encryption_enabled"].(bool); ok {
+		parameters.RequireInfrastructureEncryption = &databricks.WorkspaceCustomBooleanParameter{
 			Value: &v,
 		}
 	}

--- a/azurerm/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource_test.go
@@ -62,6 +62,8 @@ func TestAccDatabricksWorkspace_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("managed_resource_group_id").Exists(),
 				check.That(data.ResourceName).Key("managed_resource_group_name").Exists(),
 				check.That(data.ResourceName).Key("custom_parameters.0.virtual_network_id").Exists(),
+				check.That(data.ResourceName).Key("custom_parameters.0.prepare_encryption").HasValue("true"),
+				check.That(data.ResourceName).Key("custom_parameters.0.infrastructure_encryption_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
 				check.That(data.ResourceName).Key("tags.Environment").HasValue("Production"),
 				check.That(data.ResourceName).Key("tags.Pricing").HasValue("Standard"),
@@ -265,10 +267,12 @@ resource "azurerm_databricks_workspace" "test" {
   managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
 
   custom_parameters {
-    no_public_ip        = true
-    public_subnet_name  = azurerm_subnet.public.name
-    private_subnet_name = azurerm_subnet.private.name
-    virtual_network_id  = azurerm_virtual_network.test.id
+    no_public_ip        			  = true
+    public_subnet_name  		      = azurerm_subnet.public.name
+    private_subnet_name 			  = azurerm_subnet.private.name
+    virtual_network_id  			  = azurerm_virtual_network.test.id
+	prepare_encryption  			  = true
+	infrastructure_encryption_enabled = true
   }
 
   tags = {
@@ -302,7 +306,9 @@ resource "azurerm_databricks_workspace" "test" {
   }
 
   custom_parameters {
-    no_public_ip = false
+    no_public_ip       				  = false
+	prepare_encryption 				  = true
+	infrastructure_encryption_enabled = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource_test.go
@@ -267,12 +267,12 @@ resource "azurerm_databricks_workspace" "test" {
   managed_resource_group_name = "acctestRG-DBW-%[1]d-managed"
 
   custom_parameters {
-    no_public_ip        			  = true
-    public_subnet_name  		      = azurerm_subnet.public.name
-    private_subnet_name 			  = azurerm_subnet.private.name
-    virtual_network_id  			  = azurerm_virtual_network.test.id
-	prepare_encryption  			  = true
-	infrastructure_encryption_enabled = true
+    no_public_ip                      = true
+    public_subnet_name                = azurerm_subnet.public.name
+    private_subnet_name               = azurerm_subnet.private.name
+    virtual_network_id                = azurerm_virtual_network.test.id
+    prepare_encryption                = true
+    infrastructure_encryption_enabled = true
   }
 
   tags = {
@@ -306,9 +306,9 @@ resource "azurerm_databricks_workspace" "test" {
   }
 
   custom_parameters {
-    no_public_ip       				  = false
-	prepare_encryption 				  = true
-	infrastructure_encryption_enabled = true
+    no_public_ip                      = false
+    prepare_encryption                = true
+    infrastructure_encryption_enabled = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -64,6 +64,10 @@ The following arguments are supported:
 
 * `virtual_network_id` - (Optional) The ID of a Virtual Network where this Databricks Cluster should be created.
 
+* `prepare_encryption` - (Optional) Boolean value. If true, prepare the workspace for encryption. Enables the Managed Identity for managed storage account. 
+
+* `infrastructure_encryption_enabled` - (Optional) Boolean value. If true, DBFS root file system has secondary layer of encryption with platform managed keys enabled for data at rest.
+
 ~> **NOTE** Databricks requires that a network security group is associated with public and private subnets when `virtual_network_id` is set. Also, both public and private subnets must be delegated to `Microsoft.Databricks/workspaces`.
 
 ## Attributes Reference


### PR DESCRIPTION
Initial groundwork for completion of #9785 

Two booleans missing from custom paramters: PrepareEncryption (turning on the managed identity) and RequireInfrastructureEncryption. infrastructure_encryption_enabled seemed to be the common term used elsewhere in the provider.