### PR TITLE
Avoid panic if RG or ASE do not exist when creating an App Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 BUG FIXES:
 
 * `azurerm_api_management` - fix an issue where changing the location of an `additional_location` would force a new resource [GH-12468]
+* `azurerm_app_service` - fix crash when resource group or ASE is missing. [GH-11250]
 * `azurerm_kusto_eventhub_data_connection` - `APACHEAVRO` can now be used as a `data_format` option [GH-12480]
 * `azurerm_site_recovery_replicated_vm ` - Fix potential crash in reading `managed_disk` properties [GH-12509]
 * `azurerm_storage_account` - `account_replication_type` can now be updated [GH-12479]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ FEATURES:
 BUG FIXES:
 
 * `azurerm_api_management` - fix an issue where changing the location of an `additional_location` would force a new resource [GH-12468]
-* `azurerm_app_service` - fix crash when resource group or ASE is missing. [GH-11250]
 * `azurerm_kusto_eventhub_data_connection` - `APACHEAVRO` can now be used as a `data_format` option [GH-12480]
 * `azurerm_site_recovery_replicated_vm ` - Fix potential crash in reading `managed_disk` properties [GH-12509]
 * `azurerm_storage_account` - `account_replication_type` can now be updated [GH-12479]

--- a/azurerm/internal/services/web/app_service_resource.go
+++ b/azurerm/internal/services/web/app_service_resource.go
@@ -236,7 +236,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	// Check if App Service Plan is part of ASE
 	// If so, the name needs updating to <app name>.<ASE name>.appserviceenvironment.net and FQDN setting true for name availability check
 	aspDetails, err := aspClient.Get(ctx, aspID.ResourceGroup, aspID.ServerfarmName)
-	// 404 is incorrectly being considered an acceptable response, issue tracked at https://github.com/Azure/azure-sdk-for-go/issues/15002 
+	// 404 is incorrectly being considered an acceptable response, issue tracked at https://github.com/Azure/azure-sdk-for-go/issues/15002
 	if err != nil || utils.ResponseWasNotFound(aspDetails.Response) {
 		return fmt.Errorf("App Service Environment %q or Resource Group %q does not exist", aspID.ServerfarmName, aspID.ResourceGroup)
 	}

--- a/azurerm/internal/services/web/app_service_resource.go
+++ b/azurerm/internal/services/web/app_service_resource.go
@@ -236,8 +236,8 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	// Check if App Service Plan is part of ASE
 	// If so, the name needs updating to <app name>.<ASE name>.appserviceenvironment.net and FQDN setting true for name availability check
 	aspDetails, err := aspClient.Get(ctx, aspID.ResourceGroup, aspID.ServerfarmName)
-	if err != nil {
-		return fmt.Errorf("App Service Environment %q (Resource Group %q) does not exist", aspID.ServerfarmName, aspID.ResourceGroup)
+	if err != nil || utils.ResponseWasNotFound(aspDetails.Response) {
+		return fmt.Errorf("App Service Environment %q or Resource Group %q does not exist", aspID.ServerfarmName, aspID.ResourceGroup)
 	}
 	if aspDetails.HostingEnvironmentProfile != nil {
 		availabilityRequest.Name = utils.String(fmt.Sprintf("%s.%s.appserviceenvironment.net", name, *aspDetails.HostingEnvironmentProfile.Name))

--- a/azurerm/internal/services/web/app_service_resource.go
+++ b/azurerm/internal/services/web/app_service_resource.go
@@ -236,6 +236,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	// Check if App Service Plan is part of ASE
 	// If so, the name needs updating to <app name>.<ASE name>.appserviceenvironment.net and FQDN setting true for name availability check
 	aspDetails, err := aspClient.Get(ctx, aspID.ResourceGroup, aspID.ServerfarmName)
+	// 404 is incorrectly being considered an acceptable response, issue tracked at https://github.com/Azure/azure-sdk-for-go/issues/15002 
 	if err != nil || utils.ResponseWasNotFound(aspDetails.Response) {
 		return fmt.Errorf("App Service Environment %q or Resource Group %q does not exist", aspID.ServerfarmName, aspID.ResourceGroup)
 	}


### PR DESCRIPTION
Since the `Get` function of the `AppServices` client does not return an
error if the resource is not found, the code behaves as if everything is
fine and attempts to access fields of a struct that have not been
un-marshalled, since the API responded with 404.