### PR TITLE
add resource "azurerm_cognitive_account_customer_managed_key"

### DIFF
--- a/azurerm/internal/services/cognitive/cognitive_account_customer_managed_key_resource.go
+++ b/azurerm/internal/services/cognitive/cognitive_account_customer_managed_key_resource.go
@@ -1,0 +1,253 @@
+package cognitive
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/cognitiveservices/mgmt/2021-04-30/cognitiveservices"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cognitive/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cognitive/validate"
+	keyVaultParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
+	keyVaultValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceCognitiveAccountCustomerManagedKey() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceCognitiveAccountCustomerManagedKeyCreateUpdate,
+		Read:   resourceCognitiveAccountCustomerManagedKeyRead,
+		Update: resourceCognitiveAccountCustomerManagedKeyCreateUpdate,
+		Delete: resourceCognitiveAccountCustomerManagedKeyDelete,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: pluginsdk.DefaultImporter(),
+
+		Schema: map[string]*pluginsdk.Schema{
+			"cognitive_account_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.AccountID,
+			},
+
+			"key_source": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cognitiveservices.KeySourceMicrosoftKeyVault),
+					string(cognitiveservices.KeySourceMicrosoftCognitiveServices),
+				}, false),
+			},
+
+			"key_vault_key_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
+			},
+
+			"identity_client_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+		},
+	}
+}
+
+func resourceCognitiveAccountCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Cognitive.AccountsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.AccountID(d.Get("cognitive_account_id").(string))
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, "azurerm_cognitive_account")
+	defer locks.UnlockByName(id.Name, "azurerm_cognitive_account")
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	if d.IsNewResource() {
+		if resp.Properties != nil && resp.Properties.Encryption != nil {
+			return tf.ImportAsExistsError("azurerm_cognitive_account_customer_managed_key", id.ID())
+		}
+	}
+
+	keySource := cognitiveservices.KeySource(d.Get("key_source").(string))
+	props := cognitiveservices.Account{
+		Properties: &cognitiveservices.AccountProperties{
+			Encryption: &cognitiveservices.Encryption{
+				KeySource: keySource,
+			},
+		},
+	}
+	if keySource == cognitiveservices.KeySourceMicrosoftCognitiveServices {
+		if _, ok := d.GetOk("key_vault_key_id"); ok {
+			return fmt.Errorf("can't specify key_vault_key_id when using Microsoft.CognitiveServices key source")
+		}
+		if _, ok := d.GetOk("identity_client_id"); ok {
+			return fmt.Errorf("can't specify key_name when using Microsoft.CognitiveServices key source")
+		}
+	} else {
+		keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(d.Get("key_vault_key_id").(string))
+		if err != nil {
+			return err
+		}
+		props.Properties.Encryption.KeyVaultProperties = &cognitiveservices.KeyVaultProperties{
+			KeyName:          utils.String(keyId.Name),
+			KeyVersion:       utils.String(keyId.Version),
+			KeyVaultURI:      utils.String(keyId.KeyVaultBaseUrl),
+			IdentityClientID: utils.String(d.Get("identity_client_id").(string)),
+		}
+	}
+
+	if _, err = client.Update(ctx, id.ResourceGroup, id.Name, props); err != nil {
+		return fmt.Errorf("updating %s: %+v", *id, err)
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"Accepted"},
+		Target:     []string{"Succeeded"},
+		Refresh:    cognitiveAccountStateRefreshFunc(ctx, client, *id),
+		MinTimeout: 15 * time.Second,
+		Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for update of %s: %+v", *id, err)
+	}
+	d.SetId(id.ID())
+
+	return resourceCognitiveAccountCustomerManagedKeyRead(d, meta)
+}
+
+func resourceCognitiveAccountCustomerManagedKeyRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Cognitive.AccountsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.AccountID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	if resp.Properties == nil && resp.Properties.Encryption == nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("cognitive_account_id", id.ID())
+	d.Set("key_source", resp.Properties.Encryption.KeySource)
+	if props := resp.Properties.Encryption.KeyVaultProperties; props != nil {
+		var keyName string
+		if props.KeyName != nil {
+			keyName = *props.KeyName
+		}
+
+		var keyVaultUri string
+		if props.KeyVaultURI != nil {
+			keyVaultUri = *props.KeyVaultURI
+		}
+
+		var keyVersion string
+		if props.KeyVersion != nil {
+			keyVersion = *props.KeyVersion
+		}
+		keyVaultKeyId, err := keyVaultParse.NewNestedItemID(keyVaultUri, "keys", keyName, keyVersion)
+		if err != nil {
+			return fmt.Errorf("parsing `key_vault_key_id`: %+v", err)
+		}
+		d.Set("key_vault_key_id", keyVaultKeyId.ID())
+		if props.IdentityClientID != nil {
+			d.Set("identity_client_id", *props.IdentityClientID)
+		}
+	} else {
+		d.Set("key_vault_key_id", nil)
+		d.Set("identity_client_id", nil)
+	}
+
+	return nil
+}
+
+func resourceCognitiveAccountCustomerManagedKeyDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	accountsClient := meta.(*clients.Client).Cognitive.AccountsClient
+	deletedAccountsClient := meta.(*clients.Client).Cognitive.DeletedAccountsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.AccountID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, "azurerm_cognitive_account")
+	defer locks.UnlockByName(id.Name, "azurerm_cognitive_account")
+
+	account, err := accountsClient.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	// Since this isn't a real object and it cannot be disabled once Customer Managed Key at rest has been enabled
+	// And it must keep at least one key once Customer Managed Key is enabled
+	// So for the delete operation, it has to recreate the Cognitive Account with disabled Customer Managed Key
+	log.Printf("[DEBUG] Deleting %s..", *id)
+	deleteFuture, err := accountsClient.Delete(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+	if err := deleteFuture.WaitForCompletionRef(ctx, accountsClient.Client); err != nil {
+		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+	}
+
+	log.Printf("[DEBUG] Purging %s..", *id)
+	purgeFuture, err := deletedAccountsClient.Purge(ctx, *account.Location, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("purging %s: %+v", *id, err)
+	}
+	if err := purgeFuture.WaitForCompletionRef(ctx, deletedAccountsClient.Client); err != nil {
+		return fmt.Errorf("waiting for purge of %s: %+v", *id, err)
+	}
+
+	account.SystemData = nil
+	account.Properties.Encryption = nil
+	if _, err := accountsClient.Create(ctx, id.ResourceGroup, id.Name, account); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"Creating"},
+		Target:     []string{"Succeeded"},
+		Refresh:    cognitiveAccountStateRefreshFunc(ctx, accountsClient, *id),
+		MinTimeout: 15 * time.Second,
+		Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
+++ b/azurerm/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
@@ -1,0 +1,238 @@
+package cognitive_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cognitive/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type CognitiveAccountCustomerManagedKeyResource struct {
+}
+
+func TestAccCognitiveAccountCustomerManagedKey_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_customer_managed_key", "test")
+	r := CognitiveAccountCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCognitiveAccountCustomerManagedKey_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_customer_managed_key", "test")
+	r := CognitiveAccountCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccCognitiveAccountCustomerManagedKey_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_customer_managed_key", "test")
+	r := CognitiveAccountCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCognitiveAccountCustomerManagedKey_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_account_customer_managed_key", "test")
+	r := CognitiveAccountCustomerManagedKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r CognitiveAccountCustomerManagedKeyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.AccountID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Cognitive.AccountsClient.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+
+	if resp.Properties == nil || resp.Properties.Encryption == nil {
+		return utils.Bool(false), nil
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r CognitiveAccountCustomerManagedKeyResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_account_customer_managed_key" "test" {
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  key_source           = "Microsoft.CognitiveServices"
+}
+`, r.template(data))
+}
+
+func (r CognitiveAccountCustomerManagedKeyResource) requiresImport(data acceptance.TestData) string {
+	template := CognitiveAccountCustomerManagedKeyResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_account_customer_managed_key" "import" {
+  cognitive_account_id = azurerm_cognitive_account_customer_managed_key.test.cognitive_account_id
+  key_source           = azurerm_cognitive_account_customer_managed_key.test.key_source
+}
+`, template)
+}
+
+func (r CognitiveAccountCustomerManagedKeyResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_account_customer_managed_key" "test" {
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  key_source           = "Microsoft.KeyVault"
+  key_vault_key_id     = azurerm_key_vault_key.test.id
+  identity_client_id   = azurerm_user_assigned_identity.test.client_id
+}
+
+`, r.template(data))
+}
+
+func (r CognitiveAccountCustomerManagedKeyResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cognitive-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  name = "%s"
+}
+
+resource "azurerm_cognitive_account" "test" {
+  name                  = "acctest-cogacc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  kind                  = "Face"
+  sku_name              = "E0"
+  custom_subdomain_name = "acctest-cogacc-%d"
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  soft_delete_enabled      = true
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_cognitive_account.test.identity.0.tenant_id
+  object_id    = azurerm_cognitive_account.test.identity.0.principal_id
+
+  key_permissions    = ["get", "create", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "test2" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "test3" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_user_assigned_identity.test.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkvkey%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+    azurerm_key_vault_access_policy.test3,
+  ]
+}
+`, data.RandomInteger, data.Locations.Secondary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString)
+}

--- a/azurerm/internal/services/cognitive/cognitive_account_resource.go
+++ b/azurerm/internal/services/cognitive/cognitive_account_resource.go
@@ -104,7 +104,7 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"F0", "F1", "S0", "S", "S1", "S2", "S3", "S4", "S5", "S6", "P0", "P1", "P2",
+					"F0", "F1", "S0", "S", "S1", "S2", "S3", "S4", "S5", "S6", "P0", "P1", "P2", "E0",
 				}, false),
 			},
 
@@ -599,6 +599,8 @@ func expandAccountSkuName(skuName string) (*cognitiveservices.Sku, error) {
 		tier = cognitiveservices.SkuTierStandard
 	case "P":
 		tier = cognitiveservices.SkuTierPremium
+	case "E":
+		tier = cognitiveservices.SkuTierEnterprise
 	default:
 		return nil, fmt.Errorf("sku_name %s has unknown sku tier %s", skuName, skuName[0:1])
 	}

--- a/azurerm/internal/services/cognitive/registration.go
+++ b/azurerm/internal/services/cognitive/registration.go
@@ -28,6 +28,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_cognitive_account": resourceCognitiveAccount(),
+		"azurerm_cognitive_account":                      resourceCognitiveAccount(),
+		"azurerm_cognitive_account_customer_managed_key": resourceCognitiveAccountCustomerManagedKey(),
 	}
 }

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `kind` - (Required) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `AnomalyDetector`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `CognitiveServices`, `ComputerVision`, `ContentModerator`, `CustomSpeech`, `CustomVision.Prediction`, `CustomVision.Training`, `Emotion`, `Face`,`FormRecognizer`, `ImmersiveReader`, `LUIS`, `LUIS.Authoring`, `MetricsAdvisor`, `Personalizer`, `QnAMaker`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
 
--> **NOTE:** You must create your first Face, Text Analytics, or Computer Vision resources from the Azure portal to review and acknowledge the terms and conditions. More information on [Prerequisites](https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-apis-create-account-cli?tabs=windows#prerequisites).
+-> **NOTE:** You must create your first Face, Text Analytics, or Computer Vision resources from the Azure portal to review and acknowledge the terms and conditions. In Azure Portal, the checkbox to accept terms and conditions is only displayed when a US region is selected. More information on [Prerequisites](https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-apis-create-account-cli?tabs=windows#prerequisites).
 
 * `sku_name` - (Required) Specifies the SKU Name for this Cognitive Service Account. Possible values are `F0`, `F1`, `S`, `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1`, and `P2`.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `kind` - (Required) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `AnomalyDetector`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `CognitiveServices`, `ComputerVision`, `ContentModerator`, `CustomSpeech`, `CustomVision.Prediction`, `CustomVision.Training`, `Emotion`, `Face`,`FormRecognizer`, `ImmersiveReader`, `LUIS`, `LUIS.Authoring`, `MetricsAdvisor`, `Personalizer`, `QnAMaker`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
 
+-> **NOTE:** You must create your first Face, Text Analytics, or Computer Vision resources from the Azure portal to review and acknowledge the terms and conditions. More information on [Prerequisites](https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-apis-create-account-cli?tabs=windows#prerequisites).
+
 * `sku_name` - (Required) Specifies the SKU Name for this Cognitive Service Account. Possible values are `F0`, `F1`, `S`, `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1`, and `P2`.
 
 * `custom_subdomain_name` - (Optional) The subdomain name used for token-based authentication. Changing this forces a new resource to be created.

--- a/website/docs/r/cognitive_account_customer_managed_key.html.markdown
+++ b/website/docs/r/cognitive_account_customer_managed_key.html.markdown
@@ -1,0 +1,137 @@
+---
+subcategory: "Cognitive Services"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cognitive_account_customer_managed_key"
+description: |-
+  Manages a Customer Managed Key for a Cognitive Services Account.
+---
+
+# azurerm_cognitive_account_customer_managed_key
+
+Manages a Customer Managed Key for a Cognitive Services Account.
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West US"
+}
+
+resource "azurerm_user_assigned_identity" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  name = "example-identity"
+}
+
+resource "azurerm_cognitive_account" "example" {
+  name                  = "example-account"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  kind                  = "Face"
+  sku_name              = "E0"
+  custom_subdomain_name = "example-account"
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.example.id]
+  }
+}
+
+
+resource "azurerm_key_vault" "example" {
+  name                     = "example-vault"
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  soft_delete_enabled      = true
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "cognitive" {
+  key_vault_id = azurerm_key_vault.example.id
+  tenant_id    = azurerm_cognitive_account.example.identity.0.tenant_id
+  object_id    = azurerm_cognitive_account.example.identity.0.principal_id
+
+  key_permissions    = ["get", "create", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "client" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "user" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_user_assigned_identity.example.tenant_id
+  object_id    = azurerm_user_assigned_identity.example.principal_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_key" "example" {
+  name         = "example-key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.cognitive,
+    azurerm_key_vault_access_policy.client,
+    azurerm_key_vault_access_policy.user,
+  ]
+}
+
+resource "azurerm_cognitive_account_customer_managed_key" "example" {
+  cognitive_account_id = azurerm_cognitive_account.example.id
+  key_source           = "Microsoft.KeyVault"
+  key_vault_key_id     = azurerm_key_vault_key.example.id
+  identity_client_id   = azurerm_user_assigned_identity.example.client_id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `cognitive_account_id` - (Required) The ID of the Cognitive Account. Changing this forces a new resource to be created.
+
+* `key_source` - (Required) The source for Encryption. Possible values include: `KeySourceMicrosoftCognitiveServices`, `KeySourceMicrosoftKeyVault`.
+
+* `key_vault_key_id` - (Optional) The ID of the Key Vault Key.
+
+* `identity_client_id` - (Optional) The client id of the user assigned identity that has access to the key.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Cognitive Account.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Cognitive Account Customer Managed Key.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Cognitive Account Customer Managed Key.
+* `update` - (Defaults to 30 minutes) Used when updating the Cognitive Account Customer Managed Key.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Cognitive Account Customer Managed Key.
+
+## Import
+
+Customer Managed Keys for a Cognitive Account can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_cognitive_account_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.CognitiveServices/accounts/account1
+```


### PR DESCRIPTION
The tests are listed as the followings.

```
=== RUN   TestAccCognitiveAccountCustomerManagedKey_basic
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_basic
=== CONT  TestAccCognitiveAccountCustomerManagedKey_basic
--- PASS: TestAccCognitiveAccountCustomerManagedKey_basic (525.17s)
=== RUN   TestAccCognitiveAccountCustomerManagedKey_requiresImport
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_requiresImport
=== CONT  TestAccCognitiveAccountCustomerManagedKey_requiresImport
--- PASS: TestAccCognitiveAccountCustomerManagedKey_requiresImport (612.83s)
=== RUN   TestAccCognitiveAccountCustomerManagedKey_complete
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_complete
=== CONT  TestAccCognitiveAccountCustomerManagedKey_complete
--- PASS: TestAccCognitiveAccountCustomerManagedKey_complete (597.85s)
=== RUN   TestAccCognitiveAccountCustomerManagedKey_update
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_update
=== CONT  TestAccCognitiveAccountCustomerManagedKey_update
--- PASS: TestAccCognitiveAccountCustomerManagedKey_update (748.21s)
PASS
```