### PR TITLE
`azurerm_subnet_resource` - Lock virtual network and subnet on update

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -290,6 +290,12 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	locks.ByName(id.VirtualNetworkName, VirtualNetworkResourceName)
+	defer locks.UnlockByName(id.VirtualNetworkName, VirtualNetworkResourceName)
+
+	locks.ByName(id.Name, SubnetResourceName)
+	defer locks.UnlockByName(id.Name, SubnetResourceName)
+
 	existing, err := client.Get(ctx, id.ResourceGroup, id.VirtualNetworkName, id.Name, "")
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -422,6 +422,13 @@ resource "azurerm_subnet" "test" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefix       = "10.0.2.0/24"
 }
+
+resource "azurerm_subnet" "test2" {
+  name                 = "internal2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.3.0/24"
+}
 `, r.template(data))
 }
 
@@ -571,6 +578,14 @@ resource "azurerm_subnet" "test" {
   address_prefix       = "10.0.2.0/24"
   service_endpoints    = ["Microsoft.Sql"]
 }
+
+resource "azurerm_subnet" "test2" {
+  name                 = "internal2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.3.0/24"
+  service_endpoints    = ["Microsoft.Sql"]
+}
 `, r.template(data))
 }
 
@@ -583,6 +598,14 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefix       = "10.0.2.0/24"
+  service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "internal2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.3.0/24"
   service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
 }
 `, r.template(data))


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Summary

This pull request locks the subnet resource and associated virtual network when updating subnets to prevent conflicting, concurrent operations.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes: #13564

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make acctests SERVICE='network' TESTARGS='-run="^TestAccSubnet_"'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run="^TestAccSubnet_" -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSubnet_basic
=== PAUSE TestAccSubnet_basic
=== RUN   TestAccSubnet_basic_addressPrefixes
=== PAUSE TestAccSubnet_basic_addressPrefixes
=== RUN   TestAccSubnet_complete_addressPrefixes
=== PAUSE TestAccSubnet_complete_addressPrefixes
=== RUN   TestAccSubnet_update_addressPrefixes
=== PAUSE TestAccSubnet_update_addressPrefixes
=== RUN   TestAccSubnet_requiresImport
=== PAUSE TestAccSubnet_requiresImport
=== RUN   TestAccSubnet_disappears
=== PAUSE TestAccSubnet_disappears
=== RUN   TestAccSubnet_delegation
=== PAUSE TestAccSubnet_delegation
=== RUN   TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies
=== PAUSE TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies
=== RUN   TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies
=== PAUSE TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies
=== RUN   TestAccSubnet_serviceEndpoints
=== PAUSE TestAccSubnet_serviceEndpoints
=== RUN   TestAccSubnet_serviceEndpointPolicy
=== PAUSE TestAccSubnet_serviceEndpointPolicy
=== RUN   TestAccSubnet_updateAddressPrefix
=== PAUSE TestAccSubnet_updateAddressPrefix
=== CONT  TestAccSubnet_basic
=== CONT  TestAccSubnet_delegation
=== CONT  TestAccSubnet_update_addressPrefixes
=== CONT  TestAccSubnet_serviceEndpoints
=== CONT  TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies
=== CONT  TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies
=== CONT  TestAccSubnet_serviceEndpointPolicy
=== CONT  TestAccSubnet_complete_addressPrefixes
=== CONT  TestAccSubnet_updateAddressPrefix
--- PASS: TestAccSubnet_basic (202.03s)
--- PASS: TestAccSubnet_complete_addressPrefixes (374.71s)
=== CONT  TestAccSubnet_basic_addressPrefixes
--- PASS: TestAccSubnet_serviceEndpointPolicy (415.83s)
=== CONT  TestAccSubnet_disappears
--- PASS: TestAccSubnet_enforcePrivateLinkEndpointNetworkPolicies (473.57s)
=== CONT  TestAccSubnet_requiresImport
--- PASS: TestAccSubnet_update_addressPrefixes (475.50s)
--- PASS: TestAccSubnet_enforcePrivateLinkServiceNetworkPolicies (488.09s)
--- PASS: TestAccSubnet_serviceEndpoints (522.45s)
--- PASS: TestAccSubnet_updateAddressPrefix (368.98s)
--- PASS: TestAccSubnet_disappears (157.32s)
--- PASS: TestAccSubnet_basic_addressPrefixes (222.55s)
--- PASS: TestAccSubnet_delegation (615.58s)
--- PASS: TestAccSubnet_requiresImport (172.97s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       649.314s
```
