### PR TITLE
Add support for the categories property of azurerm_security_center_assessment_policy

### DIFF
--- a/azurerm/internal/services/securitycenter/security_center_assessment_policy_resource.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_policy_resource.go
@@ -59,6 +59,26 @@ func resourceArmSecurityCenterAssessmentPolicy() *pluginsdk.Resource {
 				}, false),
 			},
 
+			// API would return `Unknown` when `categories` isn't set.
+			// After synced with service team, they confirmed will add `Unknown` as possible value to this property and it will be published as a new version of this API.
+			// https://github.com/Azure/azure-rest-api-specs/issues/14918
+			"categories": {
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{
+						"Unknown",
+						string(security.Compute),
+						string(security.Data),
+						string(security.IdentityAndAccess),
+						string(security.IoT),
+						string(security.Networking),
+					}, false),
+				},
+			},
+
 			"implementation_effort": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -103,10 +123,6 @@ func resourceArmSecurityCenterAssessmentPolicy() *pluginsdk.Resource {
 				}, false),
 			},
 
-			// The `category` property doesn't take effect at the service side since the property name is incorrect and it should be `categories`.
-			// To implement this property once the bug is fixed.
-			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/12297
-
 			"name": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -143,6 +159,14 @@ func resourceArmSecurityCenterAssessmentPolicyCreate(d *pluginsdk.ResourceData, 
 			DisplayName:    utils.String(d.Get("display_name").(string)),
 			Severity:       security.Severity(d.Get("severity").(string)),
 		},
+	}
+
+	if v, ok := d.GetOk("categories"); ok {
+		categories := make([]security.Categories, 0)
+		for _, item := range v.(*pluginsdk.Set).List() {
+			categories = append(categories, (security.Categories)(item.(string)))
+		}
+		params.AssessmentMetadataProperties.Categories = &categories
 	}
 
 	if v, ok := d.GetOk("threats"); ok {
@@ -204,6 +228,14 @@ func resourceArmSecurityCenterAssessmentPolicyRead(d *pluginsdk.ResourceData, me
 		d.Set("remediation_description", props.RemediationDescription)
 		d.Set("user_impact", string(props.UserImpact))
 
+		categories := make([]string, 0)
+		if props.Categories != nil {
+			for _, item := range *props.Categories {
+				categories = append(categories, string(item))
+			}
+		}
+		d.Set("categories", utils.FlattenStringSlice(&categories))
+
 		threats := make([]string, 0)
 		if props.Threats != nil {
 			for _, item := range *props.Threats {
@@ -244,6 +276,14 @@ func resourceArmSecurityCenterAssessmentPolicyUpdate(d *pluginsdk.ResourceData, 
 
 	if d.HasChange("severity") {
 		existing.AssessmentMetadataProperties.Severity = security.Severity(d.Get("severity").(string))
+	}
+
+	if d.HasChange("categories") {
+		categories := make([]security.Categories, 0)
+		for _, item := range d.Get("categories").(*pluginsdk.Set).List() {
+			categories = append(categories, (security.Categories)(item.(string)))
+		}
+		existing.AssessmentMetadataProperties.Categories = &categories
 	}
 
 	if d.HasChange("threats") {

--- a/azurerm/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
@@ -67,6 +67,21 @@ func TestAccSecurityCenterAssessmentPolicy_update(t *testing.T) {
 	})
 }
 
+func TestAccSecurityCenterAssessmentPolicy_categories(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_assessment_policy", "test")
+	r := SecurityCenterAssessmentPolicyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.categories(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r SecurityCenterAssessmentPolicyResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	assessmentMetadataClient := client.SecurityCenter.AssessmentsMetadataClient
 	id, err := parse.AssessmentMetadataID(state.ID)
@@ -132,6 +147,21 @@ resource "azurerm_security_center_assessment_policy" "test" {
   remediation_description = "Updated Test Remediation Description"
   threats                 = ["DataExfiltration", "DataSpillage"]
   user_impact             = "Moderate"
+}
+`
+}
+
+func (r SecurityCenterAssessmentPolicyResource) categories() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_security_center_assessment_policy" "test" {
+  display_name = "Test Display Name"
+  severity     = "Medium"
+  description  = "Test Description"
+  categories   = ["Data"]
 }
 `
 }

--- a/azurerm/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
+++ b/azurerm/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
@@ -67,21 +67,6 @@ func TestAccSecurityCenterAssessmentPolicy_update(t *testing.T) {
 	})
 }
 
-func TestAccSecurityCenterAssessmentPolicy_categories(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_security_center_assessment_policy", "test")
-	r := SecurityCenterAssessmentPolicyResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.categories(),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (r SecurityCenterAssessmentPolicyResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	assessmentMetadataClient := client.SecurityCenter.AssessmentsMetadataClient
 	id, err := parse.AssessmentMetadataID(state.ID)
@@ -129,6 +114,7 @@ resource "azurerm_security_center_assessment_policy" "test" {
   remediation_description = "Test Remediation Description"
   threats                 = ["DataExfiltration", "DataSpillage", "MaliciousInsider"]
   user_impact             = "Low"
+  categories              = ["Data"]
 }
 `
 }
@@ -147,21 +133,6 @@ resource "azurerm_security_center_assessment_policy" "test" {
   remediation_description = "Updated Test Remediation Description"
   threats                 = ["DataExfiltration", "DataSpillage"]
   user_impact             = "Moderate"
-}
-`
-}
-
-func (r SecurityCenterAssessmentPolicyResource) categories() string {
-	return `
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_security_center_assessment_policy" "test" {
-  display_name = "Test Display Name"
-  severity     = "Medium"
-  description  = "Test Description"
-  categories   = ["Data"]
 }
 `
 }

--- a/website/docs/r/security_center_assessment_policy.html.markdown
+++ b/website/docs/r/security_center_assessment_policy.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 
 ---
 
+* `categories` - (Optional) A list of the categories of resource that is at risk when the Security Center Assessment is unhealthy. Possible values are `Unknown`, `Compute`, `Data`, `IdentityAndAccess`, `IoT` and `Networking`.
+
 * `implementation_effort` - (Optional) The implementation effort which is used to remediate the Security Center Assessment. Possible values are `Low`, `Moderate` and `High`.
 
 * `remediation_description` - (Optional) The description which is used to mitigate the security issue.


### PR DESCRIPTION
Hi @katbyte ,

The [PR 12278](https://github.com/terraform-providers/terraform-provider-azurerm/pull/12278) has been merged for supporting "categories" in azurerm_security_center_assessment_metadata. Seems I also need to add support for the categories property in azurerm_security_center_assessment_policy. Could you help have an another review? Thanks in advance.

--- PASS: TestAccSecurityCenterAssessmentPolicy_categories (181.28s)
--- PASS: TestAccSecurityCenterAssessmentPolicy_complete (182.80s)
--- PASS: TestAccSecurityCenterAssessmentPolicy_basic (183.52s)
--- PASS: TestAccSecurityCenterAssessmentPolicy_update (285.11s)