### PR TITLE
Tooling: upgrade `golangci-lint` to v1.41.1

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -20,5 +20,5 @@ jobs:
           go-version: '1.16.6'
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: 'v1.32'
+          version: 'v1.41.1'
           args: -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 40m
   modules-download-mode: vendor
   skip-dirs:
-    - internal/services/*/sdk # Excluding sdk folders as these are externally generated
+    - /sdk/ # Excluding sdk folders as these are externally generated
 
 issues:
   max-per-linter: 0
@@ -31,7 +31,7 @@ linters:
     - varcheck
     - vet
     - vetshadow
-#    - whitespace # Disabled for performance reasons
+    # - whitespace # Disabled for performance reasons - Ignores cache and takes 12+ minutes to run on the repo for _any_ change
 
 linters-settings:
   errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - nakedret
     - misspell
     - staticcheck

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ tools:
 	go install github.com/katbyte/terrafmt@latest
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install mvdan.cc/gofumpt@latest
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v1.32.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH || $$GOPATH)/bin v1.41.1
 
 build: fmtcheck generate
 	go install

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -321,7 +321,8 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			CustomCorrelationRequestID: os.Getenv("ARM_CORRELATION_REQUEST_ID"),
 		}
 
-		stopCtx, ok := schema.StopContext(ctx) //nolint:SA1019
+		//lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
+		stopCtx, ok := schema.StopContext(ctx) //nolint:staticcheck
 		if !ok {
 			stopCtx = ctx
 		}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -64,7 +64,9 @@ func TestResourcesSupportCustomTimeouts(t *testing.T) {
 			}
 
 			// every Resource has to have a Create, Read & Destroy timeout
-			if resource.Timeouts.Create == nil && resource.Create != nil { //nolint:SA1019
+
+			//lint:ignore SA1019 SDKv2 migration  - staticcheck's own linter directives are currently being ignored under golanci-lint
+			if resource.Timeouts.Create == nil && resource.Create != nil { //nolint:staticcheck
 				t.Fatalf("Resource %q defines a Create method but no Create Timeout", resourceName)
 			}
 			if resource.Timeouts.Delete == nil && resource.Delete != nil {

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -208,7 +208,8 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *pluginsdk.ResourceData, m
 		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
-	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists { //nolint:SA1019
+	//lint:ignore SA1019 SDKv2 migration  - staticcheck's own linter directives are currently being ignored under golanci-lint
+	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists { //nolint:staticcheck
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -172,7 +172,8 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 		parameters.Verbosity = apimanagement.Verbosity(verbosity.(string))
 	}
 
-	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists { //nolint:SA1019
+	//lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
+	if logClientIP, exists := d.GetOkExists("log_client_ip"); exists { //nolint:staticcheck
 		parameters.LogClientIP = utils.Bool(logClientIP.(bool))
 	}
 

--- a/internal/services/consumption/helpers.go
+++ b/internal/services/consumption/helpers.go
@@ -206,8 +206,8 @@ func ExpandConsumptionBudgetFilter(i []interface{}) *consumption.BudgetFilter {
 	dimensionsSet := len(dimensions) > 0
 
 	if dimensionsSet && tagsSet {
-		and := append(dimensions, tags...)
-		filter.And = &and
+		dimensions = append(dimensions, tags...)
+		filter.And = &dimensions
 	} else {
 		if dimensionsSet {
 			if len(dimensions) > 1 {

--- a/internal/services/loadbalancer/backend_address_pool_resource.go
+++ b/internal/services/loadbalancer/backend_address_pool_resource.go
@@ -343,9 +343,9 @@ func resourceArmLoadBalancerBackendAddressPoolDelete(d *pluginsdk.ResourceData, 
 			return nil
 		}
 
-		oldBackEndPools := *lb.LoadBalancerPropertiesFormat.BackendAddressPools
-		newBackEndPools := append(oldBackEndPools[:index], oldBackEndPools[index+1:]...)
-		lb.LoadBalancerPropertiesFormat.BackendAddressPools = &newBackEndPools
+		backEndPools := *lb.LoadBalancerPropertiesFormat.BackendAddressPools
+		backEndPools = append(backEndPools[:index], backEndPools[index+1:]...)
+		lb.LoadBalancerPropertiesFormat.BackendAddressPools = &backEndPools
 
 		future, err := lbClient.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, lb)
 		if err != nil {

--- a/internal/services/loadbalancer/nat_pool_resource.go
+++ b/internal/services/loadbalancer/nat_pool_resource.go
@@ -264,9 +264,9 @@ func resourceArmLoadBalancerNatPoolDelete(d *pluginsdk.ResourceData, meta interf
 		return nil
 	}
 
-	oldNatPools := *loadBalancer.LoadBalancerPropertiesFormat.InboundNatPools
-	newNatPools := append(oldNatPools[:index], oldNatPools[index+1:]...)
-	loadBalancer.LoadBalancerPropertiesFormat.InboundNatPools = &newNatPools
+	natPools := *loadBalancer.LoadBalancerPropertiesFormat.InboundNatPools
+	natPools = append(natPools[:index], natPools[index+1:]...)
+	loadBalancer.LoadBalancerPropertiesFormat.InboundNatPools = &natPools
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
 	if err != nil {

--- a/internal/services/loadbalancer/nat_rule_resource.go
+++ b/internal/services/loadbalancer/nat_rule_resource.go
@@ -288,9 +288,9 @@ func resourceArmLoadBalancerNatRuleDelete(d *pluginsdk.ResourceData, meta interf
 		return nil
 	}
 
-	oldNatRules := *loadBalancer.LoadBalancerPropertiesFormat.InboundNatRules
-	newNatRules := append(oldNatRules[:index], oldNatRules[index+1:]...)
-	loadBalancer.LoadBalancerPropertiesFormat.InboundNatRules = &newNatRules
+	natRules := *loadBalancer.LoadBalancerPropertiesFormat.InboundNatRules
+	natRules = append(natRules[:index], natRules[index+1:]...)
+	loadBalancer.LoadBalancerPropertiesFormat.InboundNatRules = &natRules
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
 	if err != nil {

--- a/internal/services/loadbalancer/outbound_rule_resource.go
+++ b/internal/services/loadbalancer/outbound_rule_resource.go
@@ -289,9 +289,9 @@ func resourceArmLoadBalancerOutboundRuleDelete(d *pluginsdk.ResourceData, meta i
 		return nil
 	}
 
-	oldOutboundRules := *loadBalancer.LoadBalancerPropertiesFormat.OutboundRules
-	newOutboundRules := append(oldOutboundRules[:index], oldOutboundRules[index+1:]...)
-	loadBalancer.LoadBalancerPropertiesFormat.OutboundRules = &newOutboundRules
+	outboundRules := *loadBalancer.LoadBalancerPropertiesFormat.OutboundRules
+	outboundRules = append(outboundRules[:index], outboundRules[index+1:]...)
+	loadBalancer.LoadBalancerPropertiesFormat.OutboundRules = &outboundRules
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
 	if err != nil {

--- a/internal/services/loadbalancer/probe_resource.go
+++ b/internal/services/loadbalancer/probe_resource.go
@@ -263,9 +263,9 @@ func resourceArmLoadBalancerProbeDelete(d *pluginsdk.ResourceData, meta interfac
 		return nil
 	}
 
-	oldProbes := *loadBalancer.LoadBalancerPropertiesFormat.Probes
-	newProbes := append(oldProbes[:index], oldProbes[index+1:]...)
-	loadBalancer.LoadBalancerPropertiesFormat.Probes = &newProbes
+	probes := *loadBalancer.LoadBalancerPropertiesFormat.Probes
+	probes = append(probes[:index], probes[index+1:]...)
+	loadBalancer.LoadBalancerPropertiesFormat.Probes = &probes
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
 	if err != nil {

--- a/internal/services/loadbalancer/rule_resource.go
+++ b/internal/services/loadbalancer/rule_resource.go
@@ -321,9 +321,9 @@ func resourceArmLoadBalancerRuleDelete(d *pluginsdk.ResourceData, meta interface
 		return nil
 	}
 
-	oldLbRules := *loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules
-	newLbRules := append(oldLbRules[:index], oldLbRules[index+1:]...)
-	loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules = &newLbRules
+	lbRules := *loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules
+	lbRules = append(lbRules[:index], lbRules[index+1:]...)
+	loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules = &lbRules
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.LoadBalancerName, loadBalancer)
 	if err != nil {

--- a/internal/services/managedapplications/managed_application_resource.go
+++ b/internal/services/managedapplications/managed_application_resource.go
@@ -382,7 +382,6 @@ func flattenManagedApplicationParametersOrOutputs(input interface{}) (map[string
 			default:
 				return nil, fmt.Errorf("unexpected parameter type %T", t)
 			}
-
 		}
 	}
 

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -1708,8 +1708,7 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["ip_restriction"]; ok {
-		ipSecurityRestrictions := v.(interface{})
-		restrictions, err := expandAppServiceIpRestriction(ipSecurityRestrictions)
+		restrictions, err := expandAppServiceIpRestriction(v)
 		if err != nil {
 			return siteConfig, err
 		}
@@ -1782,8 +1781,7 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["cors"]; ok {
-		corsSettings := v.(interface{})
-		expand := ExpandWebCorsSettings(corsSettings)
+		expand := ExpandWebCorsSettings(v)
 		siteConfig.Cors = &expand
 	}
 

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -384,8 +384,7 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 	}
 
 	if v, ok := config["cors"]; ok {
-		corsSettings := v.(interface{})
-		expand := ExpandWebCorsSettings(corsSettings)
+		expand := ExpandWebCorsSettings(v)
 		siteConfig.Cors = &expand
 	}
 
@@ -394,8 +393,7 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 	}
 
 	if v, ok := config["ip_restriction"]; ok {
-		ipSecurityRestrictions := v.(interface{})
-		restrictions, err := expandAppServiceIpRestriction(ipSecurityRestrictions)
+		restrictions, err := expandAppServiceIpRestriction(v)
 		if err != nil {
 			return siteConfig, err
 		}

--- a/internal/tf/pluginsdk/resource.go
+++ b/internal/tf/pluginsdk/resource.go
@@ -27,7 +27,8 @@ type (
 )
 
 type (
-	CreateFunc = schema.CreateFunc //nolint:SA1019
+	// lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
+	CreateFunc = schema.CreateFunc //nolint:staticcheck
 	DeleteFunc = schema.DeleteFunc
 	ExistsFunc = schema.ExistsFunc
 	ReadFunc   = schema.ReadFunc

--- a/internal/tf/pluginsdk/retries.go
+++ b/internal/tf/pluginsdk/retries.go
@@ -20,7 +20,8 @@ type RetryError = resource.RetryError
 // a function until it no longer returns an error.
 func Retry(timeout time.Duration, f RetryFunc) error {
 	// TODO: deprecate this
-	return resource.Retry(timeout, f) //nolint:SA1019
+	// lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
+	return resource.Retry(timeout, f) //nolint:staticcheck
 }
 
 // RetryableError is a helper to create a RetryError that's retryable from a

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -13,13 +13,15 @@ import (
 
 // All returns a SchemaValidateFunc which tests if the provided value
 // passes all provided SchemaValidateFunc
-func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc { //nolint:SA1019
+// lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
+func All(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.All(validators...)
 }
 
 // Any returns a SchemaValidateFunc which tests if the provided value
 // passes any of the provided SchemaValidateFunc
-func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc { //nolint:SA1019
+//lint:ignore SA1019 SDKv2 migration - staticcheck's own linter directives are currently being ignored under golanci-lint
+func Any(validators ...schema.SchemaValidateFunc) schema.SchemaValidateFunc { //nolint:staticcheck
 	return validation.Any(validators...)
 }
 

--- a/internal/tools/generator-resource-id/main.go
+++ b/internal/tools/generator-resource-id/main.go
@@ -251,7 +251,7 @@ func NewResourceID(typeName, servicePackageName, resourceId string) (*ResourceId
 				if strings.HasSuffix(key, "sses") {
 					key = strings.TrimSuffix(key, "sses")
 					key = fmt.Sprintf("%sss", key)
-				} else if strings.HasSuffix(key, "s") {
+				} else {
 					key = strings.TrimSuffix(key, "s")
 				}
 

--- a/scripts/run-lint.sh
+++ b/scripts/run-lint.sh
@@ -2,7 +2,7 @@
 
 function runLinters {
   echo "==> Checking source code against linters..."
-  golangci-lint run ./...
+  golangci-lint run -v ./...
 }
 
 function main {


### PR DESCRIPTION
Includes:
- workaround for `staticcheck` lint directives not working correctly
- Lint fixes for new rules in existing linters since `1.32`
- fixes the exclude path for filtering out the generated SDK folders in the service packages

Purposely Excludes:
- `whitespace` linter for performance reasons (skips cache on change and takes a long time due to number of files in the repo
- New linters introduced since 1.32 to reduce potential problems of change-on-change
- dropping the `timeout` value until proven to execute sufficiently faster than previously in GHA

**Note:** contributors will need to re-run `make tools` to pick up the new version and correctly lint for the additional rules covered.
