### PR TITLE
tests/provider: Fix tfproviderlint R006 ignore comments

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_cluster_resource.go
@@ -146,7 +146,6 @@ func resourceEventHubClusterDelete(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	// The EventHub Cluster can't be deleted until four hours after creation so we'll keep retrying until it can be deleted.
-	//lintignore:R006
 	return pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutDelete), func() *pluginsdk.RetryError {
 		future, err := client.ClustersDelete(ctx, *id)
 		if err != nil {
@@ -167,7 +166,7 @@ func resourceEventHubClusterDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		return nil
-	})
+	}) //lintignore:R006
 }
 
 func expandEventHubClusterSkuName(skuName string) *eventhubsclusters.ClusterSku {

--- a/azurerm/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
+++ b/azurerm/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
@@ -90,7 +90,6 @@ func resourceArmMaintenanceAssignmentDedicatedHostCreate(d *pluginsdk.ResourceDa
 	}
 
 	// It may take a few minutes after starting a VM for it to become available to assign to a configuration
-	//lintignore:R006
 	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdateParent(ctx, dedicatedHostId.ResourceGroup, "Microsoft.Compute", "hostGroups", dedicatedHostId.HostGroupName, "hosts", dedicatedHostId.HostName, assignmentName, assignment); err != nil {
 			if strings.Contains(err.Error(), "It may take a few minutes after starting a VM for it to become available to assign to a configuration") {
@@ -100,7 +99,7 @@ func resourceArmMaintenanceAssignmentDedicatedHostCreate(d *pluginsdk.ResourceDa
 		}
 
 		return nil
-	})
+	}) //lintignore:R006
 	if err != nil {
 		return err
 	}

--- a/azurerm/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/azurerm/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -90,7 +90,6 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 	}
 
 	// It may take a few minutes after starting a VM for it to become available to assign to a configuration
-	//lintignore:R006
 	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
 		if _, err := client.CreateOrUpdate(ctx, virtualMachineId.ResourceGroup, "Microsoft.Compute", "virtualMachines", virtualMachineId.Name, assignmentName, assignment); err != nil {
 			if strings.Contains(err.Error(), "It may take a few minutes after starting a VM for it to become available to assign to a configuration") {
@@ -100,7 +99,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 		}
 
 		return nil
-	})
+	}) //lintignore:R006
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The heuristics within `tfproviderlint` cannot determine that `github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk.RetryableError` is equivalent to `github.com/hashicorp/terraform-plugin-sdk/helper/resource.RetryableError` for the `R006` pass. Until an enhancement can potentially be made to allow passing an alias package path, this fixes the ignore comment to be at the end of the anonymous function definition since it is within a wrapping function call and allows the report to be properly skipped.