### PR TITLE
notificationhubs: switching to use ID Formatters

### DIFF
--- a/azurerm/internal/services/notificationhub/migration/notification_hub_authorization_rule_resource.go
+++ b/azurerm/internal/services/notificationhub/migration/notification_hub_authorization_rule_resource.go
@@ -1,0 +1,82 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/notificationhub/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = NotificationHubAuthorizationRuleResourceV0ToV1{}
+
+type NotificationHubAuthorizationRuleResourceV0ToV1 struct{}
+
+func (NotificationHubAuthorizationRuleResourceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"notification_hub_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"namespace_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"manage": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"send": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"listen": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"primary_access_key": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"secondary_access_key": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (NotificationHubAuthorizationRuleResourceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldIdRaw := rawState["id"].(string)
+		oldId, err := parse.NotificationHubAuthorizationRuleIDInsensitively(oldIdRaw)
+		if err != nil {
+			return rawState, fmt.Errorf("parsing ID %q to upgrade: %+v", oldIdRaw, err)
+		}
+
+		rawState["id"] = oldId.ID()
+		return rawState, nil
+	}
+}

--- a/azurerm/internal/services/notificationhub/migration/notification_hub_namespace_resource.go
+++ b/azurerm/internal/services/notificationhub/migration/notification_hub_namespace_resource.go
@@ -1,0 +1,77 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/notificationhub/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = NotificationHubNamespaceResourceV0ToV1{}
+
+type NotificationHubNamespaceResourceV0ToV1 struct{}
+
+func (NotificationHubNamespaceResourceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"sku_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"namespace_type": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"servicebus_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (NotificationHubNamespaceResourceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldIdRaw := rawState["id"].(string)
+		oldId, err := parse.NamespaceIDInsensitively(oldIdRaw)
+		if err != nil {
+			return rawState, fmt.Errorf("parsing ID %q to upgrade: %+v", oldIdRaw, err)
+		}
+
+		rawState["id"] = oldId.ID()
+		return rawState, nil
+	}
+}

--- a/azurerm/internal/services/notificationhub/migration/notification_hub_resource.go
+++ b/azurerm/internal/services/notificationhub/migration/notification_hub_resource.go
@@ -1,0 +1,113 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/notificationhub/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = NotificationHubResourceV0ToV1{}
+
+type NotificationHubResourceV0ToV1 struct {
+}
+
+func (NotificationHubResourceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"namespace_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"apns_credential": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					// NOTE: APNS supports two modes, certificate auth (v1) and token auth (v2)
+					// certificate authentication/v1 is marked for deprecation; as such we're not
+					// supporting it at this time.
+					"application_mode": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"bundle_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"key_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					// Team ID (within Apple & the Portal) == "AppID" (within the API)
+					"team_id": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+					"token": {
+						Type:      pluginsdk.TypeString,
+						Required:  true,
+						Sensitive: true,
+					},
+				},
+			},
+		},
+
+		"gcm_credential": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"api_key": {
+						Type:      pluginsdk.TypeString,
+						Required:  true,
+						Sensitive: true,
+					},
+				},
+			},
+		},
+
+		"tags": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
+func (NotificationHubResourceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldIdRaw := rawState["id"].(string)
+		oldId, err := parse.NotificationHubIDInsensitively(oldIdRaw)
+		if err != nil {
+			return rawState, fmt.Errorf("parsing ID %q to upgrade: %+v", oldIdRaw, err)
+		}
+
+		rawState["id"] = oldId.ID()
+		return rawState, nil
+	}
+}

--- a/azurerm/internal/services/notificationhub/notification_hub_namespace_data_source.go
+++ b/azurerm/internal/services/notificationhub/notification_hub_namespace_data_source.go
@@ -78,7 +78,7 @@ func resourceArmDataSourceNotificationHubNamespaceRead(d *pluginsdk.ResourceData
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("%s was not found", id, err)
+			return fmt.Errorf("%s was not found", id)
 		}
 
 		return fmt.Errorf("retrieving %s: %+v", id, err)

--- a/azurerm/internal/services/notificationhub/notification_hub_namespace_resource.go
+++ b/azurerm/internal/services/notificationhub/notification_hub_namespace_resource.go
@@ -7,6 +7,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/notificationhub/migration"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+
 	"github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -40,6 +44,11 @@ func resourceNotificationHubNamespace() *pluginsdk.Resource {
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.NotificationHubNamespaceResourceV0ToV1{},
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -90,51 +99,46 @@ func resourceNotificationHubNamespace() *pluginsdk.Resource {
 
 func resourceNotificationHubNamespaceCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).NotificationHubs.NamespacesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	sku := notificationhubs.Sku{
-		Name: notificationhubs.SkuName(d.Get("sku_name").(string)),
-	}
-
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-	location := azure.NormalizeLocation(d.Get("location").(string))
-	namespaceType := d.Get("namespace_type").(string)
-	enabled := d.Get("enabled").(bool)
-
+	id := parse.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroup, name)
+		existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Notification Hub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_notification_hub_namespace", *existing.ID)
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_notification_hub_namespace", id.ID())
 		}
 	}
 
+	location := location.Normalize(d.Get("location").(string))
 	parameters := notificationhubs.NamespaceCreateOrUpdateParameters{
 		Location: utils.String(location),
-		Sku:      &sku,
+		Sku: &notificationhubs.Sku{
+			Name: notificationhubs.SkuName(d.Get("sku_name").(string)),
+		},
 		NamespaceProperties: &notificationhubs.NamespaceProperties{
 			Region:        utils.String(location),
-			NamespaceType: notificationhubs.NamespaceType(namespaceType),
-			Enabled:       utils.Bool(enabled),
+			NamespaceType: notificationhubs.NamespaceType(d.Get("namespace_type").(string)),
+			Enabled:       utils.Bool(d.Get("enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
-	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters); err != nil {
-		return fmt.Errorf("Error creating/updating Notification Hub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, parameters); err != nil {
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Waiting for Notification Hub Namespace %q (Resource Group %q) to be created", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for %s to be created..", id)
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
-		Refresh:                   notificationHubNamespaceStateRefreshFunc(ctx, client, resourceGroup, name),
+		Refresh:                   notificationHubNamespaceStateRefreshFunc(ctx, client, id),
 		MinTimeout:                15 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
@@ -146,19 +150,10 @@ func resourceNotificationHubNamespaceCreateUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("Error waiting for Notification Hub %q (Resource Group %q) to finish replicating: %s", name, resourceGroup, err)
+		return fmt.Errorf("waiting for %ss to finish replicating: %+v", id, err)
 	}
 
-	read, err := client.Get(ctx, resourceGroup, name)
-	if err != nil {
-		return fmt.Errorf("Error retrieving Notification Hub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read Notification Hub Namespace %q (Resource Group %q) ID", name, resourceGroup)
-	}
-
-	d.SetId(*read.ID)
-
+	d.SetId(id.ID())
 	return resourceNotificationHubNamespaceRead(d, meta)
 }
 
@@ -175,27 +170,23 @@ func resourceNotificationHubNamespaceRead(d *pluginsdk.ResourceData, meta interf
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Notification Hub Namespace %q (Resource Group %q) was not found - removing from state!", id.Name, id.ResourceGroup)
+			log.Printf("[DEBUG] %s was not found - removing from state!", *id)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error making Read request on Notification Hub Namespace %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
+	d.Set("location", location.NormalizeNilable(resp.Location))
 
-	if sku := resp.Sku; sku != nil {
-		if err := d.Set("sku_name", string(sku.Name)); err != nil {
-			return fmt.Errorf("Error setting 'sku_name': %+v", err)
-		}
-	} else {
-		return fmt.Errorf("Error making Read request on Notification Hub Namespace %q (Resource Group %q): Unable to retrieve 'sku' value", id.Name, id.ResourceGroup)
+	skuName := ""
+	if resp.Sku != nil {
+		skuName = string(resp.Sku.Name)
 	}
+	d.Set("sku_name", skuName)
 
 	if props := resp.NamespaceProperties; props != nil {
 		d.Set("enabled", props.Enabled)
@@ -229,7 +220,7 @@ func resourceNotificationHubNamespaceDelete(d *pluginsdk.ResourceData, meta inte
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending: []string{"200", "202"},
 		Target:  []string{"404"},
-		Refresh: notificationHubNamespaceDeleteStateRefreshFunc(ctx, client, id.ResourceGroup, id.Name),
+		Refresh: notificationHubNamespaceDeleteStateRefreshFunc(ctx, client, *id),
 		Timeout: d.Timeout(pluginsdk.TimeoutDelete),
 	}
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
@@ -239,36 +230,35 @@ func resourceNotificationHubNamespaceDelete(d *pluginsdk.ResourceData, meta inte
 	return nil
 }
 
-func notificationHubNamespaceStateRefreshFunc(ctx context.Context, client *notificationhubs.NamespacesClient, resourceGroupName string, name string) pluginsdk.StateRefreshFunc {
+func notificationHubNamespaceStateRefreshFunc(ctx context.Context, client *notificationhubs.NamespacesClient, id parse.NamespaceId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.Get(ctx, resourceGroupName, name)
+		res, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if utils.ResponseWasNotFound(res.Response) {
 				return nil, "404", nil
 			}
 
-			return nil, "", fmt.Errorf("Error retrieving Notification Hub Namespace %q (Resource Group %q): %s", name, resourceGroupName, err)
+			return nil, "", fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
 		return res, strconv.Itoa(res.StatusCode), nil
 	}
 }
 
-func notificationHubNamespaceDeleteStateRefreshFunc(ctx context.Context, client *notificationhubs.NamespacesClient, resourceGroupName string, name string) pluginsdk.StateRefreshFunc {
+func notificationHubNamespaceDeleteStateRefreshFunc(ctx context.Context, client *notificationhubs.NamespacesClient, id parse.NamespaceId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.Get(ctx, resourceGroupName, name)
+		res, err := client.Get(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(res.Response) {
-				return nil, "", fmt.Errorf("Error retrieving Notification Hub Namespace %q (Resource Group %q): %s", name, resourceGroupName, err)
+				return nil, "", fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 		}
 
 		// Note: this exists as the Delete API only seems to work some of the time
 		// in this case we're going to try triggering the Deletion again, in-case it didn't work prior to this attepmpt
 		// Upstream Bug: https://github.com/Azure/azure-sdk-for-go/issues/2254
-
-		if _, err := client.Delete(ctx, resourceGroupName, name); err != nil {
-			log.Printf("Error reissuing Notification Hub Namespace %q delete request (Resource Group %q): %+v", name, resourceGroupName, err)
+		if _, err := client.Delete(ctx, id.ResourceGroup, id.Name); err != nil {
+			log.Printf("re-issuing deletion request for %s: %+v", id, err)
 		}
 
 		return res, strconv.Itoa(res.StatusCode), nil

--- a/azurerm/internal/services/notificationhub/notification_hub_resource.go
+++ b/azurerm/internal/services/notificationhub/notification_hub_resource.go
@@ -44,6 +44,7 @@ func resourceNotificationHub() *pluginsdk.Resource {
 			return err
 		}),
 
+		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.NotificationHubResourceV0ToV1{},
 		}),

--- a/azurerm/internal/services/notificationhub/parse/namespace.go
+++ b/azurerm/internal/services/notificationhub/parse/namespace.go
@@ -67,3 +67,47 @@ func NamespaceID(input string) (*NamespaceId, error) {
 
 	return &resourceId, nil
 }
+
+// NamespaceIDInsensitively parses an Namespace ID into an NamespaceId struct, insensitively
+// This should only be used to parse an ID for rewriting, the NamespaceID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func NamespaceIDInsensitively(input string) (*NamespaceId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NamespaceId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.Name, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/azurerm/internal/services/notificationhub/parse/namespace_test.go
+++ b/azurerm/internal/services/notificationhub/parse/namespace_test.go
@@ -110,3 +110,120 @@ func TestNamespaceID(t *testing.T) {
 		}
 	}
 }
+
+func TestNamespaceIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NamespaceId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1",
+			Expected: &NamespaceId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "namespace1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1",
+			Expected: &NamespaceId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "namespace1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/NAMESPACES/namespace1",
+			Expected: &NamespaceId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "namespace1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/NaMeSpAcEs/namespace1",
+			Expected: &NamespaceId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				Name:           "namespace1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NamespaceIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule.go
@@ -39,7 +39,7 @@ func (id NotificationHubAuthorizationRuleId) String() string {
 }
 
 func (id NotificationHubAuthorizationRuleId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.NotificationHubs/namespaces/%s/notificationHubs/%s/AuthorizationRules/%s"
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.NotificationHubs/namespaces/%s/notificationHubs/%s/authorizationRules/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.NamespaceName, id.NotificationHubName, id.AuthorizationRuleName)
 }
 
@@ -69,7 +69,75 @@ func NotificationHubAuthorizationRuleID(input string) (*NotificationHubAuthoriza
 	if resourceId.NotificationHubName, err = id.PopSegment("notificationHubs"); err != nil {
 		return nil, err
 	}
-	if resourceId.AuthorizationRuleName, err = id.PopSegment("AuthorizationRules"); err != nil {
+	if resourceId.AuthorizationRuleName, err = id.PopSegment("authorizationRules"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}
+
+// NotificationHubAuthorizationRuleIDInsensitively parses an NotificationHubAuthorizationRule ID into an NotificationHubAuthorizationRuleId struct, insensitively
+// This should only be used to parse an ID for rewriting, the NotificationHubAuthorizationRuleID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func NotificationHubAuthorizationRuleIDInsensitively(input string) (*NotificationHubAuthorizationRuleId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := NotificationHubAuthorizationRuleId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'namespaces' segment
+	namespacesKey := "namespaces"
+	for key := range id.Path {
+		if strings.EqualFold(key, namespacesKey) {
+			namespacesKey = key
+			break
+		}
+	}
+	if resourceId.NamespaceName, err = id.PopSegment(namespacesKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'notificationHubs' segment
+	notificationHubsKey := "notificationHubs"
+	for key := range id.Path {
+		if strings.EqualFold(key, notificationHubsKey) {
+			notificationHubsKey = key
+			break
+		}
+	}
+	if resourceId.NotificationHubName, err = id.PopSegment(notificationHubsKey); err != nil {
+		return nil, err
+	}
+
+	// find the correct casing for the 'authorizationRules' segment
+	authorizationRulesKey := "authorizationRules"
+	for key := range id.Path {
+		if strings.EqualFold(key, authorizationRulesKey) {
+			authorizationRulesKey = key
+			break
+		}
+	}
+	if resourceId.AuthorizationRuleName, err = id.PopSegment(authorizationRulesKey); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule_test.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_authorization_rule_test.go
@@ -12,7 +12,7 @@ var _ resourceid.Formatter = NotificationHubAuthorizationRuleId{}
 
 func TestNotificationHubAuthorizationRuleIDFormatter(t *testing.T) {
 	actual := NewNotificationHubAuthorizationRuleID("12345678-1234-9876-4563-123456789012", "resGroup1", "namespace1", "hub1", "authorizationRule1").ID()
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1"
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/authorizationRule1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -87,13 +87,13 @@ func TestNotificationHubAuthorizationRuleID(t *testing.T) {
 
 		{
 			// missing value for AuthorizationRuleName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/authorizationRule1",
 			Expected: &NotificationHubAuthorizationRuleId{
 				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:         "resGroup1",
@@ -114,6 +114,161 @@ func TestNotificationHubAuthorizationRuleID(t *testing.T) {
 		t.Logf("[DEBUG] Testing %q", v.Input)
 
 		actual, err := NotificationHubAuthorizationRuleID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.NotificationHubName != v.Expected.NotificationHubName {
+			t.Fatalf("Expected %q but got %q for NotificationHubName", v.Expected.NotificationHubName, actual.NotificationHubName)
+		}
+		if actual.AuthorizationRuleName != v.Expected.AuthorizationRuleName {
+			t.Fatalf("Expected %q but got %q for AuthorizationRuleName", v.Expected.AuthorizationRuleName, actual.AuthorizationRuleName)
+		}
+	}
+}
+
+func TestNotificationHubAuthorizationRuleIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NotificationHubAuthorizationRuleId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing NotificationHubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/",
+			Error: true,
+		},
+
+		{
+			// missing value for NotificationHubName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing AuthorizationRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/",
+			Error: true,
+		},
+
+		{
+			// missing value for AuthorizationRuleName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/authorizationRule1",
+			Expected: &NotificationHubAuthorizationRuleId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:         "resGroup1",
+				NamespaceName:         "namespace1",
+				NotificationHubName:   "hub1",
+				AuthorizationRuleName: "authorizationRule1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationhubs/hub1/authorizationrules/authorizationRule1",
+			Expected: &NotificationHubAuthorizationRuleId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:         "resGroup1",
+				NamespaceName:         "namespace1",
+				NotificationHubName:   "hub1",
+				AuthorizationRuleName: "authorizationRule1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/NAMESPACES/namespace1/NOTIFICATIONHUBS/hub1/AUTHORIZATIONRULES/authorizationRule1",
+			Expected: &NotificationHubAuthorizationRuleId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:         "resGroup1",
+				NamespaceName:         "namespace1",
+				NotificationHubName:   "hub1",
+				AuthorizationRuleName: "authorizationRule1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/NaMeSpAcEs/namespace1/NoTiFiCaTiOnHuBs/hub1/AuThOrIzAtIoNrUlEs/authorizationRule1",
+			Expected: &NotificationHubAuthorizationRuleId{
+				SubscriptionId:        "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:         "resGroup1",
+				NamespaceName:         "namespace1",
+				NotificationHubName:   "hub1",
+				AuthorizationRuleName: "authorizationRule1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NotificationHubAuthorizationRuleIDInsensitively(v.Input)
 		if err != nil {
 			if v.Error {
 				continue

--- a/azurerm/internal/services/notificationhub/parse/notification_hub_test.go
+++ b/azurerm/internal/services/notificationhub/parse/notification_hub_test.go
@@ -126,3 +126,139 @@ func TestNotificationHubID(t *testing.T) {
 		}
 	}
 }
+
+func TestNotificationHubIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *NotificationHubId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/",
+			Error: true,
+		},
+
+		{
+			// missing value for NamespaceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/",
+			Error: true,
+		},
+
+		{
+			// missing Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/",
+			Error: true,
+		},
+
+		{
+			// missing value for Name
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1",
+			Expected: &NotificationHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				NamespaceName:  "namespace1",
+				Name:           "hub1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationhubs/hub1",
+			Expected: &NotificationHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				NamespaceName:  "namespace1",
+				Name:           "hub1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/NAMESPACES/namespace1/NOTIFICATIONHUBS/hub1",
+			Expected: &NotificationHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				NamespaceName:  "namespace1",
+				Name:           "hub1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/NaMeSpAcEs/namespace1/NoTiFiCaTiOnHuBs/hub1",
+			Expected: &NotificationHubId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				NamespaceName:  "namespace1",
+				Name:           "hub1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := NotificationHubIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.NamespaceName != v.Expected.NamespaceName {
+			t.Fatalf("Expected %q but got %q for NamespaceName", v.Expected.NamespaceName, actual.NamespaceName)
+		}
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/notificationhub/resourceids.go
+++ b/azurerm/internal/services/notificationhub/resourceids.go
@@ -1,5 +1,5 @@
 package notificationhub
 
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Namespace -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHubAuthorizationRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Namespace -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1 -rewrite=true
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHub -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1 -rewrite=true
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=NotificationHubAuthorizationRule -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/authorizationRule1 -rewrite=true

--- a/azurerm/internal/services/notificationhub/validate/notification_hub_authorization_rule_id_test.go
+++ b/azurerm/internal/services/notificationhub/validate/notification_hub_authorization_rule_id_test.go
@@ -72,13 +72,13 @@ func TestNotificationHubAuthorizationRuleID(t *testing.T) {
 
 		{
 			// missing value for AuthorizationRuleName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/AuthorizationRules/authorizationRule1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/authorizationRule1",
 			Valid: true,
 		},
 

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -98,5 +98,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Notification Hubs can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_notification_hub.hub1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.NotificationHubs/namespaces/{namespaceName}/notificationHubs/hub1
+terraform import azurerm_notification_hub.hub1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1
 ```

--- a/website/docs/r/notification_hub_authorization_rule.html.markdown
+++ b/website/docs/r/notification_hub_authorization_rule.html.markdown
@@ -89,5 +89,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Notification Hub Authorization Rule can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_notification_hub_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.NotificationHubs/namespaces/{namespaceName}/notificationHubs/hub1/AuthorizationRules/rule1
+terraform import azurerm_notification_hub_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1/notificationHubs/hub1/authorizationRules/rule1
 ```

--- a/website/docs/r/notification_hub_namespace.html.markdown
+++ b/website/docs/r/notification_hub_namespace.html.markdown
@@ -68,5 +68,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Notification Hub Namespaces can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_notification_hub_namespace.namespace1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.NotificationHubs/namespaces/{namespaceName}
+terraform import azurerm_notification_hub_namespace.namespace1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.NotificationHubs/namespaces/namespace1
 ```


### PR DESCRIPTION
This PR supersedes #12648 and fixes #11602 by introducing ID Formatters for the Notification Hubs resources and adding a state migration to ensure these are consistent.