### PR TITLE
`azurerm_container_registry` - add supports for `region_endpoint_enabled`

### DIFF
--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -120,7 +120,7 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 							Default:  false,
 						},
 
-						"region_endpoint_enabled": {
+						"regional_endpoint_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 						},
@@ -818,7 +818,7 @@ func resourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}) 
 				replication["location"] = valueLocation
 				replication["tags"] = tags.Flatten(value.Tags)
 				replication["zone_redundancy_enabled"] = value.ZoneRedundancy == containerregistry.ZoneRedundancyEnabled
-				replication["region_endpoint_enabled"] = value.RegionEndpointEnabled != nil && *value.RegionEndpointEnabled
+				replication["regional_endpoint_enabled"] = value.RegionEndpointEnabled != nil && *value.RegionEndpointEnabled
 				geoReplications = append(geoReplications, replication)
 			}
 		}
@@ -966,7 +966,7 @@ func expandReplications(p []interface{}) []containerregistry.Replication {
 			Tags:     tags,
 			ReplicationProperties: &containerregistry.ReplicationProperties{
 				ZoneRedundancy:        zoneRedundancy,
-				RegionEndpointEnabled: utils.Bool(value["region_endpoint_enabled"].(bool)),
+				RegionEndpointEnabled: utils.Bool(value["regional_endpoint_enabled"].(bool)),
 			},
 		})
 	}

--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -1182,8 +1182,8 @@ resource "azurerm_container_registry" "test" {
   location            = azurerm_resource_group.test.location
   sku                 = "Premium"
   georeplications {
-    location                = "%s"
-    region_endpoint_enabled = true
+    location                  = "%s"
+    regional_endpoint_enabled = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary)

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -127,7 +127,7 @@ The following arguments are supported:
 
 * `quarantine_policy_enabled` - (Optional) Boolean value that indicates whether quarantine policy is enabled. Defaults to `false`.
 
-* `region_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry? Defaults to `false`.
+* `regional_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry? Defaults to `false`.
 
 * `retention_policy` - (Optional) A `retention_policy` block as documented below.
 


### PR DESCRIPTION
`azurerm_container_registry` - add supports for `region_endpoint_enabled`

## Test

```bash
💢 TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run="TestAccContainerRegistry_geoReplicationRegionEndpoint"
=== RUN   TestAccContainerRegistry_geoReplicationRegionEndpoint
=== PAUSE TestAccContainerRegistry_geoReplicationRegionEndpoint
=== CONT  TestAccContainerRegistry_geoReplicationRegionEndpoint
--- PASS: TestAccContainerRegistry_geoReplicationRegionEndpoint (295.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    295.053s
```