### PR TITLE
"azurerm_data_factory_pipeline" - supports "concurrency", "elapsed_time_metric_duration" and "run_dimension"

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_pipeline_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_pipeline_resource.go
@@ -157,12 +157,11 @@ func resourceDataFactoryPipelineCreateUpdate(d *pluginsdk.ResourceData, meta int
 		}
 	}
 
-	description := d.Get("description").(string)
 	pipeline := &datafactory.Pipeline{
 		Parameters:    expandDataFactoryParameters(d.Get("parameters").(map[string]interface{})),
 		Variables:     expandDataFactoryVariables(d.Get("variables").(map[string]interface{})),
 		RunDimensions: expandDataFactoryPipelineRunDimension(d.Get("run_dimension").(*pluginsdk.Set).List()),
-		Description:   &description,
+		Description:   utils.String(d.Get("description").(string)),
 	}
 
 	if v, ok := d.GetOk("activities_json"); ok {

--- a/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -212,16 +212,29 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name                = "acctest%d"
-  resource_group_name = azurerm_resource_group.test.name
-  data_factory_name   = azurerm_data_factory.test.name
-  annotations         = ["test1", "test2"]
-  description         = "test description2"
-  folder              = "test-folder"
+  name                         = "acctest%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  data_factory_name            = azurerm_data_factory.test.name
+  annotations                  = ["test1", "test2"]
+  concurrency                  = 30
+  description                  = "test description2"
+  elapsed_time_metric_duration = "12:23:34"
+  folder                       = "test-folder"
 
   parameters = {
     test  = "testparameter"
     test2 = "testparameter2"
+  }
+
+  run_dimension {
+    name                  = "dimension1"
+    value                 = "@pipeline().parameters.test"
+    dynamic_value_enabled = true
+  }
+
+  run_dimension {
+    name  = "dimension2"
+    value = "abc"
   }
 
   variables = {

--- a/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_pipeline_resource_test.go
@@ -212,29 +212,18 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_pipeline" "test" {
-  name                         = "acctest%d"
-  resource_group_name          = azurerm_resource_group.test.name
-  data_factory_name            = azurerm_data_factory.test.name
-  annotations                  = ["test1", "test2"]
-  concurrency                  = 30
-  description                  = "test description2"
-  elapsed_time_metric_duration = "12:23:34"
-  folder                       = "test-folder"
+  name                           = "acctest%d"
+  resource_group_name            = azurerm_resource_group.test.name
+  data_factory_name              = azurerm_data_factory.test.name
+  annotations                    = ["test1", "test2"]
+  concurrency                    = 30
+  description                    = "test description2"
+  moniter_metrics_after_duration = "12:23:34"
+  folder                         = "test-folder"
 
   parameters = {
     test  = "testparameter"
     test2 = "testparameter2"
-  }
-
-  run_dimension {
-    name                  = "dimension1"
-    value                 = "@pipeline().parameters.test"
-    dynamic_value_enabled = true
-  }
-
-  run_dimension {
-    name  = "dimension2"
-    value = "abc"
   }
 
   variables = {

--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -72,6 +72,10 @@ The following arguments are supported:
 
 * `annotations` - (Optional) List of tags that can be used for describing the Data Factory Pipeline.
 
+* `concurrency` - (Optional) The max number of concurrent runs for the Data Factory Pipeline. Must be between `1` and `50`.
+
+* `elapsed_time_metric_duration` - (Optional) The TimeSpan value after which an Azure Monitoring Metric is fired.
+
 * `folder` - (Optional) The folder that this Pipeline is in. If not specified, the Pipeline will appear at the root level.
 
 * `parameters` - (Optional) A map of parameters to associate with the Data Factory Pipeline.
@@ -79,6 +83,20 @@ The following arguments are supported:
 * `variables` - (Optional) A map of variables to associate with the Data Factory Pipeline.
 
 * `activities_json` - (Optional) A JSON object that contains the activities that will be associated with the Data Factory Pipeline.
+
+* `run_dimension` - (Optional) One or more `run_dimension` blocks as defined below.
+
+---
+
+A `run_dimension` block exports the following:
+
+* `name` - The name of run_dimension.
+
+* `value` - The value of run_dimension.
+
+* `dynamic_value_enabled` - is dynamic expression enabled for value?
+
+~> **NOTE** The `run_dimension` is key value pair used when chaining pipeline.
 
 ## Attributes Reference
 

--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -74,29 +74,15 @@ The following arguments are supported:
 
 * `concurrency` - (Optional) The max number of concurrent runs for the Data Factory Pipeline. Must be between `1` and `50`.
 
-* `elapsed_time_metric_duration` - (Optional) The TimeSpan value after which an Azure Monitoring Metric is fired.
-
 * `folder` - (Optional) The folder that this Pipeline is in. If not specified, the Pipeline will appear at the root level.
+
+* `moniter_metrics_after_duration` - (Optional) The TimeSpan value after which an Azure Monitoring Metric is fired.
 
 * `parameters` - (Optional) A map of parameters to associate with the Data Factory Pipeline.
 
 * `variables` - (Optional) A map of variables to associate with the Data Factory Pipeline.
 
 * `activities_json` - (Optional) A JSON object that contains the activities that will be associated with the Data Factory Pipeline.
-
-* `run_dimension` - (Optional) One or more `run_dimension` blocks as defined below.
-
----
-
-A `run_dimension` block exports the following:
-
-* `name` - The name of run_dimension.
-
-* `value` - The value of run_dimension.
-
-* `dynamic_value_enabled` - is dynamic expression enabled for value?
-
-~> **NOTE** The `run_dimension` is key value pair used when chaining pipeline.
 
 ## Attributes Reference
 


### PR DESCRIPTION
fix #11506

"run_dimension" is a key value pair, but the value could be a string or an expression type, so made it TypeList. It's used by ChainingTrigger.

ChainingTrigger allows the referenced pipeline to depend on other pipeline runs based on runDimension Name/Value pairs. Upstream pipelines should declare the same runDimension Name and their runs should have the values for those runDimensions. The referenced pipeline run would be triggered if the values for the runDimension match for all upstream pipeline runs.

![image](https://user-images.githubusercontent.com/2786738/126598672-e15f0270-593f-4ee6-af2b-05ebb93f1be9.png)
