### PR TITLE
azurerm_bot_channels_registration - support for cmk_key_vault_url, description, icon_url, isolated_network_enabled

### DIFF
--- a/azurerm/internal/services/bot/bot_channel_test.go
+++ b/azurerm/internal/services/bot/bot_channel_test.go
@@ -11,27 +11,27 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 	// Azure only being able provision against one app id at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
-			"basic":    testAccBotChannelsRegistration_basic,
-			"update":   testAccBotChannelsRegistration_update,
-			"complete": testAccBotChannelsRegistration_complete,
+			//"basic":    testAccBotChannelsRegistration_basic,
+			"update": testAccBotChannelsRegistration_update,
+			//"complete": testAccBotChannelsRegistration_complete,
 		},
-		"connection": {
-			"basic":    testAccBotConnection_basic,
-			"complete": testAccBotConnection_complete,
-		},
-		"channel": {
-			"slackBasic":         testAccBotChannelSlack_basic,
-			"slackUpdate":        testAccBotChannelSlack_update,
-			"msteamsBasic":       testAccBotChannelMsTeams_basic,
-			"msteamsUpdate":      testAccBotChannelMsTeams_update,
-			"directlineBasic":    testAccBotChannelDirectline_basic,
-			"directlineComplete": testAccBotChannelDirectline_complete,
-			"directlineUpdate":   testAccBotChannelDirectline_update,
-		},
-		"web_app": {
-			"basic":    testAccBotWebApp_basic,
-			"update":   testAccBotWebApp_update,
-			"complete": testAccBotWebApp_complete,
-		},
+		//"connection": {
+		//	"basic":    testAccBotConnection_basic,
+		//	"complete": testAccBotConnection_complete,
+		//},
+		//"channel": {
+		//	"slackBasic":         testAccBotChannelSlack_basic,
+		//	"slackUpdate":        testAccBotChannelSlack_update,
+		//	"msteamsBasic":       testAccBotChannelMsTeams_basic,
+		//	"msteamsUpdate":      testAccBotChannelMsTeams_update,
+		//	"directlineBasic":    testAccBotChannelDirectline_basic,
+		//	"directlineComplete": testAccBotChannelDirectline_complete,
+		//	"directlineUpdate":   testAccBotChannelDirectline_update,
+		//},
+		//"web_app": {
+		//	"basic":    testAccBotWebApp_basic,
+		//	"update":   testAccBotWebApp_update,
+		//	"complete": testAccBotWebApp_complete,
+		//},
 	})
 }

--- a/azurerm/internal/services/bot/bot_channel_test.go
+++ b/azurerm/internal/services/bot/bot_channel_test.go
@@ -11,27 +11,27 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 	// Azure only being able provision against one app id at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"basic": {
-			//"basic":    testAccBotChannelsRegistration_basic,
-			"update": testAccBotChannelsRegistration_update,
-			//"complete": testAccBotChannelsRegistration_complete,
+			"basic":    testAccBotChannelsRegistration_basic,
+			"update":   testAccBotChannelsRegistration_update,
+			"complete": testAccBotChannelsRegistration_complete,
 		},
-		//"connection": {
-		//	"basic":    testAccBotConnection_basic,
-		//	"complete": testAccBotConnection_complete,
-		//},
-		//"channel": {
-		//	"slackBasic":         testAccBotChannelSlack_basic,
-		//	"slackUpdate":        testAccBotChannelSlack_update,
-		//	"msteamsBasic":       testAccBotChannelMsTeams_basic,
-		//	"msteamsUpdate":      testAccBotChannelMsTeams_update,
-		//	"directlineBasic":    testAccBotChannelDirectline_basic,
-		//	"directlineComplete": testAccBotChannelDirectline_complete,
-		//	"directlineUpdate":   testAccBotChannelDirectline_update,
-		//},
-		//"web_app": {
-		//	"basic":    testAccBotWebApp_basic,
-		//	"update":   testAccBotWebApp_update,
-		//	"complete": testAccBotWebApp_complete,
-		//},
+		"connection": {
+			"basic":    testAccBotConnection_basic,
+			"complete": testAccBotConnection_complete,
+		},
+		"channel": {
+			"slackBasic":         testAccBotChannelSlack_basic,
+			"slackUpdate":        testAccBotChannelSlack_update,
+			"msteamsBasic":       testAccBotChannelMsTeams_basic,
+			"msteamsUpdate":      testAccBotChannelMsTeams_update,
+			"directlineBasic":    testAccBotChannelDirectline_basic,
+			"directlineComplete": testAccBotChannelDirectline_complete,
+			"directlineUpdate":   testAccBotChannelDirectline_update,
+		},
+		"web_app": {
+			"basic":    testAccBotWebApp_basic,
+			"update":   testAccBotWebApp_update,
+			"complete": testAccBotWebApp_complete,
+		},
 	})
 }

--- a/azurerm/internal/services/bot/bot_channels_registration_resource.go
+++ b/azurerm/internal/services/bot/bot_channels_registration_resource.go
@@ -91,7 +91,7 @@ func resourceBotChannelsRegistration() *pluginsdk.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 
-			"cmek_key_vault_url": {
+			"cmk_key_vault_url": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: kvValidate.NestedItemIdWithOptionalVersion,
@@ -184,7 +184,7 @@ func resourceBotChannelsRegistrationCreate(d *pluginsdk.ResourceData, meta inter
 			DisplayName:                       utils.String(displayName),
 			Endpoint:                          utils.String(d.Get("endpoint").(string)),
 			MsaAppID:                          utils.String(d.Get("microsoft_app_id").(string)),
-			CmekKeyVaultURL:                   utils.String(d.Get("cmek_key_vault_url").(string)),
+			CmekKeyVaultURL:                   utils.String(d.Get("cmk_key_vault_url").(string)),
 			Description:                       utils.String(d.Get("description").(string)),
 			DeveloperAppInsightKey:            utils.String(d.Get("developer_app_insights_key").(string)),
 			DeveloperAppInsightsAPIKey:        utils.String(d.Get("developer_app_insights_api_key").(string)),
@@ -200,7 +200,7 @@ func resourceBotChannelsRegistrationCreate(d *pluginsdk.ResourceData, meta inter
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if _, ok := d.GetOk("cmek_key_vault_url"); ok {
+	if _, ok := d.GetOk("cmk_key_vault_url"); ok {
 		bot.Properties.IsCmekEnabled = utils.Bool(true)
 	}
 
@@ -247,7 +247,7 @@ func resourceBotChannelsRegistrationRead(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if props := resp.Properties; props != nil {
-		d.Set("cmek_key_vault_url", props.CmekKeyVaultURL)
+		d.Set("cmk_key_vault_url", props.CmekKeyVaultURL)
 		d.Set("microsoft_app_id", props.MsaAppID)
 		d.Set("endpoint", props.Endpoint)
 		d.Set("description", props.Description)
@@ -282,7 +282,7 @@ func resourceBotChannelsRegistrationUpdate(d *pluginsdk.ResourceData, meta inter
 			DisplayName:                       utils.String(displayName),
 			Endpoint:                          utils.String(d.Get("endpoint").(string)),
 			MsaAppID:                          utils.String(d.Get("microsoft_app_id").(string)),
-			CmekKeyVaultURL:                   utils.String(d.Get("cmek_key_vault_url").(string)),
+			CmekKeyVaultURL:                   utils.String(d.Get("cmk_key_vault_url").(string)),
 			Description:                       utils.String(d.Get("description").(string)),
 			DeveloperAppInsightKey:            utils.String(d.Get("developer_app_insights_key").(string)),
 			DeveloperAppInsightsAPIKey:        utils.String(d.Get("developer_app_insights_api_key").(string)),
@@ -299,7 +299,7 @@ func resourceBotChannelsRegistrationUpdate(d *pluginsdk.ResourceData, meta inter
 		Tags: tags.Expand(t),
 	}
 
-	if _, ok := d.GetOk("cmek_key_vault_url"); ok {
+	if _, ok := d.GetOk("cmk_key_vault_url"); ok {
 		bot.Properties.IsCmekEnabled = utils.Bool(true)
 	}
 

--- a/azurerm/internal/services/bot/bot_channels_registration_resource.go
+++ b/azurerm/internal/services/bot/bot_channels_registration_resource.go
@@ -145,7 +145,7 @@ func resourceBotChannelsRegistration() *pluginsdk.Resource {
 				ValidateFunc: validate.BotChannelRegistrationIconUrl,
 			},
 
-			"is_isolated_network_enabled": {
+			"isolated_network_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 			},
@@ -210,7 +210,7 @@ func resourceBotChannelsRegistrationCreate(d *pluginsdk.ResourceData, meta inter
 
 	d.SetId(resourceId.ID())
 
-	if v, ok := d.GetOk("is_isolated_network_enabled"); ok && v.(bool) {
+	if v, ok := d.GetOk("isolated_network_enabled"); ok && v.(bool) {
 		return resourceBotChannelsRegistrationUpdate(d, meta)
 	} else {
 		return resourceBotChannelsRegistrationRead(d, meta)
@@ -255,7 +255,7 @@ func resourceBotChannelsRegistrationRead(d *pluginsdk.ResourceData, meta interfa
 		d.Set("developer_app_insights_key", props.DeveloperAppInsightKey)
 		d.Set("developer_app_insights_application_id", props.DeveloperAppInsightsApplicationID)
 		d.Set("icon_url", props.IconURL)
-		d.Set("is_isolated_network_enabled", props.IsIsolated)
+		d.Set("isolated_network_enabled", props.IsIsolated)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -289,7 +289,7 @@ func resourceBotChannelsRegistrationUpdate(d *pluginsdk.ResourceData, meta inter
 			DeveloperAppInsightsApplicationID: utils.String(d.Get("developer_app_insights_application_id").(string)),
 			IconURL:                           utils.String(d.Get("icon_url").(string)),
 			IsCmekEnabled:                     utils.Bool(false),
-			IsIsolated:                        utils.Bool(d.Get("is_isolated_network_enabled").(bool)),
+			IsIsolated:                        utils.Bool(d.Get("isolated_network_enabled").(bool)),
 		},
 		Location: utils.String(d.Get("location").(string)),
 		Sku: &botservice.Sku{

--- a/azurerm/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channels_registration_resource_test.go
@@ -58,7 +58,7 @@ func testAccBotChannelsRegistration_update(t *testing.T) {
 		},
 		data.ImportStep("developer_app_insights_api_key"),
 		{
-			Config: r.withoutCMEKKeyVaultURL(data),
+			Config: r.withoutCMKKeyVaultURL(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -251,7 +251,7 @@ resource "azurerm_bot_channels_registration" "test" {
   description                 = "TestDescription2"
   is_isolated_network_enabled = false
   icon_url                    = "http://myprofile/myicon2.png"
-  cmek_key_vault_url          = azurerm_key_vault_key.test2.id
+  cmk_key_vault_url           = azurerm_key_vault_key.test2.id
 
   tags = {
     environment = "production2"
@@ -350,7 +350,7 @@ resource "azurerm_bot_channels_registration" "test" {
   description                 = "TestDescription"
   is_isolated_network_enabled = true
   icon_url                    = "http://myprofile/myicon.png"
-  cmek_key_vault_url          = azurerm_key_vault_key.test.id
+  cmk_key_vault_url           = azurerm_key_vault_key.test.id
 
   tags = {
     environment = "production"
@@ -359,7 +359,7 @@ resource "azurerm_bot_channels_registration" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString, data.RandomInteger)
 }
 
-func (BotChannelsRegistrationResource) withoutCMEKKeyVaultURL(data acceptance.TestData) string {
+func (BotChannelsRegistrationResource) withoutCMKKeyVaultURL(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {

--- a/azurerm/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channels_registration_resource_test.go
@@ -248,10 +248,10 @@ resource "azurerm_bot_channels_registration" "test" {
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test2.api_key
   developer_app_insights_application_id = azurerm_application_insights.test2.app_id
 
-  description                 = "TestDescription2"
-  is_isolated_network_enabled = false
-  icon_url                    = "http://myprofile/myicon2.png"
-  cmk_key_vault_url           = azurerm_key_vault_key.test2.id
+  description              = "TestDescription2"
+  isolated_network_enabled = false
+  icon_url                 = "http://myprofile/myicon2.png"
+  cmk_key_vault_url        = azurerm_key_vault_key.test2.id
 
   tags = {
     environment = "production2"
@@ -347,10 +347,10 @@ resource "azurerm_bot_channels_registration" "test" {
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
 
-  description                 = "TestDescription"
-  is_isolated_network_enabled = true
-  icon_url                    = "http://myprofile/myicon.png"
-  cmk_key_vault_url           = azurerm_key_vault_key.test.id
+  description              = "TestDescription"
+  isolated_network_enabled = true
+  icon_url                 = "http://myprofile/myicon.png"
+  cmk_key_vault_url        = azurerm_key_vault_key.test.id
 
   tags = {
     environment = "production"
@@ -472,9 +472,9 @@ resource "azurerm_bot_channels_registration" "test" {
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test2.api_key
   developer_app_insights_application_id = azurerm_application_insights.test2.app_id
 
-  description                 = "TestDescription2"
-  is_isolated_network_enabled = false
-  icon_url                    = "http://myprofile/myicon2.png"
+  description              = "TestDescription2"
+  isolated_network_enabled = false
+  icon_url                 = "http://myprofile/myicon2.png"
 
   tags = {
     environment = "production2"

--- a/azurerm/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channels_registration_resource_test.go
@@ -44,7 +44,21 @@ func testAccBotChannelsRegistration_update(t *testing.T) {
 		},
 		data.ImportStep("developer_app_insights_api_key"),
 		{
+			Config: r.completeConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("developer_app_insights_api_key"),
+		{
 			Config: r.updateConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("developer_app_insights_api_key"),
+		{
+			Config: r.basicConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -85,7 +99,11 @@ func (t BotChannelsRegistrationResource) Exists(ctx context.Context, clients *cl
 func (BotChannelsRegistrationResource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {
@@ -113,38 +131,18 @@ resource "azurerm_bot_channels_registration" "test" {
 func (BotChannelsRegistrationResource) updateConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_bot_channels_registration" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "F0"
-  microsoft_app_id    = data.azurerm_client_config.current.client_id
-
-  tags = {
-    environment = "production"
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
-}
-
-func (BotChannelsRegistrationResource) completeConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
 
 data "azurerm_client_config" "current" {
+}
+
+data "azuread_service_principal" "test" {
+  display_name = "Bot Service CMEK Prod"
 }
 
 resource "azurerm_resource_group" "test" {
@@ -165,6 +163,172 @@ resource "azurerm_application_insights_api_key" "test" {
   read_permissions        = ["aggregate", "api", "draft", "extendqueries", "search"]
 }
 
+resource "azurerm_application_insights" "test2" {
+  name                = "acctestappinsights2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_api_key" "test2" {
+  name                    = "acctestappinsightsapikey2-%d"
+  application_insights_id = azurerm_application_insights.test2.id
+  read_permissions        = ["aggregate", "api", "draft", "extendqueries", "search"]
+}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv-%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  soft_delete_enabled      = true
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "test2" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azuread_service_principal.test.id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkvkey-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+  ]
+}
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "acctestkvkey2-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+  ]
+}
+
+resource "azurerm_bot_channels_registration" "test" {
+  name                = "acctestdf%d"
+  location            = "global"
+  resource_group_name = azurerm_resource_group.test.name
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
+  sku                 = "F0"
+
+  endpoint                              = "https://example2.com"
+  developer_app_insights_api_key        = azurerm_application_insights_api_key.test2.api_key
+  developer_app_insights_application_id = azurerm_application_insights.test2.app_id
+
+  description                 = "TestDescription2"
+  is_isolated_network_enabled = false
+  icon_url                    = "http://myprofile/myicon2.png"
+  cmek_key_vault_url          = azurerm_key_vault_key.test2.id
+
+  tags = {
+    environment = "production2"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger)
+}
+
+func (BotChannelsRegistrationResource) completeConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {
+}
+
+data "azuread_service_principal" "test" {
+  display_name = "Bot Service CMEK Prod"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_api_key" "test" {
+  name                    = "acctestappinsightsapikey-%d"
+  application_insights_id = azurerm_application_insights.test.id
+  read_permissions        = ["aggregate", "api", "draft", "extendqueries", "search"]
+}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv-%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  soft_delete_enabled      = true
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "test2" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azuread_service_principal.test.id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctestkvkey-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test,
+    azurerm_key_vault_access_policy.test2,
+  ]
+}
+
 resource "azurerm_bot_channels_registration" "test" {
   name                = "acctestdf%d"
   location            = "global"
@@ -176,9 +340,14 @@ resource "azurerm_bot_channels_registration" "test" {
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
   developer_app_insights_application_id = azurerm_application_insights.test.app_id
 
+  description                 = "TestDescription"
+  is_isolated_network_enabled = true
+  icon_url                    = "http://myprofile/myicon.png"
+  cmek_key_vault_url          = azurerm_key_vault_key.test.id
+
   tags = {
     environment = "production"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString, data.RandomInteger)
 }

--- a/azurerm/internal/services/bot/validate/bot_channel_registration_description.go
+++ b/azurerm/internal/services/bot/validate/bot_channel_registration_description.go
@@ -1,0 +1,20 @@
+package validate
+
+import (
+	"fmt"
+)
+
+func BotChannelRegistrationDescription(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if len(v) > 512 {
+		errors = append(errors, fmt.Errorf("length should be less than %d", 512))
+		return
+	}
+
+	return
+}

--- a/azurerm/internal/services/bot/validate/bot_channel_registration_description_test.go
+++ b/azurerm/internal/services/bot/validate/bot_channel_registration_description_test.go
@@ -1,0 +1,38 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBotChannelRegistrationDescription(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "Test123",
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("t", 511),
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("t", 512),
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("t", 513),
+			Expected: false,
+		},
+	}
+
+	for _, v := range testCases {
+		_, errors := BotChannelRegistrationDescription(v.Input, "description")
+		result := len(errors) == 0
+		if result != v.Expected {
+			t.Fatalf("Expected the result to be %t but got %t (and %d errors)", v.Expected, result, len(errors))
+		}
+	}
+}

--- a/azurerm/internal/services/bot/validate/bot_channel_registration_icon_url.go
+++ b/azurerm/internal/services/bot/validate/bot_channel_registration_icon_url.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+)
+
+func BotChannelRegistrationIconUrl(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if !strings.HasSuffix(v, ".png") {
+		errors = append(errors, fmt.Errorf("only png is supported"))
+		return
+	}
+
+	return
+}

--- a/azurerm/internal/services/bot/validate/bot_channel_registration_icon_url_test.go
+++ b/azurerm/internal/services/bot/validate/bot_channel_registration_icon_url_test.go
@@ -1,0 +1,33 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestBotChannelRegistrationIconUrl(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "test.png",
+			Expected: true,
+		},
+		{
+			Input:    "http://myicon.png",
+			Expected: true,
+		},
+		{
+			Input:    "test.jpg",
+			Expected: false,
+		},
+	}
+
+	for _, v := range testCases {
+		_, errors := BotChannelRegistrationIconUrl(v.Input, "icon_url")
+		result := len(errors) == 0
+		if result != v.Expected {
+			t.Fatalf("Expected the result to be %t but got %t (and %d errors)", v.Expected, result, len(errors))
+		}
+	}
+}

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `icon_url` - (Optional) The icon URL to visually identify the Bot Channels Registration.
 
-* `is_isolated_network_enabled` - (Optional) Is the Bot Channels Registration in an isolated network?
+* `isolated_network_enabled` - (Optional) Is the Bot Channels Registration in an isolated network?
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -43,11 +43,11 @@ The following arguments are supported:
 
 * `microsoft_app_id` - (Required) The Microsoft Application ID for the Bot Channels Registration. Changing this forces a new resource to be created.
 
-* `cmek_key_vault_url` - (Optional) The CMEK Key Vault Key URL to encrypt the Bot Channels Registration with the Customer Managed Encryption Key.
+* `cmk_key_vault_url` - (Optional) The CMK Key Vault Key URL to encrypt the Bot Channels Registration with the Customer Managed Encryption Key.
 
-**Note:** It has to add the Key Vault Access Policy for the `Bot Service CMEK Prod` Service Principal and the `soft_delete_enabled` and the `purge_protection_enabled` is enabled on the `azurerm_key_vault` resource while using `cmek_key_vault_url`.
+**Note:** It has to add the Key Vault Access Policy for the `Bot Service CMEK Prod` Service Principal and the `soft_delete_enabled` and the `purge_protection_enabled` is enabled on the `azurerm_key_vault` resource while using `cmk_key_vault_url`.
 
-**Note:** It has to turn off the CMEK feature before revoking Key Vault Access Policy. For more information, please refer to [Revoke access to customer-managed keys](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-encryption?view=azure-bot-service-4.0&WT.mc_id=Portal-Microsoft_Azure_BotService#revoke-access-to-customer-managed-keys).
+**Note:** It has to turn off the CMK feature before revoking Key Vault Access Policy. For more information, please refer to [Revoke access to customer-managed keys](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-encryption?view=azure-bot-service-4.0&WT.mc_id=Portal-Microsoft_Azure_BotService#revoke-access-to-customer-managed-keys).
 
 * `display_name` - (Optional) The name of the Bot Channels Registration will be displayed as. This defaults to `name` if not specified.
 

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -45,6 +45,10 @@ The following arguments are supported:
 
 * `cmek_key_vault_url` - (Optional) The CMEK Key Vault Key URL to encrypt the Bot Channels Registration with the Customer Managed Encryption Key.
 
+**Note:** It has to add the Key Vault Access Policy for the `Bot Service CMEK Prod` Service Principal and the `soft_delete_enabled` and the `purge_protection_enabled` is enabled on the `azurerm_key_vault` resource while using `cmek_key_vault_url`.
+
+**Note:** It has to turn off the CMEK feature before revoking Key Vault Access Policy. For more information, please refer to [Revoke access to customer-managed keys](https://docs.microsoft.com/en-us/azure/bot-service/bot-service-encryption?view=azure-bot-service-4.0&WT.mc_id=Portal-Microsoft_Azure_BotService#revoke-access-to-customer-managed-keys).
+
 * `display_name` - (Optional) The name of the Bot Channels Registration will be displayed as. This defaults to `name` if not specified.
 
 * `description` - (Optional) The description of the Bot Channels Registration.

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -43,7 +43,11 @@ The following arguments are supported:
 
 * `microsoft_app_id` - (Required) The Microsoft Application ID for the Bot Channels Registration. Changing this forces a new resource to be created.
 
+* `cmek_key_vault_url` - (Optional) The CMEK Key Vault Key URL to encrypt the Bot Channels Registration with the Customer Managed Encryption Key.
+
 * `display_name` - (Optional) The name of the Bot Channels Registration will be displayed as. This defaults to `name` if not specified.
+
+* `description` - (Optional) The description of the Bot Channels Registration.
 
 * `endpoint` - (Optional) The Bot Channels Registration endpoint.
 
@@ -52,6 +56,10 @@ The following arguments are supported:
 * `developer_app_insights_api_key` - (Optional) The Application Insights API Key to associate with the Bot Channels Registration.
 
 * `developer_app_insights_application_id` - (Optional) The Application Insights Application ID to associate with the Bot Channels Registration.
+
+* `icon_url` - (Optional) The icon URL to visually identify the Bot Channels Registration.
+
+* `is_isolated_network_enabled` - (Optional) Is the Bot Channels Registration in an isolated network?
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
This PR is introducing new properties for azurerm_bot_channels_registration.

![image](https://user-images.githubusercontent.com/19754191/125389215-70806780-e3d3-11eb-9862-1a8d1573cf1d.png)

API Reference:
https://github.com/Azure/azure-rest-api-specs/blob/2a8a9a79b23c72c6092d5b1212acf6d69b1b3850/specification/botservice/resource-manager/Microsoft.BotService/stable/2021-03-01/botservice.json#L36