### PR TITLE
Add os_type validation string for Windows function app (empty string)

### DIFF
--- a/azurerm/internal/services/web/function_app_resource.go
+++ b/azurerm/internal/services/web/function_app_resource.go
@@ -154,6 +154,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"linux",
+					"",
 				}, false),
 			},
 

--- a/azurerm/internal/services/web/function_app_resource.go
+++ b/azurerm/internal/services/web/function_app_resource.go
@@ -152,6 +152,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "",
 				ValidateFunc: validation.StringInSlice([]string{
 					"linux",
 					"",


### PR DESCRIPTION
Fix for #11859
Where [function_app argument os_type](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app#os_type) can be "linux" or an empty string for Windows
Currently only validates input "linux"