### PR TITLE
storage_data_lake_gen2_path note about ACL inheritance

### DIFF
--- a/website/docs/r/storage_data_lake_gen2_path.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_path.html.markdown
@@ -76,6 +76,8 @@ An `ace` block supports the following:
 
 More details on ACLs can be found here: https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control#access-control-lists-on-files-and-directories
 
+~> **Note:** Using the service's ACE inheritance features will not work well with terraform since we cannot handle changes that are taking place out-of-band. Setting the path to inherit its permissions from its parent will result in terraform trying to revert them in the next apply operation. 
+
 ~> **NOTE:** The Storage Account requires `account_kind` to be either `StorageV2` or `BlobStorage`. In addition, `is_hns_enabled` has to be set to `true`.
 
 ## Attributes Reference


### PR DESCRIPTION
Azure will automatically apply the default ACL to all nested directories
(which is expected) but terraform knows nothing about it and tries to
revert to what it believes to be right.

At this point it's not possible for terraform to handle this isse since
we cannot tell if the ACL change took place because the of inheritance
or because someone else changed the permissions manually.
