### PR TITLE
Allow importing azurerm_virtual_machine without computer_name or admin_username

### DIFF
--- a/azurerm/internal/services/compute/virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/virtual_machine_resource.go
@@ -1275,8 +1275,12 @@ func flattenAzureRmVirtualMachineDataDisk(disks *[]compute.DataDisk, disksInfo [
 
 func flattenAzureRmVirtualMachineOsProfile(input *compute.OSProfile) []interface{} {
 	result := make(map[string]interface{})
-	result["computer_name"] = *input.ComputerName
-	result["admin_username"] = *input.AdminUsername
+	if input.ComputerName != nil {
+		result["computer_name"] = *input.ComputerName
+	}
+	if input.AdminUsername != nil {
+		result["admin_username"] = *input.AdminUsername
+	}
 	if input.CustomData != nil {
 		result["custom_data"] = *input.CustomData
 	}
@@ -1895,8 +1899,12 @@ func resourceVirtualMachineStorageOsProfileHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["admin_username"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["computer_name"].(string)))
+		if m["admin_username"] != nil {
+			buf.WriteString(fmt.Sprintf("%s-", m["admin_username"].(string)))
+		}
+		if m["computer_name"] != nil {
+			buf.WriteString(fmt.Sprintf("%s-", m["computer_name"].(string)))
+		}
 	}
 
 	return pluginsdk.HashString(buf.String())


### PR DESCRIPTION
According to [the API docs](https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2018-10-01/virtualmachines?tabs=json) `computerName` and `adminUsername` are non-required attributes of `OSProfile`. Current implementation prevents existing VMs without these attributes to be imported into the state using `terraform import`. This PR fixes that.

One could argue that the terraform attributes `computer_name` and `admin_username` should be made optional, but that has not been included in this PR.