### PR TITLE
GHA: disable whitespace linter and update job params

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: 'v1.32'
-          args: --timeout=30m0s
+          args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 30m
   modules-download-mode: vendor
   skip-dirs:
-    - sdk # Excluding sdk folders as these are externally generated
+    - internal/service/*/sdk # Excluding sdk folders as these are externally generated
 
 issues:
   max-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 run:
-  deadline: 12m10s
+  timeout: 30m
   modules-download-mode: vendor
   skip-dirs:
-    - vendor
+    - sdk # Excluding sdk folders as these are externally generated
 
 issues:
   max-per-linter: 0
@@ -32,7 +32,7 @@ linters:
     - varcheck
     - vet
     - vetshadow
-    - whitespace
+#    - whitespace # Disabled for performance reasons
 
 linters-settings:
   errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 30m
   modules-download-mode: vendor
   skip-dirs:
-    - internal/service/*/sdk # Excluding sdk folders as these are externally generated
+    - internal/services/*/sdk # Excluding sdk folders as these are externally generated
 
 issues:
   max-per-linter: 0


### PR DESCRIPTION
turns on verbosity for output
omits service package generated `sdk` folders
fixes timeout setting in config file so not needed at `args` in action file