### PR TITLE
`d/azurerm_eventgrid_system_topic`: New data source

### DIFF
--- a/internal/services/eventgrid/eventgrid.go
+++ b/internal/services/eventgrid/eventgrid.go
@@ -49,6 +49,46 @@ func IdentitySchema() *schema.Schema {
 	}
 }
 
+func IdentitySchemaForDataSource() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(eventgrid.IdentityTypeNone),
+						string(eventgrid.IdentityTypeSystemAssigned),
+						string(eventgrid.IdentityTypeUserAssigned),
+					}, false),
+				},
+
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+
+				"tenant_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
 func eventSubscriptionPublicNetworkAccessEnabled() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeBool,

--- a/internal/services/eventgrid/eventgrid_system_topic_data_source.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_data_source.go
@@ -1,0 +1,103 @@
+package eventgrid
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func dataSourceEventGridSystemTopic() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceEventGridSystemTopicRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					validation.StringMatch(
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,128}$"),
+						"EventGrid Topics name must be 3 - 128 characters long, contain only letters, numbers and hyphens.",
+					),
+				),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"identity": IdentitySchemaForDataSource(),
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"source_arm_resource_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"topic_type": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"metric_arm_resource_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceEventGridSystemTopicRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).EventGrid.SystemTopicsClient
+	subscriptionId := meta.(*clients.Client).EventGrid.DomainsClient.SubscriptionID
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewSystemTopicID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[WARN] Event Grid System Topic '%s' was not found (resource group '%s')", id.Name, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("making Read request on Event Grid System Topic '%s': %+v", id.Name, err)
+	}
+
+	d.SetId(id.ID())
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+
+	if props := resp.SystemTopicProperties; props != nil {
+		d.Set("source_arm_resource_id", props.Source)
+		d.Set("topic_type", props.TopicType)
+		d.Set("metric_arm_resource_id", props.MetricResourceID)
+	}
+
+	if err := d.Set("identity", flattenIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/internal/services/eventgrid/eventgrid_system_topic_data_source_test.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_data_source_test.go
@@ -1,0 +1,99 @@
+package eventgrid_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type EventGridSystemTopicDataSource struct {
+}
+
+func TestAccEventGridSystemTopicDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_eventgrid_system_topic", "test")
+	r := EventGridSystemTopicDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.Foo").HasValue("Bar"),
+				check.That(data.ResourceName).Key("source_arm_resource_id").Exists(),
+				check.That(data.ResourceName).Key("topic_type").Exists(),
+				check.That(data.ResourceName).Key("metric_arm_resource_id").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccEventGridSystemTopicDataSource_basicWithSystemManagedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_eventgrid_system_topic", "test")
+	r := EventGridSystemTopicDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicWithSystemManagedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("0"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").Exists(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccEventGridSystemTopicDataSource_basicWithUserAssignedManagedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_eventgrid_system_topic", "test")
+	r := EventGridSystemTopicDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicWithUserAssignedManagedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("identity.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("UserAssigned"),
+				check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+				check.That(data.ResourceName).Key("identity.0.principal_id").IsEmpty(),
+				check.That(data.ResourceName).Key("identity.0.tenant_id").IsEmpty(),
+			),
+		},
+	})
+}
+
+func (EventGridSystemTopicDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_eventgrid_system_topic" "test" {
+  name                = azurerm_eventgrid_system_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, EventGridSystemTopicResource{}.complete(data))
+}
+
+func (EventGridSystemTopicDataSource) basicWithSystemManagedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_eventgrid_system_topic" "test" {
+  name                = azurerm_eventgrid_system_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, EventGridSystemTopicResource{}.basicWithSystemManagedIdentity(data))
+}
+
+func (EventGridSystemTopicDataSource) basicWithUserAssignedManagedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_eventgrid_system_topic" "test" {
+  name                = azurerm_eventgrid_system_topic.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, EventGridSystemTopicResource{}.basicWithUserAssignedManagedIdentity(data))
+}

--- a/internal/services/eventgrid/registration.go
+++ b/internal/services/eventgrid/registration.go
@@ -24,6 +24,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_eventgrid_topic":        dataSourceEventGridTopic(),
 		"azurerm_eventgrid_domain":       dataSourceEventGridDomain(),
 		"azurerm_eventgrid_domain_topic": dataSourceEventGridDomainTopic(),
+		"azurerm_eventgrid_system_topic": dataSourceEventGridSystemTopic(),
 	}
 }
 

--- a/website/docs/d/eventgrid_system_topic.html.markdown
+++ b/website/docs/d/eventgrid_system_topic.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_eventgrid_system_topic"
+description: |-
+  Gets information about an existing EventGrid System Topic
+
+---
+
+# Data Source: azurerm_eventgrid_system_topic
+
+Use this data source to access information about an existing EventGrid System Topic
+
+## Example Usage
+
+```hcl
+data "azurerm_eventgrid_system_topic" "example" {
+  name                = "eventgrid-system-topic"
+  resource_group_name = "example-resources"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The name of the EventGrid System Topic resource.
+
+* `resource_group_name` - The name of the resource group in which the EventGrid System Topic exists.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The EventGrid System Topic ID.
+
+* `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this Event Grid System Topic.
+
+* `metric_arm_resource_id` - The Metric ARM Resource ID of the Event Grid System Topic.
+
+* `source_arm_resource_id` - The ID of the Event Grid System Topic ARM Source.
+
+* `topic_type` - The Topic Type of the Event Grid System Topic. Possible values are: `Microsoft.AppConfiguration.ConfigurationStores`, `Microsoft.Communication.CommunicationServices`
+, `Microsoft.ContainerRegistry.Registries`, `Microsoft.Devices.IoTHubs`, `Microsoft.EventGrid.Domains`, `Microsoft.EventGrid.Topics`, `Microsoft.Eventhub.Namespaces`, `Microsoft.KeyVault.vaults`, `Microsoft.MachineLearningServices.Workspaces`, `Microsoft.Maps.Accounts`, `Microsoft.Media.MediaServices`, `Microsoft.Resources.ResourceGroups`, `Microsoft.Resources.Subscriptions`, `Microsoft.ServiceBus.Namespaces`, `Microsoft.SignalRService.SignalR`, `Microsoft.Storage.StorageAccounts`, `Microsoft.Web.ServerFarms` and `Microsoft.Web.Sites`. Changing this forces a new Event Grid System Topic to be created.
+
+~> **NOTE:** Some `topic_type`s (e.g. **Microsoft.Resources.Subscriptions**) have location set to `Global` instead of a real location like `West US`.
+
+* `tags` - A mapping of tags which are assigned to the Event Grid System Topic.
+
+---
+
+An `identity` block exports the following:
+
+* `type` - Specifies the type of Managed Service Identity that is configured on this Event Grid System Topic.
+
+* `principal_id` - Specifies the Principal ID of the System Assigned Managed Service Identity that is configured on this Event Grid System Topic.
+
+* `tenant_id` - Specifies the Tenant ID of the System Assigned Managed Service Identity that is configured on this Event Grid System Topic.
+
+* `identity_ids` - A list of IDs for User Assigned Managed Identity resources to be assigned.
+
+---
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the EventGrid System Topic.


### PR DESCRIPTION
Fixes #13846

## Acceptance Tests:
```bash
❯ go install && make acctests SERVICE='eventgrid' TESTARGS='-run=TestAccEventGridSystemTopicDataSource_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/eventgrid -run=TestAccEventGridSystemTopicDataSource_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccEventGridSystemTopicDataSource_complete
=== PAUSE TestAccEventGridSystemTopicDataSource_complete
=== RUN   TestAccEventGridSystemTopicDataSource_basicWithSystemManagedIdentity
=== PAUSE TestAccEventGridSystemTopicDataSource_basicWithSystemManagedIdentity
=== RUN   TestAccEventGridSystemTopicDataSource_basicWithUserAssignedManagedIdentity
=== PAUSE TestAccEventGridSystemTopicDataSource_basicWithUserAssignedManagedIdentity
=== CONT  TestAccEventGridSystemTopicDataSource_complete
=== CONT  TestAccEventGridSystemTopicDataSource_basicWithUserAssignedManagedIdentity
=== CONT  TestAccEventGridSystemTopicDataSource_basicWithSystemManagedIdentity
--- PASS: TestAccEventGridSystemTopicDataSource_complete (118.19s)
--- PASS: TestAccEventGridSystemTopicDataSource_basicWithUserAssignedManagedIdentity (126.96s)
--- PASS: TestAccEventGridSystemTopicDataSource_basicWithSystemManagedIdentity (129.14s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid     130.667s
```