### PR TITLE
azurerm_data_factory_integration_runtime_azure_ssis - support public_ips, express_custom_setup, package_store, proxy

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -475,7 +475,6 @@ func resourceDataFactoryIntegrationRuntimeAzureSsisRead(d *pluginsdk.ResourceDat
 		if err := d.Set("proxy", flattenDataFactoryIntegrationRuntimeAzureSsisProxy(ssisProps.DataProxyProperties)); err != nil {
 			return fmt.Errorf("setting `proxy`: %+v", err)
 		}
-
 	}
 
 	return nil

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -896,7 +896,6 @@ func readBackSensitiveValue(input []interface{}, propertyName string, filters ma
 		if found {
 			return raw[propertyName].(string)
 		}
-
 	}
 	return ""
 }

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -218,10 +218,10 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"env": {
+						"environment": {
 							Type:         pluginsdk.TypeMap,
 							Optional:     true,
-							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							AtLeastOneOf: []string{"express_custom_setup.0.environment", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
 							Elem: &pluginsdk.Schema{
 								Type: pluginsdk.TypeString,
 							},
@@ -230,14 +230,14 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 						"powershell_version": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							AtLeastOneOf: []string{"express_custom_setup.0.environment", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"command_key": {
 							Type:         pluginsdk.TypeList,
 							Optional:     true,
-							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							AtLeastOneOf: []string{"express_custom_setup.0.environment", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"target_name": {
@@ -265,7 +265,7 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 						"component": {
 							Type:         pluginsdk.TypeList,
 							Optional:     true,
-							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							AtLeastOneOf: []string{"express_custom_setup.0.environment", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"name": {
@@ -582,6 +582,7 @@ func expandDataFactoryIntegrationRuntimeAzureSsisProxy(input []interface{}) *dat
 		return nil
 	}
 	raw := input[0].(map[string]interface{})
+
 	result := &datafactory.IntegrationRuntimeDataProxyProperties{
 		ConnectVia: &datafactory.EntityReference{
 			Type:          datafactory.IntegrationRuntimeEntityReferenceTypeIntegrationRuntimeReference,
@@ -605,7 +606,7 @@ func expandDataFactoryIntegrationRuntimeAzureSsisExpressCustomSetUp(input []inte
 	raw := input[0].(map[string]interface{})
 
 	result := make([]datafactory.BasicCustomSetupBase, 0)
-	if env := raw["env"].(map[string]interface{}); len(env) > 0 {
+	if env := raw["environment"].(map[string]interface{}); len(env) > 0 {
 		for k, v := range env {
 			result = append(result, &datafactory.EnvironmentVariableSetup{
 				Type: datafactory.TypeBasicCustomSetupBaseTypeEnvironmentVariableSetup,
@@ -872,7 +873,7 @@ func flattenDataFactoryIntegrationRuntimeAzureSsisExpressCustomSetUp(input *[]da
 
 	return []interface{}{
 		map[string]interface{}{
-			"env":                env,
+			"environment":        env,
 			"powershell_version": powershellVersion,
 			"component":          components,
 			"command_key":        cmdkeys,

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory/validate"
+	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -134,6 +135,16 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
+						"public_ips": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							MinItems: 2,
+							MaxItems: 2,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: networkValidate.PublicIpAddressID,
+							},
+						},
 					},
 				},
 			},
@@ -191,6 +202,133 @@ func resourceDataFactoryIntegrationRuntimeAzureSsis() *pluginsdk.Resource {
 								string(datafactory.IntegrationRuntimeSsisCatalogPricingTierPremium),
 								string(datafactory.IntegrationRuntimeSsisCatalogPricingTierPremiumRS),
 							}, false),
+						},
+						"dual_standby_pair_name": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
+			"express_custom_setup": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"env": {
+							Type:         pluginsdk.TypeMap,
+							Optional:     true,
+							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"powershell_version": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"command_key": {
+							Type:         pluginsdk.TypeList,
+							Optional:     true,
+							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"target_name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"user_name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"password": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+
+						"component": {
+							Type:         pluginsdk.TypeList,
+							Optional:     true,
+							AtLeastOneOf: []string{"express_custom_setup.0.env", "express_custom_setup.0.powershell_version", "express_custom_setup.0.component", "express_custom_setup.0.command_key"},
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"name": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"license": {
+										Type:         pluginsdk.TypeString,
+										Optional:     true,
+										Sensitive:    true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"package_store": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"linked_service_name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
+			"proxy": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"self_hosted_integration_runtime_name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"staging_storage_linked_service_name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"path": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
 						},
 					},
 				},
@@ -319,12 +457,25 @@ func resourceDataFactoryIntegrationRuntimeAzureSsisRead(d *pluginsdk.ResourceDat
 		d.Set("license_type", string(ssisProps.LicenseType))
 
 		if err := d.Set("catalog_info", flattenDataFactoryIntegrationRuntimeAzureSsisCatalogInfo(ssisProps.CatalogInfo, d)); err != nil {
-			return fmt.Errorf("Error setting `vnet_integration`: %+v", err)
+			return fmt.Errorf("setting `catalog_info`: %+v", err)
 		}
 
 		if err := d.Set("custom_setup_script", flattenDataFactoryIntegrationRuntimeAzureSsisCustomSetupScript(ssisProps.CustomSetupScriptProperties, d)); err != nil {
-			return fmt.Errorf("Error setting `vnet_integration`: %+v", err)
+			return fmt.Errorf("setting `custom_setup_script`: %+v", err)
 		}
+
+		if err := d.Set("express_custom_setup", flattenDataFactoryIntegrationRuntimeAzureSsisExpressCustomSetUp(ssisProps.ExpressCustomSetupProperties, d)); err != nil {
+			return fmt.Errorf("setting `express_custom_setup`: %+v", err)
+		}
+
+		if err := d.Set("package_store", flattenDataFactoryIntegrationRuntimeAzureSsisPackageStore(ssisProps.PackageStores)); err != nil {
+			return fmt.Errorf("setting `package_store`: %+v", err)
+		}
+
+		if err := d.Set("proxy", flattenDataFactoryIntegrationRuntimeAzureSsisProxy(ssisProps.DataProxyProperties)); err != nil {
+			return fmt.Errorf("setting `proxy`: %+v", err)
+		}
+
 	}
 
 	return nil
@@ -368,6 +519,10 @@ func expandDataFactoryIntegrationRuntimeAzureSsisComputeProperties(d *pluginsdk.
 			VNetID: utils.String(vnetProps["vnet_id"].(string)),
 			Subnet: utils.String(vnetProps["subnet_name"].(string)),
 		}
+
+		if publicIPs := vnetProps["public_ips"].([]interface{}); len(publicIPs) > 0 {
+			computeProperties.VNetProperties.PublicIPs = utils.ExpandStringSlice(publicIPs)
+		}
 	}
 
 	return &computeProperties
@@ -375,8 +530,11 @@ func expandDataFactoryIntegrationRuntimeAzureSsisComputeProperties(d *pluginsdk.
 
 func expandDataFactoryIntegrationRuntimeAzureSsisProperties(d *pluginsdk.ResourceData) *datafactory.IntegrationRuntimeSsisProperties {
 	ssisProperties := &datafactory.IntegrationRuntimeSsisProperties{
-		Edition:     datafactory.IntegrationRuntimeEdition(d.Get("edition").(string)),
-		LicenseType: datafactory.IntegrationRuntimeLicenseType(d.Get("license_type").(string)),
+		LicenseType:                  datafactory.IntegrationRuntimeLicenseType(d.Get("license_type").(string)),
+		DataProxyProperties:          expandDataFactoryIntegrationRuntimeAzureSsisProxy(d.Get("proxy").([]interface{})),
+		Edition:                      datafactory.IntegrationRuntimeEdition(d.Get("edition").(string)),
+		ExpressCustomSetupProperties: expandDataFactoryIntegrationRuntimeAzureSsisExpressCustomSetUp(d.Get("express_custom_setup").([]interface{})),
+		PackageStores:                expandDataFactoryIntegrationRuntimeAzureSsisPackageStore(d.Get("package_store").([]interface{})),
 	}
 
 	if catalogInfos, ok := d.GetOk("catalog_info"); ok && len(catalogInfos.([]interface{})) > 0 {
@@ -397,6 +555,10 @@ func expandDataFactoryIntegrationRuntimeAzureSsisProperties(d *pluginsdk.Resourc
 				Type:  datafactory.TypeSecureString,
 			}
 		}
+
+		if dualStandbyPairName := catalogInfo["dual_standby_pair_name"].(string); dualStandbyPairName != "" {
+			ssisProperties.CatalogInfo.DualStandbyPairName = utils.String(dualStandbyPairName)
+		}
 	}
 
 	if customSetupScripts, ok := d.GetOk("custom_setup_script"); ok && len(customSetupScripts.([]interface{})) > 0 {
@@ -416,15 +578,129 @@ func expandDataFactoryIntegrationRuntimeAzureSsisProperties(d *pluginsdk.Resourc
 	return ssisProperties
 }
 
+func expandDataFactoryIntegrationRuntimeAzureSsisProxy(input []interface{}) *datafactory.IntegrationRuntimeDataProxyProperties {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+	raw := input[0].(map[string]interface{})
+	result := &datafactory.IntegrationRuntimeDataProxyProperties{
+		ConnectVia: &datafactory.EntityReference{
+			Type:          datafactory.IntegrationRuntimeEntityReferenceTypeIntegrationRuntimeReference,
+			ReferenceName: utils.String(raw["self_hosted_integration_runtime_name"].(string)),
+		},
+		StagingLinkedService: &datafactory.EntityReference{
+			Type:          datafactory.IntegrationRuntimeEntityReferenceTypeLinkedServiceReference,
+			ReferenceName: utils.String(raw["staging_storage_linked_service_name"].(string)),
+		},
+	}
+	if path := raw["path"].(string); len(path) > 0 {
+		result.Path = utils.String(path)
+	}
+	return result
+}
+
+func expandDataFactoryIntegrationRuntimeAzureSsisExpressCustomSetUp(input []interface{}) *[]datafactory.BasicCustomSetupBase {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+	raw := input[0].(map[string]interface{})
+
+	result := make([]datafactory.BasicCustomSetupBase, 0)
+	if env := raw["env"].(map[string]interface{}); len(env) > 0 {
+		for k, v := range env {
+			result = append(result, &datafactory.EnvironmentVariableSetup{
+				Type: datafactory.TypeBasicCustomSetupBaseTypeEnvironmentVariableSetup,
+				EnvironmentVariableSetupTypeProperties: &datafactory.EnvironmentVariableSetupTypeProperties{
+					VariableName:  utils.String(k),
+					VariableValue: utils.String(v.(string)),
+				},
+			})
+		}
+	}
+	if powershellVersion := raw["powershell_version"].(string); powershellVersion != "" {
+		result = append(result, &datafactory.AzPowerShellSetup{
+			Type: datafactory.TypeBasicCustomSetupBaseTypeAzPowerShellSetup,
+			AzPowerShellSetupTypeProperties: &datafactory.AzPowerShellSetupTypeProperties{
+				Version: utils.String(powershellVersion),
+			},
+		})
+	}
+	if components := raw["component"].([]interface{}); len(components) > 0 {
+		for _, item := range components {
+			raw := item.(map[string]interface{})
+			component := &datafactory.ComponentSetup{
+				Type: datafactory.TypeBasicCustomSetupBaseTypeComponentSetup,
+				LicensedComponentSetupTypeProperties: &datafactory.LicensedComponentSetupTypeProperties{
+					ComponentName: utils.String(raw["name"].(string)),
+				},
+			}
+			if license := raw["license"].(string); license != "" {
+				component.LicensedComponentSetupTypeProperties.LicenseKey = &datafactory.SecureString{
+					Type:  datafactory.TypeSecureString,
+					Value: utils.String(license),
+				}
+			}
+
+			result = append(result, component)
+		}
+	}
+	if cmdKeys := raw["command_key"].([]interface{}); len(cmdKeys) > 0 {
+		for _, item := range cmdKeys {
+			raw := item.(map[string]interface{})
+			result = append(result, &datafactory.CmdkeySetup{
+				Type: datafactory.TypeBasicCustomSetupBaseTypeCmdkeySetup,
+				CmdkeySetupTypeProperties: &datafactory.CmdkeySetupTypeProperties{
+					TargetName: utils.String(raw["target_name"].(string)),
+					UserName:   utils.String(raw["user_name"].(string)),
+					Password: &datafactory.SecureString{
+						Type:  datafactory.TypeSecureString,
+						Value: utils.String(raw["password"].(string)),
+					},
+				},
+			})
+		}
+	}
+
+	return &result
+}
+
+func expandDataFactoryIntegrationRuntimeAzureSsisPackageStore(input []interface{}) *[]datafactory.PackageStore {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]datafactory.PackageStore, 0)
+	for _, item := range input {
+		raw := item.(map[string]interface{})
+		result = append(result, datafactory.PackageStore{
+			Name: utils.String(raw["name"].(string)),
+			PackageStoreLinkedService: &datafactory.EntityReference{
+				Type:          datafactory.IntegrationRuntimeEntityReferenceTypeLinkedServiceReference,
+				ReferenceName: utils.String(raw["linked_service_name"].(string)),
+			},
+		})
+	}
+	return &result
+}
+
 func flattenDataFactoryIntegrationRuntimeAzureSsisVnetIntegration(vnetProperties *datafactory.IntegrationRuntimeVNetProperties) []interface{} {
 	if vnetProperties == nil {
 		return []interface{}{}
 	}
 
+	var vnetId, subnetName string
+	if vnetProperties.VNetID != nil {
+		vnetId = *vnetProperties.VNetID
+	}
+	if vnetProperties.Subnet != nil {
+		subnetName = *vnetProperties.Subnet
+	}
+
 	return []interface{}{
-		map[string]string{
-			"vnet_id":     *vnetProperties.VNetID,
-			"subnet_name": *vnetProperties.Subnet,
+		map[string]interface{}{
+			"vnet_id":     vnetId,
+			"subnet_name": subnetName,
+			"public_ips":  utils.FlattenStringSlice(vnetProperties.PublicIPs),
 		},
 	}
 }
@@ -434,20 +710,55 @@ func flattenDataFactoryIntegrationRuntimeAzureSsisCatalogInfo(ssisProperties *da
 		return []interface{}{}
 	}
 
-	catalogInfo := map[string]string{
-		"server_endpoint": *ssisProperties.CatalogServerEndpoint,
-		"pricing_tier":    string(ssisProperties.CatalogPricingTier),
+	var serverEndpoint, catalogAdminUserName, administratorPassword, dualStandbyPairName string
+	if ssisProperties.CatalogServerEndpoint != nil {
+		serverEndpoint = *ssisProperties.CatalogServerEndpoint
 	}
-
 	if ssisProperties.CatalogAdminUserName != nil {
-		catalogInfo["administrator_login"] = *ssisProperties.CatalogAdminUserName
+		catalogAdminUserName = *ssisProperties.CatalogAdminUserName
+	}
+	if ssisProperties.DualStandbyPairName != nil {
+		dualStandbyPairName = *ssisProperties.DualStandbyPairName
 	}
 
+	// read back
 	if adminPassword, ok := d.GetOk("catalog_info.0.administrator_password"); ok {
-		catalogInfo["administrator_password"] = adminPassword.(string)
+		administratorPassword = adminPassword.(string)
 	}
 
-	return []interface{}{catalogInfo}
+	return []interface{}{
+		map[string]interface{}{
+			"server_endpoint":        serverEndpoint,
+			"pricing_tier":           string(ssisProperties.CatalogPricingTier),
+			"administrator_login":    catalogAdminUserName,
+			"administrator_password": administratorPassword,
+			"dual_standby_pair_name": dualStandbyPairName,
+		},
+	}
+}
+
+func flattenDataFactoryIntegrationRuntimeAzureSsisProxy(input *datafactory.IntegrationRuntimeDataProxyProperties) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	var path, selfHostedIntegrationRuntimeName, stagingStorageLinkedServiceName string
+	if input.Path != nil {
+		path = *input.Path
+	}
+	if input.ConnectVia != nil && input.ConnectVia.ReferenceName != nil {
+		selfHostedIntegrationRuntimeName = *input.ConnectVia.ReferenceName
+	}
+	if input.StagingLinkedService != nil && input.StagingLinkedService.ReferenceName != nil {
+		stagingStorageLinkedServiceName = *input.StagingLinkedService.ReferenceName
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"path":                                 path,
+			"self_hosted_integration_runtime_name": selfHostedIntegrationRuntimeName,
+			"staging_storage_linked_service_name":  stagingStorageLinkedServiceName,
+		},
+	}
 }
 
 func flattenDataFactoryIntegrationRuntimeAzureSsisCustomSetupScript(customSetupScriptProperties *datafactory.IntegrationRuntimeCustomSetupScriptProperties, d *pluginsdk.ResourceData) []interface{} {
@@ -464,4 +775,129 @@ func flattenDataFactoryIntegrationRuntimeAzureSsisCustomSetupScript(customSetupS
 	}
 
 	return []interface{}{customSetupScript}
+}
+
+func flattenDataFactoryIntegrationRuntimeAzureSsisPackageStore(input *[]datafactory.PackageStore) []interface{} {
+	if input == nil {
+		return nil
+	}
+
+	result := make([]interface{}, 0)
+	for _, item := range *input {
+		var name, linkedServiceName string
+		if item.Name != nil {
+			name = *item.Name
+		}
+		if item.PackageStoreLinkedService != nil && item.PackageStoreLinkedService.ReferenceName != nil {
+			linkedServiceName = *item.PackageStoreLinkedService.ReferenceName
+		}
+
+		result = append(result, map[string]interface{}{
+			"name":                name,
+			"linked_service_name": linkedServiceName,
+		})
+	}
+	return result
+}
+
+func flattenDataFactoryIntegrationRuntimeAzureSsisExpressCustomSetUp(input *[]datafactory.BasicCustomSetupBase, d *pluginsdk.ResourceData) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	// retrieve old state
+	oldState := make(map[string]interface{})
+	if arr := d.Get("express_custom_setup").([]interface{}); len(arr) > 0 {
+		oldState = arr[0].(map[string]interface{})
+	}
+	oldComponents := make([]interface{}, 0)
+	if rawComponent, ok := oldState["component"]; ok {
+		if v := rawComponent.([]interface{}); len(v) > 0 {
+			oldComponents = v
+		}
+	}
+	oldCmdKey := make([]interface{}, 0)
+	if rawCmdKey, ok := oldState["command_key"]; ok {
+		if v := rawCmdKey.([]interface{}); len(v) > 0 {
+			oldCmdKey = v
+		}
+	}
+
+	env := make(map[string]interface{})
+	powershellVersion := ""
+	components := make([]interface{}, 0)
+	cmdkeys := make([]interface{}, 0)
+	for _, item := range *input {
+		switch v := item.(type) {
+		case datafactory.AzPowerShellSetup:
+			if v.Version != nil {
+				powershellVersion = *v.Version
+			}
+		case datafactory.ComponentSetup:
+			var name string
+			if v.ComponentName != nil {
+				name = *v.ComponentName
+			}
+			components = append(components, map[string]interface{}{
+				"name": name,
+				"license": readBackSensitiveValue(oldComponents, "license", map[string]string{
+					"name": name,
+				}),
+			})
+		case datafactory.EnvironmentVariableSetup:
+			if v.VariableName != nil && v.VariableValue != nil {
+				env[*v.VariableName] = *v.VariableValue
+			}
+		case datafactory.CmdkeySetup:
+			var name, userName string
+			if v.TargetName != nil {
+				if v, ok := v.TargetName.(string); ok {
+					name = v
+				}
+			}
+			if v.UserName != nil {
+				if v, ok := v.UserName.(string); ok {
+					userName = v
+				}
+			}
+			cmdkeys = append(cmdkeys, map[string]interface{}{
+				"target_name": name,
+				"user_name":   userName,
+				"password": readBackSensitiveValue(oldCmdKey, "password", map[string]string{
+					"target_name": name,
+					"user_name":   userName,
+				}),
+			})
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"env":                env,
+			"powershell_version": powershellVersion,
+			"component":          components,
+			"command_key":        cmdkeys,
+		},
+	}
+}
+
+func readBackSensitiveValue(input []interface{}, propertyName string, filters map[string]string) string {
+	if len(input) == 0 {
+		return ""
+	}
+	for _, item := range input {
+		raw := item.(map[string]interface{})
+		found := true
+		for k, v := range filters {
+			if raw[k].(string) != v {
+				found = false
+				break
+			}
+		}
+		if found {
+			return raw[propertyName].(string)
+		}
+
+	}
+	return ""
 }

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
@@ -45,30 +45,14 @@ func TestAccDataFactoryIntegrationRuntimeManagedSsis_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("name").HasValue("managed-integration-runtime"),
-				check.That(data.ResourceName).Key("description").HasValue("acctest"),
-				check.That(data.ResourceName).Key("data_factory_name").Exists(),
-				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
-				check.That(data.ResourceName).Key("node_size").HasValue("Standard_D8_v3"),
-				check.That(data.ResourceName).Key("number_of_nodes").HasValue("2"),
-				check.That(data.ResourceName).Key("max_parallel_executions_per_node").HasValue("8"),
-				check.That(data.ResourceName).Key("edition").HasValue("Standard"),
-				check.That(data.ResourceName).Key("license_type").HasValue("LicenseIncluded"),
-				check.That(data.ResourceName).Key("vnet_integration.#").HasValue("1"),
-				check.That(data.ResourceName).Key("vnet_integration.0.vnet_id").Exists(),
-				check.That(data.ResourceName).Key("vnet_integration.0.subnet_name").Exists(),
-				check.That(data.ResourceName).Key("catalog_info.#").HasValue("1"),
-				check.That(data.ResourceName).Key("catalog_info.0.server_endpoint").Exists(),
-				check.That(data.ResourceName).Key("catalog_info.0.administrator_login").HasValue("ssis_catalog_admin"),
-				check.That(data.ResourceName).Key("catalog_info.0.administrator_password").HasValue("my-s3cret-p4ssword!"),
-				check.That(data.ResourceName).Key("catalog_info.0.pricing_tier").HasValue("Basic"),
-				check.That(data.ResourceName).Key("custom_setup_script.#").HasValue("1"),
-				check.That(data.ResourceName).Key("custom_setup_script.0.blob_container_uri").Exists(),
-				check.That(data.ResourceName).Key("custom_setup_script.0.sas_token").Exists(),
 			),
 		},
-		data.ImportStep("catalog_info.0.administrator_password", "custom_setup_script.0.sas_token"),
+		data.ImportStep(
+			"catalog_info.0.administrator_password",
+			"custom_setup_script.0.sas_token",
+			"express_custom_setup.0.component.0.license",
+			"express_custom_setup.0.command_key.0.password",
+		),
 	})
 }
 
@@ -121,39 +105,60 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-df-%d"
-  location = "%s"
+  name     = "acctestRG-df-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvnet%d"
+  name                = "acctestvnet%[1]d"
   address_space       = ["10.0.0.0/16"]
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
+  name                 = "acctestsubnet%[1]d"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.2.0/24"
 }
 
+resource "azurerm_public_ip" "test1" {
+  name                = "acctpip1%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+  domain_name_label   = "acctpip1%[1]d"
+}
+
+resource "azurerm_public_ip" "test2" {
+  name                = "acctpip2%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+  domain_name_label   = "acctpip2%[1]d"
+}
+
 resource "azurerm_storage_account" "test" {
-  name                      = "acctestsa%s"
-  resource_group_name       = "${azurerm_resource_group.test.name}"
-  location                  = "${azurerm_resource_group.test.location}"
-  account_kind              = "BlobStorage"
-  account_tier              = "Standard"
-  account_replication_type  = "LRS"
-  access_tier               = "Hot"
-  enable_https_traffic_only = true
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_container" "test" {
   name                  = "setup-files"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
+}
+
+resource "azurerm_storage_share" "test" {
+  name                 = "sharename"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 30
 }
 
 data "azurerm_storage_account_blob_container_sas" "test" {
@@ -175,7 +180,7 @@ data "azurerm_storage_account_blob_container_sas" "test" {
 }
 
 resource "azurerm_sql_server" "test" {
-  name                         = "acctestsql%d"
+  name                         = "acctestsql%[1]d"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   location                     = "${azurerm_resource_group.test.location}"
   version                      = "12.0"
@@ -184,13 +189,45 @@ resource "azurerm_sql_server" "test" {
 }
 
 resource "azurerm_data_factory" "test" {
-  name                = "acctestdfirm%d"
+  name                = "acctestdfirm%[1]d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name                 = "acctestls%[1]d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureBlobStorage"
+  type_properties_json = <<JSON
+{
+  "connectionString": "${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+}
+
+resource "azurerm_data_factory_linked_custom_service" "file_share_linked_service" {
+  name                 = "acctestls1%[1]d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureFileStorage"
+  type_properties_json = <<JSON
+{
+  "host": "${azurerm_storage_share.test.url}",
+  "password": {
+    "type": "SecureString",
+    "value": "${azurerm_storage_account.test.primary_access_key}"
+  }
+}
+JSON
+}
+
+resource "azurerm_data_factory_integration_runtime_self_hosted" "test" {
+  name                = "acctestSIRsh%[1]d"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
 resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
-  name                = "managed-integration-runtime"
+  name                = "acctestiras%[1]d"
   description         = "acctest"
   data_factory_name   = azurerm_data_factory.test.name
   resource_group_name = azurerm_resource_group.test.name
@@ -205,6 +242,7 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
   vnet_integration {
     vnet_id     = "${azurerm_virtual_network.test.id}"
     subnet_name = "${azurerm_subnet.test.name}"
+    public_ips  = [azurerm_public_ip.test1.id, azurerm_public_ip.test2.id]
   }
 
   catalog_info {
@@ -212,14 +250,50 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
     administrator_login    = "ssis_catalog_admin"
     administrator_password = "my-s3cret-p4ssword!"
     pricing_tier           = "Basic"
+    dual_standby_pair_name = "dual_name"
   }
 
   custom_setup_script {
     blob_container_uri = "${azurerm_storage_account.test.primary_blob_endpoint}/${azurerm_storage_container.test.name}"
     sas_token          = "${data.azurerm_storage_account_blob_container_sas.test.sas}"
   }
+
+  express_custom_setup {
+    powershell_version = "6.2.0"
+
+    env = {
+      Env = "test"
+      Foo = "Bar"
+    }
+
+    component {
+      name    = "SentryOne.TaskFactory"
+      license = "license"
+    }
+
+    component {
+      name = "oh22is.HEDDA.IO"
+    }
+
+    command_key {
+      target_name = "name1"
+      user_name   = "username1"
+      password    = "password1"
+    }
+  }
+
+  package_store {
+    name                = "store1"
+    linked_service_name = azurerm_data_factory_linked_custom_service.file_share_linked_service.name
+  }
+
+  proxy {
+    self_hosted_integration_runtime_name = azurerm_data_factory_integration_runtime_self_hosted.test.name
+    staging_storage_linked_service_name  = azurerm_data_factory_linked_custom_service.test.name
+    path                                 = "containerpath"
+  }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (IntegrationRuntimeManagedSsisResource) aadAuth(data acceptance.TestData) string {

--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
@@ -261,7 +261,7 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
   express_custom_setup {
     powershell_version = "6.2.0"
 
-    env = {
+    environment = {
       Env = "test"
       Foo = "Bar"
     }

--- a/website/docs/r/data_factory_integration_runtime_azure_ssis.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_azure_ssis.html.markdown
@@ -100,7 +100,7 @@ An `express_custom_setup` block supports the following:
 
 * `component` - (Optional) One or more `component` blocks as defined below.
 
-* `env` - (Optional) The Environment Variables for the Azure-SSIS Integration Runtime.
+* `environment` - (Optional) The Environment Variables for the Azure-SSIS Integration Runtime.
 
 * `powershell_version` - (Optional) The version of Azure Powershell installed for the Azure-SSIS Integration Runtime.
 

--- a/website/docs/r/data_factory_integration_runtime_azure_ssis.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_azure_ssis.html.markdown
@@ -60,6 +60,12 @@ The following arguments are supported:
 
 * `custom_setup_script` - (Optional) A `custom_setup_script` block as defined below.
 
+* `express_custom_setup` - (Optional) An `express_custom_setup` block as defined below.
+
+* `package_store` - (Optional) One or more `package_store` block as defined below.
+  
+* `proxy` - (Optional) A `proxy` block as defined below.
+
 * `vnet_integration` - (Optional) A `vnet_integration` block as defined below.
 
 * `description` - (Optional) Integration runtime description.
@@ -76,6 +82,8 @@ A `catalog_info` block supports the following:
 
 * `pricing_tier` - (Optional) Pricing tier for the database that will be created for the SSIS catalog. Valid values are: `Basic`, `Standard`, `Premium` and `PremiumRS`.
 
+* `dual_standby_pair_name` - (Optional) The dual standby Azure-SSIS Integration Runtime pair with SSISDB failover.
+
 ---
 
 A `custom_setup_script` block supports the following:
@@ -86,11 +94,63 @@ A `custom_setup_script` block supports the following:
 
 ---
 
+An `express_custom_setup` block supports the following:
+
+* `command_key` - (Optional) One or more `command_key` blocks as defined below.
+
+* `component` - (Optional) One or more `component` blocks as defined below.
+
+* `env` - (Optional) The Environment Variables for the Azure-SSIS Integration Runtime.
+
+* `powershell_version` - (Optional) The version of Azure Powershell installed for the Azure-SSIS Integration Runtime.
+
+~> **NOTE** At least one of `env`, `powershell_version`, `component` and `command_key` should be specified.
+
+---
+
+A `command_key` block supports the following:
+
+* `target_name` - (Required) The target computer or domain name.
+
+* `user_name` - (Required) The username for the target device.
+
+* `password` - (Required) The password for the target device.
+
+---
+
+A `component` block supports the following:
+
+* `name` - (Required) The Component Name installed for the Azure-SSIS Integration Runtime.
+
+* `license` - (Optional) The license used for the Component.
+
+---
+
+A `package_store` block supports the following:
+
+* `name` - (Required) Name of the package store.
+
+* `linked_service_name` - (Required) Name of the Linked Service to associate with the packages.
+
+---
+
+A `proxy` block supports the following:
+
+* `self_hosted_integration_runtime_name` - (Required) Name of Self Hosted Integration Runtime as a proxy.
+
+* `staging_storage_linked_service_name` - (Required)  Name of Azure Blob Storage linked service to reference the staging data store to be used when moving data between self-hosted and Azure-SSIS integration runtimes.
+
+* `path` - (Optional) The path in the data store to be used when moving data between Self-Hosted and Azure-SSIS Integration Runtimes.
+
+---
+
 A `vnet_integration` block supports the following:
 
 * `vnet_id` - (Required) ID of the virtual network to which the nodes of the Azure-SSIS Integration Runtime will be added.
 
 * `subnet_name` - (Required) Name of the subnet to which the nodes of the Azure-SSIS Integration Runtime will be added.
+
+* `public_ips` - (Optional) Static public IP addresses for the Azure-SSIS Integration Runtime. The size must be 2.
 
 ## Attributes Reference
 


### PR DESCRIPTION
supports a bunch of properties for resource "azurerm_data_factory_integration_runtime_azure_ssis"

**notes:**
1. for the `express_custom_setup`, there are four types of polymorphism. I splitted them into four properties.
2. for the `public_ips` property, in the portal, it should be set with size 2.
![image](https://user-images.githubusercontent.com/2786738/125221034-2d9e9100-e2fa-11eb-8c96-55357c563a2e.png)


