### PR TITLE
typo: use lowercase values in azurerm_api_management_diagnostic docs

### DIFF
--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -56,7 +56,7 @@ resource "azurerm_api_management_diagnostic" "example" {
   sampling_percentage       = 5.0
   always_log_errors         = true
   log_client_ip             = true
-  verbosity                 = "Verbose"
+  verbosity                 = "verbose"
   http_correlation_protocol = "W3C"
 
   frontend_request {


### PR DESCRIPTION
* Closes #12541
Fixes a typo in the example code provided by the documentation