### PR TITLE
Handle default value for Percentage appconfig feature filters

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -376,10 +376,12 @@ func createOrUpdateFeature(ctx context.Context, client *appconfiguration.BaseCli
 		Enabled:     model.Enabled,
 	}
 
-	value.Conditions.ClientFilters.Filters = append(value.Conditions.ClientFilters.Filters, PercentageFeatureFilter{
-		Name:       PercentageFilterName,
-		Parameters: PercentageFilterParameters{Value: model.PercentageFilter},
-	})
+	if model.PercentageFilter > 0 {
+		value.Conditions.ClientFilters.Filters = append(value.Conditions.ClientFilters.Filters, PercentageFeatureFilter{
+			Name:       PercentageFilterName,
+			Parameters: PercentageFilterParameters{Value: model.PercentageFilter},
+		})
+	}
 
 	if len(model.TargetingFilters) > 0 {
 		for _, tgtf := range model.TargetingFilters {

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -24,6 +24,23 @@ func TestAccAppConfigurationFeature_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("percentage_filter_value").HasValue("10"),
+
+				check.That(data.ResourceName).Key("timewindow_filter.#").HasValue("1"),
+				check.That(data.ResourceName).Key("timewindow_filter.0.start").HasValue("2019-11-12T07:20:50.52Z"),
+				check.That(data.ResourceName).Key("timewindow_filter.0.end").HasValue("2019-11-13T07:20:50.52Z"),
+
+				check.That(data.ResourceName).Key("targeting_filter.#").HasValue("1"),
+				check.That(data.ResourceName).Key("targeting_filter.0.default_rollout_percentage").HasValue("39"),
+				check.That(data.ResourceName).Key("targeting_filter.0.users.#").HasValue("2"),
+				check.That(data.ResourceName).Key("targeting_filter.0.users.0").HasValue("random"),
+				check.That(data.ResourceName).Key("targeting_filter.0.users.1").HasValue("user"),
+
+				check.That(data.ResourceName).Key("targeting_filter.0.groups.#").HasValue("2"),
+				check.That(data.ResourceName).Key("targeting_filter.0.groups.0.name").HasValue("testgroup"),
+				check.That(data.ResourceName).Key("targeting_filter.0.groups.0.rollout_percentage").HasValue("50"),
+				check.That(data.ResourceName).Key("targeting_filter.0.groups.1.name").HasValue("testgroup2"),
+				check.That(data.ResourceName).Key("targeting_filter.0.groups.1.rollout_percentage").HasValue("30"),
 			),
 		},
 		data.ImportStep(),
@@ -36,6 +53,20 @@ func TestAccAppConfigurationFeature_basicNoLabel(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicNoLabel(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAppConfigurationFeature_basicNoFilters(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
+	r := AppConfigurationFeatureResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicNoFilters(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -289,4 +320,34 @@ resource "azurerm_app_configuration_feature" "test" {
   enabled                = %t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabledStatus)
+}
+
+func (t AppConfigurationFeatureResource) basicNoFilters(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appconfig-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_configuration" "test" {
+  name                = "testacc-appconf%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "standard"
+}
+
+resource "azurerm_app_configuration_feature" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  description            = "test description"
+  name                   = "acctest-ackey-%d"
+  label                  = "acctest-ackeylabel-%d"
+  enabled                = true
+}
+
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
The code will create a percentage filter with value of 0, unless a value
is defined. This is not an acceptable configuration.
