### PR TITLE
Infrastructure Encryption Fix

### DIFF
--- a/azurerm/internal/services/databricks/databricks_workspace_resource.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource.go
@@ -187,9 +187,6 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 				}
 			}
 
-			// if customerEncryptionEnabled.(bool) && infrastructureEncryptionEnabled.(bool) {
-			// 	return fmt.Errorf("'customer_managed_key_enabled' and 'infrastructure_encryption_enabled' cannot both be set to 'true'")
-			// }
 			if (customerEncryptionEnabled.(bool) || infrastructureEncryptionEnabled.(bool)) && !strings.EqualFold("premium", newSku.(string)) {
 				return fmt.Errorf("'customer_managed_key_enabled' and 'infrastructure_encryption_enabled' are only available with a 'premium' workspace 'sku', got %q", newSku)
 			}

--- a/azurerm/internal/services/databricks/databricks_workspace_resource.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource.go
@@ -187,9 +187,9 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 				}
 			}
 
-			if customerEncryptionEnabled.(bool) && infrastructureEncryptionEnabled.(bool) {
-				return fmt.Errorf("'customer_managed_key_enabled' and 'infrastructure_encryption_enabled' cannot both be set to 'true'")
-			}
+			// if customerEncryptionEnabled.(bool) && infrastructureEncryptionEnabled.(bool) {
+			// 	return fmt.Errorf("'customer_managed_key_enabled' and 'infrastructure_encryption_enabled' cannot both be set to 'true'")
+			// }
 			if (customerEncryptionEnabled.(bool) || infrastructureEncryptionEnabled.(bool)) && !strings.EqualFold("premium", newSku.(string)) {
 				return fmt.Errorf("'customer_managed_key_enabled' and 'infrastructure_encryption_enabled' are only available with a 'premium' workspace 'sku', got %q", newSku)
 			}


### PR DESCRIPTION
Infrastructure Encryption *should* be permitted at the same time as Customer Managed Key Encryption, it's the equivalent of double encryption in a standard storage account. 
