### PR TITLE
add free and fsv2 to `azurerm_mssql_database` sku validation

### DIFF
--- a/azurerm/internal/services/mssql/validate/database_sku_name.go
+++ b/azurerm/internal/services/mssql/validate/database_sku_name.go
@@ -1,15 +1,31 @@
 package validate
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/validation"
 )
 
+const (
+	free             = "(Free)"
+	basic            = "(Basic)"
+	elastic          = "(ElasticPool)"
+	standard         = "(S(0|1|2|3|4|6|7|9|12))"
+	premium          = "(P(1|2|4|6|11|15))"
+	dataWarehouse    = "(DW(1|2|3|4|5|6|7|8|9)5?000*c)"
+	stretch          = "(DS(1|2|3|4|5|6|10|12|15|20)00)"
+	businessCritical = "(BC_M_(8|10|12|14|16|18|20|24|32|64|128))"
+	gen4             = "((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))"
+	gen5             = "(GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80)"
+	serverlessGen5   = "(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))"
+	fsv2             = "(GP_Fsv2_(8|10|12|14|16|18|20|24|32|36|72))"
+)
+
 func DatabaseSkuName() pluginsdk.SchemaValidateFunc {
-	return validation.StringMatch(
-		regexp.MustCompile(`(?i)(^(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))$|^((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))$|^((GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80))$|^(BC_M_(8|10|12|14|16|18|20|24|32|64|128))$|^(Basic)$|^(ElasticPool)$|^(S(0|1|2|3|4|6|7|9|12))$|^(P(1|2|4|6|11|15))$|^(DW(1|2|3|4|5|6|7|8|9)5?000*c)$|^(DS(1|2|3|4|5|6|10|12|15|20)00)$)`),
+	pattern := "(?i)(^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$)"
+	return validation.StringMatch(regexp.MustCompile(fmt.Sprintf(pattern, free, basic, elastic, standard, premium, dataWarehouse, stretch, businessCritical, gen4, gen5, serverlessGen5, fsv2)),
 
 		`This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
 	)

--- a/azurerm/internal/services/mssql/validate/database_sku_name_test.go
+++ b/azurerm/internal/services/mssql/validate/database_sku_name_test.go
@@ -39,6 +39,11 @@ func TestDatabaseSkuName(t *testing.T) {
 			valid: true,
 		},
 		{
+			name:  "Valid Fsv2",
+			input: "GP_Fsv2_10",
+			valid: true,
+		},
+		{
 			name:  "Valid HS",
 			input: "HS_Gen5_2",
 			valid: true,
@@ -64,8 +69,18 @@ func TestDatabaseSkuName(t *testing.T) {
 			valid: true,
 		},
 		{
+			name:  "Valid Free",
+			input: "Free",
+			valid: true,
+		},
+		{
 			name:  "Valid Basic",
 			input: "Basic",
+			valid: true,
+		},
+		{
+			name:  "Valid ElasticPool",
+			input: "ElasticPool",
 			valid: true,
 		},
 		{


### PR DESCRIPTION
Fix: #12830

List available [mssql database SKUs](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.sql.models.database.sku?view=azure-dotnet) e.g. `az sql db list-editions -l westeurope -o table`