### PR TITLE
Fix windows function app slots on premium plans

### DIFF
--- a/azurerm/internal/services/web/function_app_slot_resource.go
+++ b/azurerm/internal/services/web/function_app_slot_resource.go
@@ -655,9 +655,11 @@ func getBasicFunctionAppSlotAppSettings(d *pluginsdk.ResourceData, appServiceTie
 		{Name: &contentFileConnStringPropName, Value: &storageConnection},
 	}
 
-	// On consumption and premium plans include WEBSITE_CONTENT components
-	if strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") {
-		return append(basicSettings, consumptionSettings...)
+	// On consumption and premium plans include WEBSITE_CONTENT components, unless it's a Linux consumption plan
+	// (see https://github.com/Azure/azure-functions-python-worker/issues/598)
+	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
+		!strings.EqualFold(d.Get("os_type").(string), "linux") {
+		return append(basicSettings, consumptionSettings...), nil
 	}
 
 	return basicSettings

--- a/azurerm/internal/services/web/function_app_slot_resource.go
+++ b/azurerm/internal/services/web/function_app_slot_resource.go
@@ -659,7 +659,7 @@ func getBasicFunctionAppSlotAppSettings(d *pluginsdk.ResourceData, appServiceTie
 	// (see https://github.com/Azure/azure-functions-python-worker/issues/598)
 	if (strings.EqualFold(appServiceTier, "dynamic") || strings.EqualFold(appServiceTier, "elasticpremium") || strings.HasPrefix(strings.ToLower(appServiceTier), "premium")) &&
 		!strings.EqualFold(d.Get("os_type").(string), "linux") {
-		return append(basicSettings, consumptionSettings...), nil
+		return append(basicSettings, consumptionSettings...)
 	}
 
 	return basicSettings


### PR DESCRIPTION
Mirrors the fix for function apps to function app slots because I forgot they existed, see PR #12553 for more information.

The settings WEBSITE_CONTENTAZUREFILECONNECTIONSTRING and WEBSITE_CONTENTSHARE are required for windows function app slots on Premium V1/V2/V3 plans.