### PR TITLE
`azurerm_keyvault_key`: udpate client cache logic to support managedHSM keys

### DIFF
--- a/internal/services/keyvault/client/client.go
+++ b/internal/services/keyvault/client/client.go
@@ -11,8 +11,6 @@ import (
 )
 
 type Client struct {
-	keyvaultCache *vaultCache
-
 	ManagedHsmClient *managedhsms.ManagedHsmsClient
 	ManagementClient *dataplane.BaseClient
 	VaultsClient     *vaults.VaultsClient
@@ -43,7 +41,6 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&mhsmRoleAssignClient.Client, o.ManagedHSMAuthorizer)
 
 	return &Client{
-		keyvaultCache:             newVaultCache(),
 		ManagedHsmClient:          &managedHsmClient,
 		ManagementClient:          &managementClient,
 		VaultsClient:              &vaultsClient,

--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -84,12 +84,14 @@ func (v *vaultCache) getCachedID(key string) *string {
 	return nil
 }
 
+var keyvaultCache = newVaultCache()
+
 func (c *Client) AddToCache(keyVaultId commonids.KeyVaultId, dataPlaneUri string) {
-	c.keyvaultCache.addKeyvaultToCache(keyvaultCacheKey(keyVaultId), keyVaultId.ID(), keyVaultId.ResourceGroupName, dataPlaneUri)
+	keyvaultCache.addKeyvaultToCache(keyvaultCacheKey(keyVaultId), keyVaultId.ID(), keyVaultId.ResourceGroupName, dataPlaneUri)
 }
 
 func (c *Client) BaseUriForKeyVault(ctx context.Context, keyVaultId commonids.KeyVaultId) (*string, error) {
-	if cached := c.keyvaultCache.getCachedBaseUri(keyvaultCacheKey(keyVaultId)); cached != nil {
+	if cached := keyvaultCache.getCachedBaseUri(keyvaultCacheKey(keyVaultId)); cached != nil {
 		return cached, nil
 	}
 
@@ -116,7 +118,7 @@ func (c *Client) BaseUriForKeyVault(ctx context.Context, keyVaultId commonids.Ke
 }
 
 func (c *Client) Exists(ctx context.Context, keyVaultId commonids.KeyVaultId) (bool, error) {
-	if c.keyvaultCache.getCachedItem(keyvaultCacheKey(keyVaultId)) != nil {
+	if keyvaultCache.getCachedItem(keyvaultCacheKey(keyVaultId)) != nil {
 		return true, nil
 	}
 
@@ -148,7 +150,7 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, subscriptionId commo
 		return nil, err
 	}
 
-	if cached := c.keyvaultCache.getCachedID(strings.ToLower(*keyVaultName)); cached != nil {
+	if cached := keyvaultCache.getCachedID(strings.ToLower(*keyVaultName)); cached != nil {
 		return cached, nil
 	}
 
@@ -198,7 +200,7 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, subscriptionId commo
 	}
 
 	// Now that the cache has been repopulated, check if we have the key vault or not
-	if cached := c.keyvaultCache.getCachedID(*keyVaultName); cached != nil {
+	if cached := keyvaultCache.getCachedID(*keyVaultName); cached != nil {
 		return cached, nil
 	}
 
@@ -207,7 +209,7 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, subscriptionId commo
 }
 
 func (c *Client) Purge(keyVaultId commonids.KeyVaultId) {
-	c.keyvaultCache.purge(keyvaultCacheKey(keyVaultId))
+	keyvaultCache.purge(keyvaultCacheKey(keyVaultId))
 }
 
 func (c *Client) parseNameFromBaseUrl(input string) (*string, error) {


### PR DESCRIPTION
The current version's cache logic only supports key vault keys. This PR refactors the cache to accommodate various vault IDs, such as manage HSM. Presently, existing locks seem fail to prevent simultaneous read/write operations on the `keyVaultCache` map by merely locking a specific cacheKey.