### PR TITLE
Don't force new resource when modifying additional subnet IDs of azurerm_api_management

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -192,7 +192,6 @@ func resourceApiManagementService() *pluginsdk.Resource {
 									"subnet_id": {
 										Type:         pluginsdk.TypeString,
 										Required:     true,
-										ForceNew:     true,
 										ValidateFunc: azure.ValidateResourceID,
 									},
 								},


### PR DESCRIPTION
Adding and removing subnet IDs (via the `additional_locations` block)
should not result in a new api management resource.
