### PR TITLE
`azurerm_mobile_network_packet_core_control_plane` - fix a potenial crash

### DIFF
--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource.go
@@ -557,6 +557,9 @@ func (r PacketCoreControlPlaneResource) Delete() sdk.ResourceFunc {
 				Refresh: func() (result interface{}, state string, err error) {
 					resp, err := client.Delete(ctx, *id)
 					if err != nil {
+						if resp.HttpResponse == nil {
+							return nil, "", fmt.Errorf("HTTP response was nil")
+						}
 						if resp.HttpResponse.StatusCode == http.StatusConflict {
 							return nil, "409", nil
 						}


### PR DESCRIPTION
In acctest it has crashed because the HTTP response was nil.