### PR TITLE
Fix issue labelling

### DIFF
--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: github/issue-labeler@v2
+    - uses: github/issue-labeler@v2.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml


### PR DESCRIPTION
The "issue triage" workflow doesn't work:
https://github.com/terraform-providers/terraform-provider-azurerm/actions/runs/978831567

Version v2 of the used github action doesn't exist, and the workflow `issue-opened.yaml` breaks every time.

It never worked since it [was introduced](https://github.com/terraform-providers/terraform-provider-azurerm/commit/e2700d9212a7ae1a4762517774b418a17ee59bc4) 27 days ago, and every time someone creates an issue, they get an email with this error:
![image](https://user-images.githubusercontent.com/5655837/123644490-b6f79300-d825-11eb-9b8f-037337d2e5ac.png)

We should use a specific minor version of this github action, e.g. 2.4.

---

See more:
* https://github.com/github/issue-labeler
* https://github.com/github/issue-labeler/pull/6/files