### PR TITLE
`r\purview_account_resource`: Make `sku_name` Computed

### DIFF
--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -51,15 +51,6 @@ func resourcePurviewAccount() *pluginsdk.Resource {
 
 			"location": azure.SchemaLocation(),
 
-			"sku_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Standard_4",
-					"Standard_16",
-				}, false),
-			},
-
 			"public_network_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -85,6 +76,11 @@ func resourcePurviewAccount() *pluginsdk.Resource {
 						},
 					},
 				},
+			},
+
+			"sku_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
 			},
 
 			"catalog_endpoint": {
@@ -148,7 +144,6 @@ func resourcePurviewAccountCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 			Type: purview.SystemAssigned,
 		},
 		Location: &location,
-		Sku:      expandPurviewSkuName(d),
 		Tags:     tags.Expand(t),
 	}
 
@@ -240,23 +235,6 @@ func resourcePurviewAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	return nil
-}
-
-func expandPurviewSkuName(d *pluginsdk.ResourceData) *purview.AccountSku {
-	sku := d.Get("sku_name").(string)
-
-	if len(sku) == 0 {
-		return nil
-	}
-
-	name, capacity, err := azure.SplitSku(sku)
-	if err != nil {
-		return nil
-	}
-	return &purview.AccountSku{
-		Name:     purview.Name(name),
-		Capacity: utils.Int32(capacity),
-	}
 }
 
 func flattenPurviewSkuName(input *purview.AccountSku) string {

--- a/internal/services/purview/purview_account_resource_test.go
+++ b/internal/services/purview/purview_account_resource_test.go
@@ -71,7 +71,6 @@ resource "azurerm_purview_account" "test" {
   name                = "acctestsw%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  sku_name            = "Standard_4"
 }
 `, template, data.RandomInteger)
 }
@@ -85,7 +84,6 @@ resource "azurerm_purview_account" "import" {
   name                = azurerm_purview_account.test.name
   resource_group_name = azurerm_purview_account.test.resource_group_name
   location            = azurerm_purview_account.test.location
-  sku_name            = azurerm_purview_account.test.sku_name
 }
 `, template)
 }

--- a/website/docs/r/purview_account.html.markdown
+++ b/website/docs/r/purview_account.html.markdown
@@ -22,7 +22,6 @@ resource "azurerm_purview_account" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  sku_name            = "Standard_4"
 }
 ```
 
@@ -35,8 +34,6 @@ The following arguments are supported:
 * `name` - (Required) The name which should be used for this Purview Account. Changing this forces a new Purview Account to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Purview Account should exist. Changing this forces a new Purview Account to be created.
-
-* `sku_name` - (Required) The SKU's capacity for platform size and catalog capabilities. Accepted values are `Standard_4` and `Standard_16`.
 
 ---
 
@@ -59,6 +56,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `guardian_endpoint` - Guardian endpoint.
 
 * `scan_endpoint` - Scan endpoint.
+
+* `sku_name` - The SKU's capacity for platform size and catalog capabilities
 
 * `identity` - A `identity` block as defined below.
 


### PR DESCRIPTION
Azure changed the `sku` property of Purview Account to be read-only, which means it will no longer be specified by user, but populated by server instead. Related change: https://github.com/Azure/azure-rest-api-specs/commit/b75f081007698cea4af16ea6a2071b498b431b71. This breaks the purview account resource, as `sku_name` is currently a `Required` property, the acc tests are breaking as well since they set the sku_name. Updating it to be `Computed` to match the sdk behavior.

Test result:
$ make acctests SERVICE='purview' TESTARGS='-run=Test' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/purview -run=Test -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccPurviewAccount_basic
=== PAUSE TestAccPurviewAccount_basic
=== RUN   TestAccPurviewAccount_requiresImport
=== PAUSE TestAccPurviewAccount_requiresImport
=== CONT  TestAccPurviewAccount_basic
=== CONT  TestAccPurviewAccount_requiresImport
--- PASS: TestAccPurviewAccount_basic (639.83s)
--- PASS: TestAccPurviewAccount_requiresImport (655.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/purview       656.199s