### PR TITLE
Add support for the maintenanceWindow property of azurerm_redis_cache

### DIFF
--- a/azurerm/internal/services/redis/redis_cache_resource.go
+++ b/azurerm/internal/services/redis/redis_cache_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	azValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
@@ -223,6 +224,14 @@ func resourceRedisCache() *pluginsdk.Resource {
 							DiffSuppressFunc: suppress.CaseDifference,
 							ValidateFunc:     validation.IsDayOfTheWeek(true),
 						},
+
+						"maintenance_window": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      "PT5H",
+							ValidateFunc: azValidate.ISO8601Duration,
+						},
+
 						"start_hour_utc": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
@@ -746,11 +755,13 @@ func expandRedisPatchSchedule(d *pluginsdk.ResourceData) *redis.PatchSchedule {
 	for _, scheduleValue := range scheduleValues {
 		vals := scheduleValue.(map[string]interface{})
 		dayOfWeek := vals["day_of_week"].(string)
+		maintenanceWindow := vals["maintenance_window"].(string)
 		startHourUtc := vals["start_hour_utc"].(int)
 
 		entry := redis.ScheduleEntry{
-			DayOfWeek:    redis.DayOfWeek(dayOfWeek),
-			StartHourUtc: utils.Int32(int32(startHourUtc)),
+			DayOfWeek:         redis.DayOfWeek(dayOfWeek),
+			MaintenanceWindow: utils.String(maintenanceWindow),
+			StartHourUtc:      utils.Int32(int32(startHourUtc)),
 		}
 		entries = append(entries, entry)
 	}
@@ -875,6 +886,7 @@ func flattenRedisPatchSchedules(schedule redis.PatchSchedule) []interface{} {
 		output := make(map[string]interface{})
 
 		output["day_of_week"] = string(entry.DayOfWeek)
+		output["maintenance_window"] = *entry.MaintenanceWindow
 		output["start_hour_utc"] = int(*entry.StartHourUtc)
 
 		outputs = append(outputs, output)

--- a/azurerm/internal/services/redis/redis_cache_resource_test.go
+++ b/azurerm/internal/services/redis/redis_cache_resource_test.go
@@ -781,8 +781,9 @@ resource "azurerm_redis_cache" "test" {
   }
 
   patch_schedule {
-    day_of_week    = "Tuesday"
-    start_hour_utc = 8
+    day_of_week        = "Tuesday"
+    start_hour_utc     = 8
+    maintenance_window = "PT7H"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -160,6 +160,8 @@ A `patch_schedule` block supports the following:
 
 ~> **Note:** The Patch Window lasts for `5` hours from the `start_hour_utc`.
 
+* `maintenance_window` - (Optional) The ISO 8601 timespan which specifies the amount of time the Redis Cache can be updated. Defaults to `PT5H`.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Currently, azurerm_redis_cache cannot specify how much time Redis Cache patching can take. So I submitted this PR to support it.

--- PASS: TestAccRedisCache_BackupDisabled (1390.66s)
--- PASS: TestAccRedisCache_ReplicasPerMaster (1417.98s)
--- PASS: TestAccRedisCache_SubscribeAllEvents (1450.55s)
--- PASS: TestAccRedisCache_BackupEnabled (1517.61s)
--- PASS: TestAccRedisCache_BackupEnabledDisabled (1522.40s)
--- PASS: TestAccRedisCache_AOFBackupEnabled (1644.17s)
--- PASS: TestAccRedisCache_NonStandardCasing (2078.53s)
--- PASS: TestAccRedisCache_basic (2148.08s)
--- PASS: TestAccRedisCache_premium (1503.06s)
--- PASS: TestAccRedisCache_premiumSharded (1743.53s)
--- PASS: TestAccRedisCache_premiumShardedScaling (3460.16s)
--- PASS: TestAccRedisCache_standard (2189.02s)
--- PASS: TestAccRedisCache_requiresImport (2057.95s)
--- PASS: TestAccRedisCache_PatchScheduleUpdated (1664.66s)
--- PASS: TestAccRedisCache_withoutSSL (2058.33s)
--- PASS: TestAccRedisCache_WithoutAuth (4750.05s)
--- PASS: TestAccRedisCache_InternalSubnet_withZone (3387.41s)
--- PASS: TestAccRedisCache_PatchSchedule (1522.45s)
--- PASS: TestAccRedisCache_InternalSubnet (3531.47s)
--- PASS: TestAccRedisCache_InternalSubnetStaticIP (3419.39s)
--- PASS: TestAccRedisCache_PublicNetworkAccessDisabledEnabled (2306.64s)
--- PASS: TestAccRedisCache_AOFBackupEnabledDisabled (2189.64s)

Overview:
https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-administration