### PR TITLE
Update active_directory_domain_service.html.markdown

### DIFF
--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -129,7 +129,6 @@ resource "azurerm_active_directory_domain_service" "example" {
   filtered_sync_enabled = false
 
   initial_replica_set {
-    location  = azurerm_virtual_network.deploy.location
     subnet_id = azurerm_subnet.deploy.id
   }
 


### PR DESCRIPTION
updated example code, `location` can not be set in `initial_replica_set` - docs (below) does not contain it either

in addition to #12711 - sorry for the super small PRs