### PR TITLE
`azurerm_vpn_gateway`: Support for `routing_preference`

### DIFF
--- a/internal/services/network/vpn_gateway_resource.go
+++ b/internal/services/network/vpn_gateway_resource.go
@@ -59,11 +59,15 @@ func resourceVPNGateway() *pluginsdk.Resource {
 				ValidateFunc: validate.VirtualHubID,
 			},
 
-			"internet_routing_preference_enabled": {
-				Type:     pluginsdk.TypeBool,
+			"routing_preference": {
+				Type:     pluginsdk.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Microsoft Network",
+					"Internet",
+				}, false),
 			},
 
 			"bgp_settings": {
@@ -220,7 +224,7 @@ func resourceVPNGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error
 				ID: utils.String(virtualHubId),
 			},
 			VpnGatewayScaleUnit:         utils.Int32(int32(scaleUnit)),
-			IsRoutingPreferenceInternet: utils.Bool(d.Get("internet_routing_preference_enabled").(bool)),
+			IsRoutingPreferenceInternet: utils.Bool(d.Get("routing_preference").(string) == "Internet"),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -362,11 +366,11 @@ func resourceVPNGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 		d.Set("virtual_hub_id", virtualHubId)
 
-		isRoutingPreferenceInternet := false
-		if props.IsRoutingPreferenceInternet != nil {
-			isRoutingPreferenceInternet = *props.IsRoutingPreferenceInternet
+		isRoutingPreferenceInternet := "Microsoft Network"
+		if props.IsRoutingPreferenceInternet != nil && *props.IsRoutingPreferenceInternet {
+			isRoutingPreferenceInternet = "Internet"
 		}
-		d.Set("internet_routing_preference_enabled", isRoutingPreferenceInternet)
+		d.Set("routing_preference", isRoutingPreferenceInternet)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/internal/services/network/vpn_gateway_resource_test.go
+++ b/internal/services/network/vpn_gateway_resource_test.go
@@ -121,7 +121,7 @@ func TestAccVPNGateway_routingPreferenceMicrosoftNetwork(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.routingPreference(data, false),
+			Config: r.routingPreference(data, "Microsoft Network"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -136,7 +136,7 @@ func TestAccVPNGateway_routingPreferenceInternet(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.routingPreference(data, true),
+			Config: r.routingPreference(data, "Internet"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -171,7 +171,7 @@ resource "azurerm_vpn_gateway" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r VPNGatewayResource) routingPreference(data acceptance.TestData, publicRoutingPreference bool) string {
+func (r VPNGatewayResource) routingPreference(data acceptance.TestData, routingPreference string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -180,10 +180,9 @@ resource "azurerm_vpn_gateway" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   virtual_hub_id      = azurerm_virtual_hub.test.id
-
-  internet_routing_preference_enabled = %t
+  routing_preference  = "%s"
 }
-`, r.template(data), data.RandomInteger, publicRoutingPreference)
+`, r.template(data), data.RandomInteger, routingPreference)
 }
 
 func (r VPNGatewayResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below.
 
-* `internet_routing_preference_enabled` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `false`), or via the ISP network (public internet, set to `true`). More context of the configuration can be found in the
+* `routing_preference` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `Microsoft Network`), or via the ISP network (public internet, set to `Internet`). More context of the configuration can be found in the
 [Microsoft Docs](https://docs.microsoft.com/en-us/azure/virtual-wan/virtual-wan-site-to-site-portal#gateway) to create a VPN Gateway. Changing this forces a new resource to be created.
 
 * `scale_unit` - (Optional) The Scale Unit for this VPN Gateway. Defaults to `1`.


### PR DESCRIPTION
Fixes #13879

## Acceptance Tests
```bash
❯ go install && make acctests SERVICE='network' TESTARGS='-run=TestAccVPNGateway_routingPreference'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/network -run=TestAccVPNGateway_routingPreference -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccVPNGateway_routingPreferenceMicrosoftNetwork
=== PAUSE TestAccVPNGateway_routingPreferenceMicrosoftNetwork
=== RUN   TestAccVPNGateway_routingPreferenceInternet
=== PAUSE TestAccVPNGateway_routingPreferenceInternet
=== CONT  TestAccVPNGateway_routingPreferenceMicrosoftNetwork
=== CONT  TestAccVPNGateway_routingPreferenceInternet
--- PASS: TestAccVPNGateway_routingPreferenceMicrosoftNetwork (3813.77s)
--- PASS: TestAccVPNGateway_routingPreferenceInternet (3956.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network3957.894s
```