### PR TITLE
`azurerm_monitor_workspace` and data source `azurerm_monitor_workspace`: add `default_data_collection_endpoint_id` and `default_data_collection_rule_id` attributes

### DIFF
--- a/internal/services/monitor/monitor_workspace_resource.go
+++ b/internal/services/monitor/monitor_workspace_resource.go
@@ -19,12 +19,14 @@ import (
 )
 
 type WorkspaceResourceModel struct {
-	Name                       string            `tfschema:"name"`
-	ResourceGroupName          string            `tfschema:"resource_group_name"`
-	QueryEndpoint              string            `tfschema:"query_endpoint"`
-	PublicNetworkAccessEnabled bool              `tfschema:"public_network_access_enabled"`
-	Location                   string            `tfschema:"location"`
-	Tags                       map[string]string `tfschema:"tags"`
+	Name                            string            `tfschema:"name"`
+	ResourceGroupName               string            `tfschema:"resource_group_name"`
+	QueryEndpoint                   string            `tfschema:"query_endpoint"`
+	DefaultDataCollectionEndpointId string            `tfschema:"default_data_collection_endpoint_id"`
+	DefaultDataCollectionRuleId     string            `tfschema:"default_data_collection_rule_id"`
+	PublicNetworkAccessEnabled      bool              `tfschema:"public_network_access_enabled"`
+	Location                        string            `tfschema:"location"`
+	Tags                            map[string]string `tfschema:"tags"`
 }
 
 type WorkspaceResource struct{}
@@ -69,6 +71,14 @@ func (r WorkspaceResource) Arguments() map[string]*pluginsdk.Schema {
 func (r WorkspaceResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"query_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"default_data_collection_endpoint_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"default_data_collection_rule_id": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
 		},
@@ -209,6 +219,15 @@ func (r WorkspaceResource) Read() sdk.ResourceFunc {
 
 					if properties.Metrics != nil && properties.Metrics.PrometheusQueryEndpoint != nil {
 						state.QueryEndpoint = *properties.Metrics.PrometheusQueryEndpoint
+					}
+
+					if properties.DefaultIngestionSettings != nil {
+						if properties.DefaultIngestionSettings.DataCollectionEndpointResourceId != nil {
+							state.DefaultDataCollectionEndpointId = *properties.DefaultIngestionSettings.DataCollectionEndpointResourceId
+						}
+						if properties.DefaultIngestionSettings.DataCollectionRuleResourceId != nil {
+							state.DefaultDataCollectionRuleId = *properties.DefaultIngestionSettings.DataCollectionRuleResourceId
+						}
 					}
 				}
 			}

--- a/website/docs/d/monitor_workspace.html.markdown
+++ b/website/docs/d/monitor_workspace.html.markdown
@@ -4,7 +4,6 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_data_collection_endpoint"
 description: |-
   Get information about the specified Workspace.
-
 ---
 
 # Data Source: azurerm_monitor_workspace
@@ -26,26 +25,30 @@ output "query_endpoint" {
 
 ## Argument Reference
 
-* `name` - Specifies the name of the Workspace.
+- `name` - Specifies the name of the Workspace.
 
-* `resource_group_name` - Specifies the name of the resource group the Workspace is located in.
+- `resource_group_name` - Specifies the name of the resource group the Workspace is located in.
 
 ## Attributes Reference
 
-* `id` - The ID of the Resource.
+- `id` - The ID of the Resource.
 
-* `kind` - The kind of the Workspace. Possible values are `Linux` and `Windows`.
+- `kind` - The kind of the Workspace. Possible values are `Linux` and `Windows`.
 
-* `location` - The Azure Region where the Workspace is located.
+- `location` - The Azure Region where the Workspace is located.
 
-* `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
+- `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
 
-* `public_network_access_enabled` - Whether network access from public internet to the Workspace are allowed.
+- `public_network_access_enabled` - Whether network access from public internet to the Workspace are allowed.
 
-* `tags` - A mapping of tags that are assigned to the Workspace.
+- `default_data_collection_endpoint_id` - The ID of the managed default Data Collection Endpoint created with the Azure Monitor Workspace.
+
+- `default_data_collection_rule_id` - The ID of the managed default Data Collection Rule created with the Azure Monitor Workspace.
+
+- `tags` - A mapping of tags that are assigned to the Workspace.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Workspace.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Workspace.

--- a/website/docs/r/monitor_workspace.html.markdown
+++ b/website/docs/r/monitor_workspace.html.markdown
@@ -32,32 +32,36 @@ resource "azurerm_monitor_workspace" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name which should be used for this Azure Monitor Workspace. Changing this forces a new resource to be created.
+- `name` - (Required) Specifies the name which should be used for this Azure Monitor Workspace. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
+- `resource_group_name` - (Required) Specifies the name of the Resource Group where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the Azure Region where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
+- `location` - (Required) Specifies the Azure Region where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
 
-* `public_network_access_enabled` - (Optional) Is public network access enabled? Defaults to `true`.
+- `public_network_access_enabled` - (Optional) Is public network access enabled? Defaults to `true`.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Azure Monitor Workspace.
+- `tags` - (Optional) A mapping of tags which should be assigned to the Azure Monitor Workspace.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Azure Monitor Workspace.
+- `id` - The ID of the Azure Monitor Workspace.
 
-* `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
+- `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
+
+- `default_data_collection_endpoint_id` - The ID of the managed default Data Collection Endpoint created with the Azure Monitor Workspace.
+
+- `default_data_collection_rule_id` - The ID of the managed default Data Collection Rule created with the Azure Monitor Workspace.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Workspace.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Workspace.
-* `update` - (Defaults to 30 minutes) Used when updating the Azure Monitor Workspace.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Workspace.
+- `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Workspace.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Workspace.
+- `update` - (Defaults to 30 minutes) Used when updating the Azure Monitor Workspace.
+- `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Workspace.
 
 ## Import
 


### PR DESCRIPTION
This PR adds attributes `default_data_collection_rule_id` and `default_data_collection_endpoint_id` to both `azurerm_monitor_workspace` and data source `azurerm_monitor_workspace`.

Fixes #24151.

Acceptance tests output:

```bash
$ make acctests SERVICE='monitor' TESTARGS='-run=TestMonitorWorkspace'  TESTTIMEOUT='90m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestMonitorWorkspace -timeout 90m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestMonitorWorkspace_basic
=== PAUSE TestMonitorWorkspace_basic
=== RUN   TestMonitorWorkspace_requiresImport
=== PAUSE TestMonitorWorkspace_requiresImport
=== RUN   TestMonitorWorkspace_complete
=== PAUSE TestMonitorWorkspace_complete
=== RUN   TestMonitorWorkspace_update
=== PAUSE TestMonitorWorkspace_update
=== RUN   TestMonitorWorkspace_publicNetworkAccess
=== PAUSE TestMonitorWorkspace_publicNetworkAccess
=== CONT  TestMonitorWorkspace_basic
=== CONT  TestMonitorWorkspace_complete
=== CONT  TestMonitorWorkspace_update
=== CONT  TestMonitorWorkspace_publicNetworkAccess
=== CONT  TestMonitorWorkspace_requiresImport
--- PASS: TestMonitorWorkspace_basic (166.61s)
--- PASS: TestMonitorWorkspace_complete (188.30s)
--- PASS: TestMonitorWorkspace_requiresImport (190.41s)
--- PASS: TestMonitorWorkspace_update (196.81s)
--- PASS: TestMonitorWorkspace_publicNetworkAccess (313.75s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       313.767s
```

```bash
$ make acctests SERVICE='monitor' TESTARGS='-run=TestAccMonitorWorkspaceDataSource'  TESTTIMEOUT='90m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestAccMonitorWorkspaceDataSource -timeout 90m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorWorkspaceDataSourceDataSource_complete
=== PAUSE TestAccMonitorWorkspaceDataSourceDataSource_complete
=== CONT  TestAccMonitorWorkspaceDataSourceDataSource_complete
--- PASS: TestAccMonitorWorkspaceDataSourceDataSource_complete (158.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       158.551s
```