### PR TITLE
new resource "azurerm_key_vault_network_acl_rule"

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_network_acl_rule_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_network_acl_rule_resource.go
@@ -1,0 +1,394 @@
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/keyvault/mgmt/2020-04-01-preview/keyvault"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	commonValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
+	networkParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
+	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceKeyVaultNetworkAclRule() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceKeyVaultNetworkAclRuleCreate,
+		Read:   resourceKeyVaultNetworkAclRuleRead,
+		Update: nil,
+		Delete: resourceKeyVaultNetworkAclDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.NetworkAclRuleID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: func() map[string]*pluginsdk.Schema {
+			rSchema := map[string]*pluginsdk.Schema{
+				"key_vault_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ForceNew:     true,
+					ValidateFunc: validate.VaultID,
+				},
+				"source": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ForceNew: true,
+					ValidateFunc: validation.Any(
+						commonValidate.IPv4Address,
+						commonValidate.CIDR,
+						networkValidate.SubnetID,
+					),
+				},
+			}
+
+			return rSchema
+		}(),
+	}
+}
+
+func resourceKeyVaultNetworkAclRuleCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).KeyVault.VaultsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+	log.Print("[INFO] Preparing arguments for Key Vault Network ACL Rule creation.")
+
+	key_vault_id := d.Get("key_vault_id").(string)
+	source := d.Get("source").(string)
+
+	id, err := parse.NewNetworkAclRuleId(key_vault_id, source)
+	if err != nil {
+		return err
+	}
+
+	// Locking to prevent parallel changes causing issues
+	locks.ByName(id.VaultId.Name, keyVaultResourceName)
+	defer locks.UnlockByName(id.VaultId.Name, keyVaultResourceName)
+
+	vault, err := client.Get(ctx, id.VaultId.ResourceGroup, id.VaultId.Name)
+	if err != nil {
+		// If the key vault does not exist but this is not a new resource, the rule
+		// which previously existed was deleted with the key vault, so reflect that in
+		// state. If this is a new resource and key vault does not exist, it's likely
+		// a bad ID was given.
+		if utils.ResponseWasNotFound(vault.Response) && !d.IsNewResource() {
+			log.Printf("[DEBUG] Parent %q was not found - removing from state!", id.VaultId)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id.VaultId, err)
+	}
+
+	vaultProperties := vault.Properties
+	if vaultProperties == nil {
+		return fmt.Errorf("parsing Key Vault: `properties` was nil")
+	}
+	if vaultProperties.NetworkAcls == nil {
+		return fmt.Errorf("parsing Key Vault: `properties.networkAcls` was nil")
+	}
+
+	networkRuleSet := keyvault.NetworkRuleSet{
+		Bypass:        vault.Properties.NetworkAcls.Bypass,
+		DefaultAction: vault.Properties.NetworkAcls.DefaultAction,
+	}
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{"notfound"},
+		Target:                    []string{"found"},
+		Delay:                     30 * time.Second,
+		PollInterval:              10 * time.Second,
+		ContinuousTargetOccurence: 10,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+	}
+
+	sourceRule := id.Rule()
+
+	switch id.Type {
+	case parse.CIDR, parse.Ip:
+		if FindKeyVaultNetworkAclIpRule(*vaultProperties.NetworkAcls.IPRules, sourceRule) != nil {
+			return tf.ImportAsExistsError("azurerm_key_vault_network_acl_rule", id.ID())
+		}
+
+		stateConf.Refresh = networkAclIpRuleRefreshFunc(ctx, client, id.VaultId.ResourceGroup, id.VaultId.Name, sourceRule)
+
+		ipRules := append(*vault.Properties.NetworkAcls.IPRules, keyvault.IPRule{Value: &source})
+		networkRuleSet.IPRules = &ipRules
+	case parse.VirtualNetwork:
+		subnetId, err := networkParse.SubnetIDInsensitively(id.Source)
+		if err != nil {
+			return err
+		}
+
+		if FindKeyVaultNetworkAclVirtualNetworkRule(*vaultProperties.NetworkAcls.VirtualNetworkRules, sourceRule) != nil {
+			return tf.ImportAsExistsError("azurerm_key_vault_network_acl_rule", id.ID())
+		}
+
+		stateConf.Refresh = networkAclVirtualNetworkRuleRefreshFunc(ctx, client, id.VaultId.ResourceGroup, id.VaultId.Name, sourceRule)
+
+		virtualNetworkRules := append(*vault.Properties.NetworkAcls.VirtualNetworkRules, keyvault.VirtualNetworkRule{ID: &source})
+		networkRuleSet.VirtualNetworkRules = &virtualNetworkRules
+
+		// also lock on the Virtual Network ID's since modifications in the networking stack are exclusive
+		virtualNetworkNames := []string{subnetId.VirtualNetworkName}
+		locks.MultipleByName(&virtualNetworkNames, network.VirtualNetworkResourceName)
+		defer locks.UnlockMultipleByName(&virtualNetworkNames, network.VirtualNetworkResourceName)
+	default:
+		return fmt.Errorf("unexpected network ACL type %s", id.Type)
+	}
+
+	parameters := keyvault.VaultPatchParameters{
+		Tags: vault.Tags,
+		Properties: &keyvault.VaultPatchProperties{
+			NetworkAcls: &networkRuleSet,
+		},
+	}
+	if _, err = client.Update(ctx, id.VaultId.ResourceGroup, id.VaultId.Name, parameters); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for %q to become available", id)
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for scaling of %q: %+v", id, err)
+	}
+	d.SetId(id.ID())
+
+	return resourceKeyVaultNetworkAclRuleRead(d, meta)
+}
+
+func resourceKeyVaultNetworkAclRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).KeyVault.VaultsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.NetworkAclRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	vault, err := client.Get(ctx, id.VaultId.ResourceGroup, id.VaultId.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(vault.Response) {
+			log.Printf("[DEBUG] Parent %q was not found - removing from state!", id.VaultId)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", id.VaultId, err)
+	}
+
+	vaultProperties := vault.Properties
+	if vaultProperties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
+	}
+	if vaultProperties.NetworkAcls == nil {
+		return fmt.Errorf("retrieving %s: `properties.networkAcls` was nil", *id)
+	}
+
+	meta.(*clients.Client).KeyVault.AddToCache(id.VaultId, *vault.Properties.VaultURI)
+
+	sourceRule := id.Rule()
+
+	switch id.Type {
+	case parse.CIDR, parse.Ip:
+		if FindKeyVaultNetworkAclIpRule(*vaultProperties.NetworkAcls.IPRules, sourceRule) == nil {
+			existingIpRules := make([]string, len(*vaultProperties.NetworkAcls.IPRules))
+			for idx, ipRule := range *vaultProperties.NetworkAcls.IPRules {
+				existingIpRules[idx] = *ipRule.Value
+			}
+			return fmt.Errorf("couldn't find ip rule %s in %v", id.Source, existingIpRules)
+		}
+	case parse.VirtualNetwork:
+		if FindKeyVaultNetworkAclVirtualNetworkRule(*vaultProperties.NetworkAcls.VirtualNetworkRules, sourceRule) == nil {
+			existingVirtualNetworkRules := make([]string, len(*vaultProperties.NetworkAcls.VirtualNetworkRules))
+			for idx, virtualNetworkRule := range *vaultProperties.NetworkAcls.VirtualNetworkRules {
+				existingVirtualNetworkRules[idx] = *virtualNetworkRule.ID
+			}
+			return fmt.Errorf("couldn't find virtual network subnet rule %s in %v", id.Source, existingVirtualNetworkRules)
+		}
+	default:
+		return fmt.Errorf("unexpected network ACL type %s", id.Type)
+	}
+
+	d.Set("key_vault_id", id.VaultId.ID())
+	d.Set("source", id.Source)
+
+	return nil
+}
+
+func resourceKeyVaultNetworkAclDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).KeyVault.VaultsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+	log.Print("[INFO] Preparing arguments for Key Vault Network ACL Rule creation.")
+
+	id, err := parse.NetworkAclRuleID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	// Locking to prevent parallel changes causing issues
+	locks.ByName(id.VaultId.Name, keyVaultResourceName)
+	defer locks.UnlockByName(id.VaultId.Name, keyVaultResourceName)
+
+	vault, err := client.Get(ctx, id.VaultId.ResourceGroup, id.VaultId.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(vault.Response) && !d.IsNewResource() {
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %q: %+v", id.VaultId, err)
+	}
+
+	vaultProperties := vault.Properties
+	if vaultProperties == nil {
+		return fmt.Errorf("parsing Key Vault: `properties` was nil")
+	}
+	if vaultProperties.NetworkAcls == nil {
+		return fmt.Errorf("parsing Key Vault: `properties.NetworkAcls` was nil")
+	}
+
+	networkRuleSet := keyvault.NetworkRuleSet{
+		Bypass:        vaultProperties.NetworkAcls.Bypass,
+		DefaultAction: vaultProperties.NetworkAcls.DefaultAction,
+	}
+	stateConf := pluginsdk.StateChangeConf{
+		Pending:                   []string{"found"},
+		Target:                    []string{"notfound"},
+		Delay:                     30 * time.Second,
+		PollInterval:              10 * time.Second,
+		ContinuousTargetOccurence: 10,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+	}
+
+	sourceRule := id.Rule()
+
+	switch id.Type {
+	case parse.CIDR, parse.Ip:
+		idx := FindKeyVaultNetworkAclIpRule(*vaultProperties.NetworkAcls.IPRules, sourceRule)
+		if idx == nil {
+			return nil
+		}
+
+		stateConf.Refresh = networkAclIpRuleRefreshFunc(ctx, client, id.VaultId.ResourceGroup, id.VaultId.Name, sourceRule)
+
+		ipRules := append((*vault.Properties.NetworkAcls.IPRules)[:*idx], (*vault.Properties.NetworkAcls.IPRules)[*idx+1:]...)
+		networkRuleSet.IPRules = &ipRules
+	case parse.VirtualNetwork:
+		subnetId, err := networkParse.SubnetIDInsensitively(id.Source)
+		if err != nil {
+			return err
+		}
+
+		idx := FindKeyVaultNetworkAclVirtualNetworkRule(*vaultProperties.NetworkAcls.VirtualNetworkRules, sourceRule)
+		if idx == nil {
+			return nil
+		}
+
+		stateConf.Refresh = networkAclVirtualNetworkRuleRefreshFunc(ctx, client, id.VaultId.ResourceGroup, id.VaultId.Name, sourceRule)
+
+		virtualNetworkRules := append((*vault.Properties.NetworkAcls.VirtualNetworkRules)[:*idx], (*vault.Properties.NetworkAcls.VirtualNetworkRules)[*idx+1:]...)
+		networkRuleSet.VirtualNetworkRules = &virtualNetworkRules
+
+		// also lock on the Virtual Network ID's since modifications in the networking stack are exclusive
+		virtualNetworkNames := []string{subnetId.VirtualNetworkName}
+		locks.MultipleByName(&virtualNetworkNames, network.VirtualNetworkResourceName)
+		defer locks.UnlockMultipleByName(&virtualNetworkNames, network.VirtualNetworkResourceName)
+	default:
+		return fmt.Errorf("unexpected network ACL type %s", id.Type)
+	}
+
+	parameters := keyvault.VaultPatchParameters{
+		Tags: vault.Tags,
+		Properties: &keyvault.VaultPatchProperties{
+			NetworkAcls: &networkRuleSet,
+		},
+	}
+	if _, err = client.Update(ctx, id.VaultId.ResourceGroup, id.VaultId.Name, parameters); err != nil {
+		return fmt.Errorf("deleting %q: %+v", id, err)
+	}
+
+	log.Printf("[DEBUG] Waiting for %q to become available", id)
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for scaling of %q: %+v", id, err)
+	}
+	d.SetId(id.ID())
+
+	return nil
+}
+
+func FindKeyVaultNetworkAclIpRule(rules []keyvault.IPRule, policyValue string) *int {
+	for idx, ipRule := range rules {
+		if ipRule.Value == nil {
+			continue
+		}
+		if policyValue == *ipRule.Value {
+			return &idx
+		}
+	}
+	return nil
+}
+
+func FindKeyVaultNetworkAclVirtualNetworkRule(rules []keyvault.VirtualNetworkRule, policyId string) *int {
+	for idx, virtualNetworkRule := range rules {
+		if virtualNetworkRule.ID == nil {
+			continue
+		}
+		if strings.EqualFold(policyId, *virtualNetworkRule.ID) {
+			return &idx
+		}
+	}
+	return nil
+}
+
+func networkAclIpRuleRefreshFunc(ctx context.Context, client *keyvault.VaultsClient, resourceGroup string, vaultName string, source string) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Checking for completion of Network ACL IP Rule create/update")
+
+		read, err := client.Get(ctx, resourceGroup, vaultName)
+		if err != nil && utils.ResponseWasNotFound(read.Response) {
+			return "vaultnotfound", "vaultnotfound", fmt.Errorf("failed to find vault %q (resource group %q)", vaultName, resourceGroup)
+		}
+
+		if read.Properties != nil && read.Properties.NetworkAcls != nil && read.Properties.NetworkAcls.IPRules != nil && FindKeyVaultNetworkAclIpRule(*read.Properties.NetworkAcls.IPRules, source) != nil {
+			return "found", "found", nil
+		}
+
+		return "notfound", "notfound", nil
+	}
+}
+
+func networkAclVirtualNetworkRuleRefreshFunc(ctx context.Context, client *keyvault.VaultsClient, resourceGroup string, vaultName string, source string) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Checking for completion of Network ACL IP Rule create/update")
+
+		read, err := client.Get(ctx, resourceGroup, vaultName)
+		if err != nil && utils.ResponseWasNotFound(read.Response) {
+			return "vaultnotfound", "vaultnotfound", fmt.Errorf("failed to find vault %q (resource group %q)", vaultName, resourceGroup)
+		}
+
+		if read.Properties != nil && read.Properties.NetworkAcls != nil && read.Properties.NetworkAcls.IPRules != nil && FindKeyVaultNetworkAclVirtualNetworkRule(*read.Properties.NetworkAcls.VirtualNetworkRules, source) != nil {
+			return "found", "found", nil
+		}
+
+		return "notfound", "notfound", nil
+	}
+}

--- a/azurerm/internal/services/keyvault/key_vault_network_acl_rule_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_network_acl_rule_resource_test.go
@@ -1,0 +1,374 @@
+package keyvault_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+type KeyVaultNetworkAclRuleResource struct {
+}
+
+func TestAccKeyVaultNetworkAclRule_ip(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ip(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check:             check.That(data.ResourceName).Key("network_acls.0.ip_rules.0").HasValue("1.2.3.4"),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_requiresImportIp(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ip(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			Config:      r.requiresImportIp(data),
+			ExpectError: acceptance.RequiresImportError("azurerm_key_vault_network_acl_rule"),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_cidr(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cidr(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check:             check.That(data.ResourceName).Key("network_acls.0.ip_rules.1").HasValue("20.42.5.0/24"),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_requiresImportCidr(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cidr(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			Config:      r.requiresImportCidr(data),
+			ExpectError: acceptance.RequiresImportError("azurerm_key_vault_network_acl_rule"),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_subnet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subnet(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check:             check.That(data.ResourceName).Key("network_acls.0.virtual_network_subnet_ids.%").HasValue("1"),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_requiresImportSubnet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subnet(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			Config:      r.requiresImportSubnet(data),
+			ExpectError: acceptance.RequiresImportError("azurerm_key_vault_network_acl_rule"),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_acls.0.ip_rules.0").HasValue("1.2.3.4"),
+				check.That(data.ResourceName).Key("network_acls.0.ip_rules.1").HasValue("20.42.5.0/24"),
+				check.That(data.ResourceName).Key("network_acls.0.virtual_network_subnet_ids.%").HasValue("2"),
+			),
+		},
+	})
+}
+
+func TestAccKeyVaultNetworkAclRule_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault", "test")
+	r := KeyVaultNetworkAclRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			Config: r.update(data),
+			Check:  check.That(data.ResourceName).ExistsInAzure(r),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_acls.0.ip_rules.0").HasValue("2.3.4.5"),
+				check.That(data.ResourceName).Key("network_acls.0.ip_rules.1").HasValue("40.82.252.0/24"),
+				check.That(data.ResourceName).Key("network_acls.0.virtual_network_subnet_ids.%").HasValue("1"),
+			),
+		},
+	})
+}
+
+func (KeyVaultNetworkAclRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VaultID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.KeyVault.VaultsClient.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("reading Key Vault (%s): %+v", id, err)
+	}
+
+	return utils.Bool(resp.ID != nil), nil
+}
+
+func (KeyVaultNetworkAclRuleResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.VaultID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := client.KeyVault.VaultsClient.Delete(ctx, id.ResourceGroup, id.Name); err != nil {
+		return nil, fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r KeyVaultNetworkAclRuleResource) vaultTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r KeyVaultNetworkAclRuleResource) basic(data acceptance.TestData) string {
+	template := r.vaultTemplate(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault" "test" {
+  name                       = "vault%[2]d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  network_acls {
+    default_action = "Deny"
+    bypass         = "None"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r KeyVaultNetworkAclRuleResource) ip(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "test_ip" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = "1.2.3.4"
+}
+`, template, data.RandomInteger)
+}
+
+func (r KeyVaultNetworkAclRuleResource) requiresImportIp(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "import" {
+  key_vault_id = azurerm_key_vault_network_acl_rule.test_ip.key_vault_id
+  source       = azurerm_key_vault_network_acl_rule.test_ip.source
+}
+`, r.ip(data))
+}
+
+func (r KeyVaultNetworkAclRuleResource) cidr(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "test_cidr" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = "20.42.5.0/24"
+}
+`, template, data.RandomInteger)
+}
+
+func (r KeyVaultNetworkAclRuleResource) requiresImportCidr(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "import" {
+  key_vault_id = azurerm_key_vault_network_acl_rule.test_cidr.key_vault_id
+  source       = azurerm_key_vault_network_acl_rule.test_cidr.source
+}
+`, r.cidr(data))
+}
+
+func (r KeyVaultNetworkAclRuleResource) networkTemplate(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[2]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test_a" {
+  name                 = "acctestsubneta%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+  service_endpoints    = ["Microsoft.KeyVault"]
+}
+
+resource "azurerm_subnet" "test_b" {
+  name                 = "acctestsubnetb%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.4.0/24"
+  service_endpoints    = ["Microsoft.KeyVault"]
+}
+`, template, data.RandomInteger)
+}
+
+func (r KeyVaultNetworkAclRuleResource) subnet(data acceptance.TestData) string {
+	template := r.networkTemplate(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "test_subnet" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = azurerm_subnet.test_a.id
+}
+`, template)
+}
+
+func (r KeyVaultNetworkAclRuleResource) requiresImportSubnet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "import" {
+  key_vault_id = azurerm_key_vault_network_acl_rule.test_subnet.key_vault_id
+  source       = azurerm_key_vault_network_acl_rule.test_subnet.source
+}
+`, r.subnet(data))
+}
+
+func (r KeyVaultNetworkAclRuleResource) complete(data acceptance.TestData) string {
+	template := r.subnet(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "test_subnet_b" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = azurerm_subnet.test_b.id
+}
+
+resource "azurerm_key_vault_network_acl_rule" "test_ip" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = "1.2.3.4"
+}
+
+resource "azurerm_key_vault_network_acl_rule" "test_cidr" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = "20.42.5.0/24"
+}
+`, template)
+}
+
+func (r KeyVaultNetworkAclRuleResource) update(data acceptance.TestData) string {
+	template := r.networkTemplate(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault_network_acl_rule" "test_subnet" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = azurerm_subnet.test_b.id
+}
+
+resource "azurerm_key_vault_network_acl_rule" "test_ip" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = "2.3.4.5"
+}
+
+resource "azurerm_key_vault_network_acl_rule" "test_cidr" {
+  key_vault_id = azurerm_key_vault.test.id
+  source       = "40.82.252.0/24"
+}
+`, template)
+}

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -167,6 +167,7 @@ func resourceKeyVault() *pluginsdk.Resource {
 							"ip_rules": {
 								Type:     pluginsdk.TypeSet,
 								Optional: true,
+								Computed: true,
 								Elem: &pluginsdk.Schema{
 									Type: pluginsdk.TypeString,
 									ValidateFunc: validation.Any(
@@ -179,6 +180,7 @@ func resourceKeyVault() *pluginsdk.Resource {
 							"virtual_network_subnet_ids": {
 								Type:     pluginsdk.TypeSet,
 								Optional: true,
+								Computed: true,
 								Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
 								Set:      set.HashStringIgnoreCase,
 							},
@@ -253,7 +255,7 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	location := azure.NormalizeLocation(d.Get("location").(string))
 
 	// Locking this resource so we don't make modifications to it at the same time if there is a
-	// key vault access policy trying to update it as well
+	// key vault access policy or key vault network acl rule trying to update it as well
 	locks.ByName(id.Name, keyVaultResourceName)
 	defer locks.UnlockByName(id.Name, keyVaultResourceName)
 

--- a/azurerm/internal/services/keyvault/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource_test.go
@@ -62,14 +62,27 @@ func TestAccKeyVault_networkAcls(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check:             check.That(data.ResourceName).Key("network_acls.0.virtual_network_subnet_ids.%").HasValue("2"),
+		},
 		{
 			Config: r.networkAclsUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("network_acls.0.ip_rules.%").HasValue("2"),
+				check.That(data.ResourceName).Key("network_acls.0.virtual_network_subnet_ids.%").HasValue("1"),
+			),
+		},
 	})
 }
 

--- a/azurerm/internal/services/keyvault/parse/network_acl_rule.go
+++ b/azurerm/internal/services/keyvault/parse/network_acl_rule.go
@@ -1,0 +1,110 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	commonValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
+)
+
+type NetworkAclRuleType string
+
+const (
+	CIDR           NetworkAclRuleType = "cidr"
+	Ip             NetworkAclRuleType = "ip"
+	VirtualNetwork NetworkAclRuleType = "virtualNetwork"
+)
+
+type NetworkAclRuleId struct {
+	VaultId VaultId
+	Type    NetworkAclRuleType
+	Source  string
+}
+
+func NewNetworkAclRuleId(vaultId, source string) (*NetworkAclRuleId, error) {
+	myvaultId, err := VaultID(vaultId)
+	if err != nil {
+		return nil, err
+	}
+
+	ruleType, err := parseNetworkAclRuleType(source)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetworkAclRuleId{
+		VaultId: *myvaultId,
+		Source:  source,
+		Type:    ruleType,
+	}, nil
+}
+
+func (id NetworkAclRuleId) String() string {
+	segments := []string{
+		fmt.Sprintf("VaultID %q", id.VaultId),
+		fmt.Sprintf("Source %q", id.Source),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Vault Network ACL Rule", segmentsStr)
+}
+
+func (id NetworkAclRuleId) ID() string {
+	fmtString := "%s|%s"
+	return fmt.Sprintf(fmtString, id.VaultId.ID(), id.Source)
+}
+
+func (id NetworkAclRuleId) Rule() string {
+	if id.Type == Ip {
+		return fmt.Sprintf("%s/32", id.Source)
+	}
+	return id.Source
+}
+
+// NetworkAclRuleId is a pseudo ID for storing Source parameter as this it not retrievable from API
+// It is formed of the Azure Resource ID for the Vault and the Source it is created against
+func NetworkAclRuleID(input string) (*NetworkAclRuleId, error) {
+	parts := strings.Split(input, "|")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("could not parse Network ACL Rule ID, invalid format %q", input)
+	}
+
+	vaultId, err := VaultID(parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	source := parts[1]
+
+	ruleType, err := parseNetworkAclRuleType(source)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetworkAclRuleId{
+		VaultId: *vaultId,
+		Source:  parts[1],
+		Type:    ruleType,
+	}, nil
+}
+
+func parseNetworkAclRuleType(source string) (NetworkAclRuleType, error) {
+	var errorList []error
+
+	_, errorList = commonValidate.IPv4Address(source, "ip_rule")
+	if len(errorList) == 0 {
+		return Ip, nil
+	}
+
+	_, errorList = commonValidate.CIDR(source, "ip_rule")
+	if len(errorList) == 0 {
+		return CIDR, nil
+	}
+
+	_, errorList = networkValidate.SubnetID(source, "virtual_network_subnet_id")
+	if len(errorList) == 0 {
+		return VirtualNetwork, nil
+	}
+
+	return "", fmt.Errorf("could not determine rule type of %s", source)
+}

--- a/azurerm/internal/services/keyvault/registration.go
+++ b/azurerm/internal/services/keyvault/registration.go
@@ -41,6 +41,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_key_vault_certificate_issuer":               resourceKeyVaultCertificateIssuer(),
 		"azurerm_key_vault_key":                              resourceKeyVaultKey(),
 		"azurerm_key_vault_managed_hardware_security_module": resourceKeyVaultManagedHardwareSecurityModule(),
+		"azurerm_key_vault_network_acl_rule":                 resourceKeyVaultNetworkAclRule(),
 		"azurerm_key_vault_secret":                           resourceKeyVaultSecret(),
 		"azurerm_key_vault":                                  resourceKeyVault(),
 	}

--- a/website/docs/r/key_vault_network_acl_rule.markdown
+++ b/website/docs/r/key_vault_network_acl_rule.markdown
@@ -1,0 +1,126 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_network_acl_rule"
+description: |-
+  Manages a Key Vault Network ACL Rule.
+---
+
+# azurerm_key_vault_network_acl_rule
+
+Manages a Key Vault Network ACL Rule.
+
+~> **NOTE:** It's possible to define Key Vault Network ACL Rules both within [the `azurerm_key_vault` resource](key_vault.html) via the `network_acls` block and by using [the `azurerm_key_vault_network_acl_rule` resource](key_vault_network_acl_rule.html). However it's not possible to use both methods to manage Network ACL Rules within a KeyVault, since there'll be conflicts.
+
+-> **NOTE:** Azure permits a maximum of 200 virtual network rules and 1000 IPv4 rules - [more information can be found in this document](https://docs.microsoft.com/en-us/azure/key-vault/general/network-security).
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoints    = ["Microsoft.KeyVault"]
+}
+
+resource "azurerm_key_vault" "example" {
+  name                = "examplekeyvault"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "premium"
+}
+
+resource "azurerm_key_vault_network_acl_rule" "example_ip" {
+  key_vault_id = azurerm_key_vault.example.id
+  source       = "1.2.3.4"
+}
+
+resource "azurerm_key_vault_network_acl_rule" "example_cidr" {
+  key_vault_id = azurerm_key_vault.example.id
+  source       = "40.82.252.0/24"
+}
+
+resource "azurerm_key_vault_network_acl_rule" "example_subnet" {
+  key_vault_id = azurerm_key_vault.example.id
+  source       = azurerm_subnet.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this
+    forces a new resource to be created.
+
+* `source` - (Required) The IP address, CIDR Blocks, or Subnet ID which should be able
+    to access this Key Vault. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Key Vault Access Policy ID.
+
+-> **NOTE:** This Identifier is unique to Terraform and doesn't map to an existing object within Azure.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Key Vault Access Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Key Vault Access Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Access Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Access Policy.
+
+## Import
+
+Key Vault Network ACL Rules can be imported using the Resource ID of the Key Vault, plus some additional metadata.
+
+
+If the `source` is an IP address, then the Access Policy can be imported using the following code:
+
+```shell
+terraform import azurerm_key_vault_access_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/vaults/test-vault|1.2.3.4
+```
+
+where `1.2.3.4` is a public, IPv4 address.
+
+---
+
+If the `source` is CIDR block, then the Access Policy can be imported using the following code:
+
+```shell
+terraform import azurerm_key_vault_access_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/vaults/test-vault|40.82.252.0/24
+```
+
+where `40.82.252.0/24` is a public, IPv4 CIDR Block.
+
+---
+
+If the `source` is a virtual network subnet, then the Access Policy can be imported using the following code:
+
+```shell
+terraform import azurerm_key_vault_access_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/vaults/test-vault|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1
+```
+
+where `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1` is a virtual network subnet ID.
+
+-> **NOTE:** All Identifiers are unique to Terraform and don't map to an existing object within Azure.


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

## Overview

This pull request creates a new resourced dedicated to the management of key vault network ACL rules. This is similar to the `key_vault_access_policy_resource` that exists today in the sense that it is a pseudo-resource that is created/managed/reflected on the key vault itself.

## Open Questions & Comments

1. Since this is a pseudo-resource, it has an associated pseudo-ID. So the parser (`network_acl_rule.go`) is hand-crafted instead of relying on generated source. The resulting `struct` has 1 additional attribute and 1 additional function that are calculated within the parser. This is a pattern that I didn't see precedent for elsewhere, but removing those attributes would litter the rest of the code with the same IP/CIDR/Subnet validation logic that is currently contained in one place. Is there an example of the "right" way to do this?
2. The acceptance tests all validate the key vault itself (not individual rules). This might be a bit of an anti-pattern, but it seemed to me to be the best way to validate atomic creates/deletes in a test case - that is, verifying the presence of a single element within a list. And since we're really talking about 2 lists (IP rules and virtual network rules) with differing types that are sourced from the same string attributes, validating at the rule level didn't seem like the right approach.
3. Related to (2), validating the `network_acls` attribute of the vault is dependent on running an `ImportStep`. Since `TestStep` instances can't be `Check`-only, merging the `ImportStep` format with a custom `Check` field seemed like the simplest way to achieve the necessary validation without bloating the number of test steps. Give the change to the `azurerm_key_vault` schema, I made a similar change to the relevant acceptance test over there.

## Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='keyvault' TESTARGS='-run=TestAccKeyVaultNetworkAclRule_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/keyvault -run=TestAccKeyVaultNetworkAclRule_ -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKeyVaultNetworkAclRule_ip
=== PAUSE TestAccKeyVaultNetworkAclRule_ip
=== RUN   TestAccKeyVaultNetworkAclRule_requiresImportIp
=== PAUSE TestAccKeyVaultNetworkAclRule_requiresImportIp
=== RUN   TestAccKeyVaultNetworkAclRule_cidr
=== PAUSE TestAccKeyVaultNetworkAclRule_cidr
=== RUN   TestAccKeyVaultNetworkAclRule_requiresImportCidr
=== PAUSE TestAccKeyVaultNetworkAclRule_requiresImportCidr
=== RUN   TestAccKeyVaultNetworkAclRule_subnet
=== PAUSE TestAccKeyVaultNetworkAclRule_subnet
=== RUN   TestAccKeyVaultNetworkAclRule_requiresImportSubnet
=== PAUSE TestAccKeyVaultNetworkAclRule_requiresImportSubnet
=== RUN   TestAccKeyVaultNetworkAclRule_complete
=== PAUSE TestAccKeyVaultNetworkAclRule_complete
=== RUN   TestAccKeyVaultNetworkAclRule_update
=== PAUSE TestAccKeyVaultNetworkAclRule_update
=== CONT  TestAccKeyVaultNetworkAclRule_ip
=== CONT  TestAccKeyVaultNetworkAclRule_requiresImportSubnet
=== CONT  TestAccKeyVaultNetworkAclRule_update
=== CONT  TestAccKeyVaultNetworkAclRule_complete
=== CONT  TestAccKeyVaultNetworkAclRule_subnet
=== CONT  TestAccKeyVaultNetworkAclRule_requiresImportCidr
=== CONT  TestAccKeyVaultNetworkAclRule_cidr
=== CONT  TestAccKeyVaultNetworkAclRule_requiresImportIp
--- PASS: TestAccKeyVaultNetworkAclRule_subnet (710.88s)
--- PASS: TestAccKeyVaultNetworkAclRule_requiresImportCidr (711.20s)
--- PASS: TestAccKeyVaultNetworkAclRule_requiresImportSubnet (711.26s)
--- PASS: TestAccKeyVaultNetworkAclRule_ip (713.70s)
--- PASS: TestAccKeyVaultNetworkAclRule_cidr (728.46s)
--- PASS: TestAccKeyVaultNetworkAclRule_requiresImportIp (774.55s)
--- PASS: TestAccKeyVaultNetworkAclRule_complete (1430.67s)
--- PASS: TestAccKeyVaultNetworkAclRule_update (2198.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault    2201.307s

$ make acctests SERVICE='keyvault' TESTARGS='-run=TestAccKeyVault_networkAcls' TESTTIMEOUT='30m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/keyvault -run=TestAccKeyVault_networkAcls -timeout 30m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKeyVault_networkAcls
=== PAUSE TestAccKeyVault_networkAcls
=== RUN   TestAccKeyVault_networkAclsAllowed
=== PAUSE TestAccKeyVault_networkAclsAllowed
=== CONT  TestAccKeyVault_networkAcls
=== CONT  TestAccKeyVault_networkAclsAllowed
--- PASS: TestAccKeyVault_networkAclsAllowed (395.88s)
--- PASS: TestAccKeyVault_networkAcls (514.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault    517.170s

```