### PR TITLE
`azurerm_storage_share` - Update document for property `access_tier`

### DIFF
--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `access_tier` - (Optional) The access tier of the File Share. Possible values are `Hot`, `Cool` and `TransactionOptimized`, `Premium`.
 
+~>**NOTE:** The `FileStorage` `account_kind` of the `azurerm_storage_account` requires `Premium` `access_tier`.
+
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 
 * `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. The `SMB` indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST. The `NFS` indicates the share can be accessed by NFSv4.1. Defaults to `SMB`. Changing this forces a new resource to be created.


### PR DESCRIPTION
Adding a note msg for `access_tier`

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19819