### PR TITLE
`azurerm_monitor_workspace` - add `private_endpoint_connections` export to resource and data source

### DIFF
--- a/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource.go
@@ -231,8 +231,8 @@ func (r ManagedPrivateEndpointResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			var mpe ManagedPrivateEndpointModel
-			if err := metadata.Decode(&mpe); err != nil {
+			var config ManagedPrivateEndpointModel
+			if err := metadata.Decode(&config); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
@@ -241,13 +241,13 @@ func (r ManagedPrivateEndpointResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			model := resp.Model
 			if resp.Model == nil {
 				return fmt.Errorf("retrieving %s: `model` was nil", id)
 			}
+			model := resp.Model
 
 			if metadata.ResourceData.HasChange("tags") {
-				model.Tags = &mpe.Tags
+				model.Tags = &config.Tags
 			}
 
 			if err := client.CreateThenPoll(ctx, *id, *model); err != nil {

--- a/internal/services/monitor/monitor_workspace_data_source_test.go
+++ b/internal/services/monitor/monitor_workspace_data_source_test.go
@@ -37,3 +37,28 @@ data "azurerm_monitor_workspace" "test" {
 }
 `, WorkspaceTestResource{}.complete(data))
 }
+
+func TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_monitor_workspace", "test")
+	d := MonitorWorkspaceDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.privateEndpointConnection(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("id").Exists(),
+			),
+		},
+	})
+}
+
+func (d MonitorWorkspaceDataSource) privateEndpointConnection(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_monitor_workspace" "test" {
+  name                = azurerm_monitor_workspace.test.name
+  resource_group_name = azurerm_monitor_workspace.test.resource_group_name
+}
+`, WorkspaceTestResource{}.privateEndpointConnection(data))
+}

--- a/internal/services/monitor/monitor_workspace_resource.go
+++ b/internal/services/monitor/monitor_workspace_resource.go
@@ -6,6 +6,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -19,14 +20,21 @@ import (
 )
 
 type WorkspaceResourceModel struct {
-	Name                            string            `tfschema:"name"`
-	ResourceGroupName               string            `tfschema:"resource_group_name"`
-	QueryEndpoint                   string            `tfschema:"query_endpoint"`
-	DefaultDataCollectionEndpointId string            `tfschema:"default_data_collection_endpoint_id"`
-	DefaultDataCollectionRuleId     string            `tfschema:"default_data_collection_rule_id"`
-	PublicNetworkAccessEnabled      bool              `tfschema:"public_network_access_enabled"`
-	Location                        string            `tfschema:"location"`
-	Tags                            map[string]string `tfschema:"tags"`
+	Name                            string                           `tfschema:"name"`
+	ResourceGroupName               string                           `tfschema:"resource_group_name"`
+	QueryEndpoint                   string                           `tfschema:"query_endpoint"`
+	DefaultDataCollectionEndpointId string                           `tfschema:"default_data_collection_endpoint_id"`
+	DefaultDataCollectionRuleId     string                           `tfschema:"default_data_collection_rule_id"`
+	PublicNetworkAccessEnabled      bool                             `tfschema:"public_network_access_enabled"`
+	PrivateEndpointConnections      []PrivateEndpointConnectionModel `tfschema:"private_endpoint_connections"`
+	Location                        string                           `tfschema:"location"`
+	Tags                            map[string]string                `tfschema:"tags"`
+}
+
+type PrivateEndpointConnectionModel struct {
+	Id       string   `tfschema:"id"`
+	Name     string   `tfschema:"name"`
+	GroupIds []string `tfschema:"group_ids"`
 }
 
 type WorkspaceResource struct{}
@@ -81,6 +89,29 @@ func (r WorkspaceResource) Attributes() map[string]*pluginsdk.Schema {
 		"default_data_collection_rule_id": {
 			Type:     pluginsdk.TypeString,
 			Computed: true,
+		},
+		"private_endpoint_connections": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"group_ids": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem:     pluginsdk.TypeString,
+					},
+				},
+			},
 		},
 	}
 }
@@ -229,6 +260,12 @@ func (r WorkspaceResource) Read() sdk.ResourceFunc {
 							state.DefaultDataCollectionRuleId = *properties.DefaultIngestionSettings.DataCollectionRuleResourceId
 						}
 					}
+
+					if properties.PrivateEndpointConnections != nil {
+						state.PrivateEndpointConnections = flattenPrivateEndpointConnections(properties.PrivateEndpointConnections)
+						log.Printf("[DEBUG] Reading Resource - parsing %q", metadata.ResourceData.Id())
+
+					}
 				}
 			}
 
@@ -256,3 +293,33 @@ func (r WorkspaceResource) Delete() sdk.ResourceFunc {
 		},
 	}
 }
+
+func flattenPrivateEndpointConnections(input *[]azuremonitorworkspaces.PrivateEndpointConnection) []PrivateEndpointConnectionModel {
+	if input == nil || len(*input) == 0 {
+		return []PrivateEndpointConnectionModel{}
+	}
+
+	result := make([]PrivateEndpointConnectionModel, 0)
+
+	conns := *input
+
+	for _, v := range conns {
+		conn := PrivateEndpointConnectionModel{
+			Id:       pointer.From(v.Id),
+			Name:     pointer.From(v.Name),
+			GroupIds: pointer.From(v.Properties.GroupIds),
+		}
+		result = append(result, conn)
+	}
+
+	return result
+}
+
+// resource "azurerm_monitor_workspace_private_endpoint_connection_approval" {
+// workspace_id = azurerm_monitor_workspace.example.id
+// group_ids = ["prometheus or whatever"]
+// service_kind = "grafana"
+// service_name = azurerm_dashboard_grafana_managed_private_endpoint.example.name
+// service_resource_group_name = azurerm_dashboard_grafana.example.resource_group_name
+// approval_message = "approved by terraform"
+// }

--- a/internal/services/monitor/monitor_workspace_resource.go
+++ b/internal/services/monitor/monitor_workspace_resource.go
@@ -6,7 +6,6 @@ package monitor
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -263,8 +262,6 @@ func (r WorkspaceResource) Read() sdk.ResourceFunc {
 
 					if properties.PrivateEndpointConnections != nil {
 						state.PrivateEndpointConnections = flattenPrivateEndpointConnections(properties.PrivateEndpointConnections)
-						log.Printf("[DEBUG] Reading Resource - parsing %q", metadata.ResourceData.Id())
-
 					}
 				}
 			}
@@ -314,12 +311,3 @@ func flattenPrivateEndpointConnections(input *[]azuremonitorworkspaces.PrivateEn
 
 	return result
 }
-
-// resource "azurerm_monitor_workspace_private_endpoint_connection_approval" {
-// workspace_id = azurerm_monitor_workspace.example.id
-// group_ids = ["prometheus or whatever"]
-// service_kind = "grafana"
-// service_name = azurerm_dashboard_grafana_managed_private_endpoint.example.name
-// service_resource_group_name = azurerm_dashboard_grafana.example.resource_group_name
-// approval_message = "approved by terraform"
-// }

--- a/internal/services/monitor/monitor_workspace_resource_test.go
+++ b/internal/services/monitor/monitor_workspace_resource_test.go
@@ -255,5 +255,5 @@ resource "azurerm_dashboard_grafana_managed_private_endpoint" "test" {
   group_ids                    = ["prometheusMetrics"]
   private_link_resource_region = azurerm_dashboard_grafana.test.location
 }
-`, template, data.RandomInteger, data.RandomIntOfLength(8))
+`, r.basic(data), data.RandomInteger, data.RandomIntOfLength(8))
 }

--- a/internal/services/monitor/monitor_workspace_resource_test.go
+++ b/internal/services/monitor/monitor_workspace_resource_test.go
@@ -236,7 +236,6 @@ resource "azurerm_monitor_workspace" "test" {
 }
 
 func (r WorkspaceTestResource) privateEndpointConnection(data acceptance.TestData) string {
-	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/d/monitor_workspace.html.markdown
+++ b/website/docs/d/monitor_workspace.html.markdown
@@ -47,6 +47,18 @@ output "query_endpoint" {
 
 - `tags` - A mapping of tags that are assigned to the Workspace.
 
+- `private_endpoint_connections` - A list of `private_endpoint_connections` blocks as described below.
+
+---
+
+a `private_endpoint_connections` block exports the following:
+
+- `name` - The name of the private endpoint connection.
+- `id` - The ID of the private endpoint connection.
+- `group_ids` - A list of group ID's (sometimes called subresource names) that this private endpoint connection allws access to.
+
+-> **NOTE:** The Azure API does not provide a way to uniquely identify a private endpoint connection based on an ID alone. The `id` exported by the `private_endpoint_connection` block does not correspond to the `id` of the private endpoint created by the connecting resource (e.g., an `azurerm_dashboard_grafana_managed_private_endpoint`), and there is no such property available. In order to identify the private endpoint connection, both `id` and `group_ids` will be required.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/d/monitor_workspace.html.markdown
+++ b/website/docs/d/monitor_workspace.html.markdown
@@ -51,11 +51,13 @@ output "query_endpoint" {
 
 ---
 
-a `private_endpoint_connections` block exports the following:
+A `private_endpoint_connections` block exports the following:
 
 - `name` - The name of the private endpoint connection.
+
 - `id` - The ID of the private endpoint connection.
-- `group_ids` - A list of group ID's (sometimes called subresource names) that this private endpoint connection allws access to.
+
+- `group_ids` - A list of group IDs (sometimes called subresource names) that this private endpoint connection allows access to.
 
 -> **NOTE:** The Azure API does not provide a way to uniquely identify a private endpoint connection based on an ID alone. The `id` exported by the `private_endpoint_connection` block does not correspond to the `id` of the private endpoint created by the connecting resource (e.g., an `azurerm_dashboard_grafana_managed_private_endpoint`), and there is no such property available. In order to identify the private endpoint connection, both `id` and `group_ids` will be required.
 

--- a/website/docs/r/monitor_workspace.html.markdown
+++ b/website/docs/r/monitor_workspace.html.markdown
@@ -32,36 +32,48 @@ resource "azurerm_monitor_workspace" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name which should be used for this Azure Monitor Workspace. Changing this forces a new resource to be created.
+- `name` - (Required) Specifies the name which should be used for this Azure Monitor Workspace. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
+- `resource_group_name` - (Required) Specifies the name of the Resource Group where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the Azure Region where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
+- `location` - (Required) Specifies the Azure Region where the Azure Monitor Workspace should exist. Changing this forces a new resource to be created.
 
-* `public_network_access_enabled` - (Optional) Is public network access enabled? Defaults to `true`.
+- `public_network_access_enabled` - (Optional) Is public network access enabled? Defaults to `true`.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Azure Monitor Workspace.
+- `tags` - (Optional) A mapping of tags which should be assigned to the Azure Monitor Workspace.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Azure Monitor Workspace.
+- `id` - The ID of the Azure Monitor Workspace.
 
-* `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
+- `query_endpoint` - The query endpoint for the Azure Monitor Workspace.
 
-* `default_data_collection_endpoint_id` - The ID of the managed default Data Collection Endpoint created with the Azure Monitor Workspace.
+- `default_data_collection_endpoint_id` - The ID of the managed default Data Collection Endpoint created with the Azure Monitor Workspace.
 
-* `default_data_collection_rule_id` - The ID of the managed default Data Collection Rule created with the Azure Monitor Workspace.
+- `default_data_collection_rule_id` - The ID of the managed default Data Collection Rule created with the Azure Monitor Workspace.
+
+- `private_endpoint_connections` - A list of `private_endpoint_connections` blocks as described below.
+
+---
+
+a `private_endpoint_connections` block exports the following:
+
+- `name` - The name of the private endpoint connection.
+- `id` - The ID of the private endpoint connection.
+- `group_ids` - A list of group ID's (sometimes called subresource names) that this private endpoint connection allws access to.
+
+-> **NOTE:** The Azure API does not provide a way to uniquely identify a private endpoint connection based on an ID alone. The `id` exported by the `private_endpoint_connection` block does not correspond to the `id` of the private endpoint created by the connecting resource (e.g., an `azurerm_dashboard_grafana_managed_private_endpoint`), and there is no such property available. In order to identify the private endpoint connection, both `id` and `group_ids` will be required.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Workspace.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Workspace.
-* `update` - (Defaults to 30 minutes) Used when updating the Azure Monitor Workspace.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Workspace.
+- `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Workspace.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Workspace.
+- `update` - (Defaults to 30 minutes) Used when updating the Azure Monitor Workspace.
+- `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Workspace.
 
 ## Import
 

--- a/website/docs/r/monitor_workspace.html.markdown
+++ b/website/docs/r/monitor_workspace.html.markdown
@@ -58,11 +58,13 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 ---
 
-a `private_endpoint_connections` block exports the following:
+A `private_endpoint_connections` block exports the following:
 
 - `name` - The name of the private endpoint connection.
+
 - `id` - The ID of the private endpoint connection.
-- `group_ids` - A list of group ID's (sometimes called subresource names) that this private endpoint connection allws access to.
+
+- `group_ids` - A list of group IDs (sometimes called subresource names) that this private endpoint connection allows access to.
 
 -> **NOTE:** The Azure API does not provide a way to uniquely identify a private endpoint connection based on an ID alone. The `id` exported by the `private_endpoint_connection` block does not correspond to the `id` of the private endpoint created by the connecting resource (e.g., an `azurerm_dashboard_grafana_managed_private_endpoint`), and there is no such property available. In order to identify the private endpoint connection, both `id` and `group_ids` will be required.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds support for an exported list of `private_endpoint_connections`, to both `azurerm_monitor_workspace` resource and data sources. This is required in order for Terraform to (eventually) be able to automatically approve connections from e.g., an `azurerm_dashboard_grafana_managed_private_endpoint`.

Acceptance tests have been added for this, and a bit of cleanup to the overall acceptance test code for the resource (reduced duplicate code).

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Acceptance test output:

```shell
$ make acctests SERVICE='monitor' TESTARGS='-run=TestMonitorWorkspace_privateEndpointConnection' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestMonitorWorkspace_privateEndpointConnection -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestMonitorWorkspace_privateEndpointConnection
=== PAUSE TestMonitorWorkspace_privateEndpointConnection
=== CONT  TestMonitorWorkspace_privateEndpointConnection
--- PASS: TestMonitorWorkspace_privateEndpointConnection (866.73s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       866.747s

$ make acctests SERVICE='monitor' TESTARGS='-run=TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/monitor -run=TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection
=== PAUSE TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection
=== CONT  TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection
--- PASS: TestAccMonitorWorkspaceDataSourceDataSource_privateEndpointConnection (802.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       802.371s

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_workspace` - export `private_endpoint_connections` property [GH-27786]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27786 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
