### PR TITLE
"azurerm_data_factory" - supports property "managed_virtual_network_enabled"

### DIFF
--- a/azurerm/internal/services/datafactory/client/client.go
+++ b/azurerm/internal/services/datafactory/client/client.go
@@ -6,12 +6,13 @@ import (
 )
 
 type Client struct {
-	DatasetClient             *datafactory.DatasetsClient
-	FactoriesClient           *datafactory.FactoriesClient
-	IntegrationRuntimesClient *datafactory.IntegrationRuntimesClient
-	LinkedServiceClient       *datafactory.LinkedServicesClient
-	PipelinesClient           *datafactory.PipelinesClient
-	TriggersClient            *datafactory.TriggersClient
+	DatasetClient                *datafactory.DatasetsClient
+	FactoriesClient              *datafactory.FactoriesClient
+	IntegrationRuntimesClient    *datafactory.IntegrationRuntimesClient
+	LinkedServiceClient          *datafactory.LinkedServicesClient
+	ManagedVirtualNetworksClient *datafactory.ManagedVirtualNetworksClient
+	PipelinesClient              *datafactory.PipelinesClient
+	TriggersClient               *datafactory.TriggersClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -27,6 +28,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	LinkedServiceClient := datafactory.NewLinkedServicesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&LinkedServiceClient.Client, o.ResourceManagerAuthorizer)
 
+	ManagedVirtualNetworksClient := datafactory.NewManagedVirtualNetworksClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&ManagedVirtualNetworksClient.Client, o.ResourceManagerAuthorizer)
+
 	PipelinesClient := datafactory.NewPipelinesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&PipelinesClient.Client, o.ResourceManagerAuthorizer)
 
@@ -34,11 +38,12 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&TriggersClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		DatasetClient:             &DatasetClient,
-		FactoriesClient:           &FactoriesClient,
-		IntegrationRuntimesClient: &IntegrationRuntimesClient,
-		LinkedServiceClient:       &LinkedServiceClient,
-		PipelinesClient:           &PipelinesClient,
-		TriggersClient:            &TriggersClient,
+		DatasetClient:                &DatasetClient,
+		FactoriesClient:              &FactoriesClient,
+		IntegrationRuntimesClient:    &IntegrationRuntimesClient,
+		LinkedServiceClient:          &LinkedServiceClient,
+		ManagedVirtualNetworksClient: &ManagedVirtualNetworksClient,
+		PipelinesClient:              &PipelinesClient,
+		TriggersClient:               &TriggersClient,
 	}
 }

--- a/azurerm/internal/services/datafactory/data_factory_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_resource_test.go
@@ -238,6 +238,43 @@ func TestAccDataFactory_globalParameterUpdate(t *testing.T) {
 	})
 }
 
+func TestAccDataFactory_managedVirtualNetwork(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
+	r := DataFactoryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.managedVirtualNetwork(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataFactory_managedVirtualNetworkUpdated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
+	r := DataFactoryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.managedVirtualNetwork(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t DataFactoryResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.DataFactoryID(state.ID)
 	if err != nil {
@@ -599,6 +636,26 @@ resource "azurerm_data_factory" "test" {
     type  = "Object"
     value = "{'name': 'value'}"
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (DataFactoryResource) managedVirtualNetwork(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestDF%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  managed_virtual_network_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/datafactory/data_factory_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_resource_test.go
@@ -652,9 +652,9 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_data_factory" "test" {
-  name                = "acctestDF%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  name                            = "acctestDF%d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
   managed_virtual_network_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/data_factory.html.markdown
+++ b/website/docs/r/data_factory.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `vsts_configuration` - (Optional) A `vsts_configuration` block as defined below.
 
+* `managed_virtual_network_enabled` - (Optional) Is Managed Virtual Network enabled?
+
 * `public_network_enabled` - (Optional) Is the Data Factory visible to the public network? Defaults to `true`.
 
 * `customer_managed_key_id` -  (Optional) Specifies the Azure Key Vault Key ID to be used as the Customer Managed Key (CMK) for double encryption. Required with user assigned identity.


### PR DESCRIPTION
fix #10542

notes:
there could be only one managed virtual network per data factory.
creating another managed virtual network will cause error

![image](https://user-images.githubusercontent.com/2786738/123221102-29543480-d501-11eb-9e43-e93a3a2d5c3f.png)

there is no rest api to delete managed virtual network. So users could switch `managed_virtual_network_enabled` from `false` to `true`, but could not switch it from `true` to `false`.

![image](https://user-images.githubusercontent.com/2786738/123221684-c44d0e80-d501-11eb-9737-59268e246009.png)




