### PR TITLE
`azurerm_key_vault_access_policy`: Extra nil check to prevent crash  (#12576)

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -177,7 +177,11 @@ func resourceKeyVaultAccessPolicyCreateOrDelete(d *pluginsdk.ResourceData, meta 
 		if resp.Properties == nil || resp.Properties.AccessPolicies == nil {
 			return fmt.Errorf("failed reading Access Policies for %q (resource group %q)", vaultName, id.ResourceGroup)
 		}
+
 		accessPolicyRaw := FindKeyVaultAccessPolicy(resp.Properties.AccessPolicies, objectId, applicationIdRaw)
+		if accessPolicyRaw == nil {
+			return fmt.Errorf("failed finding this specific Access Policy on Azure KeyVault %q (resource group %q)", vaultName, id.ResourceGroup)
+		}
 		accessPolicy = *accessPolicyRaw
 
 	default:


### PR DESCRIPTION
Fixes #12576

## Manually tested:
I'll reproduced it by:
- creating 1 policy (with config in #12576 )
- delete it in the configuration, terraform apply but leave confirmation until you've deleted the policy manually in the portal and enter yes for confirmation:

### Before
```bash
Plan: 0 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_key_vault_access_policy.example2: Destroying... [id=/subscriptions/<subs>/resourceGroups/example-resources/providers/Microsoft.KeyVault/vaults/examplekeyvault2191/objectId/a009252d-9bb1-418e-803b-939f87182168]
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain
│ more details.
╵

Stack trace from the terraform-provider-azurerm plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5856ed9]

goroutine 39 [running]:
github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault.resourceKeyVaultAccessPolicyCreateOrDelete(0xc0000c9680, 0x62169a0, 0xc00160dc00, 0x6a127fa, 0x6, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/azurerm/internal/services/keyvault/key_vault_access_policy_resource.go:181 +0x2019
github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault.resourceKeyVaultAccessPolicyDelete(0xc0000c9680, 0x62169a0, 0xc00160dc00, 0xc001be55c0, 0x6a13cf0)
        /Users/aris/git/terraform-provider-azurerm/azurerm/internal/services/keyvault/key_vault_access_policy_resource.go:273 +0x54
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).delete(0xc000ad2c40, 0x7169528, 0xc001acc180, 0xc0000c9680, 0x62169a0, 0xc00160dc00, 0x0, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:369 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000ad2c40, 0x7169528, 0xc001acc180, 0xc00045e3f0, 0xc0016ae4a0, 0x62169a0, 0xc00160dc00, 0x0, 0x0, 0x0, ...)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:428 +0x8f7
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000131890, 0x7169528, 0xc001acc180, 0xc001608500, 0xc001acc180, 0x66e01a0, 0xc001be4500)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:955 +0x8ef
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ApplyResourceChange(0xc001ada3c0, 0x71695d0, 0xc001acc180, 0xc00045e070, 0xc001ada3c0, 0xc001be45a0, 0xc001677ba0)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/server/server.go:332 +0xb5
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x66e01a0, 0xc001ada3c0, 0x71695d0, 0xc001be45a0, 0xc001ad0060, 0x0, 0x71695d0, 0xc001be45a0, 0xc001ad2600, 0x2ee)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:380 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000230a80, 0x71b2ef8, 0xc00029c600, 0xc000fc0900, 0xc001201b30, 0xa651ea0, 0x0, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:1292 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000230a80, 0x71b2ef8, 0xc00029c600, 0xc000fc0900, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:1617 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc00041d630, 0xc000230a80, 0x71b2ef8, 0xc00029c600, 0xc000fc0900)
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:940 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:938 +0x1fd

Error: The terraform-provider-azurerm plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

### After
```bash
Plan: 0 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_key_vault_access_policy.example2: Destroying... [id=/subscriptions/<subs>/resourceGroups/example-resources/providers/Microsoft.KeyVault/vaults/examplekeyvault2191/objectId/a009252d-9bb1-418e-803b-939f87182168]
╷
│ Error: failed finding this specific Access Policy on Azure KeyVault "examplekeyvault2191" (resource group "example-resources")
│ 
│ 
```