### PR TITLE
policy: fix typo in example usage

### DIFF
--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -41,7 +41,7 @@ POLICY_RULE
 resource "azurerm_resource_group_policy_assignment" "example" {
   name                 = "example"
   resource_group_id    = azurerm_resource_group.example.id
-  policy_definition_id = azurerm_policy_assignment.example.id
+  policy_definition_id = azurerm_policy_definition.example.id
 }
 ```
 


### PR DESCRIPTION
The example code in the docs is using the wrong resource name.

- Closes #12527 