### PR TITLE
Update API version for azurerm_mysql_flexible_server_configuration

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_configuration_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_configuration_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/mysql/mgmt/2021-05-01-preview/mysqlflexibleservers"
+	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2021-05-01/mysqlflexibleservers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mysql/parse"


### PR DESCRIPTION
The API version of azurerm_mysql_flexible_server_configuration also needs to be updated to stable `2021-05-01`.

--- PASS: TestAccMySQLFlexibleServerConfiguration_characterSetServer (697.68s)
--- PASS: TestAccMySQLFlexibleServerConfiguration_logSlowAdminStatements (749.36s)
--- PASS: TestAccMySQLFlexibleServerConfiguration_interactiveTimeout (765.07s)
