### PR TITLE
Use d.GetOk to set the parameters property of azurerm_bot_connection

### DIFF
--- a/azurerm/internal/services/bot/bot_connection_resource.go
+++ b/azurerm/internal/services/bot/bot_connection_resource.go
@@ -149,11 +149,14 @@ func resourceArmBotConnectionCreate(d *pluginsdk.ResourceData, meta interface{})
 			ClientID:          utils.String(d.Get("client_id").(string)),
 			ClientSecret:      utils.String(d.Get("client_secret").(string)),
 			Scopes:            utils.String(d.Get("scopes").(string)),
-			Parameters:        expandBotConnectionParameters(d.Get("parameters").(map[string]interface{})),
 		},
 		Kind:     botservice.KindBot,
 		Location: utils.String(d.Get("location").(string)),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		connection.Properties.Parameters = expandBotConnectionParameters(v.(map[string]interface{}))
 	}
 
 	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, resourceId.ConnectionName, connection); err != nil {
@@ -217,11 +220,14 @@ func resourceArmBotConnectionUpdate(d *pluginsdk.ResourceData, meta interface{})
 			ClientID:                   utils.String(d.Get("client_id").(string)),
 			ClientSecret:               utils.String(d.Get("client_secret").(string)),
 			Scopes:                     utils.String(d.Get("scopes").(string)),
-			Parameters:                 expandBotConnectionParameters(d.Get("parameters").(map[string]interface{})),
 		},
 		Kind:     botservice.KindBot,
 		Location: utils.String(d.Get("location").(string)),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		connection.Properties.Parameters = expandBotConnectionParameters(v.(map[string]interface{}))
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, id.ConnectionName, connection); err != nil {


### PR DESCRIPTION
Currently, the TCs related with BotService Connection are failed. After investigated, seems currently the API behavior would fail to create bot connection when the [`parameters`](https://github.com/terraform-providers/terraform-provider-azurerm/blob/64d274a7aece31e7b6051071c50991a9287562ab/azurerm/internal/services/bot/bot_connection_resource.go#L86) property is `[]`. After checked, seems currently this property is [optional](https://github.com/terraform-providers/terraform-provider-azurerm/blob/64d274a7aece31e7b6051071c50991a9287562ab/azurerm/internal/services/bot/bot_connection_resource.go#L88) and it would be set as [`[]`](https://github.com/terraform-providers/terraform-provider-azurerm/blob/64d274a7aece31e7b6051071c50991a9287562ab/azurerm/internal/services/bot/bot_connection_resource.go#L152) in TF when it isn't specified in tfconfig. I assume we should use `d.GetOk()` for this optional property. So I submitted this PR to fix this issue.

After fixed, the related TCs can pass now on TeamCity.
--- PASS: TestAccBotChannelsRegistration/connection/basic (228.15s)
--- PASS: TestAccBotChannelsRegistration/connection/complete (326.39s)
![image](https://user-images.githubusercontent.com/19754191/124718505-bdc68a00-df38-11eb-8379-e6dc7cb250fa.png)
