### PR TITLE
update doc, changing `tags` will cause a re-creation

### DIFF
--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -247,7 +247,7 @@ The following arguments are supported:
 
 * `certificate_policy` - (Required) A `certificate_policy` block as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
As #13315 mentioned, changing `tags` in `azurerm_key_vault_certificate` will cause a force re-creation.

In [resource code](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/keyvault/key_vault_certificate_resource.go#L390) , the `tags` argument is a force new schema, because there's no update method for key vault certificate in [rest api](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.2/certificates.json) .