### PR TITLE
`azurerm_app_service_connection,` `azurerm_spring_cloud_connection`: update docs to fix incorrect expressions

### DIFF
--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `app_service_id` - (Required) The ID of the data source web app. Changing this forces a new resource to be created.
 
-* `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible values are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`.
+* `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible target resources are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`. The integration guide can be found [here](https://learn.microsoft.com/en-us/azure/service-connector/how-to-integrate-postgres).
 
 * `authentication` - (Required) The authentication info. An `authentication` block as defined below.
 

--- a/website/docs/r/spring_cloud_connection.html.markdown
+++ b/website/docs/r/spring_cloud_connection.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `spring_cloud_id` - (Required) The ID of the data source spring cloud. Changing this forces a new resource to be created.
 
-* `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible values are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`.
+* `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible target resources are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`. The integration guide can be found [here](https://learn.microsoft.com/en-us/azure/service-connector/how-to-integrate-postgres).
 
 * `authentication` - (Required) The authentication info. An `authentication` block as defined below.
 


### PR DESCRIPTION
* `target_resource_id` should be an `id` stead of resource type names. 

* Add official guide link for complex combinations in service connector creation.