### PR TITLE
Fix example usage of azurerm_data_protection_backup_policy_blob_storage in docs for azurerm_data_protection_backup_instance_blob_storage

### DIFF
--- a/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_instance_blob_storage.html.markdown
@@ -41,10 +41,9 @@ resource "azurerm_role_assignment" "example" {
 }
 
 resource "azurerm_data_protection_backup_policy_blob_storage" "example" {
-  name                = "example-backup-policy"
-  resource_group_name = azurerm_resource_group.rg.name
-  vault_id            = azurerm_data_protection_backup_vault.example.id
-  retention_duration  = "P30D"
+  name               = "example-backup-policy"
+  vault_id           = azurerm_data_protection_backup_vault.example.id
+  retention_duration = "P30D"
 }
 
 resource "azurerm_data_protection_backup_instance_blob_storage" "example" {


### PR DESCRIPTION
resource "azurerm_data_protection_backup_policy_blob_storage" does not have an attribute resource_group_name.