### PR TITLE
[Draft] New Resource: azurerm_bot_channel_skype

### DIFF
--- a/azurerm/internal/services/bot/bot_channel_ms_teams_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_ms_teams_resource.go
@@ -56,7 +56,7 @@ func resourceBotChannelMsTeams() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validate.BotMSTeamsCallingWebHook(),
+				ValidateFunc: validate.BotCallingWebHook(),
 			},
 
 			"enable_calling": {

--- a/azurerm/internal/services/bot/bot_channel_skype_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource.go
@@ -1,0 +1,262 @@
+package bot
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/botservice/mgmt/2021-03-01/botservice"
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceBotChannelSkype() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceBotChannelSkypeCreate,
+		Read:   resourceBotChannelSkypeRead,
+		Delete: resourceBotChannelSkypeDelete,
+		Update: resourceBotChannelSkypeUpdate,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.BotChannelID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": azure.SchemaLocation(),
+
+			"bot_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.BotName,
+			},
+
+			"calling_web_hook": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validate.BotCallingWebHook(),
+			},
+
+			"enable_calling": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"enable_groups": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"enable_media_cards": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"enable_messaging": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"enable_screen_sharing": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"enable_video": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+			},
+
+			"groups_mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceBotChannelSkypeCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Bot.ChannelClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewBotChannelID(subscriptionId, d.Get("resource_group_name").(string), d.Get("bot_name").(string), string(botservice.ChannelNameSkypeChannel))
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.BotServiceName, id.ChannelName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+		if existing.ID != nil && *existing.ID != "" {
+			// As Bot Skype Channel would be created by default while creating Bot Registrations Channel
+			// So it has to delete default one
+			resp, err := client.Delete(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameSkypeChannel))
+			if err != nil {
+				if !response.WasNotFound(resp.Response) {
+					return fmt.Errorf("deleting default Bot Skype Channel %s: %+v", id, err)
+				}
+			}
+		}
+	}
+
+	parameters := botservice.BotChannel{
+		Properties: botservice.SkypeChannel{
+			Properties: &botservice.SkypeChannelProperties{
+				EnableCalling:       utils.Bool(d.Get("enable_calling").(bool)),
+				EnableGroups:        utils.Bool(d.Get("enable_groups").(bool)),
+				EnableMediaCards:    utils.Bool(d.Get("enable_media_cards").(bool)),
+				EnableMessaging:     utils.Bool(d.Get("enable_messaging").(bool)),
+				EnableScreenSharing: utils.Bool(d.Get("enable_screen_sharing").(bool)),
+				EnableVideo:         utils.Bool(d.Get("enable_video").(bool)),
+				IsEnabled:           utils.Bool(true),
+			},
+			ChannelName: botservice.ChannelNameBasicChannelChannelNameSkypeChannel,
+		},
+		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Kind:     botservice.KindBot,
+	}
+
+	if v, ok := d.GetOk("calling_web_hook"); ok {
+		channel, _ := parameters.Properties.AsSkypeChannel()
+		channel.Properties.CallingWebHook = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("groups_mode"); ok {
+		channel, _ := parameters.Properties.AsSkypeChannel()
+		channel.Properties.GroupsMode = utils.String(v.(string))
+	}
+
+	if _, err := client.Create(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSkypeChannel, parameters); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceBotChannelSkypeRead(d, meta)
+}
+
+func resourceBotChannelSkypeRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Bot.ChannelClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BotChannelID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameSkypeChannel))
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] %s was not found - removing from state!", id)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("bot_name", id.BotServiceName)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+
+	if props := resp.Properties; props != nil {
+		if channel, ok := props.AsSkypeChannel(); ok {
+			if channelProps := channel.Properties; channelProps != nil {
+				d.Set("calling_web_hook", channelProps.CallingWebHook)
+				d.Set("enable_calling", channelProps.EnableCalling)
+				d.Set("enable_groups", channelProps.EnableGroups)
+				d.Set("enable_media_cards", channelProps.EnableMediaCards)
+				d.Set("enable_messaging", channelProps.EnableMessaging)
+				d.Set("enable_screen_sharing", channelProps.EnableScreenSharing)
+				d.Set("enable_video", channelProps.EnableVideo)
+				d.Set("groups_mode", channelProps.GroupsMode)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceBotChannelSkypeUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Bot.ChannelClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BotChannelID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	parameters := botservice.BotChannel{
+		Properties: botservice.SkypeChannel{
+			Properties: &botservice.SkypeChannelProperties{
+				EnableCalling:       utils.Bool(d.Get("enable_calling").(bool)),
+				EnableGroups:        utils.Bool(d.Get("enable_groups").(bool)),
+				EnableMediaCards:    utils.Bool(d.Get("enable_media_cards").(bool)),
+				EnableMessaging:     utils.Bool(d.Get("enable_messaging").(bool)),
+				EnableScreenSharing: utils.Bool(d.Get("enable_screen_sharing").(bool)),
+				EnableVideo:         utils.Bool(d.Get("enable_video").(bool)),
+				IsEnabled:           utils.Bool(true),
+			},
+			ChannelName: botservice.ChannelNameBasicChannelChannelNameSkypeChannel,
+		},
+		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Kind:     botservice.KindBot,
+	}
+
+	if v, ok := d.GetOk("calling_web_hook"); ok {
+		channel, _ := parameters.Properties.AsSkypeChannel()
+		channel.Properties.CallingWebHook = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("groups_mode"); ok {
+		channel, _ := parameters.Properties.AsSkypeChannel()
+		channel.Properties.GroupsMode = utils.String(v.(string))
+	}
+
+	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSkypeChannel, parameters); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	return resourceBotChannelSkypeRead(d, meta)
+}
+
+func resourceBotChannelSkypeDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Bot.ChannelClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.BotChannelID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Delete(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameSkypeChannel))
+	if err != nil {
+		if !response.WasNotFound(resp.Response) {
+			return fmt.Errorf("deleting %s: %+v", id, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/bot/bot_channel_skype_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource.go
@@ -48,6 +48,8 @@ func resourceBotChannelSkype() *pluginsdk.Resource {
 				ValidateFunc: validate.BotName,
 			},
 
+			// issue: https://github.com/Azure/azure-rest-api-specs/issues/15170
+			// this field could not update to empty, so add `Computed: true` to avoid diff
 			"calling_web_hook": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -72,21 +74,6 @@ func resourceBotChannelSkype() *pluginsdk.Resource {
 
 			"enable_messaging": {
 				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"enable_screen_sharing": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"enable_video": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"groups_mode": {
-				Type:     pluginsdk.TypeString,
 				Optional: true,
 			},
 		},
@@ -122,13 +109,11 @@ func resourceBotChannelSkypeCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	parameters := botservice.BotChannel{
 		Properties: botservice.SkypeChannel{
 			Properties: &botservice.SkypeChannelProperties{
-				EnableCalling:       utils.Bool(d.Get("enable_calling").(bool)),
-				EnableGroups:        utils.Bool(d.Get("enable_groups").(bool)),
-				EnableMediaCards:    utils.Bool(d.Get("enable_media_cards").(bool)),
-				EnableMessaging:     utils.Bool(d.Get("enable_messaging").(bool)),
-				EnableScreenSharing: utils.Bool(d.Get("enable_screen_sharing").(bool)),
-				EnableVideo:         utils.Bool(d.Get("enable_video").(bool)),
-				IsEnabled:           utils.Bool(true),
+				EnableCalling:    utils.Bool(d.Get("enable_calling").(bool)),
+				EnableGroups:     utils.Bool(d.Get("enable_groups").(bool)),
+				EnableMediaCards: utils.Bool(d.Get("enable_media_cards").(bool)),
+				EnableMessaging:  utils.Bool(d.Get("enable_messaging").(bool)),
+				IsEnabled:        utils.Bool(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameSkypeChannel,
 		},
@@ -139,11 +124,6 @@ func resourceBotChannelSkypeCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("calling_web_hook"); ok {
 		channel, _ := parameters.Properties.AsSkypeChannel()
 		channel.Properties.CallingWebHook = utils.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("groups_mode"); ok {
-		channel, _ := parameters.Properties.AsSkypeChannel()
-		channel.Properties.GroupsMode = utils.String(v.(string))
 	}
 
 	if _, err := client.Create(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSkypeChannel, parameters); err != nil {
@@ -187,9 +167,6 @@ func resourceBotChannelSkypeRead(d *pluginsdk.ResourceData, meta interface{}) er
 				d.Set("enable_groups", channelProps.EnableGroups)
 				d.Set("enable_media_cards", channelProps.EnableMediaCards)
 				d.Set("enable_messaging", channelProps.EnableMessaging)
-				d.Set("enable_screen_sharing", channelProps.EnableScreenSharing)
-				d.Set("enable_video", channelProps.EnableVideo)
-				d.Set("groups_mode", channelProps.GroupsMode)
 			}
 		}
 	}
@@ -210,13 +187,11 @@ func resourceBotChannelSkypeUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	parameters := botservice.BotChannel{
 		Properties: botservice.SkypeChannel{
 			Properties: &botservice.SkypeChannelProperties{
-				EnableCalling:       utils.Bool(d.Get("enable_calling").(bool)),
-				EnableGroups:        utils.Bool(d.Get("enable_groups").(bool)),
-				EnableMediaCards:    utils.Bool(d.Get("enable_media_cards").(bool)),
-				EnableMessaging:     utils.Bool(d.Get("enable_messaging").(bool)),
-				EnableScreenSharing: utils.Bool(d.Get("enable_screen_sharing").(bool)),
-				EnableVideo:         utils.Bool(d.Get("enable_video").(bool)),
-				IsEnabled:           utils.Bool(true),
+				EnableCalling:    utils.Bool(d.Get("enable_calling").(bool)),
+				EnableGroups:     utils.Bool(d.Get("enable_groups").(bool)),
+				EnableMediaCards: utils.Bool(d.Get("enable_media_cards").(bool)),
+				EnableMessaging:  utils.Bool(d.Get("enable_messaging").(bool)),
+				IsEnabled:        utils.Bool(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameSkypeChannel,
 		},
@@ -227,11 +202,6 @@ func resourceBotChannelSkypeUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("calling_web_hook"); ok {
 		channel, _ := parameters.Properties.AsSkypeChannel()
 		channel.Properties.CallingWebHook = utils.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("groups_mode"); ok {
-		channel, _ := parameters.Properties.AsSkypeChannel()
-		channel.Properties.GroupsMode = utils.String(v.(string))
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSkypeChannel, parameters); err != nil {

--- a/azurerm/internal/services/bot/bot_channel_skype_resource.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource.go
@@ -235,7 +235,8 @@ func resourceBotChannelSkypeDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 	} else {
 		// As there is a default Skype Channel, so it has to restore it to default one
-		if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSkypeChannel, parameters); err != nil {
+		_, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSkypeChannel, parameters)
+		if err != nil {
 			return fmt.Errorf("updating for restoring %s: %+v", id, err)
 		}
 	}

--- a/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
@@ -1,0 +1,124 @@
+package bot_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/botservice/mgmt/2021-03-01/botservice"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type BotChannelSkypeResource struct {
+}
+
+func testAccBotChannelSkype_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
+	r := BotChannelSkypeResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccBotChannelSkype_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
+	r := BotChannelSkypeResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func testAccBotChannelSkype_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
+	r := BotChannelSkypeResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t BotChannelSkypeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.BotChannelID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Bot.ChannelClient.Get(ctx, id.ResourceGroup, id.BotServiceName, string(botservice.ChannelNameSkypeChannel))
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+
+	return utils.Bool(resp.Properties != nil), nil
+}
+
+func (BotChannelSkypeResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_bot_channel_skype" "test" {
+  bot_name            = azurerm_bot_channels_registration.test.name
+  location            = azurerm_bot_channels_registration.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, BotChannelsRegistrationResource{}.basicConfig(data))
+}
+
+func (BotChannelSkypeResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_bot_channel_skype" "test" {
+  bot_name            = azurerm_bot_channels_registration.test.name
+  location            = azurerm_bot_channels_registration.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  calling_web_hook      = "https://example.com/"
+  enable_calling        = true
+  enable_groups         = true
+  enable_media_cards    = true
+  enable_messaging      = true
+  enable_screen_sharing = true
+  enable_video          = true
+  groups_mode           = "test"
+}
+`, BotChannelsRegistrationResource{}.basicConfig(data))
+}

--- a/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
@@ -32,6 +32,21 @@ func testAccBotChannelSkype_basic(t *testing.T) {
 	})
 }
 
+func testAccBotChannelSkype_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
+	r := BotChannelSkypeResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
 func testAccBotChannelSkype_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
 	r := BotChannelSkypeResource{}
@@ -102,6 +117,18 @@ resource "azurerm_bot_channel_skype" "test" {
 `, BotChannelsRegistrationResource{}.basicConfig(data))
 }
 
+func (t BotChannelSkypeResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_bot_channel_skype" "import" {
+  bot_name            = azurerm_bot_channel_skype.test.bot_name
+  location            = azurerm_bot_channel_skype.test.location
+  resource_group_name = azurerm_bot_channel_skype.test.resource_group_name
+}
+`, t.basic(data))
+}
+
 func (BotChannelSkypeResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -116,9 +143,6 @@ resource "azurerm_bot_channel_skype" "test" {
   enable_groups         = true
   enable_media_cards    = true
   enable_messaging      = true
-  enable_screen_sharing = true
-  enable_video          = true
-  groups_mode           = "test"
 }
 `, BotChannelsRegistrationResource{}.basicConfig(data))
 }

--- a/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
@@ -111,11 +111,11 @@ resource "azurerm_bot_channel_skype" "test" {
   location            = azurerm_bot_channels_registration.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  calling_web_hook      = "https://example.com/"
-  enable_calling        = true
-  enable_groups         = true
-  enable_media_cards    = true
-  enable_messaging      = true
+  calling_web_hook   = "https://example.com/"
+  enable_calling     = true
+  enable_groups      = true
+  enable_media_cards = true
+  enable_messaging   = true
 }
 `, BotChannelsRegistrationResource{}.basicConfig(data))
 }

--- a/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
+++ b/azurerm/internal/services/bot/bot_channel_skype_resource_test.go
@@ -32,21 +32,6 @@ func testAccBotChannelSkype_basic(t *testing.T) {
 	})
 }
 
-func testAccBotChannelSkype_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
-	r := BotChannelSkypeResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.RequiresImportErrorStep(r.requiresImport),
-	})
-}
-
 func testAccBotChannelSkype_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_channel_skype", "test")
 	r := BotChannelSkypeResource{}
@@ -115,18 +100,6 @@ resource "azurerm_bot_channel_skype" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 `, BotChannelsRegistrationResource{}.basicConfig(data))
-}
-
-func (t BotChannelSkypeResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_bot_channel_skype" "import" {
-  bot_name            = azurerm_bot_channel_skype.test.bot_name
-  location            = azurerm_bot_channel_skype.test.location
-  resource_group_name = azurerm_bot_channel_skype.test.resource_group_name
-}
-`, t.basic(data))
 }
 
 func (BotChannelSkypeResource) complete(data acceptance.TestData) string {

--- a/azurerm/internal/services/bot/bot_channel_test.go
+++ b/azurerm/internal/services/bot/bot_channel_test.go
@@ -27,6 +27,9 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 			"directlineBasic":    testAccBotChannelDirectline_basic,
 			"directlineComplete": testAccBotChannelDirectline_complete,
 			"directlineUpdate":   testAccBotChannelDirectline_update,
+			"skypeBasic":         testAccBotChannelSkype_basic,
+			"skypeComplete":      testAccBotChannelSkype_complete,
+			"skypeUpdate":        testAccBotChannelSkype_update,
 		},
 		"web_app": {
 			"basic":    testAccBotWebApp_basic,

--- a/azurerm/internal/services/bot/bot_channel_test.go
+++ b/azurerm/internal/services/bot/bot_channel_test.go
@@ -30,7 +30,6 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 			"skypeBasic":         testAccBotChannelSkype_basic,
 			"skypeComplete":      testAccBotChannelSkype_complete,
 			"skypeUpdate":        testAccBotChannelSkype_update,
-			"skypeImport":        testAccBotChannelSkype_requiresImport,
 		},
 		"web_app": {
 			"basic":    testAccBotWebApp_basic,

--- a/azurerm/internal/services/bot/bot_channel_test.go
+++ b/azurerm/internal/services/bot/bot_channel_test.go
@@ -30,6 +30,7 @@ func TestAccBotChannelsRegistration(t *testing.T) {
 			"skypeBasic":         testAccBotChannelSkype_basic,
 			"skypeComplete":      testAccBotChannelSkype_complete,
 			"skypeUpdate":        testAccBotChannelSkype_update,
+			"skypeImport":        testAccBotChannelSkype_requiresImport,
 		},
 		"web_app": {
 			"basic":    testAccBotWebApp_basic,

--- a/azurerm/internal/services/bot/registration.go
+++ b/azurerm/internal/services/bot/registration.go
@@ -29,6 +29,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_bot_channel_directline":    resourceBotChannelDirectline(),
 		"azurerm_bot_channel_email":         resourceBotChannelEmail(),
 		"azurerm_bot_channel_ms_teams":      resourceBotChannelMsTeams(),
+		"azurerm_bot_channel_skype":         resourceBotChannelSkype(),
 		"azurerm_bot_channel_slack":         resourceBotChannelSlack(),
 		"azurerm_bot_channels_registration": resourceBotChannelsRegistration(),
 		"azurerm_bot_connection":            resourceArmBotConnection(),

--- a/azurerm/internal/services/bot/validate/bot.go
+++ b/azurerm/internal/services/bot/validate/bot.go
@@ -7,7 +7,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 )
 
-func BotMSTeamsCallingWebHook() pluginsdk.SchemaValidateFunc {
+func BotCallingWebHook() pluginsdk.SchemaValidateFunc {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		value := i.(string)
 		if !strings.HasPrefix(value, "https://") || !strings.HasSuffix(value, "/") {

--- a/azurerm/internal/services/bot/validate/bot_name.go
+++ b/azurerm/internal/services/bot/validate/bot_name.go
@@ -1,0 +1,31 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func BotName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	if len(v) < 4 {
+		errors = append(errors, fmt.Errorf("length should be greater than %d", 4))
+		return
+	}
+
+	if len(v) > 42 {
+		errors = append(errors, fmt.Errorf("length should be less than %d", 42))
+		return
+	}
+
+	if !regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`).MatchString(v) {
+		errors = append(errors, fmt.Errorf("%q must start with a letter or digit and may only contain alphanumeric characters, underscores and dashes", k))
+		return
+	}
+
+	return
+}

--- a/azurerm/internal/services/bot/validate/bot_name_test.go
+++ b/azurerm/internal/services/bot/validate/bot_name_test.go
@@ -1,0 +1,45 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBotName(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "Test123",
+			Expected: true,
+		},
+		{
+			Input:    "Test_123",
+			Expected: true,
+		},
+		{
+			Input:    "Test-123",
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("s", 41),
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("s", 42),
+			Expected: true,
+		},
+		{
+			Input:    strings.Repeat("s", 43),
+			Expected: false,
+		},
+	}
+	for _, v := range testCases {
+		_, errors := BotName(v.Input, "bot_name")
+		result := len(errors) == 0
+		if result != v.Expected {
+			t.Fatalf("Expected the result to be %t but got %t (and %d errors)", v.Expected, result, len(errors))
+		}
+	}
+}

--- a/azurerm/internal/services/bot/validate/bot_test.go
+++ b/azurerm/internal/services/bot/validate/bot_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestValidateBotMSTeamsCallingWebHook(t *testing.T) {
+func TestValidateBotCallingWebHook(t *testing.T) {
 	tests := []struct {
 		webhook string
 		valid   bool
@@ -32,7 +32,7 @@ func TestValidateBotMSTeamsCallingWebHook(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.webhook, func(t *testing.T) {
-			_, err := BotMSTeamsCallingWebHook()(tt.webhook, "")
+			_, err := BotCallingWebHook()(tt.webhook, "")
 			valid := err == nil
 			if valid != tt.valid {
 				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, tt.webhook)

--- a/website/docs/r/bot_channel_skype.markdown
+++ b/website/docs/r/bot_channel_skype.markdown
@@ -49,11 +49,11 @@ The following arguments are supported:
 
 * `calling_web_hook` - (Optional) The webhook for Skype channel calls.
 
-* `enable_calling` - (Optional) Is Skype channel calls enabled?
+* `enable_calling` - (Optional) Is Skype channel calling enabled?
 
-* `enable_groups` - (Optional) Is Skype channel groups enabled?
+* `enable_groups` - (Optional) Are Skype channel groups enabled?
 
-* `enable_media_cards` - (Optional) Is Skype channel media cards enabled?
+* `enable_media_cards` - (Optional) Are Skype channel media cards enabled?
 
 * `enable_messaging` - (Optional) Is Skype channel messaging enabled?
 

--- a/website/docs/r/bot_channel_skype.markdown
+++ b/website/docs/r/bot_channel_skype.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "Bot"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_bot_channel_skype"
+description: |-
+  Manages a Skype integration for a Bot Channel
+---
+
+# azurerm_bot_channel_skype
+
+Manages a Skype integration for a Bot Channel
+
+~> **Note** A bot can only have a single Skype Channel associated with it.
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_bot_channels_registration" "example" {
+  name                = "example-bcr"
+  location            = "global"
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "F0"
+  microsoft_app_id    = data.azurerm_client_config.current.client_id
+}
+
+resource "azurerm_bot_channel_skype" "example" {
+  bot_name            = azurerm_bot_channels_registration.example.name
+  location            = azurerm_bot_channels_registration.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_group_name` - (Required) The name of the resource group where the Skype Channel should be created. Changing this forces a new resource to be created.
+
+* `location` - (Required) The supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `bot_name` - (Required) The name of the Bot Resource this channel will be associated with. Changing this forces a new resource to be created.
+
+* `calling_web_hook` - (Optional) The webhook for Skype channel calls.
+
+* `enable_calling` - (Optional) Is Skype channel calls enabled?
+
+* `enable_groups` - (Optional) Is Skype channel groups enabled?
+
+* `enable_media_cards` - (Optional) Is Skype channel media cards enabled?
+
+* `enable_messaging` - (Optional) Is Skype channel messaging enabled?
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Skype Integration for a Bot Channel.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Skype Integration for a Bot Channel.
+* `update` - (Defaults to 30 minutes) Used when updating the Skype Integration for a Bot Channel.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Skype Integration for a Bot Channel.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Skype Integration for a Bot Channel.
+
+## Import
+
+The Skype Integration for a Bot Channel can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_bot_channel_skype.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.BotService/botServices/botService1/channels/SkypeChannel
+```


### PR DESCRIPTION
Currently, TF doesn't support to CRUD bot skype channel. So I submitted this PR to support it.

--- PASS: TestAccBotChannelsRegistration/channel/skypeBasic (264.69s)
--- PASS: TestAccBotChannelsRegistration/channel/skypeComplete (245.64s)
--- PASS: TestAccBotChannelsRegistration/channel/skypeUpdate (518.29s)

API Reference:
https://github.com/Azure/azure-rest-api-specs/blob/10873ac628ee703126f82974487d8a290e983f8c/specification/botservice/resource-manager/Microsoft.BotService/stable/2021-03-01/botservice.json#L1583