### PR TITLE
Removing http_listener_ids and path_based_rule_ids properties from docs - WAF

### DIFF
--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -122,10 +122,6 @@ The following arguments are supported:
 
 * `managed_rules` - (Required) A `managed_rules` blocks as defined below.
 
-* `http_listener_ids` - (Optional) A list of HTTP Listener IDs from an `azurerm_application_gateway`.
-
-* `path_based_rule_ids` - (Optional) A list of URL Path Map Path Rule IDs from an `azurerm_application_gateway`.
-
 * `tags` - (Optional) A mapping of tags to assign to the Web Application Firewall Policy.
 
 ---

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -216,6 +216,10 @@ The following attributes are exported:
 
 * `id` - The ID of the Web Application Firewall Policy.
 
+* `http_listener_ids` - A list of HTTP Listener IDs from an `azurerm_application_gateway`.
+
+* `path_based_rule_ids` - A list of URL Path Map Path Rule IDs from an `azurerm_application_gateway`.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
`http_listener_ids` and `path_based_rule_ids` are now read-only with this https://github.com/terraform-providers/terraform-provider-azurerm/pull/11196/. So updating the docs by removing these fields from inputs

Fix for https://github.com/terraform-providers/terraform-provider-azurerm/issues/12213