### PR TITLE
azurerm_data_factory_dataset_parquet - azure_blob_storage_location.filename is now optional

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_dataset_parquet_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_dataset_parquet_resource.go
@@ -95,7 +95,7 @@ func resourceDataFactoryDatasetParquet() *pluginsdk.Resource {
 						},
 						"filename": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 					},

--- a/azurerm/internal/services/datafactory/data_factory_dataset_parquet_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_dataset_parquet_resource_test.go
@@ -317,7 +317,6 @@ resource "azurerm_data_factory_dataset_parquet" "test" {
   azure_blob_storage_location {
     container = azurerm_storage_container.test.name
     path      = "foo/bar/"
-    filename  = "foo.txt"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/website/docs/r/data_factory_dataset_parquet.html.markdown
+++ b/website/docs/r/data_factory_dataset_parquet.html.markdown
@@ -98,7 +98,7 @@ A `http_server_location` block supports the following:
 
 * `path` - (Required) The folder path to the file on the web server.
 
-* `filename` - (Required) The filename of the file on the web server.
+* `filename` - (Optional) The filename of the file on the web server.
 
 ---
 
@@ -109,7 +109,6 @@ A `azure_blob_storage_location` block supports the following:
 * `path` - (Required) The folder path to the file on the web server.
 
 * `filename` - (Required) The filename of the file on the web server.
-
 
 ## Attributes Reference
 


### PR DESCRIPTION
The UI allows the filename to be empty/null so this being a required field doesn't seem to make sense.