### PR TITLE
Update script to use the new georeplications

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -38,8 +38,7 @@ resource "azurerm_container_registry" "acr" {
       location                = "westeurope"
       zone_redundancy_enabled = true
       tags                    = {}
-    }
-  ]
+    }]
 }
 ```
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -23,11 +23,11 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_container_registry" "acr" {
-  name                     = "containerRegistry1"
-  resource_group_name      = azurerm_resource_group.rg.name
-  location                 = azurerm_resource_group.rg.location
-  sku                      = "Premium"
-  admin_enabled            = false
+  name                = "containerRegistry1"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  sku                 = "Premium"
+  admin_enabled       = false
   georeplications = [
     {
       location                = "East US"

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -28,7 +28,18 @@ resource "azurerm_container_registry" "acr" {
   location                 = azurerm_resource_group.rg.location
   sku                      = "Premium"
   admin_enabled            = false
-  georeplication_locations = ["East US", "West Europe"]
+  georeplications = [
+    {
+      location                = "East US"
+      zone_redundancy_enabled = true
+      tags                    = {}
+    },
+    {
+      location                = "westeurope"
+      zone_redundancy_enabled = true
+      tags                    = {}
+    }
+  ]
 }
 ```
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_container_registry" "acr" {
       location                = "westeurope"
       zone_redundancy_enabled = true
       tags                    = {}
-    }]
+  }]
 }
 ```
 


### PR DESCRIPTION
georeplication_locations is obsolete, and georeplications should be used now, however your example is still showing the old georeplication_locations