### PR TITLE
Application insights `application_type` parameter is case insensitive

### DIFF
--- a/internal/services/applicationinsights/application_insights_resource.go
+++ b/internal/services/applicationinsights/application_insights_resource.go
@@ -272,7 +272,7 @@ func resourceApplicationInsightsRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if props := resp.ApplicationInsightsComponentProperties; props != nil {
-		// Accomodate application_type that only differs by case and so shouldn't cause a recreation
+		// Accommodate application_type that only differs by case and so shouldn't cause a recreation
 		vals := map[string]string{
 			"web":   "web",
 			"other": "other",


### PR DESCRIPTION
- A couple of cases where types are likely to have existing uppercase variants (e.g. Web instead of web) to ensure the read operation doesn't detect a change and hence recreation of resource

Found this difference in validation logic when we were doing a `terraform import` and then `terraform plan` at work and terraform was going to recreate the resource because of a delta between the application type defined as 'Web' in azure whereas previously terraform only allowed the argument to be 'web' (all lowercase)