### PR TITLE
Don't allow license_type to be set for serverless SQL databases

### DIFF
--- a/azurerm/internal/services/mssql/mssql_database_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource.go
@@ -393,6 +393,10 @@ func resourceMsSqlDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 
 	log.Printf("[INFO] preparing arguments for MsSql Database creation.")
 
+	if strings.HasPrefix(d.Get("sku_name").(string), "GP_S_") && d.Get("license_type").(string) != "" {
+		return fmt.Errorf("serverless databases do not support license type")
+	}
+
 	name := d.Get("name").(string)
 	sqlServerId := d.Get("server_id").(string)
 	serverId, _ := parse.ServerID(sqlServerId)


### PR DESCRIPTION
Serverless databases do not support a [license type](https://docs.microsoft.com/en-us/azure/azure-sql/azure-hybrid-benefit).

When we pull the database information from the API `licenseType` is set to `null`, 
which causes plans to always have a pending change when users set `license_type`.

This change causes the provider to throw an error before creating (or updating) the resource. 
