### PR TITLE
Return an error when ssl policy is not properly configured

### DIFF
--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -3895,6 +3895,16 @@ func applicationGatewayCustomizeDiff(ctx context.Context, d *pluginsdk.ResourceD
 		return fmt.Errorf("The Application Gateway must specify either `capacity` or `autoscale_configuration` for the selected SKU tier %q", tier)
 	}
 
+	sslPolicy := d.Get("ssl_policy").([]interface{})
+	if len(sslPolicy) > 0 && sslPolicy[0] != nil {
+		v := sslPolicy[0].(map[string]interface{})
+		disabledProtocols := v["disabled_protocols"].([]interface{})
+		policyType := v["policy_type"].(string)
+		if len(disabledProtocols) > 0 && policyType != "" {
+			return fmt.Errorf("setting disabled_protocols is not allowed when policy_type is defined")
+		}
+	}
+
 	if hasCapacity {
 		if (strings.EqualFold(tier, string(network.ApplicationGatewayTierStandard)) || strings.EqualFold(tier, string(network.ApplicationGatewayTierWAF))) && (capacity.(int) < 1 || capacity.(int) > 32) {
 			return fmt.Errorf("The value '%d' exceeds the maximum capacity allowed for a %q V1 SKU, the %q SKU must have a capacity value between 1 and 32", capacity, tier, tier)

--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -2173,7 +2173,7 @@ func flattenApplicationGatewayConnectionDraining(input *network.ApplicationGatew
 
 func expandApplicationGatewaySslPolicy(d *pluginsdk.ResourceData) *network.ApplicationGatewaySslPolicy {
 	policy := network.ApplicationGatewaySslPolicy{}
-	disabledSSLPolicies := make([]network.ApplicationGatewaySslProtocol, 0)
+	disabledSSLProtocols := make([]network.ApplicationGatewaySslProtocol, 0)
 
 	vs := d.Get("ssl_policy").([]interface{})
 
@@ -2182,7 +2182,7 @@ func expandApplicationGatewaySslPolicy(d *pluginsdk.ResourceData) *network.Appli
 		policyType := network.ApplicationGatewaySslPolicyType(v["policy_type"].(string))
 
 		for _, policy := range v["disabled_protocols"].([]interface{}) {
-			disabledSSLPolicies = append(disabledSSLPolicies, network.ApplicationGatewaySslProtocol(policy.(string)))
+			disabledSSLProtocols = append(disabledSSLProtocols, network.ApplicationGatewaySslProtocol(policy.(string)))
 		}
 
 		if policyType == network.ApplicationGatewaySslPolicyTypePredefined {
@@ -2207,9 +2207,9 @@ func expandApplicationGatewaySslPolicy(d *pluginsdk.ResourceData) *network.Appli
 		}
 	}
 
-	if len(disabledSSLPolicies) > 0 {
+	if len(disabledSSLProtocols) > 0 {
 		policy = network.ApplicationGatewaySslPolicy{
-			DisabledSslProtocols: &disabledSSLPolicies,
+			DisabledSslProtocols: &disabledSSLProtocols,
 		}
 	}
 


### PR DESCRIPTION
Azure does not allow setting disabled protocols when using a custom or a
predefined policy type. Up until now when a user supplied both the
provider silently ignored the policy type changed and kept only the
disabled protocols configuration.

This change throws an error durring the planning phase instead and asks
the user to fix their configuration.
