### PR TITLE
azurerm_container_registry: allowing the principal_id and tenant_id to be exported

### DIFF
--- a/azurerm/internal/services/containers/container_registry_resource.go
+++ b/azurerm/internal/services/containers/container_registry_resource.go
@@ -172,6 +172,10 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
+						"tenant_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
 						"identity_ids": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
@@ -1039,6 +1043,12 @@ func flattenIdentityProperties(identityProperties *containerregistry.IdentityPro
 			identityIds = append(identityIds, parsedId.ID())
 		}
 		identity["identity_ids"] = identityIds
+	}
+	if identityProperties.PrincipalID != nil {
+		identity["principal_id"] = *identityProperties.PrincipalID
+	}
+	if identityProperties.TenantID != nil {
+		identity["tenant_id"] = *identityProperties.TenantID
 	}
 	return []interface{}{identity}, nil
 }

--- a/azurerm/internal/services/containers/container_registry_resource_test.go
+++ b/azurerm/internal/services/containers/container_registry_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	validateHelper "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -502,6 +503,27 @@ func TestAccContainerRegistry_identity(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
 				check.That(data.ResourceName).Key("identity.0.type").HasValue(userAssigned),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerRegistry_identitySystemAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_registry", "test")
+	r := ContainerRegistryResource{}
+	skuPremium := "Premium"
+	userAssigned := "systemAssigned"
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		// creates an ACR with encryption
+		{
+			Config: r.identitySystemAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue(skuPremium),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue(userAssigned),
+				acceptance.TestMatchResourceAttr(data.ResourceName, "identity.0.principal_id", validateHelper.UUIDRegExp),
+				acceptance.TestMatchResourceAttr(data.ResourceName, "identity.0.tenant_id", validateHelper.UUIDRegExp),
 			),
 		},
 		data.ImportStep(),
@@ -1064,6 +1086,31 @@ resource "azurerm_user_assigned_identity" "test" {
   name = "testaccuai%d"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (ContainerRegistryResource) identitySystemAssigned(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-acr-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_registry" "test" {
+  name                = "testacccr%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Premium"
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (ContainerRegistryResource) zoneRedundancy(data acceptance.TestData) string {

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -216,6 +216,20 @@ The following attributes are exported:
 
 * `admin_password` - The Password associated with the Container Registry Admin account - if the admin account is enabled.
 
+* `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this Container Registry.
+
+---
+
+A `identity` block exports the following:
+
+* `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this Container Registry.
+
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this Container Registry.
+
+-> You can access the Principal ID via `azurerm_container_registry.example.identity.0.principal_id` and the Tenant ID via `azurerm_container_registry.example.identity.0.tenant_id`
+
+---
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
This is to help issue #9955 by adding support to expose the prinicpal_id and tenant_id from the container registry identity block with systemAssigned managed identities.