### PR TITLE
`azurerm_private_endpoint` - correct casing issue for `private_connection_resource_id` field for `Microsoft.DBforPostgreSQL`

### DIFF
--- a/azurerm/internal/services/network/private_endpoint_resource.go
+++ b/azurerm/internal/services/network/private_endpoint_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
+	postgresqlParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/parse"
 	privateDnsParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/parse"
 	privateDnsValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/privatedns/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -581,6 +582,12 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 			if strings.HasSuffix(privateConnectionId, ".azure.privatelinkservice") {
 				attrs["private_connection_resource_alias"] = privateConnectionId
 			} else {
+				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
+				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
+					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err != nil {
+						privateConnectionId = serverId.ID()
+					}
+				}
 				attrs["private_connection_resource_id"] = privateConnectionId
 			}
 
@@ -621,6 +628,12 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 			if strings.HasSuffix(privateConnectionId, ".azure.privatelinkservice") {
 				attrs["private_connection_resource_alias"] = privateConnectionId
 			} else {
+				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
+				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
+					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err != nil {
+						privateConnectionId = serverId.ID()
+					}
+				}
 				attrs["private_connection_resource_id"] = privateConnectionId
 			}
 

--- a/azurerm/internal/services/network/private_endpoint_resource.go
+++ b/azurerm/internal/services/network/private_endpoint_resource.go
@@ -584,7 +584,7 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 			if strings.HasSuffix(privateConnectionId, ".azure.privatelinkservice") {
 				attrs["private_connection_resource_alias"] = privateConnectionId
 			} else {
-				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
+				// There is a bug from service, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
 				// and for Mysql and MariaDB
 				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
 					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err == nil {
@@ -641,7 +641,7 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 			if strings.HasSuffix(privateConnectionId, ".azure.privatelinkservice") {
 				attrs["private_connection_resource_alias"] = privateConnectionId
 			} else {
-				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
+				// There is a bug from service, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
 				// and for Mysql and MariaDB
 				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
 					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err == nil {

--- a/azurerm/internal/services/network/private_endpoint_resource.go
+++ b/azurerm/internal/services/network/private_endpoint_resource.go
@@ -13,6 +13,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+	mariaDBParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mariadb/parse"
+	mysqlParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mysql/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
 	postgresqlParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/parse"
@@ -583,8 +585,19 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 				attrs["private_connection_resource_alias"] = privateConnectionId
 			} else {
 				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
+				// and for Mysql and MariaDB
 				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
 					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err == nil {
+						privateConnectionId = serverId.ID()
+					}
+				}
+				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbformysql") {
+					if serverId, err := mysqlParse.ServerID(privateConnectionId); err == nil {
+						privateConnectionId = serverId.ID()
+					}
+				}
+				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbformariadb") {
+					if serverId, err := mariaDBParse.ServerID(privateConnectionId); err == nil {
 						privateConnectionId = serverId.ID()
 					}
 				}
@@ -629,8 +642,19 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 				attrs["private_connection_resource_alias"] = privateConnectionId
 			} else {
 				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
+				// and for Mysql and MariaDB
 				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
 					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err == nil {
+						privateConnectionId = serverId.ID()
+					}
+				}
+				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbformysql") {
+					if serverId, err := mysqlParse.ServerID(privateConnectionId); err == nil {
+						privateConnectionId = serverId.ID()
+					}
+				}
+				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbformariadb") {
+					if serverId, err := mariaDBParse.ServerID(privateConnectionId); err == nil {
 						privateConnectionId = serverId.ID()
 					}
 				}

--- a/azurerm/internal/services/network/private_endpoint_resource.go
+++ b/azurerm/internal/services/network/private_endpoint_resource.go
@@ -584,7 +584,7 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 			} else {
 				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
 				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
-					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err != nil {
+					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err == nil {
 						privateConnectionId = serverId.ID()
 					}
 				}
@@ -630,7 +630,7 @@ func flattenPrivateLinkEndpointServiceConnection(serviceConnections *[]network.P
 			} else {
 				// There is a bug from ARM Cache, the PE created from portal could be with the connection id for postgresql server "Microsoft.DBForPostgreSQL" instead of "Microsoft.DBforPostgreSQL"
 				if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
-					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err != nil {
+					if serverId, err := postgresqlParse.ServerID(privateConnectionId); err == nil {
 						privateConnectionId = serverId.ID()
 					}
 				}


### PR DESCRIPTION
There is a ticket from customer. 
The customer created a Private Endpoint through portal connecting to a postgresql server.
The PE created is with "PrivateConnectionId" "...Microsoft.DBForPostgreSQL.." instead of "...Microsoft.DBforPostgreSQL..." (wrong casing "F").
Then he imports the PE into TF, and the TF requires a recreation of the PE.
Here we support to be compatible with this problem. 