### PR TITLE
Check casing of resource provider in parser generator

### DIFF
--- a/internal/tools/generator-resource-id/main.go
+++ b/internal/tools/generator-resource-id/main.go
@@ -204,7 +204,7 @@ func NewResourceID(typeName, servicePackageName, resourceId string) (*ResourceId
 		// the RP shouldn't be transformed
 		if key == "providers" {
 			if features.ThreePointOh() {
-				r := regexp.MustCompile(`^Microsoft.[A-Z][a-z]+$`)
+				r := regexp.MustCompile(`^Microsoft.[A-Z][A-Za-z]+$`)
 				if !r.MatchString(value) {
 					return nil, fmt.Errorf("the resource provider in the id must begin with upper case got: %s", value)
 				}


### PR DESCRIPTION
Placed the check behind the `ThreePointOh` feature flag which is currently hardcoded to be disabled. 