### PR TITLE
feat: add kusto_eventhub_data_connection supports retrieval_start_date parameter

### DIFF
--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -148,7 +148,7 @@ func resourceKustoEventHubDataConnection() *pluginsdk.Resource {
 			"retrieval_start_date": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.IsRFC3339Time,
 			},
 		},
 	}

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -144,6 +144,12 @@ func resourceKustoEventHubDataConnection() *pluginsdk.Resource {
 				Default:      string(dataconnections.DatabaseRoutingSingle),
 				ValidateFunc: validation.StringInSlice(dataconnections.PossibleValuesForDatabaseRouting(), false),
 			},
+
+			"retrieval_start_date": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 	}
 }
@@ -231,6 +237,7 @@ func resourceKustoEventHubDataConnectionRead(d *pluginsdk.ResourceData, meta int
 				d.Set("consumer_group", props.ConsumerGroup)
 				d.Set("table_name", props.TableName)
 				d.Set("mapping_rule_name", props.MappingRuleName)
+				d.Set("retrieval_start_date", props.RetrievalStartDate)
 				d.Set("data_format", string(pointer.From(props.DataFormat)))
 				d.Set("database_routing_type", string(pointer.From(props.DatabaseRouting)))
 				d.Set("compression", string(pointer.From(props.Compression)))
@@ -294,6 +301,10 @@ func expandKustoEventHubDataConnectionProperties(d *pluginsdk.ResourceData) *dat
 
 	if mappingRuleName, ok := d.GetOk("mapping_rule_name"); ok {
 		eventHubConnectionProperties.MappingRuleName = utils.String(mappingRuleName.(string))
+	}
+
+	if retrievalStartDate, ok := d.GetOk("retrieval_start_date"); ok {
+		eventHubConnectionProperties.RetrievalStartDate = utils.String(retrievalStartDate.(string))
 	}
 
 	if df, ok := d.GetOk("data_format"); ok {

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -311,9 +311,9 @@ resource "azurerm_kusto_eventhub_data_connection" "test" {
   cluster_name        = azurerm_kusto_cluster.test.name
   database_name       = azurerm_kusto_database.test.name
 
-  eventhub_id    	   	= azurerm_eventhub.test.id
-  consumer_group		= azurerm_eventhub_consumer_group.test.name
-  retrieval_start_date 	= "2024-11-16T11:12:11Z"
+  eventhub_id          = azurerm_eventhub.test.id
+  consumer_group       = azurerm_eventhub_consumer_group.test.name
+  retrieval_start_date = "2024-11-16T11:12:11Z"
 
   identity_id = azurerm_kusto_cluster.test.id
 

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -107,6 +107,21 @@ func TestAccKustoEventHubDataConnection_userAssignedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccKustoEventHubDataConnection_retrievalStartDate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.retrievalStartDate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKustoEventHubDataConnection_databaseRoutingType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
 	r := KustoEventHubDataConnectionResource{}
@@ -271,6 +286,34 @@ resource "azurerm_kusto_eventhub_data_connection" "test" {
 
   eventhub_id    = azurerm_eventhub.test.id
   consumer_group = azurerm_eventhub_consumer_group.test.name
+
+  identity_id = azurerm_kusto_cluster.test.id
+
+  depends_on = [azurerm_role_assignment.test]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoEventHubDataConnectionResource) retrievalStartDate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_eventhub.test.id
+  role_definition_name = "Azure Event Hubs Data Receiver"
+  principal_id         = azurerm_kusto_cluster.test.identity.0.principal_id
+}
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id    	   	= azurerm_eventhub.test.id
+  consumer_group		= azurerm_eventhub_consumer_group.test.name
+  retrieval_start_date 	= "2024-11-16T11:12:11Z"
 
   identity_id = azurerm_kusto_cluster.test.id
 

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -67,9 +67,9 @@ resource "azurerm_kusto_eventhub_data_connection" "eventhub_connection" {
   cluster_name        = azurerm_kusto_cluster.cluster.name
   database_name       = azurerm_kusto_database.database.name
 
-  eventhub_id           = azurerm_eventhub.eventhub.id
-  consumer_group        = azurerm_eventhub_consumer_group.consumer_group.name
-  retrieval_start_date  = "2024-11-25T04:44:44Z"
+  eventhub_id          = azurerm_eventhub.eventhub.id
+  consumer_group       = azurerm_eventhub_consumer_group.consumer_group.name
+  retrieval_start_date = "2024-11-25T04:44:44Z"
 
   table_name        = "my-table"         #(Optional)
   mapping_rule_name = "my-table-mapping" #(Optional)

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -67,9 +67,8 @@ resource "azurerm_kusto_eventhub_data_connection" "eventhub_connection" {
   cluster_name        = azurerm_kusto_cluster.cluster.name
   database_name       = azurerm_kusto_database.database.name
 
-  eventhub_id          = azurerm_eventhub.eventhub.id
-  consumer_group       = azurerm_eventhub_consumer_group.consumer_group.name
-  retrieval_start_date = "2024-11-25T04:44:44Z"
+  eventhub_id    = azurerm_eventhub.eventhub.id
+  consumer_group = azurerm_eventhub_consumer_group.consumer_group.name
 
   table_name        = "my-table"         #(Optional)
   mapping_rule_name = "my-table-mapping" #(Optional)

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -67,8 +67,9 @@ resource "azurerm_kusto_eventhub_data_connection" "eventhub_connection" {
   cluster_name        = azurerm_kusto_cluster.cluster.name
   database_name       = azurerm_kusto_database.database.name
 
-  eventhub_id    = azurerm_eventhub.eventhub.id
-  consumer_group = azurerm_eventhub_consumer_group.consumer_group.name
+  eventhub_id           = azurerm_eventhub.eventhub.id
+  consumer_group        = azurerm_eventhub_consumer_group.consumer_group.name
+  retrieval_start_date  = "2024-11-25T04:44:44Z"
 
   table_name        = "my-table"         #(Optional)
   mapping_rule_name = "my-table-mapping" #(Optional)
@@ -103,6 +104,8 @@ The following arguments are supported:
 * `identity_id` - (Optional) The resource ID of a managed identity (system or user assigned) to be used to authenticate with event hub.
 
 * `mapping_rule_name` - (Optional) Specifies the mapping rule used for the message ingestion. Mapping rule must exist before resource is created.
+
+* `retrieval_start_date` - (Optional) When defined, the data connection retrieves existing Event hub events created since the Retrieval start date. It can only retrieve events retained by the Event hub, based on its retention period.
 
 * `data_format` - (Optional) Specifies the data format of the EventHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSVE`, `TSV`, `TXT`, and `W3CLOGFILE`.
 


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Add for the kusto_eventhub_data_connection the parameter "retrieval_start_date" to ingest older stored data from an Event Hub. 

When defined, the data connection retrieves existing Event hub events created since the Retrieval start date. It can only retrieve events retained by the Event hub, based on its retention period.

- add the missing parameter for CRUD
- add test case for the new parameter
- add updated docs

Made CRUD tests locally. 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kusto_eventhub_data_connection` - support the `retrieval_start_date` parameter 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

No known open issue for that. 