### PR TITLE
`azurerm_firewall_application_rule_collection`: Make `rule.protocol.port` required

### DIFF
--- a/internal/services/firewall/firewall_application_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_application_rule_collection_resource.go
@@ -126,7 +126,7 @@ func resourceFirewallApplicationRuleCollection() *pluginsdk.Resource {
 									},
 									"port": {
 										Type:         pluginsdk.TypeInt,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validate.PortNumber,
 									},
 								},

--- a/website/docs/r/firewall_application_rule_collection.html.markdown
+++ b/website/docs/r/firewall_application_rule_collection.html.markdown
@@ -119,7 +119,7 @@ A `rule` block supports the following:
 
 A `protocol` block supports the following:
 
-* `port` - (Optional) Specify a port for the connection.
+* `port` - (Required) Specify a port for the connection.
 
 * `type` - (Required) Specifies the type of connection. Possible values are `Http`, `Https` and `Mssql`.
 


### PR DESCRIPTION
Fixes #13868