### PR TITLE
"azurerm_data_factory_integration_runtime_azure" - supports property "virtual_network_enabled"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_resource_test.go
@@ -82,6 +82,21 @@ func TestAccDataFactoryIntegrationRuntimeAzure_timeToLive(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryIntegrationRuntimeAzure_virtualNetwork(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_integration_runtime_azure", "test")
+	r := IntegrationRuntimeAzureResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.virtualNetwork(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (IntegrationRuntimeAzureResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -185,6 +200,34 @@ resource "azurerm_data_factory_integration_runtime_azure" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   time_to_live_min    = 10
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (IntegrationRuntimeAzureResource) virtualNetwork(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                            = "acctestdf%d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
+  managed_virtual_network_enabled = true
+}
+
+resource "azurerm_data_factory_integration_runtime_azure" "test" {
+  name                    = "azure-integration-runtime"
+  data_factory_name       = azurerm_data_factory.test.name
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  virtual_network_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/data_factory_integration_runtime_azure.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_azure.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `time_to_live_min` - (Optional) Time to live (in minutes) setting of the cluster which will execute data flow job. Defaults to `0`.
 
+* `virtual_network_enabled` - (Optional) Is Integration Runtime compute provisioned within Managed Virtual Network? Changing this forces a new resource to be created.
+
 ---
 
 ## Import


### PR DESCRIPTION
supports creating a azure hosted integration runtime integrated with vnet.

![image](https://user-images.githubusercontent.com/2786738/125916833-c77e9a4c-573f-4318-bd9b-ff26ffe853fc.png)
