### PR TITLE
fix: wrong order of arguments and attributes

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -323,6 +323,36 @@ A `static_website` block supports the following:
 
 * `error_404_document` - (Optional) The absolute path to a custom webpage that should be used when a request is made which does not correspond to an existing file.
 
+---
+
+A `share_properties` block supports the following:
+
+* `cors_rule` - (Optional) A `cors_rule` block as defined below.
+
+* `retention_policy` - (Optional) A `retention_policy` block as defined below.
+
+* `smb` - (Optional) A `smb` block as defined below.
+
+---
+
+A `retention_policy` block supports the following:
+
+* `days` - (Optional) Specifies the number of days that the `azurerm_storage_share` should be retained, between `1` and `365` days. Defaults to `7`.
+
+---
+
+A `smb` block supports the following:
+
+* `versions` - (Optional) A set of SMB protocol versions. Possible values are `SMB2.1`, `SMB3.0`, and `SMB3.1.1`.
+
+* `authentication_types` - (Optional) A set of SMB authentication methods. Possible values are `NTLMv2`, and `Kerberos`.
+
+* `kerberos_ticket_encryption_type` - (Optional) A set of Kerberos ticket encryption. Possible values are `RC4-HMAC`, and `AES-256`.
+
+* `channel_encryption_type` - (Optional) A set of SMB channel encryption. Possible values are `AES-128-CCM`, `AES-128-GCM`, and `AES-256-GCM`.
+
+---
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
@@ -396,34 +426,6 @@ The following attributes are exported in addition to the arguments listed above:
 ~> **NOTE:** If there's a Write Lock on the Storage Account, or the account doesn't have permission then these fields will have an empty value [due to a bug in the Azure API](https://github.com/Azure/azure-rest-api-specs/issues/6363)
 
 * `identity` - An `identity` block as defined below, which contains the Identity information for this Storage Account.
-
----
-
-A `share_properties` block supports the following:
-
-* `cors_rule` - (Optional) A `cors_rule` block as defined below.
-
-* `retention_policy` - (Optional) A `retention_policy` block as defined below.
-
-* `smb` - (Optional) A `smb` block as defined below.
-
----
-
-A `retention_policy` block supports the following:
-
-* `days` - (Optional) Specifies the number of days that the `azurerm_storage_share` should be retained, between `1` and `365` days. Defaults to `7`.
-
----
-
-A `smb` block supports the following:
-
-* `versions` - (Optional) A set of SMB protocol versions. Possible values are `SMB2.1`, `SMB3.0`, and `SMB3.1.1`.
-
-* `authentication_types` - (Optional) A set of SMB authentication methods. Possible values are `NTLMv2`, and `Kerberos`.
-
-* `kerberos_ticket_encryption_type` - (Optional) A set of Kerberos ticket encryption. Possible values are `RC4-HMAC`, and `AES-256`.
-
-* `channel_encryption_type` - (Optional) A set of SMB channel encryption. Possible values are `AES-128-CCM`, `AES-128-GCM`, and `AES-256-GCM`.
 
 ---
 


### PR DESCRIPTION
Whilst developing an environment i found that some arguments blocks are listed below the attributes section.