### PR TITLE
docs: rename monitor_action_group to fix refs

### DIFF
--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -18,7 +18,7 @@ resource "azurerm_resource_group" "example" {
   location = "eastus"
 }
 
-resource "azurerm_monitor_action_group" "test" {
+resource "azurerm_monitor_action_group" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   short_name          = "example"

--- a/website/docs/r/consumption_budget_subscription.html.markdown
+++ b/website/docs/r/consumption_budget_subscription.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
   location = "eastus"
 }
 
-resource "azurerm_monitor_action_group" "test" {
+resource "azurerm_monitor_action_group" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   short_name          = "example"


### PR DESCRIPTION
# Description

This PR fixes the following errors:

For `azurerm_consumption_budget_resource_group`

![image](https://user-images.githubusercontent.com/31919569/124301035-d548f000-db91-11eb-8f4c-71a78c03c11d.png)

For `azurerm_consumption_budget_subscription`

![image](https://user-images.githubusercontent.com/31919569/124301149-fc9fbd00-db91-11eb-86c2-83e650e31cd5.png)

# Fix

Rename the `azurerm_monitor_action_group` resource from `test` to `example` following the naming convention of the other resources in the `Example Usage`
