### PR TITLE
`azurerm_firewall_policy`: Fix import by removing potential nilpointers

### DIFF
--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -668,6 +668,18 @@ func flattenFirewallPolicyIntrusionDetection(input *network.FirewallPolicyIntrus
 	}
 
 	signatureOverrides := make([]interface{}, 0)
+	trafficBypass := make([]interface{}, 0)
+
+	if input.Configuration == nil {
+		return []interface{}{
+			map[string]interface{}{
+				"mode":                string(input.Mode),
+				"signature_overrides": signatureOverrides,
+				"traffic_bypass":      trafficBypass,
+			},
+		}
+	}
+
 	if overrides := input.Configuration.SignatureOverrides; overrides != nil {
 		for _, override := range *overrides {
 			id := ""
@@ -681,7 +693,6 @@ func flattenFirewallPolicyIntrusionDetection(input *network.FirewallPolicyIntrus
 		}
 	}
 
-	trafficBypass := make([]interface{}, 0)
 	if bypasses := input.Configuration.BypassTrafficSettings; bypasses != nil {
 		for _, bypass := range *bypasses {
 			name := ""
@@ -742,7 +753,7 @@ func flattenFirewallPolicyIntrusionDetection(input *network.FirewallPolicyIntrus
 }
 
 func flattenFirewallPolicyTransportSecurity(input *network.FirewallPolicyTransportSecurity) []interface{} {
-	if input == nil {
+	if input == nil || input.CertificateAuthority == nil {
 		return []interface{}{}
 	}
 


### PR DESCRIPTION
Fixes #13857

## Reproduction
```bash

❯ tf import azurerm_firewall_policy.xxxxx  /subscriptions/<subscriptionId>/resourceGroups/example-firewall/providers/Microsoft.Network/firewallPolicies/testaris91
azurerm_firewall_policy.xxxxx: Importing from ID "/subscriptions/<subscriptionId>/resourceGroups/example-firewall/providers/Microsoft.Network/firewallPolicies/testaris91"...
azurerm_firewall_policy.xxxxx: Import prepared!
  Prepared azurerm_firewall_policy for import
azurerm_firewall_policy.xxxxx: Refreshing state... [id=/subscriptions/<subscriptionId>/resourceGroups/example-firewall/providers/Microsoft.Network/firewallPolicies/testaris91]
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ReadResource call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-azurerm plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5df1483]

goroutine 106 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall.flattenFirewallPolicyIntrusionDetection(0xc001572fa8, 0x72e6eeb, 0x3, 0x6847500)
        /Users/aris/git/terraform-provider-azurerm/internal/services/firewall/firewall_policy_resource.go:683 +0xa3
github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall.resourceFirewallPolicyRead(0xc001881600, 0x6a06e60, 0xc0014ab500, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/internal/services/firewall/firewall_policy_resource.go:460 +0x9dd
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000aaad20, 0x7ace288, 0xc001535800, 0xc001881600, 0x6a06e60, 0xc0014ab500, 0x0, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:335 +0x1ee
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000aaad20, 0x7ace288, 0xc001535800, 0xc001746620, 0x6a06e60, 0xc0014ab500, 0xc0005dcaa8, 0x0, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/resource.go:624 +0x1cb
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc00000f830, 0x7ace288, 0xc001535800, 0xc001535840, 0xc001535800, 0x100d165, 0x6d58680)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/grpc_provider.go:575 +0x43b
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadResource(0xc001dc18a0, 0x7ace330, 0xc001535800, 0xc001517b60, 0xc001dc18a0, 0xc001e43650, 0xc001ea8ba0)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/server/server.go:298 +0x105
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0x6f30bc0, 0xc001dc18a0, 0x7ace330, 0xc001e43650, 0xc001517b00, 0x0, 0x7ace330, 0xc001e43650, 0xc001e9f400, 0x26e)
        /Users/aris/git/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000b728c0, 0x7b211b8, 0xc000602900, 0xc00182ab40, 0xc001111890, 0xb7bbb10, 0x0, 0x0, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:1292 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000b728c0, 0x7b211b8, 0xc000602900, 0xc00182ab40, 0x0)
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:1617 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc0010d4e80, 0xc000b728c0, 0x7b211b8, 0xc000602900, 0xc00182ab40)
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:940 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/aris/git/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:938 +0x1fd

Error: The terraform-provider-azurerm plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

## Solved

```bash
❯ tf import azurerm_firewall_policy.xxxxx  /subscriptions/<subscriptionId>/resourceGroups/example-firewall/providers/Microsoft.Network/firewallPolicies/testaris91
azurerm_firewall_policy.xxxxx: Importing from ID "/subscriptions/<subscriptionId>/resourceGroups/example-firewall/providers/Microsoft.Network/firewallPolicies/testaris91"...
azurerm_firewall_policy.xxxxx: Import prepared!
  Prepared azurerm_firewall_policy for import
azurerm_firewall_policy.xxxxx: Refreshing state... [id=/subscriptions/<subscriptionId>/resourceGroups/example-firewall/providers/Microsoft.Network/firewallPolicies/testaris91]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

## Acceptance Tests
```bash
❯ go install && make acctests SERVICE='firewall' TESTARGS='-run=TestAccFirewallPolicy_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/firewall -run=TestAccFirewallPolicy_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFirewallPolicy_basic
=== PAUSE TestAccFirewallPolicy_basic
=== RUN   TestAccFirewallPolicy_basicPremium
=== PAUSE TestAccFirewallPolicy_basicPremium
=== RUN   TestAccFirewallPolicy_complete
=== PAUSE TestAccFirewallPolicy_complete
=== RUN   TestAccFirewallPolicy_completePremium
=== PAUSE TestAccFirewallPolicy_completePremium
=== RUN   TestAccFirewallPolicy_update
=== PAUSE TestAccFirewallPolicy_update
=== RUN   TestAccFirewallPolicy_updatePremium
=== PAUSE TestAccFirewallPolicy_updatePremium
=== RUN   TestAccFirewallPolicy_requiresImport
=== PAUSE TestAccFirewallPolicy_requiresImport
=== RUN   TestAccFirewallPolicy_inherit
=== PAUSE TestAccFirewallPolicy_inherit
=== CONT  TestAccFirewallPolicy_basic
=== CONT  TestAccFirewallPolicy_updatePremium
=== CONT  TestAccFirewallPolicy_completePremium
=== CONT  TestAccFirewallPolicy_complete
=== CONT  TestAccFirewallPolicy_inherit
=== CONT  TestAccFirewallPolicy_update
=== CONT  TestAccFirewallPolicy_requiresImport
=== CONT  TestAccFirewallPolicy_basicPremium
--- PASS: TestAccFirewallPolicy_complete (104.46s)
--- PASS: TestAccFirewallPolicy_basic (110.55s)
--- PASS: TestAccFirewallPolicy_inherit (112.79s)
--- PASS: TestAccFirewallPolicy_basicPremium (113.53s)
--- PASS: TestAccFirewallPolicy_requiresImport (122.74s)
--- PASS: TestAccFirewallPolicy_update (228.96s)
--- PASS: TestAccFirewallPolicy_completePremium (280.80s)
--- PASS: TestAccFirewallPolicy_updatePremium (402.61s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall      404.176s
```