### PR TITLE
azurerm_data_factory_dataset_delimited_text - support empty values for the column_delimiter, row_delimiter, quote_character, escape_character, encoding propeties

### DIFF
--- a/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
+++ b/internal/services/datafactory/data_factory_dataset_delimited_text_resource.go
@@ -142,34 +142,30 @@ func resourceDataFactoryDatasetDelimitedText() *pluginsdk.Resource {
 
 			// Delimited Text Specific Field
 			"column_delimiter": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
 			},
 
 			// Delimited Text Specific Field
 			"row_delimiter": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			// Delimited Text Specific Field
-			"encoding": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
 			},
 
 			// Delimited Text Specific Field
 			"quote_character": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:     pluginsdk.TypeString,
+				Optional: true,
 			},
 
 			// Delimited Text Specific Field
 			"escape_character": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+
+			// Delimited Text Specific Field
+			"encoding": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
@@ -322,24 +318,24 @@ func resourceDataFactoryDatasetDelimitedTextCreateUpdate(d *pluginsdk.ResourceDa
 		Location: location,
 	}
 
-	if v, ok := d.GetOk("column_delimiter"); ok {
-		delimited_textDatasetProperties.ColumnDelimiter = v.(string)
+	if v, ok := d.Get("column_delimiter").(string); ok {
+		delimited_textDatasetProperties.ColumnDelimiter = v
 	}
 
-	if v, ok := d.GetOk("row_delimiter"); ok {
-		delimited_textDatasetProperties.RowDelimiter = v.(string)
+	if v, ok := d.Get("row_delimiter").(string); ok {
+		delimited_textDatasetProperties.RowDelimiter = v
+	}
+
+	if v, ok := d.Get("quote_character").(string); ok {
+		delimited_textDatasetProperties.QuoteChar = v
+	}
+
+	if v, ok := d.Get("escape_character").(string); ok {
+		delimited_textDatasetProperties.EscapeChar = v
 	}
 
 	if v, ok := d.GetOk("encoding"); ok {
 		delimited_textDatasetProperties.EncodingName = v.(string)
-	}
-
-	if v, ok := d.GetOk("quote_character"); ok {
-		delimited_textDatasetProperties.QuoteChar = v.(string)
-	}
-
-	if v, ok := d.GetOk("escape_character"); ok {
-		delimited_textDatasetProperties.EscapeChar = v.(string)
 	}
 
 	if v, ok := d.GetOk("first_row_as_header"); ok {

--- a/internal/services/datafactory/data_factory_dataset_delimited_text_resource_test.go
+++ b/internal/services/datafactory/data_factory_dataset_delimited_text_resource_test.go
@@ -25,6 +25,10 @@ func TestAccDataFactoryDatasetDelimitedText_http(t *testing.T) {
 			Config: r.http(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("column_delimiter").HasValue(""),
+				check.That(data.ResourceName).Key("row_delimiter").HasValue(""),
+				check.That(data.ResourceName).Key("quote_character").HasValue(""),
+				check.That(data.ResourceName).Key("escape_character").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -47,6 +51,10 @@ func TestAccDataFactoryDatasetDelimitedText_http_update(t *testing.T) {
 				check.That(data.ResourceName).Key("description").HasValue("test description"),
 				check.That(data.ResourceName).Key("compression_codec").HasValue("gzip"),
 				check.That(data.ResourceName).Key("compression_level").HasValue("Optimal"),
+				check.That(data.ResourceName).Key("column_delimiter").HasValue(","),
+				check.That(data.ResourceName).Key("row_delimiter").HasValue("NEW"),
+				check.That(data.ResourceName).Key("quote_character").HasValue("x"),
+				check.That(data.ResourceName).Key("escape_character").HasValue("f"),
 			),
 		},
 		data.ImportStep(),
@@ -166,11 +174,11 @@ resource "azurerm_data_factory_dataset_delimited_text" "test" {
     filename     = "foo.txt"
   }
 
-  column_delimiter    = ","
-  row_delimiter       = "NEW"
+  column_delimiter    = ""
+  row_delimiter       = ""
   encoding            = "UTF-8"
-  quote_character     = "x"
-  escape_character    = "f"
+  quote_character     = ""
+  escape_character    = ""
   first_row_as_header = true
   null_value          = "NULL"
 


### PR DESCRIPTION
The delimited text format treats the changed values differently depending on whether they are omitted or set as empty strings. This PR allows the appropriate values to be set as empty strings as well as being omitted. See: https://docs.microsoft.com/en-us/azure/data-factory/format-delimited-text for documentation.

```
➜  ~/go/src/github.com/hashicorp/terraform-provider-azurerm: git:(adf-dataset-delimited-fix-pt2) ✗ make acctests SERVICE='datafactory/data_factory_dataset_delimited_text_resource_test.go' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/datafactory/data_factory_dataset_delimited_text_resource_test.go  -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataFactoryDatasetDelimitedText_http
=== PAUSE TestAccDataFactoryDatasetDelimitedText_http
=== RUN   TestAccDataFactoryDatasetDelimitedText_http_update
=== PAUSE TestAccDataFactoryDatasetDelimitedText_http_update
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob_basic
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob_basic
=== RUN   TestAccDataFactoryDatasetDelimitedText_blob
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blob
=== RUN   TestAccDataFactoryDatasetDelimitedText_blobFS
=== PAUSE TestAccDataFactoryDatasetDelimitedText_blobFS
=== CONT  TestAccDataFactoryDatasetDelimitedText_http
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob
=== CONT  TestAccDataFactoryDatasetDelimitedText_blob_basic
=== CONT  TestAccDataFactoryDatasetDelimitedText_blobFS
=== CONT  TestAccDataFactoryDatasetDelimitedText_http_update
--- PASS: TestAccDataFactoryDatasetDelimitedText_http (94.20s)
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob (104.20s)
--- PASS: TestAccDataFactoryDatasetDelimitedText_blob_basic (111.27s)
--- PASS: TestAccDataFactoryDatasetDelimitedText_blobFS (127.20s)
--- PASS: TestAccDataFactoryDatasetDelimitedText_http_update (141.36s)
PASS
ok  	command-line-arguments	144.400s
```