### PR TITLE
add nil check to fix #13646

### DIFF
--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -722,7 +722,7 @@ func expandLogicAppWorkflowAccessControl(input []interface{}) *logic.FlowAccessC
 }
 
 func expandLogicAppWorkflowAccessControlConfigurationPolicy(input []interface{}) *logic.FlowAccessControlConfigurationPolicy {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 	v := input[0].(map[string]interface{})


### PR DESCRIPTION
Try to fix #13646 .

The failed test `TestAccLogicAppWorkflow_integrationServiceEnvironment` also failed on upstream's main branch, so this fix should be ok I guess.

=== RUN   TestAccLogicAppWorkflow_empty
=== PAUSE TestAccLogicAppWorkflow_empty
=== CONT  TestAccLogicAppWorkflow_empty
--- PASS: TestAccLogicAppWorkflow_empty (308.00s)
=== RUN   TestAccLogicAppWorkflow_requiresImport
=== PAUSE TestAccLogicAppWorkflow_requiresImport
=== CONT  TestAccLogicAppWorkflow_requiresImport
--- PASS: TestAccLogicAppWorkflow_requiresImport (279.67s)
=== RUN   TestAccLogicAppWorkflow_tags
=== PAUSE TestAccLogicAppWorkflow_tags
=== CONT  TestAccLogicAppWorkflow_tags
--- PASS: TestAccLogicAppWorkflow_tags (544.30s)
=== RUN   TestAccLogicAppWorkflow_integrationAccount
=== PAUSE TestAccLogicAppWorkflow_integrationAccount
=== CONT  TestAccLogicAppWorkflow_integrationAccount
--- PASS: TestAccLogicAppWorkflow_integrationAccount (847.01s)
=== RUN   TestAccLogicAppWorkflow_parameters
=== PAUSE TestAccLogicAppWorkflow_parameters
=== CONT  TestAccLogicAppWorkflow_parameters
--- PASS: TestAccLogicAppWorkflow_parameters (263.44s)
=== RUN   TestAccLogicAppWorkflow_accessControl
=== PAUSE TestAccLogicAppWorkflow_accessControl
=== CONT  TestAccLogicAppWorkflow_accessControl
--- PASS: TestAccLogicAppWorkflow_accessControl (435.17s)
=== RUN   TestAccLogicAppWorkflow_integrationServiceEnvironment
=== PAUSE TestAccLogicAppWorkflow_integrationServiceEnvironment
=== CONT  TestAccLogicAppWorkflow_integrationServiceEnvironment
    testcase.go:88: Step 1/2 error: Error running apply: exit status 1
        
        Error: waiting for completion of Integration Service Environment "acctestRG-logic-211011124032403569" (Resource Group "acctestRG-logic-211011124032403569"): Code="IntegrationServiceEnvironmentVirtualNetworkConnectivityFailure" Message="The integration service environment 'acctestRG-logic-211011124032403569' provisioning failed because the required connectivity to and from the virtual network 'acctest-vnet-211011124032403569' for management and runtime operations could not be established. Please make sure all the required ports are open https://aka.ms/integration-service-environment#set-up-network-ports."
        
          with azurerm_integration_service_environment.test,
          on terraform_plugin_test.tf line 57, in resource "azurerm_integration_service_environment" "test":
          57: resource "azurerm_integration_service_environment" "test" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Subnet: (Name "isesubnet2" / Virtual Network Name "acctest-vnet-211011124032403569" / Resource Group "acctestRG-logic-211011124032403569"): network.SubnetsClient#Delete: Failure sending request: StatusCode=0 -- Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet isesubnet2 is in use by /subscriptions/c73bac49-6143-4da3-bbdd-2d8e09a178dc/resourceGroups/easia_45506_bbb367447f584d79a4cf91db2470f7a9/providers/Microsoft.Network/loadBalancers/easia-45506-479743803/frontendIPConfigurations/frontend and cannot be deleted. In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet." Details=[]
        
        
        Error: deleting Subnet: (Name "isesubnet3" / Virtual Network Name "acctest-vnet-211011124032403569" / Resource Group "acctestRG-logic-211011124032403569"): network.SubnetsClient#Delete: Failure sending request: StatusCode=0 -- Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet isesubnet3 is in use by /subscriptions/cd3cfe23-a890-4a2d-b81b-49d9e764a7c1/providers/Microsoft.ApiManagement/service?vnetResourceGuid=00dc3e56-b804-47f6-abb2-cc851312017d&subnet=isesubnet3&api-version=2016-07-07 and cannot be deleted. In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet." Details=[]
        
--- FAIL: TestAccLogicAppWorkflow_integrationServiceEnvironment (1898.79s)

FAIL

Process finished with the exit code 1