### PR TITLE
Support for `operation_name_format` in `azurerm_api_management_api_diagnostic`

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -109,6 +109,16 @@ func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 			"backend_request": resourceApiManagementApiDiagnosticAdditionalContentSchema(),
 
 			"backend_response": resourceApiManagementApiDiagnosticAdditionalContentSchema(),
+
+			"operation_name_format": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  string(apimanagement.Name),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(apimanagement.Name),
+					string(apimanagement.URL),
+				}, false),
+			},
 		},
 	}
 }
@@ -176,7 +186,8 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *pluginsdk.ResourceData, m
 
 	parameters := apimanagement.DiagnosticContract{
 		DiagnosticContractProperties: &apimanagement.DiagnosticContractProperties{
-			LoggerID: utils.String(d.Get("api_management_logger_id").(string)),
+			LoggerID:            utils.String(d.Get("api_management_logger_id").(string)),
+			OperationNameFormat: apimanagement.OperationNameFormat(d.Get("operation_name_format").(string)),
 		},
 	}
 
@@ -293,6 +304,12 @@ func resourceApiManagementApiDiagnosticRead(d *pluginsdk.ResourceData, meta inte
 			d.Set("backend_request", nil)
 			d.Set("backend_response", nil)
 		}
+
+		format := string(apimanagement.Name)
+		if props.OperationNameFormat != "" {
+			format = string(props.OperationNameFormat)
+		}
+		d.Set("operation_name_format", format)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource_test.go
@@ -83,6 +83,28 @@ func TestAccApiManagementApiDiagnostic_complete(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementApiDiagnostic_completeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
+	r := ApiManagementApiDiagnosticResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccApiManagementApiDiagnostic_dataMasking(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
 	r := ApiManagementApiDiagnosticResource{}
@@ -247,6 +269,7 @@ resource "azurerm_api_management_api_diagnostic" "test" {
   log_client_ip             = true
   http_correlation_protocol = "W3C"
   verbosity                 = "verbose"
+  operation_name_format     = "Name"
 
   backend_request {
     body_bytes     = 1
@@ -309,6 +332,26 @@ resource "azurerm_api_management_api_diagnostic" "test" {
       }
     }
   }
+}
+`, r.template(data))
+}
+
+func (r ApiManagementApiDiagnosticResource) completeUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api_diagnostic" "test" {
+  identifier                = "applicationinsights"
+  resource_group_name       = azurerm_resource_group.test.name
+  api_management_name       = azurerm_api_management.test.name
+  api_name                  = azurerm_api_management_api.test.name
+  api_management_logger_id  = azurerm_api_management_logger.test.id
+  sampling_percentage       = 1.0
+  always_log_errors         = true
+  log_client_ip             = true
+  http_correlation_protocol = "W3C"
+  verbosity                 = "verbose"
+  operation_name_format     = "Url"
 }
 `, r.template(data))
 }

--- a/website/docs/r/api_management_api_diagnostic.html.markdown
+++ b/website/docs/r/api_management_api_diagnostic.html.markdown
@@ -147,6 +147,8 @@ The following arguments are supported:
 
 * `verbosity` - (Optional) Logging verbosity. Possible values are `verbose`, `information` or `error`.
 
+* `operation_name_format` - (Optional) The format of the Operation Name for Application Insights telemetries. Possible values are `Name`, and `Url`. Defaults to `Name`.
+
 ---
 
 A `backend_request`, `backend_response`, `frontend_request` or `frontend_response` block supports the following:


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/12733

--- PASS: TestAccApiManagementApiDiagnostic_basic (293.48s)
--- PASS: TestAccApiManagementApiDiagnostic_update (394.98s)
--- PASS: TestAccApiManagementApiDiagnostic_requiresImport (333.46s)
--- PASS: TestAccApiManagementApiDiagnostic_complete (296.55s)
--- PASS: TestAccApiManagementApiDiagnostic_completeUpdate (371.88s)
--- PASS: TestAccApiManagementApiDiagnostic_dataMasking (369.53s)