### PR TITLE
azurerm_cosmosdb_account: Ignore the change of capabilities property

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -237,6 +237,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 			"capabilities": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -60,6 +60,10 @@ func TestAccCosmosDBAccount_basic_mongo_strong(t *testing.T) {
 	testAccCosmosDBAccount_basicMongoDBWith(t, documentdb.DefaultConsistencyLevelStrong)
 }
 
+func TestAccCosmosDBAccount_basic_mongo_strong_without_capability(t *testing.T) {
+	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindMongoDB, documentdb.DefaultConsistencyLevelStrong)
+}
+
 func TestAccCosmosDBAccount_basic_parse_boundedStaleness(t *testing.T) {
 	testAccCosmosDBAccount_basicWith(t, documentdb.DatabaseAccountKindParse, documentdb.DefaultConsistencyLevelBoundedStaleness)
 }

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this CosmosDB account.
 
-* `capabilities` - (Optional) The capabilities which should be enabled for this Cosmos DB account. Value is a `capabilities` block as defined below.
+* `capabilities` - (Optional) The capabilities which should be enabled for this Cosmos DB account. Value is a `capabilities` block as defined below. Changing this forces a new resource to be created.
 
 * `is_virtual_network_filter_enabled` - (Optional) Enables virtual network filtering for this Cosmos DB account.
 


### PR DESCRIPTION
The purpose of this PR:
1. For “capabilities” property, the description as following come from service team:

> _Our resource, “Cosmos DB Database Account”, expose a property called “capabilities” which is an array of objects.It is by design that this capabilities array may contain capability objects that are injected by the system, even if user does not directly request for it._

> Per the info above, add computed to true for  the `capabilities` property to prevent changing the `capabilities` cause the db to be re-created, because it is a `ForceNew` property. 

2. Add test case that is not covered in TF test, that is the value of `kind` property is `MongoDB` and the `capabilities` property is not set.

3. Doc fix: Supplement "Changing this forces a new resource to be created” info for capabilities property since it is a `ForceNew` property.

Test Results (The failed testcase report the same error before modification):
PASS: TestAccCosmosDBAccount_backupContinuous (1228.48s)
PASS: TestAccCosmosDBAccount_failover_boundedStaleness (1272.34s)
PASS: TestAccCosmosDBAccount_analyticalStorage (1310.55s)
PASS: TestAccCosmosDBAccount_mongoVersion32 (1329.41s)
PASS: TestAccCosmosDBAccount_mongoVersion40 (1336.93s)
PASS: TestAccCosmosDBAccount_vNetFilters (1415.75s)
PASS: TestAccCosmosDBAccount_localAuthenticationDisabled (1514.48s)
PASS: TestAccCosmosDBAccount_capabilities_MongoDBv34_NoEnableMongo (12.20s)
PASS: TestAccCosmosDBAccount_backup (1786.01s)
PASS: TestAccCosmosDBAccount_networkBypass (1906.86s)
PASS: TestAccCosmosDBAccount_identity (1976.16s)
PASS: TestAccCosmosDBAccount_capabilities_AllowSelfServeUpgradeToMongo36 (1291.54s)
PASS: TestAccCosmosDBAccount_capabilities_mongoEnableDocLevelTTL (1253.87s)
PASS: TestAccCosmosDBAccount_capabilities_DisableRateLimitingResponses (1382.68s)
PASS: TestAccCosmosDBAccount_mongoVersionUpdate (2736.63s)
PASS: TestAccCosmosDBAccount_capabilities_MongoDBv34 (1387.08s)
PASS: TestAccCosmosDBAccount_capabilities_EnableServerless (1155.39s)
PASS: TestAccCosmosDBAccount_capabilities_EnableMongo (1446.85s)
PASS: TestAccCosmosDBAccount_capabilities_EnableTable (1317.48s)
PASS: TestAccCosmosDBAccount_geoLocationsUpdate (2484.71s)
PASS: TestAccCosmosDBAccount_basic_parse_session (1155.63s)
PASS: TestAccCosmosDBAccount_capabilities_EnableGremlin (1291.07s)
PASS: TestAccCosmosDBAccount_capabilitiesUpdate (2626.74s)
PASS: TestAccCosmosDBAccount_mongoVersion36 (1291.04s)
PASS: TestAccCosmosDBAccount_capabilitiesAdd (2659.18s)
PASS: TestAccCosmosDBAccount_capabilities_EnableCassandra (1287.80s)
PASS: TestAccCosmosDBAccount_basic_global_session (1157.07s)
PASS: TestAccCosmosDBAccount_capabilities_EnableAggregationPipeline (1267.69s)
PASS: TestAccCosmosDBAccount_basic_parse_eventual (1146.85s)
PASS: TestAccCosmosDBAccount_basic_global_consistentPrefix (1143.25s)
PASS: TestAccCosmosDBAccount_basic_global_eventual (1312.31s)
PASS: TestAccCosmosDBAccount_basic_parse_consistentPrefix (1152.49s)
PASS: TestAccCosmosDBAccount_basic_parse_boundedStaleness (1119.87s)
PASS: TestAccCosmosDBAccount_basic_global_boundedStaleness (1141.53s)
PASS: TestAccCosmosDBAccount_basic_mongo_strong_without_capability (1269.62s)
PASS: TestAccCosmosDBAccount_failover_strong (1135.91s)
PASS: TestAccCosmosDBAccount_failover_boundedStalenessComplete (1139.19s)
PASS: TestAccCosmosDBAccount_failover_eventualConsistency (1267.47s)
PASS: TestAccCosmosDBAccount_failover_geoReplicated (2109.75s)
PASS: TestAccCosmosDBAccount_basic_mongo_strong (1257.47s)
PASS: TestAccCosmosDBAccount_failover_session (1144.09s)
PASS: TestAccCosmosDBAccount_failover_mongoDB (1433.00s)
PASS: TestAccCosmosDBAccount_public_network_access_enabled (1410.39s)
PASS: TestAccCosmosDBAccount_updateConsistency_global (2091.45s)
PASS: TestAccCosmosDBAccount_basic_mongo_session (1456.65s)
PASS: TestAccCosmosDBAccount_update_parse (5239.98s)
PASS: TestAccCosmosDBAccount_basic_mongo_consistentPrefix (1297.97s)
PASS: TestAccCosmosDBAccount_update_global (5181.26s)
PASS: TestAccCosmosDBAccount_basic_mongo_boundedStaleness (1447.98s)
PASS: TestAccCosmosDBAccount_basic_mongo_eventual (1466.22s)
PASS: TestAccCosmosDBAccount_basic_global_strong (1334.57s)
PASS: TestAccCosmosDBAccount_complete_parse (3413.54s)
PASS: TestAccCosmosDBAccount_requiresImport (1292.77s)
PASS: TestAccCosmosDBAccount_complete_global (3516.99s)
PASS: TestAccCosmosDBAccount_update_mongo (6167.12s)
PASS: TestAccCosmosDBAccount_basic_parse_strong (1159.85s)
PASS: TestAccCosmosDBAccount_complete_mongo (3971.36s)
PASS: TestAccCosmosDBAccount_updateConsistency_mongo (2616.97s)
PASS: TestAccCosmosDBAccount_networkBypass (1935.91s)
PASS: TestAccCosmosDBAccount_failover_boundedStaleness (1243.21s)
PASS: TestAccCosmosDBAccount_mongoVersion32 (1198.73s)
PASS: TestAccCosmosDBAccount_backup (1772.21s)

FAIL: TestAccCosmosDBAccount_freeTier (122.53s)
FAIL: TestAccCosmosDBAccount_completeZoneRedundant_parse (1459.63s)
FAIL: TestAccCosmosDBAccount_completeZoneRedundant_global (1455.25s)
FAIL: TestAccCosmosDBAccount_zoneRedundant_update_mongo (1644.91s)
FAIL: TestAccCosmosDBAccount_keyVaultUri (13.80s)
FAIL: TestAccCosmosDBAccount_keyVaultUriUpdateConsistancy (14.31s)
FAIL: TestAccCosmosDBAccount_completeZoneRedundant_mongo (1520.00s)
