### PR TITLE
Add support for auto key rotation in disk encryption set

### DIFF
--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -70,6 +70,7 @@ func TestAccDiskEncryptionSet_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enable_auto_key_rotation").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -77,6 +78,7 @@ func TestAccDiskEncryptionSet_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enable_auto_key_rotation").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -244,6 +246,8 @@ resource "azurerm_disk_encryption_set" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  enable_auto_key_rotation = true
 
   tags = {
     Hello = "woRld"

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -107,6 +107,8 @@ The following arguments are supported:
 
 * `identity` - (Required) A `identity` block defined below.
 
+* `enable_auto_key_rotation` - (Optional) Boolean flag to specify whether Azure automatically rotate to your latest key version of the selected key. Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags to assign to the Disk Encryption Set.
 
 ---


### PR DESCRIPTION
rotationToLatestKeyVersionEnabled is not present in disk_encryption_set_resource, which makes [automatic key rotation](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-enable-customer-managed-keys-powershell#set-up-an-azure-key-vault-and-diskencryptionset-optionally-with-automatic-key-rotation) not possible.

