### PR TITLE
data source: `azurerm_ssh_public_key` - normalize ssh public key attribute

### DIFF
--- a/azurerm/internal/services/compute/ssh_keys.go
+++ b/azurerm/internal/services/compute/ssh_keys.go
@@ -115,19 +115,19 @@ func parseUsernameFromAuthorizedKeysPath(input string) *string {
 }
 
 func SSHKeyDiffSuppress(_, old, new string, _ *pluginsdk.ResourceData) bool {
-	oldNormalised, err := NormaliseSSHKey(old)
+	oldNormalized, err := utils.NormalizeSSHKey(old)
 	if err != nil {
 		log.Printf("[DEBUG] error normalising ssh key %q: %+v", old, err)
 		return false
 	}
 
-	newNormalised, err := NormaliseSSHKey(new)
+	newNormalized, err := utils.NormalizeSSHKey(new)
 	if err != nil {
 		log.Printf("[DEBUG] error normalising ssh key %q: %+v", new, err)
 		return false
 	}
 
-	if *oldNormalised == *newNormalised {
+	if *oldNormalized == *newNormalized {
 		return true
 	}
 
@@ -138,7 +138,7 @@ func SSHKeySchemaHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		normalisedKey, err := NormaliseSSHKey(m["public_key"].(string))
+		normalisedKey, err := utils.NormalizeSSHKey(m["public_key"].(string))
 		if err != nil {
 			log.Printf("[DEBUG] error normalising ssh key %q: %+v", m["public_key"].(string), err)
 		}

--- a/azurerm/internal/services/compute/ssh_public_key_data_source.go
+++ b/azurerm/internal/services/compute/ssh_public_key_data_source.go
@@ -56,9 +56,9 @@ func dataSourceSshPublicKeyRead(d *pluginsdk.ResourceData, meta interface{}) err
 	resp, err := client.Get(ctx, resGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error: SSH Public Key %q (Resource Group %q) was not found", name, resGroup)
+			return fmt.Errorf("SSH Public Key %q (Resource Group %q) was not found", name, resGroup)
 		}
-		return fmt.Errorf("[ERROR] Error making Read request on Azure SSH Public Key %q (Resource Group %q): %s", name, resGroup, err)
+		return fmt.Errorf("making Read request on Azure SSH Public Key %q (Resource Group %q): %s", name, resGroup, err)
 	}
 
 	d.SetId(*resp.ID)
@@ -66,9 +66,14 @@ func dataSourceSshPublicKeyRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)
 
-	if props := resp.SSHPublicKeyResourceProperties; props != nil {
-		d.Set("public_key", props.PublicKey)
+	var publicKey *string
+	if props := resp.SSHPublicKeyResourceProperties; props.PublicKey != nil {
+		publicKey, err = utils.NormalizeSSHKey(*props.PublicKey)
+		if err != nil {
+			return fmt.Errorf("normalising public key: %+v", err)
+		}
 	}
+	d.Set("public_key", publicKey)
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/utils/ssh_key.go
+++ b/azurerm/utils/ssh_key.go
@@ -1,15 +1,13 @@
-package compute
+package utils
 
 import (
 	"fmt"
 	"strings"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-// NormaliseSSHKey attempts to remove invalid formatting and line breaks that can be present in some cases
+// NormalizeSSHKey attempts to remove invalid formatting and line breaks that can be present in some cases
 // when querying the Azure APIs
-func NormaliseSSHKey(input string) (*string, error) {
+func NormalizeSSHKey(input string) (*string, error) {
 	if input == "" {
 		return nil, fmt.Errorf("empty string supplied")
 	}
@@ -26,5 +24,5 @@ func NormaliseSSHKey(input string) (*string, error) {
 
 	normalised := strings.Join(lines, "")
 
-	return utils.String(normalised), nil
+	return String(normalised), nil
 }

--- a/azurerm/utils/ssh_key_test.go
+++ b/azurerm/utils/ssh_key_test.go
@@ -1,8 +1,8 @@
-package compute
+package utils
 
 import "testing"
 
-func TestNormaliseSSHKey(t *testing.T) {
+func TestNormalizeSSHKey(t *testing.T) {
 	cases := []struct {
 		Input    string
 		Error    bool
@@ -104,10 +104,10 @@ func TestNormaliseSSHKey(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Input, func(t *testing.T) {
-			output, err := NormaliseSSHKey(tc.Input)
+			output, err := NormalizeSSHKey(tc.Input)
 			if err != nil {
 				if !tc.Error {
-					t.Fatalf("expected NormaliseSSHKey to error")
+					t.Fatalf("expected NormalizeSSHKey to error")
 				}
 			}
 			if output != nil && *output != tc.Expected {


### PR DESCRIPTION
Fixes #12794

- rename NormaliseSSHKey func to NormalizeSSHKey (better fit in naming compared to other functions)
- move NormalizeSSHKey to utils package, so we could use same func for other resources e.g. kubernetes_cluster_resource
- normalize public_key attribute in azurerm_ssh_public_key data source