### PR TITLE
`resource` - fix `TestAccResourceProviderRegistration_feature/requiresImport`

### DIFF
--- a/internal/services/resource/resource_provider_registration_resource_test.go
+++ b/internal/services/resource/resource_provider_registration_resource_test.go
@@ -6,6 +6,7 @@ package resource_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +47,12 @@ func TestAccResourceProviderRegistration_requiresImport(t *testing.T) {
 	r := ResourceProviderRegistrationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			PreConfig: func() {
+				// Last error may cause resource provider still in `Registered` status.Need to unregister it before a new test.
+				if err := r.unRegisterProviders("Microsoft.AgFoodPlatform"); err != nil {
+					t.Fatalf("Failed to reset feature registration with error: %+v", err)
+				}
+			},
 			Config: r.basic("Microsoft.AgFoodPlatform"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -63,6 +70,8 @@ func TestAccResourceProviderRegistration_feature(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			PreConfig: func() {
+				_ = os.Setenv("ARM_PROVIDER_ENHANCED_VALIDATION", "false")
+
 				// Last error may cause resource provider still in `Registered` status.Need to unregister it before a new test.
 				if err := r.unRegisterProviders("Microsoft.ApiSecurity"); err != nil {
 					t.Fatalf("Failed to reset feature registration with error: %+v", err)

--- a/internal/services/resource/resource_provider_registration_resource_test.go
+++ b/internal/services/resource/resource_provider_registration_resource_test.go
@@ -6,7 +6,6 @@ package resource_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func TestAccResourceProviderRegistration_requiresImport(t *testing.T) {
 			PreConfig: func() {
 				// Last error may cause resource provider still in `Registered` status.Need to unregister it before a new test.
 				if err := r.unRegisterProviders("Microsoft.AgFoodPlatform"); err != nil {
-					t.Fatalf("Failed to reset feature registration with error: %+v", err)
+					t.Fatalf("Failed to reset resource provider registration with error: %+v", err)
 				}
 			},
 			Config: r.basic("Microsoft.AgFoodPlatform"),
@@ -70,35 +69,19 @@ func TestAccResourceProviderRegistration_feature(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			PreConfig: func() {
-				_ = os.Setenv("ARM_PROVIDER_ENHANCED_VALIDATION", "false")
-
 				// Last error may cause resource provider still in `Registered` status.Need to unregister it before a new test.
-				if err := r.unRegisterProviders("Microsoft.ApiSecurity"); err != nil {
+				if err := r.unRegisterProviders("Microsoft.ManufacturingPlatform"); err != nil {
 					t.Fatalf("Failed to reset feature registration with error: %+v", err)
 				}
 			},
-			Config: r.multiFeature(true, true),
+			Config: r.feature(true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.multiFeature(true, false),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.multiFeature(false, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.multiFeature(false, false),
+			Config: r.feature(false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -207,7 +190,7 @@ func (r ResourceProviderRegistrationResource) unRegisterProvider(client *clients
 	return nil
 }
 
-func (ResourceProviderRegistrationResource) multiFeature(registered1 bool, registered2 bool) string {
+func (ResourceProviderRegistrationResource) feature(registered bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -215,15 +198,11 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_provider_registration" "test" {
-  name = "Microsoft.ApiSecurity"
+  name = "Microsoft.ManufacturingPlatform"
   feature {
-    name       = "PP2CanaryAccessDEV"
-    registered = %t
-  }
-  feature {
-    name       = "PP3CanaryAccessDEV"
+    name       = "DefaultFeature"
     registered = %t
   }
 }
-`, registered1, registered2)
+`, registered)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/e4e5dde0-7a05-4321-ab5e-d8c213e5aaa5)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #0000


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
