### PR TITLE
fix typo and acctest for `azurerm_data_factory_integration_runtime_self_hosted`

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource.go
@@ -210,7 +210,7 @@ func resourceDataFactoryIntegrationRuntimeSelfHostedRead(d *pluginsdk.ResourceDa
 	}
 
 	d.Set("auth_key_1", respKey.AuthKey1)
-	d.Set("auth_key_1", respKey.AuthKey2)
+	d.Set("auth_key_2", respKey.AuthKey2)
 
 	return nil
 }

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource_test.go
@@ -185,7 +185,7 @@ resource "azurerm_resource_group" "target" {
 }
 
 resource "azurerm_role_assignment" "target" {
-  scope                = azurerm_data_factory.host.id
+  scope                = azurerm_data_factory_integration_runtime_self_hosted.host.id
   role_definition_name = "Contributor"
   principal_id         = azurerm_data_factory.target.identity[0].principal_id
 }


### PR DESCRIPTION
in the acctest, the scenario is one data factory could create a self hosted runtime, and another data factory could create a runtime to link it.  The role assignment should be assign permission to second data factory on scope runtime. 

In the portal, it's the same as I described.

![image](https://user-images.githubusercontent.com/2786738/125016225-8fb18900-e0a3-11eb-82d9-cb56aa1cc814.png)
