### PR TITLE
new resource "azurerm_data_factory_custom_dataset"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource.go
@@ -1,0 +1,401 @@
+package datafactory
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceDataFactoryCustomDataset() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceDataFactoryCustomDatasetCreateUpdate,
+		Read:   resourceDataFactoryCustomDatasetRead,
+		Update: resourceDataFactoryCustomDatasetCreateUpdate,
+		Delete: resourceDataFactoryCustomDatasetDelete,
+
+		// TODO: replace this with an importer which validates the ID during import
+		Importer: pluginsdk.DefaultImporter(),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.LinkedServiceDatasetName,
+			},
+
+			"data_factory_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataFactoryID,
+			},
+
+			"linked_service": {
+				Type:     pluginsdk.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"parameters": {
+							Type:     pluginsdk.TypeMap,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"type": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type_properties_json": {
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				StateFunc:        utils.NormalizeJson,
+				DiffSuppressFunc: suppressJsonOrderingDifference,
+			},
+
+			"additional_properties": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"annotations": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"description": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"folder": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"parameters": {
+				Type:     pluginsdk.TypeMap,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"schema_json": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				StateFunc:        utils.NormalizeJson,
+				DiffSuppressFunc: suppressJsonOrderingDifference,
+			},
+		},
+	}
+}
+
+func resourceDataFactoryCustomDatasetCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.DatasetClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	dataFactoryId, err := parse.DataFactoryID(d.Get("data_factory_id").(string))
+	if err != nil {
+		return err
+	}
+
+	id := parse.NewDataSetID(subscriptionId, dataFactoryId.ResourceGroup, dataFactoryId.FactoryName, d.Get("name").(string))
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_data_factory_custom_dataset", id.ID())
+		}
+	}
+
+	props := map[string]interface{}{
+		"type":              d.Get("type").(string),
+		"linkedServiceName": expandDataFactoryLinkedService(d.Get("linked_service").([]interface{})),
+	}
+
+	typePropertiesJson := fmt.Sprintf(`{ "typeProperties": %s }`, d.Get("type_properties_json").(string))
+	if err = json.Unmarshal([]byte(typePropertiesJson), &props); err != nil {
+		return err
+	}
+
+	additionalProperties := d.Get("additional_properties").(map[string]interface{})
+	for k, v := range additionalProperties {
+		props[k] = v
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		props["annotations"] = v.([]interface{})
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		props["description"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("folder"); ok {
+		props["folder"] = &datafactory.DatasetFolder{
+			Name: utils.String(v.(string)),
+		}
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		props["parameters"] = expandDataFactoryParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("schema_json"); ok {
+		schemaJson := fmt.Sprintf(`{ "schema": %s }`, v.(string))
+		if err = json.Unmarshal([]byte(schemaJson), &props); err != nil {
+			return err
+		}
+	}
+
+	jsonData, err := json.Marshal(map[string]interface{}{
+		"properties": props,
+	})
+	if err != nil {
+		return err
+	}
+
+	dataset := &datafactory.DatasetResource{}
+	if err := dataset.UnmarshalJSON(jsonData); err != nil {
+		return err
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.FactoryName, id.Name, *dataset, ""); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceDataFactoryCustomDatasetRead(d, meta)
+}
+
+func resourceDataFactoryCustomDatasetRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.DatasetClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DataSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("data_factory_id", parse.NewDataFactoryID(subscriptionId, id.ResourceGroup, id.FactoryName).ID())
+
+	byteArr, err := json.Marshal(resp.Properties)
+	if err != nil {
+		return err
+	}
+
+	var m map[string]*json.RawMessage
+	if err = json.Unmarshal(byteArr, &m); err != nil {
+		return err
+	}
+
+	description := ""
+	if v, ok := m["description"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &description); err != nil {
+			return err
+		}
+		delete(m, "description")
+	}
+	d.Set("description", description)
+
+	t := ""
+	if v, ok := m["type"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &t); err != nil {
+			return err
+		}
+		delete(m, "type")
+	}
+	d.Set("type", t)
+
+	folder := ""
+	if v, ok := m["folder"]; ok && v != nil {
+		datasetFolder := &datafactory.DatasetFolder{}
+		if err := json.Unmarshal(*v, datasetFolder); err != nil {
+			return err
+		}
+		if datasetFolder.Name != nil {
+			folder = *datasetFolder.Name
+		}
+		delete(m, "folder")
+	}
+	d.Set("folder", folder)
+
+	annotations := make([]interface{}, 0)
+	if v, ok := m["annotations"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &annotations); err != nil {
+			return err
+		}
+		delete(m, "annotations")
+	}
+	d.Set("annotations", annotations)
+
+	parameters := make(map[string]*datafactory.ParameterSpecification)
+	if v, ok := m["parameters"]; ok && v != nil {
+		if err := json.Unmarshal(*v, &parameters); err != nil {
+			return err
+		}
+		delete(m, "parameters")
+	}
+	if err := d.Set("parameters", flattenDataFactoryParameters(parameters)); err != nil {
+		return fmt.Errorf("setting `parameters`: %+v", err)
+	}
+
+	var linkedService *datafactory.LinkedServiceReference
+	if v, ok := m["linkedServiceName"]; ok && v != nil {
+		linkedService = &datafactory.LinkedServiceReference{}
+		if err := json.Unmarshal(*v, linkedService); err != nil {
+			return err
+		}
+		delete(m, "linkedServiceName")
+	}
+	if err := d.Set("linked_service", flattenDataFactoryLinkedService(linkedService)); err != nil {
+		return fmt.Errorf("setting `linked_service`: %+v", err)
+	}
+
+	// set "schema"
+	schemaJson := ""
+	if v, ok := m["schema"]; ok {
+		schemaBytes, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		schemaJson = string(schemaBytes)
+		delete(m, "schema")
+	}
+	d.Set("schema_json", schemaJson)
+
+	// set "type_properties_json"
+	typePropertiesJson := ""
+	if v, ok := m["typeProperties"]; ok {
+		typePropertiesBytes, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		typePropertiesJson = string(typePropertiesBytes)
+		delete(m, "typeProperties")
+	}
+	d.Set("type_properties_json", typePropertiesJson)
+
+	delete(m, "structure")
+
+	// set "additional_properties"
+	additionalProperties := make(map[string]interface{})
+	bytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(bytes, &additionalProperties); err != nil {
+		return err
+	}
+	d.Set("additional_properties", additionalProperties)
+
+	return nil
+}
+
+func resourceDataFactoryCustomDatasetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.DatasetClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DataSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.FactoryName, id.Name); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	return nil
+}
+
+func expandDataFactoryLinkedService(input []interface{}) *datafactory.LinkedServiceReference {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+	return &datafactory.LinkedServiceReference{
+		ReferenceName: utils.String(v["name"].(string)),
+		Type:          utils.String("LinkedServiceReference"),
+		Parameters:    v["parameters"].(map[string]interface{}),
+	}
+}
+
+func flattenDataFactoryLinkedService(input *datafactory.LinkedServiceReference) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	name := ""
+	if input.ReferenceName != nil {
+		name = *input.ReferenceName
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":       name,
+			"parameters": input.Parameters,
+		},
+	}
+}

--- a/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource.go
@@ -23,8 +23,10 @@ func resourceDataFactoryCustomDataset() *pluginsdk.Resource {
 		Update: resourceDataFactoryCustomDatasetCreateUpdate,
 		Delete: resourceDataFactoryCustomDatasetDelete,
 
-		// TODO: replace this with an importer which validates the ID during import
-		Importer: pluginsdk.DefaultImporter(),
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.DataSetID(id)
+			return err
+		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),

--- a/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource_test.go
@@ -1,0 +1,393 @@
+package datafactory_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type CustomDatasetResource struct {
+}
+
+func TestAccDataFactoryCustomDataset_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_custom_dataset", "test")
+	r := CustomDatasetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataFactoryCustomDataset_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_custom_dataset", "test")
+	r := CustomDatasetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccDataFactoryCustomDataset_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_custom_dataset", "test")
+	r := CustomDatasetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataFactoryCustomDataset_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_custom_dataset", "test")
+	r := CustomDatasetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataFactoryCustomDataset_delimitedText(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_custom_dataset", "test")
+	r := CustomDatasetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.delimitedText(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDataFactoryCustomDataset_avro(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_custom_dataset", "test")
+	r := CustomDatasetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.avro(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t CustomDatasetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.DataSetID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.DataFactory.DatasetClient.Get(ctx, id.ResourceGroup, id.FactoryName, id.Name, "")
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (r CustomDatasetResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_custom_dataset" "test" {
+  name            = "acctestds%d"
+  data_factory_id = azurerm_data_factory.test.id
+  type            = "Json"
+
+  linked_service {
+    name = azurerm_data_factory_linked_custom_service.test.name
+  }
+
+  type_properties_json = <<JSON
+{
+  "location": {
+    "container": "${azurerm_storage_container.test.name}",
+    "type": "AzureBlobStorageLocation"
+  }
+}
+JSON
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r CustomDatasetResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_custom_dataset" "import" {
+  name                 = azurerm_data_factory_custom_dataset.test.name
+  data_factory_id      = azurerm_data_factory_custom_dataset.test.data_factory_id
+  type                 = azurerm_data_factory_custom_dataset.test.type
+  type_properties_json = azurerm_data_factory_custom_dataset.test.type_properties_json
+  
+  linked_service {
+    name = azurerm_data_factory_custom_dataset.test.linked_service.0.name
+  }
+}
+`, r.basic(data))
+}
+
+func (r CustomDatasetResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_custom_dataset" "test" {
+  name            = "acctestds%d"
+  data_factory_id = azurerm_data_factory.test.id
+  type            = "Json"
+
+  linked_service {
+    name = azurerm_data_factory_linked_custom_service.test.name
+    parameters = {
+      key1 = "value1"
+      key2 = "value2"
+    }
+  }
+
+  type_properties_json = <<JSON
+{
+  "location": {
+    "container":"${azurerm_storage_container.test.name}",
+    "fileName":"foo.txt",
+    "folderPath": "foo/bar/",
+    "type":"AzureBlobStorageLocation"
+  },
+  "encodingName":"UTF-8"
+}
+JSON
+
+  description = "test description"
+  annotations = ["test1", "test2", "test3"]
+  folder      = "testFolder"
+
+  parameters = {
+    foo = "test1"
+    Bar = "Test2"
+  }
+
+  additional_properties = {
+    foo = "test1"
+    bar = "test2"
+  }
+
+  schema_json = <<JSON
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}
+JSON
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r CustomDatasetResource) delimitedText(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_custom_dataset" "test" {
+  name            = "acctestds%d"
+  data_factory_id = azurerm_data_factory.test.id
+  type            = "DelimitedText"
+
+  linked_service {
+    name = azurerm_data_factory_linked_custom_service.test.name
+  }
+
+  type_properties_json = <<JSON
+{
+  "location": {
+    "container":"test",
+    "fileName":"foo.txt",
+    "folderPath": "foo/bar/",
+    "type":"AzureBlobStorageLocation"
+  },
+  "columnDelimiter": "\n",
+  "rowDelimiter": "\t",
+  "encodingName": "UTF-8",
+  "compressionCodec": "bzip2",
+  "compressionLevel": "Farest",
+  "quoteChar": "",
+  "escapeChar": "",
+  "firstRowAsHeader": false,
+  "nullValue": ""
+}
+JSON
+
+  schema_json = <<JSON
+[
+  {
+    "name": "col1",
+    "type": "INT_32"
+  },
+  {
+    "name": "col2",
+    "type": "Decimal",
+    "precision": "38",
+    "scale": "2"
+  }
+]
+JSON
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r CustomDatasetResource) avro(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_factory_custom_dataset" "test" {
+  name            = "acctestds%d"
+  data_factory_id = azurerm_data_factory.test.id
+  type            = "Avro"
+
+  linked_service {
+    name = azurerm_data_factory_linked_custom_service.test.name
+  }
+
+  type_properties_json = <<JSON
+{
+  "location": {
+    "fileName":".avro",
+    "folderPath": "foo",
+    "type":"AzureBlobStorageLocation"
+  },
+  "avroCompressionCodec": "deflate",
+  "avroCompressionLevel": 4
+}
+JSON
+
+  schema_json = <<JSON
+{
+  "type": "record",
+  "namespace": "com.example",
+  "name": "test",
+  "fields": [
+    {
+      "name": "first",
+      "type": "string"
+    },
+    {
+      "name": "last",
+      "type": "int"
+    },
+    {
+      "name": "Hobby",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    }
+  ]
+}
+JSON
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (CustomDatasetResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestdf%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "content"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name                 = "acctestls%d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureBlobStorage"
+  type_properties_json = <<JSON
+{
+  "connectionString": "${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_custom_dataset_resource_test.go
@@ -168,7 +168,7 @@ resource "azurerm_data_factory_custom_dataset" "import" {
   data_factory_id      = azurerm_data_factory_custom_dataset.test.data_factory_id
   type                 = azurerm_data_factory_custom_dataset.test.type
   type_properties_json = azurerm_data_factory_custom_dataset.test.type_properties_json
-  
+
   linked_service {
     name = azurerm_data_factory_custom_dataset.test.linked_service.0.name
   }

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -39,6 +39,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_data_factory_dataset_postgresql":                    resourceDataFactoryDatasetPostgreSQL(),
 		"azurerm_data_factory_dataset_snowflake":                     resourceDataFactoryDatasetSnowflake(),
 		"azurerm_data_factory_dataset_sql_server_table":              resourceDataFactoryDatasetSQLServerTable(),
+		"azurerm_data_factory_custom_dataset":                        resourceDataFactoryCustomDataset(),
 		"azurerm_data_factory_integration_runtime_managed":           resourceDataFactoryIntegrationRuntimeManaged(),
 		"azurerm_data_factory_integration_runtime_azure":             resourceDataFactoryIntegrationRuntimeAzure(),
 		"azurerm_data_factory_integration_runtime_azure_ssis":        resourceDataFactoryIntegrationRuntimeAzureSsis(),

--- a/website/docs/r/data_factory_custom_dataset.html.markdown
+++ b/website/docs/r/data_factory_custom_dataset.html.markdown
@@ -139,7 +139,7 @@ A `linked_service` block supports the following:
 
 * `name` - (Required) The name of the Data Factory Linked Service.
 
-* `parameters` - (Required) A map of parameters to associate with the Data Factory Linked Service.
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linked Service.
 
 ## Attributes Reference
 

--- a/website/docs/r/data_factory_custom_dataset.html.markdown
+++ b/website/docs/r/data_factory_custom_dataset.html.markdown
@@ -1,0 +1,165 @@
+---
+subcategory: "Data Factory"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_factory_custom_dataset"
+description: |-
+  Manages a Dataset inside an Azure Data Factory. This is a generic resource that supports all different Dataset Types.
+---
+
+# azurerm_data_factory_custom_dataset
+
+Manages a Dataset inside an Azure Data Factory. This is a generic resource that supports all different Dataset Types.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_data_factory" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "example"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_data_factory_linked_custom_service" "example" {
+  name                 = "example"
+  data_factory_id      = azurerm_data_factory.example.id
+  type                 = "AzureBlobStorage"
+  type_properties_json = <<JSON
+{
+  "connectionString":"${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+}
+
+resource "azurerm_data_factory_custom_dataset" "example" {
+  name            = "example"
+  data_factory_id = azurerm_data_factory.example.id
+  type            = "Json"
+
+  linked_service {
+    name = azurerm_data_factory_linked_custom_service.test.name
+    parameters = {
+      key1 = "value1"
+    }
+  }
+
+  type_properties_json = <<JSON
+{
+  "location": {
+    "container":"${azurerm_storage_container.test.name}",
+    "fileName":"foo.txt",
+    "folderPath": "foo/bar/",
+    "type":"AzureBlobStorageLocation"
+  },
+  "encodingName":"UTF-8"
+}
+JSON
+
+  description = "test description"
+  annotations = ["test1", "test2", "test3"]
+  folder      = "testFolder"
+
+  parameters = {
+    foo = "test1"
+    Bar = "Test2"
+  }
+
+  additional_properties = {
+    foo = "test1"
+    bar = "test2"
+  }
+
+  schema_json = <<JSON
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "age": {
+      "type": "integer"
+    }
+  }
+}
+JSON
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the Data Factory Dataset. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+
+* `data_factory_id` - (Required) The Data Factory ID in which to associate the Dataset with. Changing this forces a new resource.
+
+* `linked_service` - (Required) A `linked_service` block as defined below.
+
+* `type` - (Required) The type of dataset that will be associated with Data Factory.
+
+* `type_properties_json` - (Required) A JSON object that contains the properties of the Data Factory Dataset.
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Dataset.
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Dataset.
+
+* `description` - (Optional) The description for the Data Factory Dataset.
+
+* `folder` - (Optional) The folder that this Dataset is in. If not specified, the Dataset will appear at the root level.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Dataset.
+
+* `schema_json` - (Optional) A JSON object that contains the schema of the Data Factory Dataset.
+
+---
+
+A `linked_service` block supports the following:
+
+* `name` - (Required) The name of the Data Factory Linked Service.
+
+* `parameters` - (Required) A map of parameters to associate with the Data Factory Linked Service.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Data Factory Dataset.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Dataset.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Dataset.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Dataset.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Dataset.
+
+## Import
+
+Data Factory Datasets can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_factory_custom_dataset.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/datasets/example
+```


### PR DESCRIPTION
generic resource about dataset

*notes*:
1. according to the service team, `structure` is deprecated and `schema` is prefered. So in this resource, I didn't imeplement `structure` property.
2. `schema` is type interface, according to the service team, it could be either a object or an array. So I also made it a json string. In the acctest, both cases are covered.  

![image](https://user-images.githubusercontent.com/2786738/124548031-b41d2380-de5f-11eb-931f-4bc927c1e6b0.png)
