### PR TITLE
Update active_directory_domain_service.html.markdown

### DIFF
--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -96,7 +96,7 @@ resource azurerm_subnet_network_security_group_association "deploy" {
 }
 
 resource "azuread_group" "dc_admins" {
-  name = "AAD DC Administrators"
+  display_name = "AAD DC Administrators"
 }
 
 resource "azuread_user" "admin" {


### PR DESCRIPTION
`name` is deprecated in `azuread_group` - replaced with `display_name`