### PR TITLE
`azurerm_application_gateway`: Fix Acc Test `TestAccApplicationGateway_customFirewallPolicy`

### DIFF
--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -2905,7 +2905,7 @@ resource "azurerm_web_application_firewall_policy" "testfwp" {
     enabled                     = true
     mode                        = "Prevention"
     file_upload_limit_in_mb     = 100
-    max_request_body_size_in_kb = 100
+    max_request_body_size_in_kb = 128
     request_body_check          = "true"
   }
 


### PR DESCRIPTION
Current waf policy configuration will cause error `ApplicationGatewayFirewallUnsupportedRuleSetVersionForInspectionLimit: Inspection Limit feature is not supported for the current ruleset versions in context`:

```
        Application Gateway Web Application Firewall Policy Name: "acctest-fwp-231127050516526761"): unexpected status 400 with error: ApplicationGatewayFirewallUnsupportedRuleSetVersionForInspectionLimit: Inspection Limit feature is not supported for the current ruleset versions in context '/subscriptions/*******/resourceGroups/acctestRG-231127050516526761/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/acctest-fwp-231127050516526761'.
          with azurerm_web_application_firewall_policy.testfwp,
          on terraform_plugin_test.tf line 68, in resource "azurerm_web_application_firewall_policy" "testfwp":
          68: resource "azurerm_web_application_firewall_policy" "testfwp" {
```

Update the configuration can fix the issue:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/133cc76e-2e99-495f-8b8e-7db27f8bc63a)

```
------- Stdout: -------
=== RUN   TestAccApplicationGateway_customFirewallPolicy
=== PAUSE TestAccApplicationGateway_customFirewallPolicy
=== CONT  TestAccApplicationGateway_customFirewallPolicy
--- PASS: TestAccApplicationGateway_customFirewallPolicy (1158.12s)
PASS
```