### PR TITLE
azurerm_cosmosdb_mongo_collection - fix resource creation and update by adjusting '_id' index specification

### DIFF
--- a/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -174,9 +174,9 @@ func resourceCosmosDbMongoCollectionCreate(d *pluginsdk.ResourceData, meta inter
 		ttl = pointer.To(v.(int))
 	}
 
-	indexes, hasIdKey := expandCosmosMongoCollectionIndex(d.Get("index").(*pluginsdk.Set).List(), ttl)
-	if !hasIdKey {
-		return fmt.Errorf("index with '_id' key is required")
+	indexes, hasUniqueIdKey := expandCosmosMongoCollectionIndex(d.Get("index").(*pluginsdk.Set).List(), ttl)
+	if !hasUniqueIdKey {
+		return fmt.Errorf("index with '_id' key and 'unique' property set to true is required")
 	}
 
 	db := documentdb.MongoDBCollectionCreateUpdateParameters{
@@ -243,9 +243,9 @@ func resourceCosmosDbMongoCollectionUpdate(d *pluginsdk.ResourceData, meta inter
 		ttl = pointer.To(v.(int))
 	}
 
-	indexes, hasIdKey := expandCosmosMongoCollectionIndex(d.Get("index").(*pluginsdk.Set).List(), ttl)
-	if !hasIdKey {
-		return fmt.Errorf("index with '_id' key is required")
+	indexes, hasUniqueIdKey := expandCosmosMongoCollectionIndex(d.Get("index").(*pluginsdk.Set).List(), ttl)
+	if !hasUniqueIdKey {
+		return fmt.Errorf("index with '_id' key and 'unique' property set to true is required")
 	}
 
 	db := documentdb.MongoDBCollectionCreateUpdateParameters{
@@ -413,16 +413,22 @@ func resourceCosmosDbMongoCollectionDelete(d *pluginsdk.ResourceData, meta inter
 func expandCosmosMongoCollectionIndex(indexes []interface{}, defaultTtl *int) (*[]documentdb.MongoIndex, bool) {
 	results := make([]documentdb.MongoIndex, 0)
 
-	hasIdKey := false
+	hasUniqueIdKey := false
 
 	if len(indexes) != 0 {
 		for _, v := range indexes {
 			index := v.(map[string]interface{})
 			keys := index["keys"].([]interface{})
+			unique := utils.Bool(index["unique"].(bool))
 
 			for _, key := range keys {
-				if strings.EqualFold("_id", key.(string)) {
-					hasIdKey = true
+				if strings.EqualFold("_id", key.(string)) && index["unique"] == true {
+					hasUniqueIdKey = true
+
+					// The index `_id` is unique by default and API rejects requests that contain value for 'unique'
+					// property. This property needs to be manually removed to avoid getting "The field 'unique' is
+					// not valid for _id index specification." message.
+					unique = nil
 				}
 			}
 
@@ -431,7 +437,7 @@ func expandCosmosMongoCollectionIndex(indexes []interface{}, defaultTtl *int) (*
 					Keys: utils.ExpandStringSlice(index["keys"].([]interface{})),
 				},
 				Options: &documentdb.MongoIndexOptions{
-					Unique: utils.Bool(index["unique"].(bool)),
+					Unique: unique,
 				},
 			})
 		}
@@ -448,7 +454,7 @@ func expandCosmosMongoCollectionIndex(indexes []interface{}, defaultTtl *int) (*
 		})
 	}
 
-	return &results, hasIdKey
+	return &results, hasUniqueIdKey
 }
 
 func flattenCosmosMongoCollectionIndex(input *[]documentdb.MongoIndex, accountIsVersion36 bool) (*[]map[string]interface{}, *[]map[string]interface{}, *int32) {

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -72,7 +72,7 @@ The `index` block supports the following:
 
 * `unique` - (Optional) Is the index unique or not? Defaults to `false`.
 
-~> **Note:** An index with an "_id" key must be specified.
+~> **Note:** An index with an "_id" key must be specified and it must have 'unique' property set to true.
 
 ## Attributes Reference
 


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Underlying Azure REST API does not accept `unique` property for `_id` index specification. This index is always unique by design and API call fails when this property is set to either true or false. This causes issues when `unique` field is set in Terraform configuration file - both true and false values result in a failure during `azurerm_cosmosdb_mongo_collection` resource creation.

Existing behavior during resource creation:
- If `_id` index's `unique` property is set to `true` or `false`, then resource creation fails with `The field 'unique' is not valid for _id index specification.` message. This is exactly this issue: #24853 
- If `_id` index's `unique` property is not set, then resource is created successfully (with unique `_id` index, despite the default for this `unique` property being `false`)

Existing behavior during resource update:
- If nothing has changed (unique is still not set), `terraform plan` shows that `unique` property is currently `true` but needs to be changed to `false` (as it's the default value). Running `terraform apply` is successful, but it does not change anything in Azure and does not fix invalid terraform state, resulting in repeating this behavior each time `terraform plan` is executed, as described in [landintrees's comment](https://github.com/hashicorp/terraform-provider-azurerm/issues/24853#issuecomment-1938843413) and [BosBer's comment](https://github.com/hashicorp/terraform-provider-azurerm/issues/24853#issuecomment-2077754661)
- If `_id` index's `unique` property is changed to `true`, then `terraform plan` outputs no changes to be made.
- If `_id` index's `unique` property is changed to `false`, then `terraform apply` fails with `The field 'unique' is not valid for _id index specification.` message.

Expected behavior during resource creation:
- If `_id` index's `unique` property is not set or set to `false`, then resource creation fails with `index with '_id' key and 'unique' property set to true is required` message.
- If `_id` index's `unique` property is set to `true`, then resource is created successfully.

Expected behavior during resource update:
- If `_id` index's `unique` property is not set or set to `false`, then `terraform plan` fails with `index with '_id' key and 'unique' property set to true is required` message.
- If `_id` index's `unique` property is still set to `true`, then `terraform plan` outputs no changes to be made.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #24853 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
