### PR TITLE
Network Security Group | True Up Protocols

### DIFF
--- a/azurerm/internal/services/network/network_security_group_resource.go
+++ b/azurerm/internal/services/network/network_security_group_resource.go
@@ -78,6 +78,8 @@ func resourceNetworkSecurityGroup() *pluginsdk.Resource {
 								string(network.SecurityRuleProtocolTCP),
 								string(network.SecurityRuleProtocolUDP),
 								string(network.SecurityRuleProtocolIcmp),
+								string(network.SecurityRuleProtocolAh),
+								string(network.SecurityRuleProtocolEsp),
 							}, true),
 							DiffSuppressFunc: suppress.CaseDifference,
 						},

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -69,7 +69,7 @@ Elements of `security_rule` support:
 
 * `description` - (Optional) A description for this rule. Restricted to 140 characters.
 
-* `protocol` - (Required) Network protocol this rule applies to. Can be `Tcp`, `Udp`, `Icmp`, or `*` to match all.
+* `protocol` - (Required) Network protocol this rule applies to. Possible values include `Tcp`, `Udp`, `Icmp`, `Esp`, `Ah` or `*` (which matches all).
 
 * `source_port_range` - (Optional) Source Port or Range. Integer or range between `0` and `65535` or `*` to match any. This is required if `source_port_ranges` is not specified.
 


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-azurerm/pull/11581 adds the new Esp and Ah protocols to the network security group rules, but misses adding it to the network security group as well.

This PR should true up the existing protocols for NSGs with NSRs