### PR TITLE
Add support for NetworkACL property of SignalR

### DIFF
--- a/azurerm/internal/services/signalr/signalr_service_resource.go
+++ b/azurerm/internal/services/signalr/signalr_service_resource.go
@@ -696,31 +696,6 @@ func expandSignalRServicePublicNetwork(input []interface{}) *signalr.NetworkACL 
 	}
 }
 
-func expandSignalRServicePrivateEndpoint(input []interface{}) *[]signalr.PrivateEndpointACL {
-	results := make([]signalr.PrivateEndpointACL, 0)
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		allow := make([]signalr.RequestType, 0)
-		for _, item := range *(utils.ExpandStringSlice(v["allowed_request_types"].(*pluginsdk.Set).List())) {
-			allow = append(allow, (signalr.RequestType)(item))
-		}
-
-		deny := make([]signalr.RequestType, 0)
-		for _, item := range *(utils.ExpandStringSlice(v["denied_request_types"].(*pluginsdk.Set).List())) {
-			deny = append(deny, (signalr.RequestType)(item))
-		}
-
-		results = append(results, signalr.PrivateEndpointACL{
-			Allow: &allow,
-			Deny:  &deny,
-			Name:  utils.String(v["name"].(string)),
-		})
-	}
-
-	return &results
-}
-
 func flattenSignalRServiceSku(input *signalr.ResourceSku) []interface{} {
 	if input == nil {
 		return []interface{}{}
@@ -760,44 +735,6 @@ func flattenSignalRServiceNetworkACL(input *signalr.NetworkACLs) []interface{} {
 			"public_network": flattenSignalRServicePublicNetwork(input.PublicNetwork),
 		},
 	}
-}
-
-func flattenSignalRServicePrivateEndpoint(input *[]signalr.PrivateEndpointACL) []interface{} {
-	results := make([]interface{}, 0)
-	if input == nil {
-		return results
-	}
-
-	for _, item := range *input {
-		var name string
-		if item.Name != nil {
-			name = *item.Name
-		}
-
-		allowedRequestTypes := make([]string, 0)
-		if item.Allow != nil {
-			for _, item := range *item.Allow {
-				allowedRequestTypes = append(allowedRequestTypes, (string)(item))
-			}
-		}
-		allow := utils.FlattenStringSlice(&allowedRequestTypes)
-
-		deniedRequestTypes := make([]string, 0)
-		if item.Deny != nil {
-			for _, item := range *item.Deny {
-				deniedRequestTypes = append(deniedRequestTypes, (string)(item))
-			}
-		}
-		deny := utils.FlattenStringSlice(&deniedRequestTypes)
-
-		results = append(results, map[string]interface{}{
-			"name":                  name,
-			"allowed_request_types": allow,
-			"denied_request_types":  deny,
-		})
-	}
-
-	return results
 }
 
 func flattenSignalRServicePublicNetwork(input *signalr.NetworkACL) []interface{} {

--- a/azurerm/internal/services/signalr/signalr_service_resource_test.go
+++ b/azurerm/internal/services/signalr/signalr_service_resource_test.go
@@ -493,6 +493,11 @@ resource "azurerm_signalr_service" "test" {
     flag  = "EnableMessagingLogs"
     value = "False"
   }
+
+  features {
+    flag  = "EnableLiveTrace"
+    value = "False"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, serviceMode)
 }
@@ -530,6 +535,11 @@ resource "azurerm_signalr_service" "test" {
 
   features {
     flag  = "EnableMessagingLogs"
+    value = "False"
+  }
+
+  features {
+    flag  = "EnableLiveTrace"
     value = "False"
   }
 

--- a/azurerm/internal/services/signalr/signalr_service_resource_test.go
+++ b/azurerm/internal/services/signalr/signalr_service_resource_test.go
@@ -353,21 +353,21 @@ func TestAccSignalRService_updateFeaturePropertiesAndNetworkACL(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.featurePropertiesAndNetworkACL(data),
+			Config: r.NetworkACL(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.updateFeaturePropertiesAndNetworkACL(data),
+			Config: r.updateNetworkACL(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.featurePropertiesAndNetworkACL(data),
+			Config: r.NetworkACL(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -603,7 +603,7 @@ resource "azurerm_signalr_service" "test" {
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r SignalRServiceResource) featurePropertiesAndNetworkACL(data acceptance.TestData) string {
+func (r SignalRServiceResource) NetworkACL(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -623,29 +623,6 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Standard_S1"
     capacity = 1
-  }
-
-  features {
-    flag  = "ServiceMode"
-    value = "False"
-  }
-
-  features {
-    flag  = "EnableConnectivityLogs"
-    value = "False"
-    properties = {
-      description = "TestDescription"
-    }
-  }
-
-  features {
-    flag  = "EnableMessagingLogs"
-    value = "False"
-  }
-
-  features {
-    flag  = "EnableLiveTrace"
-    value = "False"
   }
 
   network_acl {
@@ -659,7 +636,7 @@ resource "azurerm_signalr_service" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r SignalRServiceResource) updateFeaturePropertiesAndNetworkACL(data acceptance.TestData) string {
+func (r SignalRServiceResource) updateNetworkACL(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -679,29 +656,6 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Standard_S1"
     capacity = 1
-  }
-
-  features {
-    flag  = "ServiceMode"
-    value = "False"
-  }
-
-  features {
-    flag  = "EnableConnectivityLogs"
-    value = "False"
-    properties = {
-      descrp = "TestDescription2"
-    }
-  }
-
-  features {
-    flag  = "EnableMessagingLogs"
-    value = "False"
-  }
-
-  features {
-    flag  = "EnableLiveTrace"
-    value = "False"
   }
 
   network_acl {

--- a/azurerm/internal/services/signalr/signalr_service_resource_test.go
+++ b/azurerm/internal/services/signalr/signalr_service_resource_test.go
@@ -610,7 +610,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-signalr-%d"
   location = "%s"
 }
 
@@ -643,7 +643,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-signalr-%d"
   location = "%s"
 }
 

--- a/azurerm/internal/services/signalr/signalr_service_resource_test.go
+++ b/azurerm/internal/services/signalr/signalr_service_resource_test.go
@@ -347,7 +347,7 @@ func TestAccSignalRService_upstreamSetting(t *testing.T) {
 	})
 }
 
-func TestAccSignalRService_updateFeaturePropertiesAndNetworkACL(t *testing.T) {
+func TestAccSignalRService_updateNetworkACL(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
 	r := SignalRServiceResource{}
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -62,6 +62,10 @@ The following arguments are supported:
 
 * `features` - (Optional) A `features` block as documented below.
 
+* `kind` - (Optional) The kind of the SignalR service. Possible values are `SignalR` and `RawWebSockets`. Defaults to `SignalR`.
+
+* `network_acl` - (Optional) A `network_acl` block as documented below.
+
 * `upstream_endpoint` - (Optional) An `upstream_endpoint` block as documented below. Using this block requires the SignalR service to be Serverless. When creating multiple blocks they will be processed in the order they are defined in.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -79,6 +83,30 @@ A `features` block supports the following:
 * `flag` - (Required) The kind of Feature. Possible values are `EnableConnectivityLogs`, `EnableMessagingLogs`, and `ServiceMode`.
 
 * `value` - (Required) A value of a feature flag. Possible values are `Classic`, `Default` and `Serverless`.
+
+* `properties` - (Optional) Optional properties related to this feature.
+
+---
+
+A `network_acl` block supports the following:
+
+* `default_action` - (Optional) The default action when no other rule matches. Possible values are `Allow` and `Deny`.
+
+* `public_network` - (Optional) A `public_network` block as defined below.
+
+---
+
+A `public_network` block supports the following:
+
+**Note:** `allowed_request_types` and `denied_request_types` cannot be set together.
+
+* `allowed_request_types` - (Optional) The allowed request types. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
+
+**Note:** When `default_action` is `Allow`, `allowed_request_types`cannot be set.
+
+* `denied_request_types` - (Optional) The denied request types. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
+
+**Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
 
 ---
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -86,7 +86,7 @@ A `features` block supports the following:
 
 A `network_acl` block supports the following:
 
-* `default_action` - (Optional) The default action when no other rule matches. Possible values are `Allow` and `Deny`.
+* `default_action` - (Optional) The default action when no other rule matches. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
 
 * `public_network` - (Optional) A `public_network` block as defined below.
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -62,8 +62,6 @@ The following arguments are supported:
 
 * `features` - (Optional) A `features` block as documented below.
 
-* `kind` - (Optional) The kind of the SignalR service. Possible values are `SignalR` and `RawWebSockets`. Defaults to `SignalR`.
-
 * `network_acl` - (Optional) A `network_acl` block as documented below.
 
 * `upstream_endpoint` - (Optional) An `upstream_endpoint` block as documented below. Using this block requires the SignalR service to be Serverless. When creating multiple blocks they will be processed in the order they are defined in.
@@ -83,8 +81,6 @@ A `features` block supports the following:
 * `flag` - (Required) The kind of Feature. Possible values are `EnableConnectivityLogs`, `EnableMessagingLogs`, and `ServiceMode`.
 
 * `value` - (Required) A value of a feature flag. Possible values are `Classic`, `Default` and `Serverless`.
-
-* `properties` - (Optional) Optional properties related to this feature.
 
 ---
 


### PR DESCRIPTION
Currently, azurerm_signalr_service doesn't support to set network access control for SignalR. So I raised this PR to implement it.

Note:
The NetworkACLs property contains the [privateEndpoints](https://github.com/Azure/azure-rest-api-specs/blob/f1448ad24d840cb6190e0b7495ea758c202d8732/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2020-05-01/signalr.json#L1350) property. I will make it as a separate resource in another new PR so that I wouldn't implement it in this PR. Because service team confirmed that the networkACLs.privateEndpoints is updatable only after a corresponding private endpoint is created and a private endpoint can only be created after a signalr resource is created, it cannot be set during signalr creation. So we have to implement the networkACLs.privateEndpoints property as a separate resource.

Reference:
https://docs.microsoft.com/en-us/azure/azure-signalr/howto-network-access-control
https://github.com/Azure/azure-rest-api-specs/blob/f1448ad24d840cb6190e0b7495ea758c202d8732/specification/signalr/resource-manager/Microsoft.SignalRService/stable/2020-05-01/signalr.json#L1337