### PR TITLE
`azurerm_servicebus_subscription`: Support for `name="_somename_"`

### DIFF
--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -238,7 +238,7 @@ resource "azurerm_servicebus_topic" "test" {
 }
 
 resource "azurerm_servicebus_subscription" "test" {
-  name                = "acctestservicebussubscription-%d"
+  name                = "_acctestservicebussubscription-%d_"
   namespace_name      = "${azurerm_servicebus_namespace.test.name}"
   topic_name          = "${azurerm_servicebus_topic.test.name}"
   resource_group_name = "${azurerm_resource_group.test.name}"

--- a/internal/services/servicebus/validate/subscription_name.go
+++ b/internal/services/servicebus/validate/subscription_name.go
@@ -9,7 +9,7 @@ import (
 
 func SubscriptionName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile("^[a-zA-Z0-9][-._a-zA-Z0-9]{0,48}([a-zA-Z0-9])?$"),
-		"The name can contain only letters, numbers, periods, hyphens and underscores. The name must start and end with a letter or number and be a maximum of 50 characters long.",
+		regexp.MustCompile("^[_a-zA-Z0-9][-._a-zA-Z0-9]{0,48}([_a-zA-Z0-9])?$"),
+		"The name can contain only letters, numbers, periods, hyphens and underscores. The name must start and end with a letter, number or underscore and be a maximum of 50 characters long.",
 	)
 }


### PR DESCRIPTION
Fixes #13789

## Acceptance Tests
```bash
❯ make acctests SERVICE='servicebus' TESTARGS='-run=TestAccServiceBusSubscription_basic'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/servicebus -run=TestAccServiceBusSubscription_basic -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccServiceBusSubscription_basic
=== PAUSE TestAccServiceBusSubscription_basic
=== CONT  TestAccServiceBusSubscription_basic
--- PASS: TestAccServiceBusSubscription_basic (295.41s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus    297.556s
```