### PR TITLE
Doc Fix: add note for `exclusion.x.selector` usage

### DIFF
--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -241,7 +241,9 @@ An `exclusion` block supports the following:
 
 * `operator` - (Required) Comparison operator to apply to the selector when specifying which elements in the collection this exclusion applies to. Possible values are: `Equals`, `Contains`, `StartsWith`, `EndsWith`, `EqualsAny`.
 
-* `selector` - (Required) Selector for the value in the `match_variable` attribute this exclusion applies to. Set to `"*"` if the `operator` is `EqualsAny`.
+* `selector` - (Required) Selector for the value in the `match_variable` attribute this exclusion applies to.
+
+-> **NOTE:** `selector` must be set to `*` if `operator` is set to `EqualsAny`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Explain how to set the exclusion selector when the operator is "EqualsAny"