### PR TITLE
Fix issue: `azurerm_(resource_group|subscription)_template_deployment` delete provisioned resources fix - apiVersion

### DIFF
--- a/azurerm/internal/services/resource/template_deployment_common.go
+++ b/azurerm/internal/services/resource/template_deployment_common.go
@@ -239,19 +239,9 @@ func findApiVersionForResourceType(resourceType string, availableResourceTypes [
 			continue
 		}
 
-		if strings.ToLower(resourceType) == strings.ToLower(*item.ResourceType) {
-			apiVersions := *item.APIVersions
-			apiVersion := apiVersions[0]
-			return &apiVersion
-		}
-	}
-
-	for _, item := range availableResourceTypes {
-		if item.ResourceType == nil || item.APIVersions == nil {
-			continue
-		}
-
-		if strings.HasPrefix(strings.ToLower(resourceType), strings.ToLower(*item.ResourceType)) {
+		isExactMatch := strings.EqualFold(resourceType, *item.ResourceType)
+		isPrefixMatch := strings.HasPrefix(strings.ToLower(resourceType), strings.ToLower(*item.ResourceType))
+		if isExactMatch || isPrefixMatch {
 			apiVersions := *item.APIVersions
 			apiVersion := apiVersions[0]
 			return &apiVersion

--- a/azurerm/internal/services/resource/template_deployment_common.go
+++ b/azurerm/internal/services/resource/template_deployment_common.go
@@ -239,6 +239,18 @@ func findApiVersionForResourceType(resourceType string, availableResourceTypes [
 			continue
 		}
 
+		if strings.ToLower(resourceType) == strings.ToLower(*item.ResourceType) {
+			apiVersions := *item.APIVersions
+			apiVersion := apiVersions[0]
+			return &apiVersion
+		}
+	}
+
+	for _, item := range availableResourceTypes {
+		if item.ResourceType == nil || item.APIVersions == nil {
+			continue
+		}
+
 		if strings.HasPrefix(strings.ToLower(resourceType), strings.ToLower(*item.ResourceType)) {
 			apiVersions := *item.APIVersions
 			apiVersion := apiVersions[0]


### PR DESCRIPTION
This PR adds an additional cycle for searching _apiVersion_ for a resource type in Resource Provider metadata response.
Currently, for instance, in case we are looking for an apiVersion for `automationAccounts/softwareUpdateConfigurations` and Resource Provider metadata (for `Microsoft.Automation`) contains:

- `automationAccounts`
- `automationAccounts/runbooks`
- `...`
- `automationAccounts/softwareUpdateConfigurations`
- `...`

The _apiVersion_ returned will be one for `automationAccounts` instead of the existing exact match.

Issue link: https://github.com/terraform-providers/terraform-provider-azurerm/issues/10654

Fixes #10654