### PR TITLE
Included Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
What changes were proposed in this pull request?

Enable dependabot to get security updates and if needed version updates on dependencies.

Why are the changes needed?

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

Having knowledge about vulnerabilities of the dependencies helps the project owners decide on their dependency's security posture to make decisions.

If the project decides to get updates only on security updates and not on any version updates then setting these options would not open any PR's open-pull-requests-limit: 0

This option has to be enabled in the security section of the project.
https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories