### PR TITLE
Fix un-necessary VMSS instance rolling request

### DIFF
--- a/azurerm/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_update.go
@@ -86,7 +86,7 @@ func (metadata virtualMachineScaleSetUpdateMetaData) updateVmss(ctx context.Cont
 	log.Printf("[DEBUG] Updating %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)
 	future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
 	if err != nil {
-		return fmt.Errorf("Error updating L%sinux Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("Error updating %s Virtual Machine Scale Set %q (Resource Group %q): %+v", metadata.OSType, id.Name, id.ResourceGroup, err)
 	}
 
 	log.Printf("[DEBUG] Waiting for update of %s Virtual Machine Scale Set %q (Resource Group %q)..", metadata.OSType, id.Name, id.ResourceGroup)

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_update.go
@@ -47,7 +47,9 @@ func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.C
 		upgradeMode := metadata.Existing.VirtualMachineScaleSetProperties.UpgradePolicy.Mode
 
 		if userWantsToRollInstances {
-			if upgradeMode == compute.Automatic {
+			// If the updated image version is not "latest" and upgrade mode is automatic then azure will roll the instances automatically.
+			// Calling upgradeInstancesForAutomaticUpgradePolicy() in this case will cause an error.
+			if upgradeMode == compute.Automatic && *update.VirtualMachineProfile.StorageProfile.ImageReference.Version == "latest" {
 				if err := metadata.upgradeInstancesForAutomaticUpgradePolicy(ctx); err != nil {
 					return err
 				}


### PR DESCRIPTION
Rolling VMSS instances when upgrade mode is set to `Automatic` is only
allowed of the image version is set to `latest`, otherwise we get the
following error:

```
The OS Rolling Upgrade API cannot be used on a Virtual Machine Scale Set unless the Virtual Machine Scale Set has some unprotected instances which have imageReference.version set to latest.
```

This change makes sure we only roll instances if the image version is
`latest`. The VMSS will roll instances on its own for non-latest images
as long as upgrade_type is set to `Automatic`
