### PR TITLE
docs: constraint on contacts in notification block

### DIFF
--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -137,6 +137,8 @@ A `notification` block supports the following:
 
 * `enabled` - (Optional) Should the notification be enabled?
 
+~> **NOTE:** A `notification` block cannot have all of `contact_emails`, `contact_roles`, and `contact_groups` empty. This means that at least one of the three must be specified.
+
 ---
 
 A `dimension` block supports the following:

--- a/website/docs/r/consumption_budget_subscription.html.markdown
+++ b/website/docs/r/consumption_budget_subscription.html.markdown
@@ -139,6 +139,8 @@ A `notification` block supports the following:
 
 * `enabled` - (Optional) Should the notification be enabled?
 
+~> **NOTE:** A `notification` block cannot have all of `contact_emails`, `contact_roles`, and `contact_groups` empty. This means that at least one of the three must be specified.
+
 ---
 
 A `dimension` block supports the following:


### PR DESCRIPTION
# Description

Minor addition of a Note section to state that one of the contact attributes are needed although individually, they are `optional`.

Code snippet for reproducing this error is:

```terraform
terraform {
  required_providers {
    azurerm = {
      source = "hashicorp/azurerm"
      version = "2.61.0"
    }
  }
}

provider "azurerm" {
  # Configuration options
  features {}
}

resource "azurerm_resource_group" "example" {
  name     = "example"
  location = "eastus"
}

resource "azurerm_monitor_action_group" "example" {
  name                = "example"
  resource_group_name = azurerm_resource_group.example.name
  short_name          = "example"
}

resource "azurerm_consumption_budget_resource_group" "example" {
  name              = "example"
  resource_group_id = azurerm_resource_group.example.id

  amount     = 1000
  time_grain = "Monthly"

  time_period {
    start_date = "2022-06-01T00:00:00Z"
    end_date   = "2022-07-01T00:00:00Z"
  }

  notification {
    enabled   = true
    threshold = 90.0
    operator  = "EqualTo"
  }
}
```

The resulting error indicating that one of the contact attributes are required for the notification block

![image](https://user-images.githubusercontent.com/31919569/124430437-c173d880-dda1-11eb-80db-865eafe7f70a.png)

