### PR TITLE
Add None to compression types

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
@@ -267,6 +267,7 @@ func resourceDataFactoryDatasetDelimitedText() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
+					"None",
 					"bzip2",
 					"gzip",
 					"deflate",


### PR DESCRIPTION
In the Azure UI Compression type includes the option None from the dropdown. Not sure why it's not an available option.

<img width="506" alt="Screen Shot 2021-06-29 at 11 18 11 AM" src="https://user-images.githubusercontent.com/12501773/123833530-0bede480-d8cc-11eb-9ff2-2a8275360b04.png">
