### PR TITLE
azurerm_firewall_policy - changing the identity will no longer create a new resource

### DIFF
--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -247,7 +247,6 @@ func resourceFirewallPolicy() *pluginsdk.Resource {
 			"identity": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				ForceNew: false,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{


### PR DESCRIPTION
Firewall policy allows changing identity after creation, no need to force new policy on identity change.