### PR TITLE
`azurerm_data_factory_trigger_blob_event`: Support for activation

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource.go
@@ -170,7 +170,6 @@ func resourceDataFactoryTriggerBlobEventCreateUpdate(d *pluginsdk.ResourceData, 
 		if err != nil {
 			return fmt.Errorf("stopping %s: %+v", id, err)
 		}
-
 		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting to stop %s: %+v", id, err)
 		}
@@ -217,7 +216,6 @@ func resourceDataFactoryTriggerBlobEventCreateUpdate(d *pluginsdk.ResourceData, 
 		if err != nil {
 			return fmt.Errorf("starting %s: %+v", id, err)
 		}
-
 		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting on start %s: %+v", id, err)
 		}
@@ -296,7 +294,6 @@ func resourceDataFactoryTriggerBlobEventDelete(d *pluginsdk.ResourceData, meta i
 	if err != nil {
 		return fmt.Errorf("stopping %s: %+v", id, err)
 	}
-
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting to stop %s: %+v", id, err)
 	}

--- a/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource.go
@@ -256,6 +256,7 @@ func resourceDataFactoryTriggerBlobEventRead(d *pluginsdk.ResourceData, meta int
 	d.Set("name", id.Name)
 	d.Set("data_factory_id", parse.NewDataFactoryID(subscriptionId, id.ResourceGroup, id.FactoryName).ID())
 
+	d.Set("activated", blobEventsTrigger.RuntimeState == datafactory.TriggerRuntimeStateStarted)
 	d.Set("additional_properties", blobEventsTrigger.AdditionalProperties)
 	d.Set("description", blobEventsTrigger.Description)
 
@@ -266,7 +267,6 @@ func resourceDataFactoryTriggerBlobEventRead(d *pluginsdk.ResourceData, meta int
 	if err := d.Set("pipeline", flattenDataFactoryTriggerPipeline(blobEventsTrigger.Pipelines)); err != nil {
 		return fmt.Errorf("setting `pipeline`: %+v", err)
 	}
-	d.Set("activated", blobEventsTrigger.RuntimeState == datafactory.TriggerRuntimeStateStarted)
 
 	if props := blobEventsTrigger.BlobEventsTriggerTypeProperties; props != nil {
 		d.Set("storage_account_id", props.Scope)

--- a/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource.go
@@ -95,6 +95,7 @@ func resourceDataFactoryTriggerBlobEvent() *pluginsdk.Resource {
 			"activated": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 
 			"additional_properties": {

--- a/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_trigger_blob_event_resource_test.go
@@ -111,6 +111,14 @@ func TestAccDataFactoryTriggerBlobEvent_startStop(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.activated(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("activated").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 

--- a/website/docs/r/data_factory_trigger_blob_event.html.markdown
+++ b/website/docs/r/data_factory_trigger_blob_event.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `pipeline` - (Required) One or more `pipeline` blocks as defined below.
 
-* `activated` - (Optional) Specifies if the Data Factory Blob Event Trigger is activated.
+* `activated` - (Optional) Specifies if the Data Factory Blob Event Trigger is activated. Defaults to `true`.
 
 * `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Blob Event Trigger.
 

--- a/website/docs/r/data_factory_trigger_blob_event.html.markdown
+++ b/website/docs/r/data_factory_trigger_blob_event.html.markdown
@@ -45,6 +45,7 @@ resource "azurerm_data_factory_trigger_blob_event" "example" {
   events              = ["Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted"]
   blob_path_ends_with = ".txt"
   ignore_empty_blobs  = true
+  activated           = true
 
   annotations = ["test1", "test2", "test3"]
   description = "example description"
@@ -76,6 +77,8 @@ The following arguments are supported:
 * `events` - (Required) List of events that will fire this trigger. Possible values are `Microsoft.Storage.BlobCreated` and `Microsoft.Storage.BlobDeleted`.
 
 * `pipeline` - (Required) One or more `pipeline` blocks as defined below.
+
+* `activated` - (Optional) Specifies if the Data Factory Blob Event Trigger is activated.
 
 * `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Blob Event Trigger.
 


### PR DESCRIPTION
Fixes #12621

## Acceptance Tests
```
❯ make acctests SERVICE='datafactory' TESTARGS='-run=TestAccDataFactoryTriggerBlobEvent'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/datafactory -run=TestAccDataFactoryTriggerBlobEvent -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataFactoryTriggerBlobEvent_basic
=== PAUSE TestAccDataFactoryTriggerBlobEvent_basic
=== RUN   TestAccDataFactoryTriggerBlobEvent_requiresImport
=== PAUSE TestAccDataFactoryTriggerBlobEvent_requiresImport
=== RUN   TestAccDataFactoryTriggerBlobEvent_complete
=== PAUSE TestAccDataFactoryTriggerBlobEvent_complete
=== RUN   TestAccDataFactoryTriggerBlobEvent_update
=== PAUSE TestAccDataFactoryTriggerBlobEvent_update
=== RUN   TestAccDataFactoryTriggerBlobEvent_startStop
=== PAUSE TestAccDataFactoryTriggerBlobEvent_startStop
=== CONT  TestAccDataFactoryTriggerBlobEvent_basic
=== CONT  TestAccDataFactoryTriggerBlobEvent_update
=== CONT  TestAccDataFactoryTriggerBlobEvent_startStop
=== CONT  TestAccDataFactoryTriggerBlobEvent_complete
=== CONT  TestAccDataFactoryTriggerBlobEvent_requiresImport
--- PASS: TestAccDataFactoryTriggerBlobEvent_basic (173.05s)
--- PASS: TestAccDataFactoryTriggerBlobEvent_complete (182.11s)
--- PASS: TestAccDataFactoryTriggerBlobEvent_requiresImport (188.63s)
--- PASS: TestAccDataFactoryTriggerBlobEvent_startStop (264.47s)
--- PASS: TestAccDataFactoryTriggerBlobEvent_update (324.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datafactory 325.861s
```