### PR TITLE
Add `StoragePool/diskpools` to subnet's `service_delegation` allow list, get ready for DisksPool resource

### DIFF
--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -134,6 +134,7 @@ func resourceSubnet() *pluginsdk.Resource {
 											"Microsoft.ServiceFabricMesh/networks",
 											"Microsoft.Sql/managedInstances",
 											"Microsoft.Sql/servers",
+											"Microsoft.StoragePool/diskpools",
 											"Microsoft.StreamAnalytics/streamingJobs",
 											"Microsoft.Synapse/workspaces",
 											"Microsoft.Web/hostingEnvironments",


### PR DESCRIPTION
We're working on new resource for Disks Pool service, which require subnet with `service_delegation` to `Microsoft.StoragePool/diskpools` according to this [doc](https://docs.microsoft.com/en-us/azure/virtual-machines/disks-pools-deploy?tabs=azure-portal#delegate-subnet-permission) and this [blog](https://www.virtualworkloads.com/2021/07/deploy-and-attach-azure-disk-pool-to-azure-vmware-solution-private-cloud/), since the new resource is a rather bigger pr, and this modification is for subnet only, I think maybe an independent pr would be easy to review and merge.