### PR TITLE
kubernetes_cluster supports maintenance_config

### DIFF
--- a/azurerm/internal/services/containers/client/client.go
+++ b/azurerm/internal/services/containers/client/client.go
@@ -10,15 +10,16 @@ import (
 )
 
 type Client struct {
-	AgentPoolsClient         *containerservice.AgentPoolsClient
-	GroupsClient             *containerinstance.ContainerGroupsClient
-	KubernetesClustersClient *containerservice.ManagedClustersClient
-	RegistriesClient         *containerregistry.RegistriesClient
-	ReplicationsClient       *containerregistry.ReplicationsClient
-	ServicesClient           *legacy.ContainerServicesClient
-	WebhooksClient           *containerregistry.WebhooksClient
-	TokensClient             *containerregistry.TokensClient
-	ScopeMapsClient          *containerregistry.ScopeMapsClient
+	AgentPoolsClient                *containerservice.AgentPoolsClient
+	GroupsClient                    *containerinstance.ContainerGroupsClient
+	KubernetesClustersClient        *containerservice.ManagedClustersClient
+	MaintenanceConfigurationsClient *containerservice.MaintenanceConfigurationsClient
+	RegistriesClient                *containerregistry.RegistriesClient
+	ReplicationsClient              *containerregistry.ReplicationsClient
+	ServicesClient                  *legacy.ContainerServicesClient
+	WebhooksClient                  *containerregistry.WebhooksClient
+	TokensClient                    *containerregistry.TokensClient
+	ScopeMapsClient                 *containerregistry.ScopeMapsClient
 
 	Environment azure.Environment
 }
@@ -49,19 +50,23 @@ func NewClient(o *common.ClientOptions) *Client {
 	agentPoolsClient := containerservice.NewAgentPoolsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&agentPoolsClient.Client, o.ResourceManagerAuthorizer)
 
+	maintenanceConfigurationsClient := containerservice.NewMaintenanceConfigurationsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&maintenanceConfigurationsClient.Client, o.ResourceManagerAuthorizer)
+
 	servicesClient := legacy.NewContainerServicesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&servicesClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		AgentPoolsClient:         &agentPoolsClient,
-		KubernetesClustersClient: &kubernetesClustersClient,
-		GroupsClient:             &groupsClient,
-		RegistriesClient:         &registriesClient,
-		WebhooksClient:           &webhooksClient,
-		ReplicationsClient:       &replicationsClient,
-		ServicesClient:           &servicesClient,
-		Environment:              o.Environment,
-		TokensClient:             &tokensClient,
-		ScopeMapsClient:          &scopeMapsClient,
+		AgentPoolsClient:                &agentPoolsClient,
+		KubernetesClustersClient:        &kubernetesClustersClient,
+		GroupsClient:                    &groupsClient,
+		MaintenanceConfigurationsClient: &maintenanceConfigurationsClient,
+		RegistriesClient:                &registriesClient,
+		WebhooksClient:                  &webhooksClient,
+		ReplicationsClient:              &replicationsClient,
+		ServicesClient:                  &servicesClient,
+		Environment:                     o.Environment,
+		TokensClient:                    &tokensClient,
+		ScopeMapsClient:                 &scopeMapsClient,
 	}
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1702,10 +1702,10 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-  maintenance_config {
-    maintenance_allowed {
-      day        = "Monday"
-      hour_slots = [1, 2]
+  maintenance_window {
+    allowed {
+      day   = "Monday"
+      hours = [1, 2]
     }
   }
 }
@@ -1736,22 +1736,22 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-  maintenance_config {
-    maintenance_not_allowed_window {
+  maintenance_window {
+    not_allowed {
       end   = "2021-11-30T12:00:00Z"
       start = "2021-11-26T03:00:00Z"
     }
-    maintenance_not_allowed_window {
+    not_allowed {
       end   = "2021-12-30T12:00:00Z"
       start = "2021-12-26T03:00:00Z"
     }
-    maintenance_allowed {
-      day        = "Monday"
-      hour_slots = [1, 2]
+    allowed {
+      day   = "Monday"
+      hours = [1, 2]
     }
-    maintenance_allowed {
-      day        = "Sunday"
-      hour_slots = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+    allowed {
+      day   = "Sunday"
+      hours = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
     }
   }
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -588,6 +588,80 @@ func testAccKubernetesCluster_upgradeChannel(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_basicMaintenanceConfig(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_basicMaintenanceConfig(t)
+}
+
+func testAccKubernetesCluster_basicMaintenanceConfig(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicMaintenanceConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_completeMaintenanceConfig(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_completeMaintenanceConfig(t)
+}
+
+func testAccKubernetesCluster_completeMaintenanceConfig(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeMaintenanceConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_updateMaintenanceConfig(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccKubernetesCluster_updateMaintenanceConfig(t)
+}
+
+func testAccKubernetesCluster_updateMaintenanceConfig(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicMaintenanceConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeMaintenanceConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicMaintenanceConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KubernetesClusterResource) basicAvailabilitySetConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1602,4 +1676,84 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion, upgradeChannel)
+}
+
+func (KubernetesClusterResource) basicMaintenanceConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+  maintenance_config {
+    maintenance_allowed {
+      day        = "Monday"
+      hour_slots = [1, 2]
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (KubernetesClusterResource) completeMaintenanceConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+  maintenance_config {
+    maintenance_not_allowed_window {
+      end   = "2021-11-30T12:00:00Z"
+      start = "2021-11-26T03:00:00Z"
+    }
+    maintenance_not_allowed_window {
+      end   = "2021-12-30T12:00:00Z"
+      start = "2021-12-26T03:00:00Z"
+    }
+    maintenance_allowed {
+      day        = "Monday"
+      hour_slots = [1, 2]
+    }
+    maintenance_allowed {
+      day        = "Sunday"
+      hour_slots = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2021-05-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
@@ -329,6 +330,71 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			"local_account_disabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
+			},
+
+			"maintenance_config": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"maintenance_allowed": {
+							Type:         pluginsdk.TypeSet,
+							Optional:     true,
+							AtLeastOneOf: []string{"maintenance_config.0.maintenance_allowed", "maintenance_config.0.maintenance_not_allowed_window"},
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"day": {
+										Type:     pluginsdk.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(containerservice.WeekDaySunday),
+											string(containerservice.WeekDayMonday),
+											string(containerservice.WeekDayTuesday),
+											string(containerservice.WeekDayWednesday),
+											string(containerservice.WeekDayThursday),
+											string(containerservice.WeekDayFriday),
+											string(containerservice.WeekDaySaturday),
+										}, false),
+									},
+
+									"hour_slots": {
+										Type:     pluginsdk.TypeSet,
+										Required: true,
+										MinItems: 1,
+										Elem: &pluginsdk.Schema{
+											Type:         pluginsdk.TypeInt,
+											ValidateFunc: validation.IntBetween(0, 23),
+										},
+									},
+								},
+							},
+						},
+
+						"maintenance_not_allowed_window": {
+							Type:         pluginsdk.TypeSet,
+							Optional:     true,
+							AtLeastOneOf: []string{"maintenance_config.0.maintenance_allowed", "maintenance_config.0.maintenance_not_allowed_window"},
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"end": {
+										Type:             pluginsdk.TypeString,
+										Required:         true,
+										DiffSuppressFunc: suppress.RFC3339Time,
+										ValidateFunc:     validation.IsRFC3339Time,
+									},
+
+									"start": {
+										Type:             pluginsdk.TypeString,
+										Required:         true,
+										DiffSuppressFunc: suppress.RFC3339Time,
+										ValidateFunc:     validation.IsRFC3339Time,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 
 			"network_profile": {
@@ -989,6 +1055,16 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("cannot read ID for Managed Kubernetes Cluster %q (Resource Group %q)", name, resGroup)
 	}
 
+	if maintenanceConfigRaw, ok := d.GetOk("maintenance_config"); ok {
+		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
+		parameters := containerservice.MaintenanceConfiguration{
+			MaintenanceConfigurationProperties: expandKubernetesClusterMaintenanceConfiguration(maintenanceConfigRaw.([]interface{})),
+		}
+		if _, err := client.CreateOrUpdate(ctx, resGroup, name, "default", parameters); err != nil {
+			return fmt.Errorf("creating/updating maintenance config for Managed Kubernetes Cluster %q (Resource Group %q)", name, resGroup)
+		}
+	}
+
 	d.SetId(*read.ID)
 
 	return resourceKubernetesClusterRead(d, meta)
@@ -1333,6 +1409,16 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		log.Printf("[DEBUG] Updated Default Node Pool.")
 	}
 
+	if d.HasChange("maintenance_config") {
+		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
+		parameters := containerservice.MaintenanceConfiguration{
+			MaintenanceConfigurationProperties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_config").([]interface{})),
+		}
+		if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ManagedClusterName, "default", parameters); err != nil {
+			return fmt.Errorf("creating/updating Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+		}
+	}
+
 	d.Partial(false)
 
 	return resourceKubernetesClusterRead(d, meta)
@@ -1492,6 +1578,12 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 		return fmt.Errorf("setting `kube_config`: %+v", err)
 	}
 
+	maintenanceConfigurationsClient := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
+	configResp, _ := maintenanceConfigurationsClient.Get(ctx, id.ResourceGroup, id.ManagedClusterName, "default")
+	if props := configResp.MaintenanceConfigurationProperties; props != nil {
+		d.Set("maintenance_config", flattenKubernetesClusterMaintenanceConfiguration(props))
+	}
+
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 
@@ -1503,6 +1595,13 @@ func resourceKubernetesClusterDelete(d *pluginsdk.ResourceData, meta interface{}
 	id, err := parse.ClusterID(d.Id())
 	if err != nil {
 		return err
+	}
+
+	if _, ok := d.GetOk("maintenance_config"); ok {
+		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
+		if _, err := client.Delete(ctx, id.ResourceGroup, id.ManagedClusterName, "default"); err != nil {
+			return fmt.Errorf("deleting Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+		}
 	}
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.ManagedClusterName)
@@ -2351,4 +2450,91 @@ func expandKubernetesClusterAutoScalerProfile(input []interface{}) *containerser
 		SkipNodesWithLocalStorage:     utils.String(strconv.FormatBool(skipNodesWithLocalStorage)),
 		SkipNodesWithSystemPods:       utils.String(strconv.FormatBool(skipNodesWithSystemPods)),
 	}
+}
+
+func expandKubernetesClusterMaintenanceConfiguration(input []interface{}) *containerservice.MaintenanceConfigurationProperties {
+	if len(input) == 0 {
+		return nil
+	}
+	value := input[0].(map[string]interface{})
+	return &containerservice.MaintenanceConfigurationProperties{
+		NotAllowedTime: expandKubernetesClusterMaintenanceConfigurationTimeSpans(value["maintenance_not_allowed_window"].(*pluginsdk.Set).List()),
+		TimeInWeek:     expandKubernetesClusterMaintenanceConfigurationTimeInWeeks(value["maintenance_allowed"].(*pluginsdk.Set).List()),
+	}
+}
+
+func expandKubernetesClusterMaintenanceConfigurationTimeSpans(input []interface{}) *[]containerservice.TimeSpan {
+	results := make([]containerservice.TimeSpan, 0)
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		start, _ := time.Parse(time.RFC3339, v["start"].(string))
+		end, _ := time.Parse(time.RFC3339, v["end"].(string))
+		results = append(results, containerservice.TimeSpan{
+			Start: &date.Time{Time: start},
+			End:   &date.Time{Time: end},
+		})
+	}
+	return &results
+}
+
+func expandKubernetesClusterMaintenanceConfigurationTimeInWeeks(input []interface{}) *[]containerservice.TimeInWeek {
+	results := make([]containerservice.TimeInWeek, 0)
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		results = append(results, containerservice.TimeInWeek{
+			Day:       containerservice.WeekDay(v["day"].(string)),
+			HourSlots: utils.ExpandInt32Slice(v["hour_slots"].(*pluginsdk.Set).List()),
+		})
+	}
+	return &results
+}
+
+func flattenKubernetesClusterMaintenanceConfiguration(input *containerservice.MaintenanceConfigurationProperties) interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+	results = append(results, map[string]interface{}{
+		"maintenance_not_allowed_window": flattenKubernetesClusterMaintenanceConfigurationTimeSpans(input.NotAllowedTime),
+		"maintenance_allowed":            flattenKubernetesClusterMaintenanceConfigurationTimeInWeeks(input.TimeInWeek),
+	})
+	return results
+}
+
+func flattenKubernetesClusterMaintenanceConfigurationTimeSpans(input *[]containerservice.TimeSpan) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		var end string
+		if item.End != nil {
+			end = item.End.Format(time.RFC3339)
+		}
+		var start string
+		if item.Start != nil {
+			start = item.Start.Format(time.RFC3339)
+		}
+		results = append(results, map[string]interface{}{
+			"end":   end,
+			"start": start,
+		})
+	}
+	return results
+}
+
+func flattenKubernetesClusterMaintenanceConfigurationTimeInWeeks(input *[]containerservice.TimeInWeek) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		results = append(results, map[string]interface{}{
+			"day":        string(item.Day),
+			"hour_slots": utils.FlattenInt32Slice(item.HourSlots),
+		})
+	}
+	return results
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -106,6 +106,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `linux_profile` - (Optional) A `linux_profile` block as defined below.
 
+* `maintenance_config` - (Optional) A `maintenance_config` block as defined below.
+
 * `network_profile` - (Optional) A `network_profile` block as defined below.
 
 -> **NOTE:** If `network_profile` is not defined, `kubenet` profile will be used by default.
@@ -439,6 +441,30 @@ A `linux_profile` block supports the following:
 * `admin_username` - (Required) The Admin Username for the Cluster. Changing this forces a new resource to be created.
 
 * `ssh_key` - (Required) An `ssh_key` block. Only one is currently allowed. Changing this forces a new resource to be created.
+
+---
+
+A `maintenance_config` block supports the following:
+
+* `maintenance_allowed` - (Optional) One or more `maintenance_allowed` block as defined below.
+
+* `maintenance_not_allowed_window` - (Optional) One or more `maintenance_not_allowed_window` block as defined below.
+
+---
+
+An `maintenance_allowed` block exports the following:
+
+* `day` - (Required) A day in a week. Possible values are `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` and `Saturday`.
+
+* `hour_slots` - (Required) An array of hour slots in a day. Possible values are between `0` and `23`.
+
+---
+
+An `maintenance_not_allowed_window` block exports the following:
+
+* `end` - (Required) The end of a time span, formatted as an RFC3339 string.
+
+* `start` - (Required) The start of a time span, formatted as an RFC3339 string.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -106,7 +106,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `linux_profile` - (Optional) A `linux_profile` block as defined below.
 
-* `maintenance_config` - (Optional) A `maintenance_config` block as defined below.
+* `maintenance_window` - (Optional) A `maintenance_window` block as defined below.
 
 * `network_profile` - (Optional) A `network_profile` block as defined below.
 
@@ -444,23 +444,23 @@ A `linux_profile` block supports the following:
 
 ---
 
-A `maintenance_config` block supports the following:
+A `maintenance_window` block supports the following:
 
-* `maintenance_allowed` - (Optional) One or more `maintenance_allowed` block as defined below.
+* `allowed` - (Optional) One or more `allowed` block as defined below.
 
-* `maintenance_not_allowed_window` - (Optional) One or more `maintenance_not_allowed_window` block as defined below.
+* `not_allowed` - (Optional) One or more `not_allowed` block as defined below.
 
 ---
 
-An `maintenance_allowed` block exports the following:
+An `allowed` block exports the following:
 
 * `day` - (Required) A day in a week. Possible values are `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` and `Saturday`.
 
-* `hour_slots` - (Required) An array of hour slots in a day. Possible values are between `0` and `23`.
+* `hours` - (Required) An array of hour slots in a day. Possible values are between `0` and `23`.
 
 ---
 
-An `maintenance_not_allowed_window` block exports the following:
+An `not_allowed` block exports the following:
 
 * `end` - (Required) The end of a time span, formatted as an RFC3339 string.
 


### PR DESCRIPTION
rewrite https://github.com/terraform-providers/terraform-provider-azurerm/pull/12305, embed maintenance resource to kubernetes_cluster
```
=== RUN   TestAccKubernetesCluster_updateMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_updateMaintenanceConfig
=== CONT  TestAccKubernetesCluster_updateMaintenanceConfig
--- PASS: TestAccKubernetesCluster_updateMaintenanceConfig (913.75s)

=== RUN   TestAccKubernetesCluster_basicMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_basicMaintenanceConfig
=== CONT  TestAccKubernetesCluster_basicMaintenanceConfig
--- PASS: TestAccKubernetesCluster_basicMaintenanceConfig (910.13s)

=== RUN   TestAccKubernetesCluster_completeMaintenanceConfig
=== PAUSE TestAccKubernetesCluster_completeMaintenanceConfig
=== CONT  TestAccKubernetesCluster_completeMaintenanceConfig
--- PASS: TestAccKubernetesCluster_completeMaintenanceConfig(916.23s)
```