### PR TITLE
r/azurerm_api_management_api_subscription: fix subscription for all apis

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -3,6 +3,7 @@ package apimanagement
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2020-12-01/apimanagement"
@@ -158,7 +159,7 @@ func resourceApiManagementSubscriptionCreateUpdate(d *pluginsdk.ResourceData, me
 	case apiSet:
 		scope = apiId.(string)
 	default:
-		scope = "all_apis"
+		scope = "/apis"
 	}
 
 	params := apimanagement.SubscriptionCreateParameters{
@@ -227,8 +228,9 @@ func resourceApiManagementSubscriptionRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("state", string(props.State))
 		productId := ""
 		apiId := ""
-		if *props.Scope != "" {
-			// the scope is either a product or api id or "all_apis" constant
+		// check if the subscription is for all apis or a specific product/ api
+		if *props.Scope != "" && !strings.HasSuffix(*props.Scope, "/apis") {
+		// the scope is either a product or api id
 			parseId, err := parse.ProductID(*props.Scope)
 			if err == nil {
 				productId = parseId.ID()

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -229,7 +229,7 @@ func resourceApiManagementSubscriptionRead(d *pluginsdk.ResourceData, meta inter
 		productId := ""
 		apiId := ""
 		// check if the subscription is for all apis or a specific product/ api
-		if *props.Scope != "" && !strings.HasSuffix(*props.Scope, "/apis") {
+		if props.Scope != nil && *props.Scope != "" && !strings.HasSuffix(*props.Scope, "/apis") {
 			// the scope is either a product or api id
 			parseId, err := parse.ProductID(*props.Scope)
 			if err == nil {

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource.go
@@ -230,7 +230,7 @@ func resourceApiManagementSubscriptionRead(d *pluginsdk.ResourceData, meta inter
 		apiId := ""
 		// check if the subscription is for all apis or a specific product/ api
 		if *props.Scope != "" && !strings.HasSuffix(*props.Scope, "/apis") {
-		// the scope is either a product or api id
+			// the scope is either a product or api id
 			parseId, err := parse.ProductID(*props.Scope)
 			if err == nil {
 				productId = parseId.ID()

--- a/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go
@@ -159,6 +159,23 @@ func TestAccApiManagementSubscription_withApiId(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementSubscription_allApis(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_subscription", "test")
+	r := ApiManagementSubscriptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.allApis(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("product_id").HasValue(""),
+				check.That(data.ResourceName).Key("user_id").HasValue(""),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ApiManagementSubscriptionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SubscriptionID(state.ID)
 	if err != nil {
@@ -269,6 +286,29 @@ resource "azurerm_api_management_subscription" "test" {
   resource_group_name = azurerm_api_management.test.resource_group_name
   api_management_name = azurerm_api_management.test.name
   api_id              = azurerm_api_management_api.test.id
+  display_name        = "Butter Parser API Enterprise Edition"
+}
+`, template)
+}
+
+func (ApiManagementSubscriptionResource) allApis(data acceptance.TestData) string {
+	template := ApiManagementSubscriptionResource{}.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "TestApi"
+  resource_group_name = azurerm_api_management.test.resource_group_name
+  api_management_name = azurerm_api_management.test.name
+  revision            = "1"
+  protocols           = ["https"]
+  display_name        = "Test API"
+  path                = "test"
+}
+
+resource "azurerm_api_management_subscription" "test" {
+  resource_group_name = azurerm_api_management.test.resource_group_name
+  api_management_name = azurerm_api_management.test.name
   display_name        = "Butter Parser API Enterprise Edition"
 }
 `, template)

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `api_id` - (Optional) The ID of the API which should be assigned to this Subscription. Changing this forces a new resource to be created.
 
--> **Info:** Only one of `product_id` and `api_id` can be set. If both are missing `all_apis` scope is used for the subscription.
+-> **Info:** Only one of `product_id` and `api_id` can be set. If both are missing `/apis` scope is used for the subscription and all apis are accessible.
 
 * `primary_key` - (Optional) The primary subscription key to use for the subscription.
 


### PR DESCRIPTION
As stated in #4482 it is currently not possible to create a subscription for all apis.

Trying to do this by omitting `product_id` and `api_id` results in an error because the scope is wrong:

_Error: creating/updating Subscription "7bf58dda-717a-4314-81c3-175c6b656c12" (API Management Service "apim-apim-box-gwc-apim" / Resource Group "rg-apim-box-gwc-apim"): apimanagement.SubscriptionClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="ValidationError" Message="One or more fields contain incorrect values:" Details=[{​​​​​​​​"code":"ValidationError","message":"Subscription scope should be one of '/apis', '/apis/{​​​​​​​​apiId}​​​​​​​​', '/products/{​​​​​​​​productId}​​​​​​​​'","target":"scope"}​​​​​​​​]_

According to the REST docs the scope must be `/apis` to be valid for all apis:

I tested this pull requests with running two API management test cases:

```
terraform-provider-azurerm git:(4482-fix-all-apis-subscriptions) ✗ make testacc TEST='./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go' TESTARGS='-run=TestAccApiManagementSubscription_allApis' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go -v -run=TestAccApiManagementSubscription_allApis -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementSubscription_allApis
=== PAUSE TestAccApiManagementSubscription_allApis
=== CONT  TestAccApiManagementSubscription_allApis
--- PASS: TestAccApiManagementSubscription_allApis (4048.97s)
PASS
ok      command-line-arguments  4050.544s


 make testacc TEST='./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go' TESTARGS='-run=TestAccApiManagementSubscription_withApiId' TESTTIMEOUT='120m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/apimanagement/api_management_subscription_resource_test.go -v -run=TestAccApiManagementSubscription_withApiId -timeout 120m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApiManagementSubscription_withApiId
=== PAUSE TestAccApiManagementSubscription_withApiId
=== CONT  TestAccApiManagementSubscription_withApiId
--- PASS: TestAccApiManagementSubscription_withApiId (3988.82s)
PASS
ok      command-line-arguments  3990.262s
```




