### PR TITLE
azurerm_network_watcher_flow_log - document update import directives

### DIFF
--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -133,5 +133,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Network Watcher Flow Logs can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_network_watcher_flow_log.watcher1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/networkWatchers/watcher1
+terraform import azurerm_network_watcher_flow_log.watcher1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/networkWatchers/watcher1/networkSecurityGroupId/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/networkSecurityGroups/group1
 ```


### PR DESCRIPTION
Fix the incorrect import directives. Note that #11670 doesn't change the way to import, this was just incorrect at that time.