### PR TITLE
add deprecation meesage for "azurerm_data_factory_integration_runtime_managed"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_managed_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
@@ -24,6 +25,8 @@ func resourceDataFactoryIntegrationRuntimeManaged() *pluginsdk.Resource {
 		Delete: resourceDataFactoryIntegrationRuntimeManagedDelete,
 		// TODO: replace this with an importer which validates the ID during import
 		Importer: pluginsdk.DefaultImporter(),
+
+		DeprecationMessage: features.DeprecatedInThreePointOh("The resource 'azurerm_data_factory_integration_runtime_managed' has been superseded by the 'azurerm_data_factory_integration_runtime_azure_ssis'."),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),


### PR DESCRIPTION
according to https://github.com/terraform-providers/terraform-provider-azurerm/pull/10236#issue-557006016, 

The existing azurerm_data_factory_integration_runtime_managed was marked as deprecated in favor of azurerm_data_factory_integration_runtime_azure_ssis.

The deprecation message is noted in the doc https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/data_factory_integration_runtime_managed

this PR adds message in the resource, so Users who use this resource will get notification.