### PR TITLE
"azurerm_lighthouse_definition" - supports block "plan"

### DIFF
--- a/azurerm/internal/services/lighthouse/lighthouse_definition_resource_test.go
+++ b/azurerm/internal/services/lighthouse/lighthouse_definition_resource_test.go
@@ -169,6 +169,32 @@ func TestAccLighthouseDefinition_emptyID(t *testing.T) {
 	})
 }
 
+func TestAccLighthouseDefinition_plan(t *testing.T) {
+	secondTenantID := os.Getenv("ARM_TENANT_ID_ALT")
+	principalID := os.Getenv("ARM_PRINCIPAL_ID_ALT_TENANT")
+	planName := os.Getenv("ARM_PLAN_NAME")
+	planPublisher := os.Getenv("ARM_PLAN_PUBLISHER")
+	planProduct := os.Getenv("ARM_PLAN_PRODUCT")
+	planVersion := os.Getenv("ARM_PLAN_VERSION")
+	if secondTenantID == "" || principalID == "" || planName == "" || planPublisher == "" || planProduct == "" || planVersion == "" {
+		t.Skip("Skipping as ARM_TENANT_ID_ALT, ARM_PRINCIPAL_ID_ALT_TENANT, ARM_PLAN_NAME, ARM_PLAN_PUBLISHER, ARM_PLAN_PRODUCT or ARM_PLAN_VERSION are not specified")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_lighthouse_definition", "test")
+	r := LighthouseDefinitionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.plan(data, secondTenantID, principalID, planName, planPublisher, planProduct, planVersion),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("id").Exists(),
+				check.That(data.ResourceName).Key("lighthouse_definition_id").Exists(),
+			),
+		},
+	})
+}
+
 func (LighthouseDefinitionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LighthouseDefinitionID(state.ID)
 	if err != nil {
@@ -324,4 +350,38 @@ resource "azurerm_lighthouse_definition" "test" {
   }
 }
 `, data.RandomInteger, secondTenantID, principalID)
+}
+
+func (LighthouseDefinitionResource) plan(data acceptance.TestData, secondTenantID, principalID, planName, planPublisher, planProduct, planVersion string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_role_definition" "reader" {
+  role_definition_id = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+}
+
+data "azurerm_subscription" "test" {}
+
+resource "azurerm_lighthouse_definition" "test" {
+  name               = "acctest-LD-%d"
+  description        = "Acceptance Test Lighthouse Definition"
+  managing_tenant_id = "%s"
+  scope              = data.azurerm_subscription.test.id
+
+  authorization {
+    principal_id           = "%s"
+    role_definition_id     = data.azurerm_role_definition.reader.role_definition_id
+    principal_display_name = "Reader"
+  }
+
+  plan {
+    name      = "%s"
+    publisher = "%s"
+    product   = "%s"
+    version   = "%s"
+  }
+}
+`, data.RandomInteger, secondTenantID, principalID, planName, planPublisher, planProduct, planVersion)
 }

--- a/website/docs/r/lighthouse_definition.html.markdown
+++ b/website/docs/r/lighthouse_definition.html.markdown
@@ -38,15 +38,17 @@ The following arguments are supported:
 
 * `lighthouse_definition_id` - (Optional) A unique UUID/GUID which identifies this lighthouse definition - one will be generated if not specified. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name of the Lighthouse Definition.
+* `name` - (Required) The name of the Lighthouse Definition. Changing this forces a new resource to be created.
 
-* `managing_tenant_id` - (Required) The ID of the managing tenant.
+* `managing_tenant_id` - (Required) The ID of the managing tenant. Changing this forces a new resource to be created.
 
-* `scope` - (Required) The ID of the managed subscription.
+* `scope` - (Required) The ID of the managed subscription. Changing this forces a new resource to be created.
 
+* `authorization` - (Required) An authorization block as defined below.
+  
 * `description` - (Optional) A description of the Lighthouse Definition.
 
-* `authorization` - (Required) An authorization block as defined below.  
+* `plan` - (Optional) A `plan` block as defined below.
 
 ---
 
@@ -59,6 +61,18 @@ An `authorization` block supports the following:
 * `delegated_role_definition_ids` - (Optional) The set of role definition ids which define all the permissions that the principal id can assign.
   
 * `principal_display_name` - (Optional) The display name of the security group/service principal/user that would be assigned permissions to the projected subscription.
+
+---
+
+A `plan` block supports the following:
+
+* `name` - (Required) The plan name of the marketplace offer.
+
+* `publisher` - (Required) The publisher ID of the plan.
+
+* `product` - (Required) The product code of the plan.
+
+* `version` - (Required) The version of the plan.
 
 ## Attributes Reference
 


### PR DESCRIPTION
this "plan" property is used to bind a marketplace plan. It needs the permission of partner center. Users could refer to https://docs.microsoft.com/en-us/azure/lighthouse/concepts/managed-services-offers.

to run the acctest, we need to pass the variables about marketplace offer through env

![image](https://user-images.githubusercontent.com/2786738/123376462-1737cc00-d5bd-11eb-9109-78a072bc35be.png)
