### PR TITLE
r/`machine_learning_compute_cluster`: make `subnet_resource_id` optional

### DIFF
--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -156,13 +156,23 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return tf.ImportAsExistsError("azurerm_machine_learning_compute_cluster", *existing.ID)
 	}
 
+	computeClusterAmlComputeProperties := machinelearningservices.AmlComputeProperties{
+		VMSize:        utils.String(d.Get("vm_size").(string)),
+		VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
+		ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
+	}
+
+	if d.Get("subnet_resource_id") != nil {
+		computeClusterAmlComputeProperties = machinelearningservices.AmlComputeProperties{
+		VMSize:        utils.String(d.Get("vm_size").(string)),
+		VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
+		ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
+		Subnet:        &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))},
+		}
+	}
+
 	computeClusterProperties := machinelearningservices.AmlCompute{
-		Properties: &machinelearningservices.AmlComputeProperties{
-			VMSize:        utils.String(d.Get("vm_size").(string)),
-			VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
-			ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
-			Subnet:        &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))},
-		},
+		Properties: &computeClusterAmlComputeProperties,
 		ComputeLocation: utils.String(d.Get("location").(string)),
 		Description:     utils.String(d.Get("description").(string)),
 	}

--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -163,7 +163,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if d.Get("subnet_resource_id") != nil {
-		computeClusterAmlComputeProperties = machinelearningservices.AmlComputeProperties{
+		computeClusterAmlComputeProperties.AmlComputeProperties.Subnet = &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))}
 			VMSize:        utils.String(d.Get("vm_size").(string)),
 			VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
 			ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),

--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -163,12 +163,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if d.Get("subnet_resource_id") != nil {
-		computeClusterAmlComputeProperties.AmlComputeProperties.Subnet = &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))}
-			VMSize:        utils.String(d.Get("vm_size").(string)),
-			VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
-			ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
-			Subnet:        &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))},
-		}
+		computeClusterAmlComputeProperties.Subnet = &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))}
 	}
 
 	computeClusterProperties := machinelearningservices.AmlCompute{

--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -164,15 +164,15 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if d.Get("subnet_resource_id") != nil {
 		computeClusterAmlComputeProperties = machinelearningservices.AmlComputeProperties{
-		VMSize:        utils.String(d.Get("vm_size").(string)),
-		VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
-		ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
-		Subnet:        &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))},
+			VMSize:        utils.String(d.Get("vm_size").(string)),
+			VMPriority:    machinelearningservices.VMPriority(d.Get("vm_priority").(string)),
+			ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
+			Subnet:        &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))},
 		}
 	}
 
 	computeClusterProperties := machinelearningservices.AmlCompute{
-		Properties: &computeClusterAmlComputeProperties,
+		Properties:      &computeClusterAmlComputeProperties,
 		ComputeLocation: utils.String(d.Get("location").(string)),
 		Description:     utils.String(d.Get("description").(string)),
 	}

--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -162,8 +162,8 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		ScaleSettings: expandScaleSettings(d.Get("scale_settings").([]interface{})),
 	}
 
-	if d.Get("subnet_resource_id") != nil {
-		computeClusterAmlComputeProperties.Subnet = &machinelearningservices.ResourceID{ID: utils.String(d.Get("subnet_resource_id").(string))}
+	if subnetId, ok := d.GetOk("subnet_resource_id"); ok && subnetId.(string) != "" {
+		computeClusterAmlComputeProperties.Subnet = &machinelearningservices.ResourceID{ID: utils.String(subnetId.(string))}
 	}
 
 	computeClusterProperties := machinelearningservices.AmlCompute{

--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -38,6 +38,29 @@ func TestAccComputeCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeCluster_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_compute_cluster", "test")
+	r := ComputeClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
+				check.That(data.ResourceName).Key("scale_settings.#").HasValue("1"),
+				check.That(data.ResourceName).Key("scale_settings.0.max_node_count").Exists(),
+				check.That(data.ResourceName).Key("scale_settings.0.min_node_count").Exists(),
+				check.That(data.ResourceName).Key("scale_settings.0.scale_down_nodes_after_idle_duration").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccComputeCluster_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_machine_learning_compute_cluster", "test")
 	r := ComputeClusterResource{}
@@ -80,7 +103,32 @@ func (r ComputeClusterResource) Exists(ctx context.Context, client *clients.Clie
 }
 
 func (r ComputeClusterResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
+	template := r.template_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_compute_cluster" "test" {
+  name                          = "CC-%d"
+  location                      = azurerm_resource_group.test.location
+  vm_priority                   = "LowPriority"
+  vm_size                       = "STANDARD_DS2_V2"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = 1
+    scale_down_nodes_after_idle_duration = "PT30S" # 30 seconds
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomIntOfLength(8))
+}
+
+func (r ComputeClusterResource) complete(data acceptance.TestData) string {
+	template := r.template_complete(data)
 	return fmt.Sprintf(`
 %s
 
@@ -131,7 +179,66 @@ resource "azurerm_machine_learning_compute_cluster" "import" {
 `, template)
 }
 
-func (r ComputeClusterResource) template(data acceptance.TestData) string {
+func (r ComputeClusterResource) template_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-ml-%[1]d"
+  location = "%[2]s"
+  tags = {
+    "stage" = "test"
+  }
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestai-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestvault%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "standard"
+
+  purge_protection_enabled = true
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[4]d"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_machine_learning_workspace" "test" {
+  name                    = "acctest-MLW%[5]d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  key_vault_id            = azurerm_key_vault.test.id
+  storage_account_id      = azurerm_storage_account.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary,
+		data.RandomIntOfLength(12), data.RandomIntOfLength(15), data.RandomIntOfLength(16),
+		data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r ComputeClusterResource) template_complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -203,3 +310,4 @@ resource "azurerm_subnet" "test" {
 		data.RandomIntOfLength(12), data.RandomIntOfLength(15), data.RandomIntOfLength(16),
 		data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
+

--- a/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/azurerm/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -310,4 +310,3 @@ resource "azurerm_subnet" "test" {
 		data.RandomIntOfLength(12), data.RandomIntOfLength(15), data.RandomIntOfLength(16),
 		data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
-


### PR DESCRIPTION
PR to address complaint in https://github.com/terraform-providers/terraform-provider-azurerm/pull/12508 that `subnet_resource_id` is *not really* optional.