### PR TITLE
Fix #13647

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -563,7 +563,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 		props.EnableNodePublicIP = utils.Bool(d.Get("enable_node_public_ip").(bool))
 	}
 
-	if d.HasChange("max_count") {
+	if d.HasChange("max_count") || d.Get("enable_auto_scaling").(bool) {
 		props.MaxCount = utils.Int32(int32(d.Get("max_count").(int)))
 	}
 
@@ -571,7 +571,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 		props.Mode = containerservice.AgentPoolMode(d.Get("mode").(string))
 	}
 
-	if d.HasChange("min_count") {
+	if d.HasChange("min_count") || d.Get("enable_auto_scaling").(bool) {
 		props.MinCount = utils.Int32(int32(d.Get("min_count").(int)))
 	}
 


### PR DESCRIPTION
Try to fix #13647 .
The origin code ignore `max_count` and `min_count` if they didn't change, but in case user provided zero value to these two fields as placeholder alone with a false` enable_auto_scaling`, then turned on `enable_auto_scaling` will cause plugin pass nil as `min_count` to sdk api and cause an error. This patch read `max_count` and `min_count` no matter user has changed their values when `enable_auto_scaling` is true.

Acc tests:
=== RUN   TestAccKubernetesClusterNodePool_autoScale
=== PAUSE TestAccKubernetesClusterNodePool_autoScale
=== CONT  TestAccKubernetesClusterNodePool_autoScale
--- PASS: TestAccKubernetesClusterNodePool_autoScale (1886.35s)
=== RUN   TestAccKubernetesClusterNodePool_autoScaleUpdate
=== PAUSE TestAccKubernetesClusterNodePool_autoScaleUpdate
=== RUN   TestAccKubernetesClusterNodePool_availabilityZones
=== PAUSE TestAccKubernetesClusterNodePool_availabilityZones
=== RUN   TestAccKubernetesClusterNodePool_errorForAvailabilitySet
=== PAUSE TestAccKubernetesClusterNodePool_errorForAvailabilitySet
=== RUN   TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
=== RUN   TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== RUN   TestAccKubernetesClusterNodePool_other
=== PAUSE TestAccKubernetesClusterNodePool_other
=== RUN   TestAccKubernetesClusterNodePool_multiplePools
=== PAUSE TestAccKubernetesClusterNodePool_multiplePools
=== RUN   TestAccKubernetesClusterNodePool_manualScale
=== PAUSE TestAccKubernetesClusterNodePool_manualScale
=== RUN   TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== CONT  TestAccKubernetesClusterNodePool_manualScaleMultiplePools
=== RUN   TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
=== RUN   TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
=== RUN   TestAccKubernetesClusterNodePool_manualScaleUpdate
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleUpdate
=== RUN   TestAccKubernetesClusterNodePool_manualScaleVMSku
=== PAUSE TestAccKubernetesClusterNodePool_manualScaleVMSku
=== RUN   TestAccKubernetesClusterNodePool_modeSystem
=== PAUSE TestAccKubernetesClusterNodePool_modeSystem
=== RUN   TestAccKubernetesClusterNodePool_modeUpdate
=== PAUSE TestAccKubernetesClusterNodePool_modeUpdate
=== RUN   TestAccKubernetesClusterNodePool_nodeLabels
=== PAUSE TestAccKubernetesClusterNodePool_nodeLabels
=== RUN   TestAccKubernetesClusterNodePool_nodePublicIP
=== PAUSE TestAccKubernetesClusterNodePool_nodePublicIP
=== CONT  TestAccKubernetesClusterNodePool_nodePublicIP
=== RUN   TestAccKubernetesClusterNodePool_nodeTaints
=== PAUSE TestAccKubernetesClusterNodePool_nodeTaints
=== CONT  TestAccKubernetesClusterNodePool_nodeTaints
--- PASS: TestAccKubernetesClusterNodePool_nodeTaints (1342.69s)
=== RUN   TestAccKubernetesClusterNodePool_podSubnet
=== PAUSE TestAccKubernetesClusterNodePool_podSubnet
=== RUN   TestAccKubernetesClusterNodePool_osDiskSizeGB
=== PAUSE TestAccKubernetesClusterNodePool_osDiskSizeGB
=== RUN   TestAccKubernetesClusterNodePool_proximityPlacementGroupId
=== PAUSE TestAccKubernetesClusterNodePool_proximityPlacementGroupId
=== RUN   TestAccKubernetesClusterNodePool_osDiskType
=== PAUSE TestAccKubernetesClusterNodePool_osDiskType
=== RUN   TestAccKubernetesClusterNodePool_requiresImport
=== PAUSE TestAccKubernetesClusterNodePool_requiresImport
=== CONT  TestAccKubernetesClusterNodePool_requiresImport
=== RUN   TestAccKubernetesClusterNodePool_spot
=== PAUSE TestAccKubernetesClusterNodePool_spot
=== CONT  TestAccKubernetesClusterNodePool_spot
=== RUN   TestAccKubernetesClusterNodePool_upgradeSettings
=== PAUSE TestAccKubernetesClusterNodePool_upgradeSettings
=== CONT  TestAccKubernetesClusterNodePool_upgradeSettings
=== RUN   TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== CONT  TestAccKubernetesClusterNodePool_virtualNetworkAutomatic
=== RUN   TestAccKubernetesClusterNodePool_virtualNetworkManual
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkManual
=== CONT  TestAccKubernetesClusterNodePool_virtualNetworkManual
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkManual (1418.24s)
=== RUN   TestAccKubernetesClusterNodePool_windows
=== PAUSE TestAccKubernetesClusterNodePool_windows
=== CONT  TestAccKubernetesClusterNodePool_windows
=== RUN   TestAccKubernetesClusterNodePool_windowsAndLinux
=== PAUSE TestAccKubernetesClusterNodePool_windowsAndLinux
=== CONT  TestAccKubernetesClusterNodePool_windowsAndLinux
=== RUN   TestAccKubernetesClusterNodePool_zeroSize
=== PAUSE TestAccKubernetesClusterNodePool_zeroSize
=== CONT  TestAccKubernetesClusterNodePool_zeroSize
--- PASS: TestAccKubernetesClusterNodePool_zeroSize (1104.25s)
=== RUN   TestAccKubernetesClusterNodePool_hostEncryption
=== PAUSE TestAccKubernetesClusterNodePool_hostEncryption
=== CONT  TestAccKubernetesClusterNodePool_hostEncryption
--- PASS: TestAccKubernetesClusterNodePool_hostEncryption (1303.15s)
=== RUN   TestAccKubernetesClusterNodePool_maxSize
=== PAUSE TestAccKubernetesClusterNodePool_maxSize
=== CONT  TestAccKubernetesClusterNodePool_maxSize
--- PASS: TestAccKubernetesClusterNodePool_maxSize (1407.88s)
=== RUN   TestAccKubernetesClusterNodePool_sameSize
=== PAUSE TestAccKubernetesClusterNodePool_sameSize
=== CONT  TestAccKubernetesClusterNodePool_sameSize
--- PASS: TestAccKubernetesClusterNodePool_sameSize (1345.45s)
=== RUN   TestAccKubernetesClusterNodePool_ultraSSD
=== PAUSE TestAccKubernetesClusterNodePool_ultraSSD
=== CONT  TestAccKubernetesClusterNodePool_ultraSSD
--- PASS: TestAccKubernetesClusterNodePool_ultraSSD (1364.91s)
=== RUN   TestAccKubernetesClusterNodePool_osSku
=== PAUSE TestAccKubernetesClusterNodePool_osSku
=== CONT  TestAccKubernetesClusterNodePool_osSku
--- PASS: TestAccKubernetesClusterNodePool_osSku (1197.40s)
--- PASS: TestAccKubernetesClusterNodePool_requiresImport (1276.01s)
=== CONT  TestAccKubernetesClusterNodePool_proximityPlacementGroupId
--- PASS: TestAccKubernetesClusterNodePool_spot (1243.81s)
=== CONT  TestAccKubernetesClusterNodePool_nodeLabels
--- PASS: TestAccKubernetesClusterNodePool_windows (1368.64s)
=== CONT  TestAccKubernetesClusterNodePool_osDiskType
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkAutomatic (1378.60s)
=== CONT  TestAccKubernetesClusterNodePool_modeUpdate
--- PASS: TestAccKubernetesClusterNodePool_manualScaleMultiplePools (1313.93s)
=== CONT  TestAccKubernetesClusterNodePool_osDiskSizeGB
--- PASS: TestAccKubernetesClusterNodePool_upgradeSettings (1787.22s)
=== CONT  TestAccKubernetesClusterNodePool_modeSystem
--- PASS: TestAccKubernetesClusterNodePool_windowsAndLinux (1543.00s)
=== CONT  TestAccKubernetesClusterNodePool_manualScaleUpdate
--- PASS: TestAccKubernetesClusterNodePool_nodePublicIP (1376.00s)
=== CONT  TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges
--- PASS: TestAccKubernetesClusterNodePool_osDiskType (1203.62s)
=== CONT  TestAccKubernetesClusterNodePool_manualScaleVMSku
--- PASS: TestAccKubernetesClusterNodePool_proximityPlacementGroupId (1309.50s)
=== CONT  TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate
--- PASS: TestAccKubernetesClusterNodePool_osDiskSizeGB (1311.50s)
=== CONT  TestAccKubernetesClusterNodePool_podSubnet
--- PASS: TestAccKubernetesClusterNodePool_modeSystem (1250.83s)
=== CONT  TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== CONT  TestAccKubernetesClusterNodePool_errorForAvailabilitySet
--- PASS: TestAccKubernetesClusterNodePool_modeUpdate (1769.23s)
--- PASS: TestAccKubernetesClusterNodePool_nodeLabels (2143.79s)
=== CONT  TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig
--- PASS: TestAccKubernetesClusterNodePool_errorForAvailabilitySet (827.08s)
=== CONT  TestAccKubernetesClusterNodePool_other
--- PASS: TestAccKubernetesClusterNodePool_manualScaleIgnoreChanges (1676.00s)
=== CONT  TestAccKubernetesClusterNodePool_manualScale
--- PASS: TestAccKubernetesClusterNodePool_manualScaleUpdate (2017.05s)
=== CONT  TestAccKubernetesClusterNodePool_availabilityZones
--- PASS: TestAccKubernetesClusterNodePool_podSubnet (1463.26s)
=== CONT  TestAccKubernetesClusterNodePool_autoScaleUpdate
--- PASS: TestAccKubernetesClusterNodePool_manualScaleVMSku (1730.95s)
=== CONT  TestAccKubernetesClusterNodePool_multiplePools
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial (1276.95s)
--- PASS: TestAccKubernetesClusterNodePool_manualScaleMultiplePoolsUpdate (1852.48s)
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfig (1280.10s)
--- PASS: TestAccKubernetesClusterNodePool_manualScale (1250.52s)
--- PASS: TestAccKubernetesClusterNodePool_other (1438.53s)
--- PASS: TestAccKubernetesClusterNodePool_availabilityZones (1333.10s)
--- PASS: TestAccKubernetesClusterNodePool_multiplePools (1333.99s)
--- PASS: TestAccKubernetesClusterNodePool_autoScaleUpdate (1835.04s)
PASS

I've added a new acc test `TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings`:
=== RUN   TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
=== PAUSE TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
=== CONT  TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings
--- PASS: TestAccKubernetesClusterNodePool_turnOnEnableAutoScalingWithDefaultMaxMinCountSettings (1330.75s)
PASS

