### PR TITLE
"azurerm_data_factory_integration_runtime_azure_ssis" - supports "key_vault_password", "key_vault_license" for "express_custom_setup"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_integration_runtime_azure_ssis_resource_test.go
@@ -56,6 +56,24 @@ func TestAccDataFactoryIntegrationRuntimeManagedSsis_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryIntegrationRuntimeManagedSsis_keyVaultSecretReference(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_integration_runtime_azure_ssis", "test")
+	r := IntegrationRuntimeManagedSsisResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.keyVaultSecretReference(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"catalog_info.0.administrator_password",
+			"custom_setup_script.0.sas_token",
+		),
+	})
+}
+
 func TestAccDataFactoryIntegrationRuntimeManagedSsis_aadAuth(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_data_factory_integration_runtime_azure_ssis", "test")
 	r := IntegrationRuntimeManagedSsisResource{}
@@ -279,6 +297,248 @@ resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
       target_name = "name1"
       user_name   = "username1"
       password    = "password1"
+    }
+  }
+
+  package_store {
+    name                = "store1"
+    linked_service_name = azurerm_data_factory_linked_custom_service.file_share_linked_service.name
+  }
+
+  proxy {
+    self_hosted_integration_runtime_name = azurerm_data_factory_integration_runtime_self_hosted.test.name
+    staging_storage_linked_service_name  = azurerm_data_factory_linked_custom_service.test.name
+    path                                 = "containerpath"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (IntegrationRuntimeManagedSsisResource) keyVaultSecretReference(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctkv%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    secret_permissions = ["Get", "Delete", "List", "Purge", "Recover", "Set"]
+  }
+}
+
+resource "azurerm_key_vault_secret" "test" {
+  name         = "secret-%[3]s"
+  value        = "password"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test1" {
+  name                = "acctpip1%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+  domain_name_label   = "acctpip1%[1]d"
+}
+
+resource "azurerm_public_ip" "test2" {
+  name                = "acctpip2%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+  domain_name_label   = "acctpip2%[1]d"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "setup-files"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_share" "test" {
+  name                 = "sharename"
+  storage_account_name = azurerm_storage_account.test.name
+  quota                = 30
+}
+
+data "azurerm_storage_account_blob_container_sas" "test" {
+  connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+  container_name    = "${azurerm_storage_container.test.name}"
+  https_only        = true
+
+  start  = "2017-03-21"
+  expiry = "2022-03-21"
+
+  permissions {
+    read   = true
+    add    = false
+    create = false
+    write  = true
+    delete = false
+    list   = true
+  }
+}
+
+resource "azurerm_sql_server" "test" {
+  name                         = "acctestsql%[1]d"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  location                     = "${azurerm_resource_group.test.location}"
+  version                      = "12.0"
+  administrator_login          = "ssis_catalog_admin"
+  administrator_login_password = "my-s3cret-p4ssword!"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdfirm%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_data_factory_linked_custom_service" "test" {
+  name                 = "acctestls%[1]d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureBlobStorage"
+  type_properties_json = <<JSON
+{
+  "connectionString": "${azurerm_storage_account.test.primary_connection_string}"
+}
+JSON
+}
+
+resource "azurerm_data_factory_linked_custom_service" "file_share_linked_service" {
+  name                 = "acctestls1%[1]d"
+  data_factory_id      = azurerm_data_factory.test.id
+  type                 = "AzureFileStorage"
+  type_properties_json = <<JSON
+{
+  "host": "${azurerm_storage_share.test.url}",
+  "password": {
+    "type": "SecureString",
+    "value": "${azurerm_storage_account.test.primary_access_key}"
+  }
+}
+JSON
+}
+
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+  name                = "acctestlinkkv%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  key_vault_id        = azurerm_key_vault.test.id
+}
+
+resource "azurerm_data_factory_integration_runtime_self_hosted" "test" {
+  name                = "acctestSIRsh%[1]d"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_integration_runtime_azure_ssis" "test" {
+  name                = "acctestiras%[1]d"
+  description         = "acctest"
+  data_factory_name   = azurerm_data_factory.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  node_size                        = "Standard_D8_v3"
+  number_of_nodes                  = 2
+  max_parallel_executions_per_node = 8
+  edition                          = "Standard"
+  license_type                     = "LicenseIncluded"
+
+  vnet_integration {
+    vnet_id     = "${azurerm_virtual_network.test.id}"
+    subnet_name = "${azurerm_subnet.test.name}"
+    public_ips  = [azurerm_public_ip.test1.id, azurerm_public_ip.test2.id]
+  }
+
+  catalog_info {
+    server_endpoint        = "${azurerm_sql_server.test.fully_qualified_domain_name}"
+    administrator_login    = "ssis_catalog_admin"
+    administrator_password = "my-s3cret-p4ssword!"
+    pricing_tier           = "Basic"
+    dual_standby_pair_name = "dual_name"
+  }
+
+  custom_setup_script {
+    blob_container_uri = "${azurerm_storage_account.test.primary_blob_endpoint}/${azurerm_storage_container.test.name}"
+    sas_token          = "${data.azurerm_storage_account_blob_container_sas.test.sas}"
+  }
+
+  express_custom_setup {
+    powershell_version = "6.2.0"
+
+    environment = {
+      Env = "test"
+      Foo = "Bar"
+    }
+
+    component {
+      name = "SentryOne.TaskFactory"
+      key_vault_license {
+        linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+        secret_name         = azurerm_key_vault_secret.test.name
+        secret_version      = azurerm_key_vault_secret.test.version
+        parameters = {
+          "Env" : "Pro",
+        }
+      }
+    }
+
+    component {
+      name = "oh22is.HEDDA.IO"
+    }
+
+    command_key {
+      target_name = "name1"
+      user_name   = "username1"
+      key_vault_password {
+        linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+        secret_name         = azurerm_key_vault_secret.test.name
+        secret_version      = azurerm_key_vault_secret.test.version
+        parameters = {
+          "Env" : "Pro",
+        }
+      }
     }
   }
 

--- a/website/docs/r/data_factory_integration_runtime_azure_ssis.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_azure_ssis.html.markdown
@@ -114,7 +114,9 @@ A `command_key` block supports the following:
 
 * `user_name` - (Required) The username for the target device.
 
-* `password` - (Required) The password for the target device.
+* `password` - (Optional) The password for the target device.
+
+* `key_vault_password` - (Optional) A `key_vault_secret_reference` block as defined below.
 
 ---
 
@@ -123,6 +125,20 @@ A `component` block supports the following:
 * `name` - (Required) The Component Name installed for the Azure-SSIS Integration Runtime.
 
 * `license` - (Optional) The license used for the Component.
+
+* `key_vault_license` - (Optional) A `key_vault_secret_reference` block as defined below.
+
+---
+
+A `key_vault_secret_reference` block supports the following:
+
+* `linked_service_name` - (Required) Specifies the name of an existing Key Vault Data Factory Linked Service.
+
+* `secret_name` - (Required) Specifies the secret name in Azure Key Vault.
+
+* `secret_version` - (Optional) Specifies the secret version in Azure Key Vault.
+
+* `parameters` - (Optional) A map of parameters to associate with the Key Vault Data Factory Linked Service.
 
 ---
 


### PR DESCRIPTION
for the "express_custom_setup", "command_key" and "component" supports key vault secret reference, this PR adds support for this feature.

![image](https://user-images.githubusercontent.com/2786738/126266401-13eda46d-651e-4b1e-99b4-d471be3712d7.png)
