### PR TITLE
azurerm_cognitive_account supports ignore_missing_vnet_service_endpoint

### DIFF
--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -86,7 +86,13 @@ A `network_acls` block supports the following:
 
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Cognitive Account.
 
-* `virtual_network_subnet_ids` - (Optional) One or more Subnet ID's which should be able to access this Cognitive Account.
+* `virtual_network_rules` - (Optional) A `virtual_network_rules` block as defined below.
+
+A `virtual_network_rules` block supports the following:
+
+* `subnet_id` - (Required) The ID of the subnet which should be able to access this Cognitive Account.
+
+* `ignore_missing_vnet_service_endpoint` - (Optional) Whether ignore missing vnet service endpoint or not. Default to `false`.
 
 ---
 


### PR DESCRIPTION
The tests are listed as the followings.
```

=== RUN   TestAccCognitiveAccount_basic
=== PAUSE TestAccCognitiveAccount_basic
=== CONT  TestAccCognitiveAccount_basic
--- PASS: TestAccCognitiveAccount_basic (180.97s)
=== RUN   TestAccCognitiveAccount_speechServices
=== PAUSE TestAccCognitiveAccount_speechServices
=== CONT  TestAccCognitiveAccount_speechServices
--- PASS: TestAccCognitiveAccount_speechServices (160.87s)
=== RUN   TestAccCognitiveAccount_speechServicesWithStorage
=== PAUSE TestAccCognitiveAccount_speechServicesWithStorage
=== CONT  TestAccCognitiveAccount_speechServicesWithStorage
--- PASS: TestAccCognitiveAccount_speechServicesWithStorage (220.35s)
=== RUN   TestAccCognitiveAccount_requiresImport
=== PAUSE TestAccCognitiveAccount_requiresImport
=== CONT  TestAccCognitiveAccount_requiresImport
--- PASS: TestAccCognitiveAccount_requiresImport (169.58s)
=== RUN   TestAccCognitiveAccount_complete
=== PAUSE TestAccCognitiveAccount_complete
=== CONT  TestAccCognitiveAccount_complete
--- PASS: TestAccCognitiveAccount_complete (200.67s)
=== RUN   TestAccCognitiveAccount_update
=== PAUSE TestAccCognitiveAccount_update
=== CONT  TestAccCognitiveAccount_update
--- PASS: TestAccCognitiveAccount_update (229.76s)
=== RUN   TestAccCognitiveAccount_qnaRuntimeEndpoint
=== PAUSE TestAccCognitiveAccount_qnaRuntimeEndpoint
=== CONT  TestAccCognitiveAccount_qnaRuntimeEndpoint
--- PASS: TestAccCognitiveAccount_qnaRuntimeEndpoint (245.51s)
=== RUN   TestAccCognitiveAccount_qnaRuntimeEndpointUnspecified
=== PAUSE TestAccCognitiveAccount_qnaRuntimeEndpointUnspecified
=== CONT  TestAccCognitiveAccount_qnaRuntimeEndpointUnspecified
--- PASS: TestAccCognitiveAccount_qnaRuntimeEndpointUnspecified (105.04s)
=== RUN   TestAccCognitiveAccount_cognitiveServices
=== PAUSE TestAccCognitiveAccount_cognitiveServices
=== CONT  TestAccCognitiveAccount_cognitiveServices
--- PASS: TestAccCognitiveAccount_cognitiveServices (153.07s)
=== RUN   TestAccCognitiveAccount_withMultipleCognitiveAccounts
=== PAUSE TestAccCognitiveAccount_withMultipleCognitiveAccounts
=== CONT  TestAccCognitiveAccount_withMultipleCognitiveAccounts
--- PASS: TestAccCognitiveAccount_withMultipleCognitiveAccounts (152.45s)
=== RUN   TestAccCognitiveAccount_networkAclsVirtualNetworkRules
=== PAUSE TestAccCognitiveAccount_networkAclsVirtualNetworkRules
=== CONT  TestAccCognitiveAccount_networkAclsVirtualNetworkRules
--- PASS: TestAccCognitiveAccount_networkAclsVirtualNetworkRules (289.90s)
=== RUN   TestAccCognitiveAccount_networkAcls
=== PAUSE TestAccCognitiveAccount_networkAcls
=== CONT  TestAccCognitiveAccount_networkAcls
--- PASS: TestAccCognitiveAccount_networkAcls (333.67s)
=== RUN   TestAccCognitiveAccount_identity
=== PAUSE TestAccCognitiveAccount_identity
=== CONT  TestAccCognitiveAccount_identity
--- PASS: TestAccCognitiveAccount_identity (436.54s)
=== RUN   TestAccCognitiveAccount_metricsAdvisor
=== PAUSE TestAccCognitiveAccount_metricsAdvisor
=== CONT  TestAccCognitiveAccount_metricsAdvisor
--- PASS: TestAccCognitiveAccount_metricsAdvisor (714.99s)

```