### PR TITLE
`azurerm_mssql_database`: Fix `threat_detection_policy` options for AccTests

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -805,7 +805,9 @@ func flattenMsSqlServerSecurityAlertPolicy(d *pluginsdk.ResourceData, policy sql
 	if disabledAlerts := properties.DisabledAlerts; disabledAlerts != nil {
 		flattenedAlerts := pluginsdk.NewSet(pluginsdk.HashString, []interface{}{})
 		for _, a := range *disabledAlerts {
-			flattenedAlerts.Add(a)
+			if a != "" {
+				flattenedAlerts.Add(a)
+			}
 		}
 		securityAlertPolicy["disabled_alerts"] = flattenedAlerts
 	}


### PR DESCRIPTION
Fixes Acceptance Tests:
- [x] TestAccMsSqlDatabase_storageAccountType
- [x] TestAccMsSqlDatabase_threatDetectionPolicy

```bash
❯ go install && make acctests SERVICE='mssql' TESTARGS='-run=TestAccMsSqlDatabase_storageAccountType\|TestAccMsSqlDatabase_threatDetectionPolicy'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/mssql -run=TestAccMsSqlDatabase_storageAccountType\|TestAccMsSqlDatabase_threatDetectionPolicy -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMsSqlDatabase_storageAccountType
=== PAUSE TestAccMsSqlDatabase_storageAccountType
=== RUN   TestAccMsSqlDatabase_threatDetectionPolicy
=== PAUSE TestAccMsSqlDatabase_threatDetectionPolicy
=== CONT  TestAccMsSqlDatabase_storageAccountType
=== CONT  TestAccMsSqlDatabase_threatDetectionPolicy
--- PASS: TestAccMsSqlDatabase_threatDetectionPolicy (587.21s)
--- PASS: TestAccMsSqlDatabase_storageAccountType (721.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql 723.086s
```