### PR TITLE
Fix windows function apps on premium plans

### DIFF
--- a/azurerm/internal/services/web/function_app.go
+++ b/azurerm/internal/services/web/function_app.go
@@ -278,7 +278,7 @@ func getBasicFunctionAppAppSettings(d *pluginsdk.ResourceData, appServiceTier, e
 
 	// On consumption and premium plans include WEBSITE_CONTENT components, unless it's a Linux consumption plan
 	// (see https://github.com/Azure/azure-functions-python-worker/issues/598)
-	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium")) &&
+	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
 		!strings.EqualFold(d.Get("os_type").(string), "linux") {
 		return append(basicSettings, consumptionSettings...), nil
 	}


### PR DESCRIPTION
The settings WEBSITE_CONTENTAZUREFILECONNECTIONSTRING and WEBSITE_CONTENTSHARE are required for windows function apps on Premium V1/V2/V3 plans. Currently Terraform removes these settings when functions are hosted on premium plans rendering the function useless as it can't find its code.

This PR checks for the prefix of premium to handle the case when further premium plans are released.

Ref: https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_contentazurefileconnectionstring
Ref: https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_contentshare