### PR TITLE
testing: registering the AzureAD Provider

### DIFF
--- a/azurerm/internal/acceptance/testcase.go
+++ b/azurerm/internal/acceptance/testcase.go
@@ -83,22 +83,21 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 }
 
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
-	testCase.ProviderFactories = map[string]func() (*schema.Provider, error){
-		"azurerm": func() (*schema.Provider, error) { //nolint:unparam
-			azurerm := provider.TestAzureProvider()
-			return azurerm, nil
-		},
-		"azurerm-alt": func() (*schema.Provider, error) { //nolint:unparam
-			azurerm := provider.TestAzureProvider()
-			return azurerm, nil
-		},
-	}
+	testCase.ExternalProviders = td.externalProviders()
+	testCase.ProviderFactories = td.providers()
 
 	resource.ParallelTest(t, testCase)
 }
 
 func (td TestData) runAcceptanceSequentialTest(t *testing.T, testCase resource.TestCase) {
-	testCase.ProviderFactories = map[string]func() (*schema.Provider, error){
+	testCase.ExternalProviders = td.externalProviders()
+	testCase.ProviderFactories = td.providers()
+
+	resource.Test(t, testCase)
+}
+
+func (td TestData) providers() map[string]func() (*schema.Provider, error) {
+	return map[string]func() (*schema.Provider, error){
 		"azurerm": func() (*schema.Provider, error) { //nolint:unparam
 			azurerm := provider.TestAzureProvider()
 			return azurerm, nil
@@ -108,6 +107,13 @@ func (td TestData) runAcceptanceSequentialTest(t *testing.T, testCase resource.T
 			return azurerm, nil
 		},
 	}
+}
 
-	resource.Test(t, testCase)
+func (td TestData) externalProviders() map[string]resource.ExternalProvider {
+	return map[string]resource.ExternalProvider{
+		"azuread": {
+			VersionConstraint: "=1.5.1",
+			Source:            "registry.terraform.io/hashicorp/azuread",
+		},
+	}
 }


### PR DESCRIPTION
Turns out in Plugin SDK2 that providers which aren't imported need to be registered,
as such this commit does that - so that those tests pass again.