### PR TITLE
`azurerm_mssql_server`: Set `azuread_administrator` inline on creation

### DIFF
--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -134,6 +134,21 @@ func TestAccMsSqlServer_azureadAdmin(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.aadAdmin(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_login_password"),
+	})
+}
+
+func TestAccMsSqlServer_azureadAdminUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MsSqlServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),


### PR DESCRIPTION
Fixes #13677

Besides:
- it reduces the calls around the replacement of an `azuread_administrator`
- it prevents a possible violation of mentioned Azure Policies (#13677) on update for the same reason the inline creation was required

## Acceptance tests
```
❯ go install && make acctests SERVICE='mssql' TESTARGS='-run=TestAccMsSqlServer_azureadAdminUpdate'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/mssql -run=TestAccMsSqlServer_azureadAdminUpdate -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMsSqlServer_azureadAdminUpdate
=== PAUSE TestAccMsSqlServer_azureadAdminUpdate
=== CONT  TestAccMsSqlServer_azureadAdminUpdate
--- PASS: TestAccMsSqlServer_azureadAdminUpdate (904.20s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql    905.764s
```