### PR TITLE
Adding resource "azurerm_static_web_app_build" to set environment variables for Preview Environment

### DIFF
--- a/internal/services/appservice/registration.go
+++ b/internal/services/appservice/registration.go
@@ -51,6 +51,7 @@ func (r Registration) Resources() []sdk.Resource {
 		SourceControlResource{},
 		SourceControlSlotResource{},
 		StaticWebAppResource{},
+		StaticWebAppBuildResource{},
 		StaticWebAppCustomDomainResource{},
 		StaticWebAppFunctionAppRegistrationResource{},
 		WebAppActiveSlotResource{},

--- a/internal/services/appservice/static_web_app_build_resource.go
+++ b/internal/services/appservice/static_web_app_build_resource.go
@@ -1,0 +1,193 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package appservice
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-01-01/staticsites"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type StaticWebAppBuildResource struct{}
+
+var _ sdk.ResourceWithUpdate = StaticWebAppBuildResource{}
+
+type StaticWebAppBuildResourceModel struct {
+	Name                 string            `tfschema:"name"`
+	ResourceGroupName    string            `tfschema:"resource_group_name"`
+	EnvironmentVariables map[string]string `tfschema:"environment_variables"`
+	Build                string            `tfschema:"build"`
+}
+
+func (r StaticWebAppBuildResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.StaticWebAppName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"environment_variables": {
+			Type:     pluginsdk.TypeMap,
+			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"build": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r StaticWebAppBuildResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r StaticWebAppBuildResource) ModelObject() interface{} {
+	return &StaticWebAppBuildResourceModel{}
+}
+
+func (r StaticWebAppBuildResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return staticsites.ValidateStaticSiteID
+}
+
+func (r StaticWebAppBuildResource) ResourceType() string {
+	return "azurerm_static_web_app_build"
+}
+
+func (r StaticWebAppBuildResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			model := StaticWebAppBuildResourceModel{}
+
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			id := staticsites.NewBuildID(subscriptionId, model.ResourceGroupName, model.Name, model.Build)
+
+			metadata.SetID(id)
+
+			appSettings := staticsites.StringDictionary{
+				Properties: pointer.To(model.EnvironmentVariables),
+			}
+
+			if _, err := client.CreateOrUpdateStaticSiteBuildAppSettings(ctx, id, appSettings); err != nil {
+				return fmt.Errorf("updating app settings for %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r StaticWebAppBuildResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+
+			id, err := staticsites.ParseBuildID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			appSettings, err := client.ListStaticSiteBuildAppSettings(ctx, *id)
+			if err != nil || appSettings.Model == nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := StaticWebAppBuildResourceModel{
+				Name:              id.StaticSiteName,
+				ResourceGroupName: id.ResourceGroupName,
+				Build:             id.BuildName,
+			}
+
+			if appSettingsModel := appSettings.Model; appSettingsModel != nil {
+				state.EnvironmentVariables = pointer.From(appSettingsModel.Properties)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r StaticWebAppBuildResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+
+			config := StaticWebAppBuildResourceModel{}
+
+			if err := metadata.Decode(&config); err != nil {
+				return err
+			}
+
+			id, err := staticsites.ParseBuildID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			emptyAppSettings := staticsites.StringDictionary{
+				Properties: pointer.To(map[string]string{}),
+			}
+
+			if _, err := client.CreateOrUpdateStaticSiteBuildAppSettings(ctx, *id, emptyAppSettings); err != nil {
+				return fmt.Errorf("deleting app settings for %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r StaticWebAppBuildResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppService.StaticSitesClient
+
+			config := StaticWebAppBuildResourceModel{}
+
+			if err := metadata.Decode(&config); err != nil {
+				return err
+			}
+
+			id, err := staticsites.ParseBuildID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			appSettings := staticsites.StringDictionary{
+				Properties: pointer.To(config.EnvironmentVariables),
+			}
+
+			if _, err := client.CreateOrUpdateStaticSiteBuildAppSettings(ctx, *id, appSettings); err != nil {
+				return fmt.Errorf("updating app settings for %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This pull request introduces a new resource, `azurerm_static_web_app_build`, designed to configure environment variables specifically for the preview environment of a static web app. The existing `azurerm_static_web_app` resource only supports setting environment variables for the production environment via the `app_settings` property.

Below is an example of how to use the resource.
```terraform
resource "azurerm_static_web_app_build" "preview" {
  name                     = azurerm_static_web_app.this.name
  resource_group_name      = azurerm_resource_group.this.name
  build                    = "preview"
  environment_variables    = {
    "X_API_KEY" = "API Key"
  }
}
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Because it needs to deploy something to the Static Web to create a preview environment, which is not currently supported without SWA or AZ cli, the tests are done manually. Please find the test evidence below.
 
Create a new resource
![Screenshot 2024-11-24 at 21 29 15](https://github.com/user-attachments/assets/1ca4343f-83d8-4c0e-9125-6ebba18e95a9)
![Screenshot 2024-11-24 at 21 29 33](https://github.com/user-attachments/assets/32fbde2d-4197-4e03-9dbe-ab19bfecfb48)

Destroy a resource
![Screenshot 2024-11-24 at 21 30 13](https://github.com/user-attachments/assets/4aaf0488-2dcb-47ca-8bfb-dc9e322a8e0c)
![Screenshot 2024-11-24 at 21 30 24](https://github.com/user-attachments/assets/3ed660df-589f-4afc-9945-ca79f3eacac8)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
