### PR TITLE
Support for `user_assigned_identity_id` in `azurerm_storage_account_customer_managed_key`

### DIFF
--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
 
 * `key_version` - (Optional) The version of Key Vault Key. Remove or omit this argument to enable Automatic Key Rotation.
 
+* `user_assigned_identity_id` - (Optional) The ID of a user assigned identity.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:


### PR DESCRIPTION
Close #12489

### acctests result

```
vscode ➜ /workspaces/terraform-provider-azurerm (storage-cmk-user-identity ✗) $ make acctests SERVICE='storage' TESTARGS='-run=TestAccStorageAccountCustomerManagedKey_'==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/storage -run=TestAccStorageAccountCustomerManagedKey_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStorageAccountCustomerManagedKey_basic
=== PAUSE TestAccStorageAccountCustomerManagedKey_basic
=== RUN   TestAccStorageAccountCustomerManagedKey_requiresImport
=== PAUSE TestAccStorageAccountCustomerManagedKey_requiresImport
=== RUN   TestAccStorageAccountCustomerManagedKey_updateKey
=== PAUSE TestAccStorageAccountCustomerManagedKey_updateKey
=== RUN   TestAccStorageAccountCustomerManagedKey_testKeyVersion
=== PAUSE TestAccStorageAccountCustomerManagedKey_testKeyVersion
=== RUN   TestAccStorageAccountCustomerManagedKey_userAssignedIdentity
=== PAUSE TestAccStorageAccountCustomerManagedKey_userAssignedIdentity
=== CONT  TestAccStorageAccountCustomerManagedKey_basic
=== CONT  TestAccStorageAccountCustomerManagedKey_testKeyVersion
=== CONT  TestAccStorageAccountCustomerManagedKey_userAssignedIdentity
=== CONT  TestAccStorageAccountCustomerManagedKey_updateKey
=== CONT  TestAccStorageAccountCustomerManagedKey_requiresImport
--- PASS: TestAccStorageAccountCustomerManagedKey_userAssignedIdentity (331.83s)
--- PASS: TestAccStorageAccountCustomerManagedKey_requiresImport (343.49s)
--- PASS: TestAccStorageAccountCustomerManagedKey_basic (379.26s)
--- PASS: TestAccStorageAccountCustomerManagedKey_updateKey (393.19s)
--- PASS: TestAccStorageAccountCustomerManagedKey_testKeyVersion (406.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage     406.196s
```