### PR TITLE
sku is mandatory for resource azurerm_container_registry

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -98,6 +98,7 @@ resource "azurerm_container_registry" "example" {
   name                = "containerRegistry1"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
+  sku                 = "Premium"
 }
 
 resource "azurerm_kubernetes_cluster" "example" {


### PR DESCRIPTION
Updating the example because failing to use `sku` will
result in the following error.

```
Original Error: Code="ClassicSkuDeprecated" Message="Classic SKU is now deprecated. Please select a managed SKU. Kindly refer to docs for instructions: https://docs.microsoft.com/en-us/azure/container-registry/container-registry-upgrade"
```