### PR TITLE
`azurerm_kubernetes_cluster`: Support for downgrade `sku_tier`

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -344,6 +344,13 @@ func testAccKubernetesCluster_upgradeSkuTier(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.freeSkuConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -1156,9 +1163,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func (KubernetesClusterResource) paidSkuConfig(data acceptance.TestData) string {
-	// @tombuildsstuff (2020-05-29) - this is only supported in a handful of regions
-	// 								  whilst in Preview - hard-coding for now
-	location := "westus2" // TODO: data.Locations.Primary
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1186,13 +1190,10 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, location, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) freeSkuConfig(data acceptance.TestData) string {
-	// @tombuildsstuff (2020-05-29) - this is only supported in a handful of regions
-	// 								  whilst in Preview - hard-coding for now
-	location := "westus2" // TODO: data.Locations.Primary
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1208,6 +1209,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%d"
+  sku_tier            = "Free"
 
   default_node_pool {
     name       = "default"
@@ -1219,7 +1221,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, location, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (KubernetesClusterResource) tagsConfig(data acceptance.TestData) string {

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1209,7 +1209,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%d"
-  sku_tier            = "Free"
 
   default_node_pool {
     name       = "default"

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -41,10 +41,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 		}),
 
 		CustomizeDiff: pluginsdk.CustomDiffInSequence(
-			// Downgrade from Paid to Free is not supported and requires rebuild to apply
-			pluginsdk.ForceNewIfChange("sku_tier", func(ctx context.Context, old, new, meta interface{}) bool {
-				return new == "Free"
-			}),
 			// Migration of `identity` to `service_principal` is not allowed, the other way around is
 			pluginsdk.ForceNewIfChange("service_principal.0.client_id", func(ctx context.Context, old, new, meta interface{}) bool {
 				return old == "msi" || old == ""
@@ -657,12 +653,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			"sku_tier": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				// @tombuildsstuff (2020-05-29) - Preview limitations:
-				//  * Currently, there is no way to remove Uptime SLA from an AKS cluster after creation with it enabled.
-				//  * Private clusters aren't currently supported.
-				// @jackofallops (2020-07-21) - Update:
-				//  * sku_tier can now be upgraded in place, downgrade requires rebuild
-				Default: string(containerservice.ManagedClusterSKUTierFree),
+				Default:  string(containerservice.ManagedClusterSKUTierFree),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(containerservice.ManagedClusterSKUTierFree),
 					string(containerservice.ManagedClusterSKUTierPaid),

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -166,8 +166,6 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 * `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free` and `Paid` (which includes the Uptime SLA). Defaults to `Free`.
 
-~> **Note:**  It is currently possible to upgrade in place from `Free` to `Paid`. However, changing this value from `Paid` to `Free` will force a new resource to be created.
-
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `windows_profile` - (Optional) A `windows_profile` block as defined below.


### PR DESCRIPTION
Fixes #12643

## Acceptance tests
```bash
❯ make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_upgradeSkuTier'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/containers -run=TestAccKubernetesCluster_upgradeSkuTier -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesCluster_upgradeSkuTier
=== PAUSE TestAccKubernetesCluster_upgradeSkuTier
=== CONT  TestAccKubernetesCluster_upgradeSkuTier
--- PASS: TestAccKubernetesCluster_upgradeSkuTier (992.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers  993.548s
```