### PR TITLE
Enhancement to azurerm_servicebus_namespace_network_rule_set: Support 'allow trusted services'  

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_network_rule_set_resource.go
@@ -70,7 +70,7 @@ func resourceServiceBusNamespaceNetworkRuleSet() *pluginsdk.Resource {
 				},
 			},
 
-			"allow_trusted_services": {
+			"trusted_services_allowed": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -128,7 +128,7 @@ func resourceServiceBusNamespaceNetworkRuleSetCreateUpdate(d *pluginsdk.Resource
 			DefaultAction:               servicebus.DefaultAction(d.Get("default_action").(string)),
 			VirtualNetworkRules:         expandServiceBusNamespaceVirtualNetworkRules(d.Get("network_rules").(*pluginsdk.Set).List()),
 			IPRules:                     expandServiceBusNamespaceIPRules(d.Get("ip_rules").(*pluginsdk.Set).List()),
-			TrustedServiceAccessEnabled: utils.Bool(d.Get("allow_trusted_services").(bool)),
+			TrustedServiceAccessEnabled: utils.Bool(d.Get("trusted_services_allowed").(bool)),
 		},
 	}
 
@@ -165,7 +165,7 @@ func resourceServiceBusNamespaceNetworkRuleSetRead(d *pluginsdk.ResourceData, me
 
 	if props := resp.NetworkRuleSetProperties; props != nil {
 		d.Set("default_action", string(props.DefaultAction))
-		d.Set("allow_trusted_services", props.TrustedServiceAccessEnabled)
+		d.Set("trusted_services_allowed", props.TrustedServiceAccessEnabled)
 
 		if err := d.Set("network_rules", pluginsdk.NewSet(networkRuleHash, flattenServiceBusNamespaceVirtualNetworkRules(props.VirtualNetworkRules))); err != nil {
 			return fmt.Errorf("failed to set `network_rules`: %+v", err)

--- a/internal/services/servicebus/servicebus_namespace_network_rule_set_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_network_rule_set_resource_test.go
@@ -40,7 +40,7 @@ func TestAccServiceBusNamespaceNetworkRule_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("allow_trusted_services").HasValue("true"),
+				check.That(data.ResourceName).Key("trusted_services_allowed").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -131,8 +131,8 @@ resource "azurerm_servicebus_namespace_network_rule_set" "test" {
   namespace_name      = azurerm_servicebus_namespace.test.name
   resource_group_name = azurerm_resource_group.test.name
 
-  default_action         = "Deny"
-  allow_trusted_services = true
+  default_action           = "Deny"
+  trusted_services_allowed = true
 
   network_rules {
     subnet_id                            = azurerm_subnet.test.id

--- a/website/docs/r/servicebus_namespace_network_rule_set.html.markdown
+++ b/website/docs/r/servicebus_namespace_network_rule_set.html.markdown
@@ -75,8 +75,7 @@ The following arguments are supported:
 
 * `default_action` - (Optional) Specifies the default action for the ServiceBus Namespace Network Rule Set. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
 
-
-* `allow_trusted_services` - (Optional) If True, then Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration. See [Trusted Microsoft Services](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/service-bus-messaging/includes/service-bus-trusted-services.md)  
+* `trusted_services_allowed` - (Optional) If True, then Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration. See [Trusted Microsoft Services](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/service-bus-messaging/includes/service-bus-trusted-services.md)  
 
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the ServiceBus Namespace.
 


### PR DESCRIPTION
Per #9740, supporting allow_trusted_services on service bus namespace network restrictions

```
 TF_ACC=1 go test -v ./internal/services/servicebus -run=TestAccServiceB usNamespaceNetworkRule_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccServiceBusNamespaceNetworkRule_basic
=== PAUSE TestAccServiceBusNamespaceNetworkRule_basic
=== RUN   TestAccServiceBusNamespaceNetworkRule_complete
=== PAUSE TestAccServiceBusNamespaceNetworkRule_complete
=== RUN   TestAccServiceBusNamespaceNetworkRule_update
=== PAUSE TestAccServiceBusNamespaceNetworkRule_update
=== RUN   TestAccServiceBusNamespaceNetworkRule_requiresImport
=== PAUSE TestAccServiceBusNamespaceNetworkRule_requiresImport
=== CONT  TestAccServiceBusNamespaceNetworkRule_basic
=== CONT  TestAccServiceBusNamespaceNetworkRule_requiresImport
=== CONT  TestAccServiceBusNamespaceNetworkRule_update
=== CONT  TestAccServiceBusNamespaceNetworkRule_complete
--- PASS: TestAccServiceBusNamespaceNetworkRule_basic (424.04s)
--- PASS: TestAccServiceBusNamespaceNetworkRule_update (631.10s)
--- PASS: TestAccServiceBusNamespaceNetworkRule_requiresImport (648.90s)
--- PASS: TestAccServiceBusNamespaceNetworkRule_complete (718.80s)
PASS
```