### PR TITLE
Removed note of container soft delete preview

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -159,8 +159,6 @@ A `blob_properties` block supports the following:
 
 * `container_delete_retention_policy` - (Optional) A `container_delete_retention_policy` block as defined below.
 
-~> **Note:** Before setting `container_delete_retention_policy`, the feature `ContainerSoftDelete` needs to be enabled by [steps](https://docs.microsoft.com/en-us/azure/storage/blobs/soft-delete-container-overview?tabs=powershell#register-for-the-preview)
-
 ---
 
 A `cors_rule` block supports the following:


### PR DESCRIPTION
The feature is in GA since July 12, 2021([announcement](https://azure.microsoft.com/en-us/updates/azure-blob-storage-container-soft-delete-generally-available/)). The link target was removed from the Microsoft Azure documentation at September 1.