### PR TITLE
Bugfix: `azurerm_data_factory_dataset_binary` - Make blob path/filename optional

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_dataset_binary_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_dataset_binary_resource.go
@@ -122,12 +122,12 @@ func resourceDataFactoryDatasetBinary() *pluginsdk.Resource {
 						},
 						"path": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"filename": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 					},

--- a/website/docs/r/data_factory_dataset_binary.html.markdown
+++ b/website/docs/r/data_factory_dataset_binary.html.markdown
@@ -106,9 +106,9 @@ A `azure_blob_storage_location` block supports the following:
 
 * `container` - (Required) The container on the Azure Blob Storage Account hosting the file.
 
-* `path` - (Required) The folder path to the file on the web server.
+* `path` - (Optional) The folder path to the file in the blob container.
 
-* `filename` - (Required) The filename of the file on the web server.
+* `filename` - (Optional) The filename of the file in the blob container.
 
 ---
 
@@ -121,7 +121,7 @@ A `sftp_server_location` block supports the following:
 
 ## Attributes Reference
 
-In addition to the Arguments listed above - the following Attributes are exported: 
+In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Data Factory Dataset.
 


### PR DESCRIPTION
```
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/datafactory/data_factory_dataset_binary_resource_test.go  -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataFactoryDatasetBinary_blob
=== PAUSE TestAccDataFactoryDatasetBinary_blob
=== RUN   TestAccDataFactoryDatasetBinary_blob_with_filepath
=== PAUSE TestAccDataFactoryDatasetBinary_blob_with_filepath
=== RUN   TestAccDataFactoryDatasetBinary_http
=== PAUSE TestAccDataFactoryDatasetBinary_http
=== RUN   TestAccDataFactoryDatasetBinary_sftp
=== PAUSE TestAccDataFactoryDatasetBinary_sftp
=== RUN   TestAccDataFactoryDatasetBinary_sftpComplete
=== PAUSE TestAccDataFactoryDatasetBinary_sftpComplete
=== CONT  TestAccDataFactoryDatasetBinary_blob
=== CONT  TestAccDataFactoryDatasetBinary_sftp
=== CONT  TestAccDataFactoryDatasetBinary_http
=== CONT  TestAccDataFactoryDatasetBinary_sftpComplete
=== CONT  TestAccDataFactoryDatasetBinary_blob_with_filepath
--- PASS: TestAccDataFactoryDatasetBinary_http (110.23s)
--- PASS: TestAccDataFactoryDatasetBinary_sftpComplete (113.74s)
--- PASS: TestAccDataFactoryDatasetBinary_sftp (115.86s)
--- PASS: TestAccDataFactoryDatasetBinary_blob_with_filepath (126.59s)
--- PASS: TestAccDataFactoryDatasetBinary_blob (127.02s)
PASS
ok  	command-line-arguments	128.510s
```