### PR TITLE
`azurerm_automation_dsc_nodeconfiguration` - fix typo in config

### DIFF
--- a/azurerm/internal/services/automation/automation_dsc_nodeconfiguration_resource_test.go
+++ b/azurerm/internal/services/automation/automation_dsc_nodeconfiguration_resource_test.go
@@ -91,7 +91,7 @@ resource "azurerm_automation_dsc_configuration" "test" {
 }
 
 resource "azurerm_automation_dsc_nodeconfiguration" "test" {
-  name                    = "acceptance.localhost"
+  name                    = "acctest.localhost"
   resource_group_name     = azurerm_resource_group.test.name
   automation_account_name = azurerm_automation_account.test.name
   depends_on              = [azurerm_automation_dsc_configuration.test]


### PR DESCRIPTION
Name needs to match the associated `azurerm_automation_dsc_configuration` name.