### PR TITLE
`azurerm_container_app`, `data.azurerm_container_app` - support for `additional_port_mapping` in `ingress` block

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -2376,6 +2376,11 @@ resource "azurerm_container_app" "test" {
       latest_revision = true
       percentage      = 100
     }
+    additional_port_mapping {
+      external = true
+      exposed_port = 5556
+      target_port = 5556
+    }
   }
 }
 `, r.templateWithVnet(data), data.RandomInteger, revisionSuffix)

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -2377,9 +2377,9 @@ resource "azurerm_container_app" "test" {
       percentage      = 100
     }
     additional_port_mapping {
-      external = true
+      external     = true
       exposed_port = 5556
-      target_port = 5556
+      target_port  = 5556
     }
   }
 }

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -5,13 +5,13 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/containerapps"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/daprcomponents"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -5,13 +5,13 @@ package helpers
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/containerapps"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/daprcomponents"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/managedenvironments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/containerapps"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/daprcomponents"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-01-01/managedenvironments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
@@ -159,6 +160,7 @@ type Ingress struct {
 	Transport              string                  `tfschema:"transport"`
 	IpSecurityRestrictions []IpSecurityRestriction `tfschema:"ip_security_restriction"`
 	ClientCertificateMode  string                  `tfschema:"client_certificate_mode"`
+	AdditionalPortMappings []IngressPortMapping    `tfschema:"additional_port_mapping"`
 }
 
 func ContainerAppIngressSchema() *pluginsdk.Schema {
@@ -226,6 +228,7 @@ func ContainerAppIngressSchema() *pluginsdk.Schema {
 					}, false),
 					Description: "Client certificate mode for mTLS authentication. Ignore indicates server drops client certificate on forwarding. Accept indicates server forwards client certificate but does not require a client certificate. Require indicates server requires a client certificate.",
 				},
+				"additional_port_mapping": ContainerAppIngressAdditionalPortMapping(),
 			},
 		},
 	}
@@ -284,6 +287,7 @@ func ContainerAppIngressSchemaComputed() *pluginsdk.Schema {
 					Computed:    true,
 					Description: "Client certificate mode for mTLS authentication. Ignore indicates server drops client certificate on forwarding. Accept indicates server forwards client certificate but does not require a client certificate. Require indicates server requires a client certificate.",
 				},
+				"additional_port_mapping": ContainerAppIngressAdditionalPortMappingComputed(),
 			},
 		},
 	}
@@ -304,6 +308,7 @@ func ExpandContainerAppIngress(input []Ingress, appName string) *containerapps.I
 		ExposedPort:            pointer.To(ingress.ExposedPort),
 		Traffic:                expandContainerAppIngressTraffic(ingress.TrafficWeights, appName),
 		IPSecurityRestrictions: expandIpSecurityRestrictions(ingress.IpSecurityRestrictions),
+		AdditionalPortMappings: expandAdditionalPortMappings(ingress.AdditionalPortMappings),
 	}
 	transport := containerapps.IngressTransportMethod(ingress.Transport)
 	result.Transport = &transport
@@ -330,6 +335,7 @@ func FlattenContainerAppIngress(input *containerapps.Ingress, appName string) []
 		ExposedPort:            pointer.From(ingress.ExposedPort),
 		TrafficWeights:         flattenContainerAppIngressTraffic(ingress.Traffic, appName),
 		IpSecurityRestrictions: flattenContainerAppIngressIpSecurityRestrictions(ingress.IPSecurityRestrictions),
+		AdditionalPortMappings: flattenContainerAppIngressAdditionalPortMappings(ingress.AdditionalPortMappings),
 	}
 
 	if ingress.Transport != nil {
@@ -454,6 +460,12 @@ type IpSecurityRestriction struct {
 	Name           string `tfschema:"name"`
 }
 
+type IngressPortMapping struct {
+	ExposedPort *int64 `tfschema:"exposed_port"`
+	External    bool   `tfschema:"external"`
+	TargetPort  int64  `tfschema:"target_port"`
+}
+
 func ContainerAppIngressIpSecurityRestriction() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -563,6 +575,59 @@ func ContainerAppIngressTrafficWeight() *pluginsdk.Schema {
 	}
 }
 
+func ContainerAppIngressAdditionalPortMapping() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"external": {
+					Type:        pluginsdk.TypeBool,
+					Required:    true,
+					Description: "Whether the app port is accessible outside of the environment",
+				},
+				"target_port": {
+					Type:        pluginsdk.TypeInt,
+					Required:    true,
+					Description: "The additional target port on the container for the Ingress traffic.",
+				},
+				"exposed_port": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntBetween(1, 65535),
+					Description:  "The additional exposed port for the Ingress traffic.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerAppIngressAdditionalPortMappingComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*schema.Schema{
+				"external": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Whether the app port is accessible outside of the environment",
+				},
+				"target_port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The additional target port on the container for the Ingress traffic.",
+				},
+				"exposed_port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The additional exposed port for the Ingress traffic.",
+				},
+			},
+		},
+	}
+}
+
 func ContainerAppIngressTrafficWeightComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -660,6 +725,36 @@ func expandIpSecurityRestrictions(input []IpSecurityRestriction) *[]containerapp
 	}
 
 	return &result
+}
+
+func expandAdditionalPortMappings(input []IngressPortMapping) *[]containerapps.IngressPortMapping {
+	if input == nil {
+		return &[]containerapps.IngressPortMapping{}
+	}
+	result := make([]containerapps.IngressPortMapping, len(input))
+	for i, mapping := range input {
+		result[i] = containerapps.IngressPortMapping{
+			ExposedPort: mapping.ExposedPort,
+			External:    mapping.External,
+			TargetPort:  mapping.TargetPort,
+		}
+	}
+	return &result
+}
+
+func flattenContainerAppIngressAdditionalPortMappings(input *[]containerapps.IngressPortMapping) []IngressPortMapping {
+	if input == nil {
+		return []IngressPortMapping{}
+	}
+	result := make([]IngressPortMapping, len(*input))
+	for i, v := range *input {
+		result[i] = IngressPortMapping{
+			ExposedPort: v.ExposedPort,
+			External:    v.External,
+			TargetPort:  v.TargetPort,
+		}
+	}
+	return result
 }
 
 type Dapr struct {

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -43,6 +43,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `ingress` - An `ingress` block as detailed below.
 
+* `additional_port_mapping` - One or more `additional_port_mapping` blocks as detailed below.
+
 * `registry` - A `registry` block as detailed below.
 
 * `secret` - One or more `secret` block as detailed below.
@@ -285,6 +287,16 @@ An `ingress` block supports the following:
 * `traffic_weight` - A `traffic_weight` block as detailed below.
 
 * `transport` - The transport method for the Ingress. Possible values include `auto`, `http`, and `http2`. Defaults to `auto`
+
+---
+
+An `additional_port_mapping` block supports the following:
+
+* `external` - Whether the app port is accessible outside of the environment.
+
+* `target_port` - The additional target port on the container for the Ingress traffic.
+
+* `exposed_port` - The additional exposed port for the Ingress traffic.
 
 ---
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -401,6 +401,8 @@ An `ingress` block supports the following:
 
 * `client_certificate_mode` - (Optional) The client certificate mode for the Ingress. Possible values are `require`, `accept`, and `ignore`.
 
+* `additional_port_mapping` - (Optional) One or more `additional_port_mapping` blocks as detailed below.
+
 ---
 
 A `ip_security_restriction` block supports the following:
@@ -432,6 +434,16 @@ A `traffic_weight` block supports the following:
 * `percentage` - (Required) The percentage of traffic which should be sent this revision.
 
 ~> **Note:** The cumulative values for `weight` must equal 100 exactly and explicitly, no default weights are assumed.
+
+---
+
+An `additional_port_mapping` block supports the following:
+
+* `external` - (Required) Whether the app port is accessible outside of the environment.
+
+* `target_port` - (Required) The additional target port on the container for the Ingress traffic.
+
+* `exposed_port` - (Optional) The additional exposed port for the Ingress traffic.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
This pr added a new `additional_port_mapping` block in `ingress` block. It should solve #23442

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

=== RUN   TestAccContainerAppDataSource_basic
=== PAUSE TestAccContainerAppDataSource_basic
=== RUN   TestAccContainerAppDataSource_complete
=== PAUSE TestAccContainerAppDataSource_complete
=== CONT  TestAccContainerAppDataSource_basic
=== CONT  TestAccContainerAppDataSource_complete
--- PASS: TestAccContainerAppDataSource_basic (603.13s)
--- PASS: TestAccContainerAppDataSource_complete (663.33s)
=== RUN   TestAccContainerAppResource_basic
=== PAUSE TestAccContainerAppResource_basic
=== RUN   TestAccContainerAppResource_workloadProfile
=== PAUSE TestAccContainerAppResource_workloadProfile
=== RUN   TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations
=== PAUSE TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations
=== RUN   TestAccContainerAppResource_workloadProfileUpdate
=== PAUSE TestAccContainerAppResource_workloadProfileUpdate
=== RUN   TestAccContainerAppResource_withSystemAssignedIdentity
=== PAUSE TestAccContainerAppResource_withSystemAssignedIdentity
=== RUN   TestAccContainerAppResource_withUserAssignedIdentity
=== PAUSE TestAccContainerAppResource_withUserAssignedIdentity
=== RUN   TestAccContainerAppResource_withSystemAndUserAssignedIdentity
=== PAUSE TestAccContainerAppResource_withSystemAndUserAssignedIdentity
=== RUN   TestAccContainerAppResource_withIdentityUpdate
=== PAUSE TestAccContainerAppResource_withIdentityUpdate
=== RUN   TestAccContainerAppResource_withKeyVaultSecretVersioningUpdate
=== PAUSE TestAccContainerAppResource_withKeyVaultSecretVersioningUpdate
=== RUN   TestAccContainerAppResource_withKeyVaultSecretIdentityUpdate
=== PAUSE TestAccContainerAppResource_withKeyVaultSecretIdentityUpdate
=== RUN   TestAccContainerAppResource_basicUpdate
=== PAUSE TestAccContainerAppResource_basicUpdate
=== RUN   TestAccContainerAppResource_requiresImport
=== PAUSE TestAccContainerAppResource_requiresImport
=== RUN   TestAccContainerAppResource_complete
=== PAUSE TestAccContainerAppResource_complete
=== RUN   TestAccContainerAppResource_completeVolumeEmptyDir
=== PAUSE TestAccContainerAppResource_completeVolumeEmptyDir
=== RUN   TestAccContainerAppResource_completeWithNoDaprAppPort
=== PAUSE TestAccContainerAppResource_completeWithNoDaprAppPort
=== RUN   TestAccContainerAppResource_completeWithVNet
=== PAUSE TestAccContainerAppResource_completeWithVNet
=== RUN   TestAccContainerAppResource_completeWithSidecar
=== PAUSE TestAccContainerAppResource_completeWithSidecar
=== RUN   TestAccContainerAppResource_completeWithMultipleContainers
=== PAUSE TestAccContainerAppResource_completeWithMultipleContainers
=== RUN   TestAccContainerAppResource_completeUpdate
=== PAUSE TestAccContainerAppResource_completeUpdate
=== RUN   TestAccContainerAppResource_completeTcpExposedPort
=== PAUSE TestAccContainerAppResource_completeTcpExposedPort
=== RUN   TestAccContainerAppResource_removeDaprAppPort
=== PAUSE TestAccContainerAppResource_removeDaprAppPort
=== RUN   TestAccContainerAppResource_secretChangeName
=== PAUSE TestAccContainerAppResource_secretChangeName
=== RUN   TestAccContainerAppResource_secretRemove
=== PAUSE TestAccContainerAppResource_secretRemove
=== RUN   TestAccContainerAppResource_scaleRules
=== PAUSE TestAccContainerAppResource_scaleRules
=== RUN   TestAccContainerAppResource_multipleScaleRules
=== PAUSE TestAccContainerAppResource_multipleScaleRules
=== RUN   TestAccContainerAppResource_scaleRulesUpdate
=== PAUSE TestAccContainerAppResource_scaleRulesUpdate
=== RUN   TestAccContainerAppResource_ipSecurityRulesUpdate
=== PAUSE TestAccContainerAppResource_ipSecurityRulesUpdate
=== RUN   TestAccContainerAppResource_ingressTrafficValidation
=== PAUSE TestAccContainerAppResource_ingressTrafficValidation
=== RUN   TestAccContainerAppResource_maxInactiveRevisionsUpdate
=== PAUSE TestAccContainerAppResource_maxInactiveRevisionsUpdate
=== CONT  TestAccContainerAppResource_basic
=== CONT  TestAccContainerAppResource_completeWithVNet
=== CONT  TestAccContainerAppResource_secretRemove
=== CONT  TestAccContainerAppResource_removeDaprAppPort
=== CONT  TestAccContainerAppResource_withKeyVaultSecretVersioningUpdate
=== CONT  TestAccContainerAppResource_completeTcpExposedPort
=== CONT  TestAccContainerAppResource_secretChangeName
=== CONT  TestAccContainerAppResource_completeWithMultipleContainers
=== CONT  TestAccContainerAppResource_completeUpdate
=== CONT  TestAccContainerAppResource_completeWithSidecar
=== CONT  TestAccContainerAppResource_complete
=== CONT  TestAccContainerAppResource_completeWithNoDaprAppPort
=== CONT  TestAccContainerAppResource_completeVolumeEmptyDir
=== CONT  TestAccContainerAppResource_withSystemAssignedIdentity
=== CONT  TestAccContainerAppResource_withIdentityUpdate
=== CONT  TestAccContainerAppResource_withSystemAndUserAssignedIdentity
--- PASS: TestAccContainerAppResource_completeWithNoDaprAppPort (567.57s)
=== CONT  TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations
=== CONT  TestAccContainerAppResource_workloadProfileUpdate
--- PASS: TestAccContainerAppResource_withSystemAndUserAssignedIdentity (631.74s)
--- PASS: TestAccContainerAppResource_basic (646.26s)
=== CONT  TestAccContainerAppResource_ipSecurityRulesUpdate
--- PASS: TestAccContainerAppResource_removeDaprAppPort (665.38s)
=== CONT  TestAccContainerAppResource_maxInactiveRevisionsUpdate
--- PASS: TestAccContainerAppResource_withSystemAssignedIdentity (665.57s)
=== CONT  TestAccContainerAppResource_ingressTrafficValidation
--- PASS: TestAccContainerAppResource_ingressTrafficValidation (6.68s)
=== CONT  TestAccContainerAppResource_basicUpdate
--- PASS: TestAccContainerAppResource_secretRemove (672.78s)
=== CONT  TestAccContainerAppResource_requiresImport
--- PASS: TestAccContainerAppResource_completeUpdate (677.83s)
=== CONT  TestAccContainerAppResource_withKeyVaultSecretIdentityUpdate
--- PASS: TestAccContainerAppResource_complete (690.53s)
=== CONT  TestAccContainerAppResource_multipleScaleRules
--- PASS: TestAccContainerAppResource_completeWithSidecar (693.16s)
=== CONT  TestAccContainerAppResource_scaleRulesUpdate
--- PASS: TestAccContainerAppResource_completeWithMultipleContainers (710.02s)
=== CONT  TestAccContainerAppResource_scaleRules
--- PASS: TestAccContainerAppResource_completeVolumeEmptyDir (721.59s)
=== CONT  TestAccContainerAppResource_workloadProfile
=== CONT  TestAccContainerAppResource_withUserAssignedIdentity
--- PASS: TestAccContainerAppResource_secretChangeName (726.70s)
--- PASS: TestAccContainerAppResource_withIdentityUpdate (744.50s)
--- PASS: TestAccContainerAppResource_completeTcpExposedPort (1000.37s)
--- PASS: TestAccContainerAppResource_withKeyVaultSecretVersioningUpdate (1023.90s)
--- PASS: TestAccContainerAppResource_completeWithVNet (1042.43s)
--- PASS: TestAccContainerAppResource_requiresImport (627.52s)
--- PASS: TestAccContainerAppResource_scaleRules (596.93s)
--- PASS: TestAccContainerAppResource_basicUpdate (641.92s)
--- PASS: TestAccContainerAppResource_multipleScaleRules (626.96s)
--- PASS: TestAccContainerAppResource_withUserAssignedIdentity (592.47s)
--- PASS: TestAccContainerAppResource_maxInactiveRevisionsUpdate (686.10s)
--- PASS: TestAccContainerAppResource_scaleRulesUpdate (709.43s)
--- PASS: TestAccContainerAppResource_ipSecurityRulesUpdate (856.75s)
--- PASS: TestAccContainerAppResource_withKeyVaultSecretIdentityUpdate (1175.85s)
--- PASS: TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations (1977.41s)
--- PASS: TestAccContainerAppResource_workloadProfile (1945.72s)
--- PASS: TestAccContainerAppResource_workloadProfileUpdate (2213.81s)
PASS



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app` - support for the `additional_port_mapping` block #23442
* Data Source: `azurerm_container_app` - support for the `additional_port_mapping` block #23442


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #23442


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
