### PR TITLE
`azurerm_monitor_metric_alert`: Tags added to AccTests

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -181,6 +181,13 @@ resource "azurerm_monitor_metric_alert" "test" {
   }
 
   window_size = "PT1H"
+
+  tags = {
+    test      = "123"
+    Example   = "Example123"
+    terraform = "Coolllll"
+    CUSTOMER  = "CUSTOMERx"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
@@ -269,6 +276,16 @@ resource "azurerm_monitor_metric_alert" "test" {
 
   action {
     action_group_id = azurerm_monitor_action_group.test2.id
+  }
+
+  tags = {
+    test          = "456"
+    Example       = "Example456"
+    Terraform     = "Coolllll"
+    tfazurerm     = "Awesome"
+    CUSTOMER      = "CUSTOMERx"
+    "EXAMPLE.TAG" = "sample"
+    "Foo.Bar"     = "Test tag"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)


### PR DESCRIPTION
Fixes #13360

Fix is based on a backend bug fix, thus no change in code is required

### Acceptance Test

```bash
❯ go install && make acctests SERVICE='monitor' TESTARGS='-run=TestAccMonitorMetricAlert_basicAnd'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run= TestAccMonitorMetricAlert_basicAndCompleteUpdate -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorMetricAlert_basicAndCompleteUpdate
=== PAUSE TestAccMonitorMetricAlert_basicAndCompleteUpdate
=== CONT  TestAccMonitorMetricAlert_basicAndCompleteUpdate
--- PASS: TestAccMonitorMetricAlert_basicAndCompleteUpdate (620.32s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       622.033s
```