### PR TITLE
add resource "azurerm_data_protection_backup_policy_disk"

### DIFF
--- a/azurerm/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
+++ b/azurerm/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
@@ -1,0 +1,439 @@
+package dataprotection
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/legacysdk/dataprotection"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDataProtectionBackupPolicyDisk() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDataProtectionBackupPolicyDiskCreate,
+		Read:   resourceDataProtectionBackupPolicyDiskRead,
+		Delete: resourceDataProtectionBackupPolicyDiskDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.BackupPolicyID(id)
+			return err
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[-a-zA-Z0-9]{3,150}$"),
+					"DataProtection BackupPolicy name must be 3 - 150 characters long, contain only letters, numbers and hyphens.",
+				),
+			},
+
+			"vault_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.BackupVaultID,
+			},
+
+			"backup_repeating_time_intervals": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"default_retention_duration": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"retention_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"duration": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"criteria": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"absolute_criteria": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(dataprotection.FirstOfDay),
+											string(dataprotection.FirstOfWeek),
+										}, false),
+									},
+								},
+							},
+						},
+
+						"priority": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func resourceDataProtectionBackupPolicyDiskCreate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).DataProtection.BackupPolicyClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	vaultId, _ := parse.BackupVaultID(d.Get("vault_id").(string))
+	id := parse.NewBackupPolicyID(subscriptionId, vaultId.ResourceGroup, vaultId.Name, name)
+
+	existing, err := client.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for existing DataProtection BackupPolicy (%q): %+v", id, err)
+		}
+	}
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_data_protection_backup_policy_disk", id.ID())
+	}
+
+	taggingCriteria := expandBackupPolicyDiskTaggingCriteriaArray(d.Get("retention_rule").([]interface{}))
+	policyRules := make([]dataprotection.BasicBasePolicyRule, 0)
+	policyRules = append(policyRules, expandBackupPolicyDiskAzureBackupRuleArray(d.Get("backup_repeating_time_intervals").([]interface{}), taggingCriteria)...)
+	policyRules = append(policyRules, expandBackupPolicyDiskDefaultAzureRetentionRule(d.Get("default_retention_duration")))
+	policyRules = append(policyRules, expandBackupPolicyDiskAzureRetentionRuleArray(d.Get("retention_rule").([]interface{}))...)
+	parameters := dataprotection.BaseBackupPolicyResource{
+		Properties: &dataprotection.BackupPolicy{
+			PolicyRules:     &policyRules,
+			DatasourceTypes: &[]string{"Microsoft.Compute/disks"},
+			ObjectType:      dataprotection.ObjectTypeBackupPolicy,
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.BackupVaultName, id.ResourceGroup, id.Name, parameters); err != nil {
+		return fmt.Errorf("creating/updating DataProtection BackupPolicy (%q): %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceDataProtectionBackupPolicyDiskRead(d, meta)
+}
+
+func resourceDataProtectionBackupPolicyDiskRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataProtection.BackupPolicyClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BackupPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] dataprotection %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving DataProtection BackupPolicy (%q): %+v", id, err)
+	}
+	vaultId := parse.NewBackupVaultID(id.SubscriptionId, id.ResourceGroup, id.BackupVaultName)
+	d.Set("name", id.Name)
+	d.Set("vault_id", vaultId.ID())
+	if resp.Properties != nil {
+		if props, ok := resp.Properties.AsBackupPolicy(); ok {
+			if err := d.Set("backup_repeating_time_intervals", flattenBackupPolicyDiskBackupRuleArray(props.PolicyRules)); err != nil {
+				return fmt.Errorf("setting `backup_repeating_time_intervals`: %+v", err)
+			}
+			if err := d.Set("default_retention_duration", flattenBackupPolicyDiskDefaultRetentionRuleDuration(props.PolicyRules)); err != nil {
+				return fmt.Errorf("setting `default_retention_duration`: %+v", err)
+			}
+			if err := d.Set("retention_rule", flattenBackupPolicyDiskRetentionRuleArray(props.PolicyRules)); err != nil {
+				return fmt.Errorf("setting `retention_rule`: %+v", err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceDataProtectionBackupPolicyDiskDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataProtection.BackupPolicyClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BackupPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if resp, err := client.Delete(ctx, id.BackupVaultName, id.ResourceGroup, id.Name); err != nil {
+		if utils.ResponseWasNotFound(resp) {
+			return nil
+		}
+
+		return fmt.Errorf("deleting DataProtection BackupPolicy (%q): %+v", id, err)
+	}
+	return nil
+}
+
+func expandBackupPolicyDiskAzureBackupRuleArray(input []interface{}, taggingCriteria *[]dataprotection.TaggingCriteria) []dataprotection.BasicBasePolicyRule {
+	results := make([]dataprotection.BasicBasePolicyRule, 0)
+
+	results = append(results, dataprotection.AzureBackupRule{
+		Name:       utils.String("BackupIntervals"),
+		ObjectType: dataprotection.ObjectTypeAzureBackupRule,
+		DataStore: &dataprotection.DataStoreInfoBase{
+			DataStoreType: dataprotection.OperationalStore,
+			ObjectType:    utils.String("DataStoreInfoBase"),
+		},
+		BackupParameters: &dataprotection.AzureBackupParams{
+			BackupType: utils.String("Incremental"),
+			ObjectType: dataprotection.ObjectTypeAzureBackupParams,
+		},
+		Trigger: dataprotection.ScheduleBasedTriggerContext{
+			Schedule: &dataprotection.BackupSchedule{
+				RepeatingTimeIntervals: utils.ExpandStringSlice(input),
+			},
+			TaggingCriteria: taggingCriteria,
+			ObjectType:      dataprotection.ObjectTypeScheduleBasedTriggerContext,
+		},
+	})
+	return results
+}
+
+func expandBackupPolicyDiskAzureRetentionRuleArray(input []interface{}) []dataprotection.BasicBasePolicyRule {
+	results := make([]dataprotection.BasicBasePolicyRule, 0)
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		results = append(results, dataprotection.AzureRetentionRule{
+			Name:       utils.String(v["name"].(string)),
+			ObjectType: dataprotection.ObjectTypeAzureRetentionRule,
+			IsDefault:  utils.Bool(false),
+			Lifecycles: &[]dataprotection.SourceLifeCycle{
+				{
+					DeleteAfter: dataprotection.AbsoluteDeleteOption{
+						Duration:   utils.String(v["duration"].(string)),
+						ObjectType: dataprotection.ObjectTypeAbsoluteDeleteOption,
+					},
+					SourceDataStore: &dataprotection.DataStoreInfoBase{
+						DataStoreType: "OperationalStore",
+						ObjectType:    utils.String("DataStoreInfoBase"),
+					},
+					TargetDataStoreCopySettings: &[]dataprotection.TargetCopySetting{},
+				},
+			},
+		})
+	}
+	return results
+}
+
+func expandBackupPolicyDiskDefaultAzureRetentionRule(input interface{}) dataprotection.BasicBasePolicyRule {
+	return dataprotection.AzureRetentionRule{
+		Name:       utils.String("Default"),
+		ObjectType: dataprotection.ObjectTypeAzureRetentionRule,
+		IsDefault:  utils.Bool(true),
+		Lifecycles: &[]dataprotection.SourceLifeCycle{
+			{
+				DeleteAfter: dataprotection.AbsoluteDeleteOption{
+					Duration:   utils.String(input.(string)),
+					ObjectType: dataprotection.ObjectTypeAbsoluteDeleteOption,
+				},
+				SourceDataStore: &dataprotection.DataStoreInfoBase{
+					DataStoreType: "OperationalStore",
+					ObjectType:    utils.String("DataStoreInfoBase"),
+				},
+				TargetDataStoreCopySettings: &[]dataprotection.TargetCopySetting{},
+			},
+		},
+	}
+}
+
+func expandBackupPolicyDiskTaggingCriteriaArray(input []interface{}) *[]dataprotection.TaggingCriteria {
+	results := []dataprotection.TaggingCriteria{
+		{
+			Criteria:        nil,
+			IsDefault:       utils.Bool(true),
+			TaggingPriority: utils.Int64(99),
+			TagInfo: &dataprotection.RetentionTag{
+				ID:      utils.String("Default_"),
+				TagName: utils.String("Default"),
+			},
+		},
+	}
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		results = append(results, dataprotection.TaggingCriteria{
+			Criteria:        expandBackupPolicyDiskCriteriaArray(v["criteria"].([]interface{})),
+			IsDefault:       utils.Bool(false),
+			TaggingPriority: utils.Int64(int64(v["priority"].(int))),
+			TagInfo: &dataprotection.RetentionTag{
+				ID:      utils.String(v["name"].(string) + "_"),
+				TagName: utils.String(v["name"].(string)),
+			},
+		})
+	}
+	return &results
+}
+
+func expandBackupPolicyDiskCriteriaArray(input []interface{}) *[]dataprotection.BasicBackupCriteria {
+	results := make([]dataprotection.BasicBackupCriteria, 0)
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		var absoluteCriteria []dataprotection.AbsoluteMarker
+		if absoluteCriteriaRaw := v["absolute_criteria"].(string); len(absoluteCriteriaRaw) > 0 {
+			absoluteCriteria = []dataprotection.AbsoluteMarker{dataprotection.AbsoluteMarker(absoluteCriteriaRaw)}
+		}
+		results = append(results, dataprotection.ScheduleBasedBackupCriteria{
+			AbsoluteCriteria: &absoluteCriteria,
+			ObjectType:       dataprotection.ObjectTypeScheduleBasedBackupCriteria,
+		})
+	}
+	return &results
+}
+
+func flattenBackupPolicyDiskBackupRuleArray(input *[]dataprotection.BasicBasePolicyRule) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+	for _, item := range *input {
+		if backupRule, ok := item.AsAzureBackupRule(); ok {
+			if backupRule.Trigger != nil {
+				if scheduleBasedTrigger, ok := backupRule.Trigger.AsScheduleBasedTriggerContext(); ok {
+					if scheduleBasedTrigger.Schedule != nil {
+						return utils.FlattenStringSlice(scheduleBasedTrigger.Schedule.RepeatingTimeIntervals)
+					}
+				}
+			}
+		}
+	}
+	return make([]interface{}, 0)
+}
+
+func flattenBackupPolicyDiskDefaultRetentionRuleDuration(input *[]dataprotection.BasicBasePolicyRule) interface{} {
+	if input == nil {
+		return nil
+	}
+
+	for _, item := range *input {
+		if retentionRule, ok := item.AsAzureRetentionRule(); ok && retentionRule.IsDefault != nil && *retentionRule.IsDefault {
+			if retentionRule.Lifecycles != nil && len(*retentionRule.Lifecycles) > 0 {
+				if deleteOption, ok := (*retentionRule.Lifecycles)[0].DeleteAfter.AsAbsoluteDeleteOption(); ok {
+					return *deleteOption.Duration
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func flattenBackupPolicyDiskRetentionRuleArray(input *[]dataprotection.BasicBasePolicyRule) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	var taggingCriterias []dataprotection.TaggingCriteria
+	for _, item := range *input {
+		if backupRule, ok := item.AsAzureBackupRule(); ok {
+			if trigger, ok := backupRule.Trigger.AsScheduleBasedTriggerContext(); ok {
+				if trigger.TaggingCriteria != nil {
+					taggingCriterias = *trigger.TaggingCriteria
+				}
+			}
+		}
+	}
+
+	for _, item := range *input {
+		if retentionRule, ok := item.AsAzureRetentionRule(); ok && (retentionRule.IsDefault == nil || !*retentionRule.IsDefault) {
+			var name string
+			if retentionRule.Name != nil {
+				name = *retentionRule.Name
+			}
+			var taggingPriority int64
+			var taggingCriteria []interface{}
+			for _, criteria := range taggingCriterias {
+				if criteria.TagInfo != nil && criteria.TagInfo.TagName != nil && strings.EqualFold(*criteria.TagInfo.TagName, name) {
+					taggingPriority = *criteria.TaggingPriority
+					taggingCriteria = flattenBackupPolicyDiskBackupCriteriaArray(criteria.Criteria)
+				}
+			}
+			var duration string
+			if retentionRule.Lifecycles != nil && len(*retentionRule.Lifecycles) > 0 {
+				if deleteOption, ok := (*retentionRule.Lifecycles)[0].DeleteAfter.AsAbsoluteDeleteOption(); ok {
+					duration = *deleteOption.Duration
+				}
+			}
+			results = append(results, map[string]interface{}{
+				"name":     name,
+				"priority": taggingPriority,
+				"criteria": taggingCriteria,
+				"duration": duration,
+			})
+		}
+	}
+	return results
+}
+
+func flattenBackupPolicyDiskBackupCriteriaArray(input *[]dataprotection.BasicBackupCriteria) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		if criteria, ok := item.AsScheduleBasedBackupCriteria(); ok {
+			var absoluteCriteria string
+			if criteria.AbsoluteCriteria != nil && len(*criteria.AbsoluteCriteria) > 0 {
+				absoluteCriteria = string((*criteria.AbsoluteCriteria)[0])
+			}
+
+			results = append(results, map[string]interface{}{
+				"absolute_criteria": absoluteCriteria,
+			})
+		}
+	}
+	return results
+}

--- a/azurerm/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
+++ b/azurerm/internal/services/dataprotection/data_protection_backup_policy_disk_resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	helperValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/legacysdk/dataprotection"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
@@ -66,9 +67,10 @@ func resourceDataProtectionBackupPolicyDisk() *schema.Resource {
 			},
 
 			"default_retention_duration": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: helperValidate.ISO8601Duration,
 			},
 
 			"retention_rule": {
@@ -84,9 +86,10 @@ func resourceDataProtectionBackupPolicyDisk() *schema.Resource {
 						},
 
 						"duration": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: helperValidate.ISO8601Duration,
 						},
 
 						"criteria": {

--- a/azurerm/internal/services/dataprotection/data_protection_backup_policy_disk_resource_test.go
+++ b/azurerm/internal/services/dataprotection/data_protection_backup_policy_disk_resource_test.go
@@ -1,0 +1,182 @@
+package dataprotection_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dataprotection/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type DataProtectionBackupPolicyDiskResource struct{}
+
+func TestAccDataProtectionBackupPolicyDisk_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_disk", "test")
+	r := DataProtectionBackupPolicyDiskResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataProtectionBackupPolicyDisk_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_disk", "test")
+	r := DataProtectionBackupPolicyDiskResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccDataProtectionBackupPolicyDisk_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_disk", "test")
+	r := DataProtectionBackupPolicyDiskResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataProtectionBackupPolicyDisk_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_disk", "test")
+	r := DataProtectionBackupPolicyDiskResource{}
+	data.ResourceTest(t, r, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r DataProtectionBackupPolicyDiskResource) Exists(ctx context.Context, client *clients.Client, state *terraform.InstanceState) (*bool, error) {
+	id, err := parse.BackupPolicyID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.DataProtection.BackupPolicyClient.Get(ctx, id.BackupVaultName, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving DataProtection BackupPolicy (%q): %+v", id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (r DataProtectionBackupPolicyDiskResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-dataprotection-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_protection_backup_vault" "test" {
+  name                = "acctest-dbv-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r DataProtectionBackupPolicyDiskResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_disk" "test" {
+  name                            = "acctest-dbp-%d"
+  vault_id                        = azurerm_data_protection_backup_vault.test.id
+  backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
+  default_retention_duration      = "P7D"
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupPolicyDiskResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_disk" "import" {
+  name                            = azurerm_data_protection_backup_policy_disk.test.name
+  vault_id                        = azurerm_data_protection_backup_policy_disk.test.vault_id
+  backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
+  default_retention_duration      = "P7D"
+}
+`, config)
+}
+
+func (r DataProtectionBackupPolicyDiskResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_data_protection_backup_policy_disk" "test" {
+  name                            = "acctest-dbp-%d"
+  vault_id                        = azurerm_data_protection_backup_vault.test.id
+  backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
+  default_retention_duration      = "P7D"
+
+  retention_rule {
+    name     = "Daily"
+    duration = "P7D"
+    priority = 25
+    criteria {
+      absolute_criteria = "FirstOfDay"
+    }
+  }
+
+  retention_rule {
+    name     = "Weekly"
+    duration = "P7D"
+    priority = 20
+    criteria {
+      absolute_criteria = "FirstOfWeek"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/dataprotection/registration.go
+++ b/azurerm/internal/services/dataprotection/registration.go
@@ -25,6 +25,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azurerm_data_protection_backup_vault":               resourceDataProtectionBackupVault(),
+		"azurerm_data_protection_backup_policy_disk":         resourceDataProtectionBackupPolicyDisk(),
 		"azurerm_data_protection_backup_policy_postgresql":   resourceDataProtectionBackupPolicyPostgreSQL(),
 		"azurerm_data_protection_backup_instance_postgresql": resourceDataProtectionBackupInstancePostgreSQL(),
 	}

--- a/website/docs/r/data_protection_backup_policy_disk.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_disk.html.markdown
@@ -1,0 +1,112 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_protection_backup_policy_disk"
+description: |-
+  Manages a Backup Policy Disk.
+---
+
+# azurerm_data_protection_backup_policy_disk
+
+Manages a Backup Policy Disk.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_data_protection_backup_vault" "example" {
+  name                = "example-backup-vault"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+}
+
+resource "azurerm_data_protection_backup_policy_disk" "example" {
+  name     = "example-backup-policy"
+  vault_id = azurerm_data_protection_backup_vault.example.id
+
+  backup_repeating_time_intervals = ["R/2021-05-19T06:33:16+00:00/PT4H"]
+  default_retention_duration      = "P7D"
+
+  retention_rule {
+    name     = "Daily"
+    duration = "P7D"
+    priority = 25
+    criteria {
+      absolute_criteria = "FirstOfDay"
+    }
+  }
+
+  retention_rule {
+    name     = "Weekly"
+    duration = "P7D"
+    priority = 20
+    criteria {
+      absolute_criteria = "FirstOfWeek"
+    }
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+* `name` - (Required) The name which should be used for this Backup Policy Disk. Changing this forces a new Backup Policy Disk to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Backup Policy Disk should exist. Changing this forces a new Backup Policy Disk to be created.
+
+* `vault_id` - (Required) The ID of the Backup Vault within which the Backup Policy Disk should exist. Changing this forces a new Backup Policy Disk to be created.
+
+* `backup_repeating_time_intervals` - (Required) Specifies a list of repeating time interval. It should follow `ISO 8601` repeating time interval . Changing this forces a new Backup Policy Disk to be created.
+
+* `default_retention_duration` - (Required) The duration of default retention rule. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Disk to be created.
+
+---
+
+* `retention_rule` - (Optional) One or more `retention_rule` blocks as defined below. Changing this forces a new Backup Policy Disk to be created.
+
+---
+
+A `retention_rule` block supports the following:
+
+* `name` - (Required) The name which should be used for this retention rule. Changing this forces a new Backup Policy Disk to be created.
+
+* `duration` - (Required) Duration of deletion after given timespan. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Disk to be created.
+
+* `criteria` - (Required) A `criteria` block as defined below. Changing this forces a new Backup Policy Disk to be created.
+
+* `priority` - (Required) Retention Tag priority. Changing this forces a new Backup Policy Disk to be created.
+
+---
+
+A `criteria` block supports the following:
+
+* `absolute_criteria` - (Optional) Possible values are `FirstOfDay` and `FirstOfWeek`. Changing this forces a new Backup Policy Disk to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Backup Policy Disk.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Backup Policy Disk.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy Disk.
+* `update` - (Defaults to 30 minutes) Used when updating the Backup Policy Disk.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Backup Policy Disk.
+
+## Import
+
+Backup Policy Disks can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_protection_backup_policy_disk.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DataProtection/backupVaults/vault1/backupPolicies/backupPolicy1
+```


### PR DESCRIPTION
To address this issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/11768
The tests are listed as the following.

```
=== RUN   TestAccDataProtectionBackupPolicyDisk_basic
=== PAUSE TestAccDataProtectionBackupPolicyDisk_basic
=== CONT  TestAccDataProtectionBackupPolicyDisk_basic
--- PASS: TestAccDataProtectionBackupPolicyDisk_basic (291.24s)
=== RUN   TestAccDataProtectionBackupPolicyDisk_requiresImport
=== PAUSE TestAccDataProtectionBackupPolicyDisk_requiresImport
=== CONT  TestAccDataProtectionBackupPolicyDisk_requiresImport
--- PASS: TestAccDataProtectionBackupPolicyDisk_requiresImport (268.14s)
=== RUN   TestAccDataProtectionBackupPolicyDisk_complete
=== PAUSE TestAccDataProtectionBackupPolicyDisk_complete
=== CONT  TestAccDataProtectionBackupPolicyDisk_complete
--- PASS: TestAccDataProtectionBackupPolicyDisk_complete (252.59s)
=== RUN   TestAccDataProtectionBackupPolicyDisk_update
=== PAUSE TestAccDataProtectionBackupPolicyDisk_update
=== CONT  TestAccDataProtectionBackupPolicyDisk_update
--- PASS: TestAccDataProtectionBackupPolicyDisk_update (419.55s)

```