### PR TITLE
`name` value must be globally unique across all of Azure for PostgreSQL Flexible Server

### DIFF
--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -79,7 +79,9 @@ resource "azurerm_postgresql_flexible_server" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created. This must be unique across the entire Azure service, not just within the resource group.
+* `name` - (Required) The name which should be used for this PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created. 
+
+~> **Note** This must be unique across the entire Azure service, not just within the resource group.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the PostgreSQL Flexible Server should exist. Changing this forces a new PostgreSQL Flexible Server to be created.
 


### PR DESCRIPTION
For `azurerm_postgresql_flexible_server`, it's `name` value must be globally unique across all of Azure.