### PR TITLE
Docs: Add a note for MySQL/PostgreSQL AAD Admin + Managed Identities

### DIFF
--- a/website/docs/r/mysql_active_directory_administrator.html.markdown
+++ b/website/docs/r/mysql_active_directory_administrator.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `login` - (Required) The login name of the principal to set as the server administrator
 
-* `object_id` - (Required) The ID of the principal to set as the server administrator
+* `object_id` - (Required) The ID of the principal to set as the server administrator. For a managed identity this should be the Client ID of the identity.
 
 * `tenant_id` - (Required) The Azure Tenant ID
 

--- a/website/docs/r/postgresql_active_directory_administrator.html.markdown
+++ b/website/docs/r/postgresql_active_directory_administrator.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `login` - (Required) The login name of the principal to set as the server administrator
 
-* `object_id` - (Required) The ID of the principal to set as the server administrator
+* `object_id` - (Required) The ID of the principal to set as the server administrator. For a managed identity this should be the Client ID of the identity.
 
 * `tenant_id` - (Required) The Azure Tenant ID
 


### PR DESCRIPTION
Add a documentation note to both the `mysql_active_directory_administrator` and
`postgresql_active_directory_administrator` resources relating to how to assign
admin permissions to a Managed Identity.

--

This took me more time than I care to admit to figure out, so I figure it would be a useful addition to the provider docs :smile: 