### PR TITLE
support for Azure Event Hubs Namespace Premium tier

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/eventhub/mgmt/2018-01-01-preview/eventhub"
@@ -253,14 +254,14 @@ func resourceEventHubNamespace() *pluginsdk.Resource {
 		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
 			oldSku, newSku := d.GetChange("sku")
 			if d.HasChange("sku") {
-				if newSku.(string) == string(namespaces.SkuNamePremium) || oldSku.(string) == string(namespaces.SkuTierPremium) {
+				if strings.EqualFold(newSku.(string), string(namespaces.SkuNamePremium)) || strings.EqualFold(oldSku.(string), string(namespaces.SkuTierPremium)) {
 					log.Printf("[DEBUG] cannot migrate a namespace from or to Premium SKU")
 					d.ForceNew("sku")
 				}
-				if newSku.(string) == string(namespaces.SkuTierPremium) {
+				if strings.EqualFold(newSku.(string), string(namespaces.SkuTierPremium)) {
 					zoneRedundant := d.Get("zone_redundant").(bool)
 					if !zoneRedundant {
-						return fmt.Errorf("zone_redundant needs to be set to true when using premium SKU.")
+						return fmt.Errorf("zone_redundant needs to be set to true when using premium SKU")
 					}
 				}
 			}

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -388,6 +388,14 @@ func TestAccEventHubNamespace_BasicWithSkuUpdate(t *testing.T) {
 				check.That(data.ResourceName).Key("capacity").HasValue("2"),
 			),
 		},
+		{
+			Config: r.premium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("Premium"),
+				check.That(data.ResourceName).Key("capacity").HasValue("1"),
+			),
+		},
 	})
 }
 
@@ -584,6 +592,28 @@ resource "azurerm_eventhub_namespace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
   capacity            = "2"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (EventHubNamespaceResource) premium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eh-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Premium"
+  capacity            = "1"
+  zone_redundant      = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Defines which tier to use. Valid options are `Basic` and `Standard`.
+* `sku` - (Required) Defines which tier to use. Valid options are `Basic`, `Standard`, and `Premium`. Please not that setting this field to `Premium` will force the creation of a new resource and also requires setting `zone_redundant` to true.
 
 * `capacity` - (Optional) Specifies the Capacity / Throughput Units for a `Standard` SKU namespace. Default capacity has a maximum of `20`, but can be increased in blocks of 20 on a committed purchase basis.
 


### PR DESCRIPTION
Adds support for the Premium tier of the event hubs namespace resource.
It is not possible to actually move from/to that tier so setting the sku
to `Premium` forces the resource to be re-created.

This will also throw an error if someone attempts to create a premium
namespace without setting zone_redundant to true.
