### PR TITLE
storage_account_resource : fixed property customer_managed_key

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1128,6 +1128,10 @@ func resourceStorageAccount() *pluginsdk.Resource {
 					}
 				}
 
+				if err := validateCustomerManagedKeyUserAssignedIdentity(d); err != nil {
+					return err
+				}
+
 				if !features.FivePointOh() && !v.(*clients.Client).Features.Storage.DataPlaneAvailable {
 					rawQueueProperties, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("queue_properties"))
 					if diags.HasError() {
@@ -1247,7 +1251,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 
 					"user_assigned_identity_id": {
 						Type:         pluginsdk.TypeString,
-						Required:     true,
+						Optional:     true,
 						ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 					},
 				},
@@ -2465,6 +2469,31 @@ func resourceStorageAccountDelete(d *pluginsdk.ResourceData, meta interface{}) e
 
 	// remove this from the cache
 	storageUtils.RemoveAccountFromCache(*id)
+
+	return nil
+}
+
+func validateCustomerManagedKeyUserAssignedIdentity(d *pluginsdk.ResourceDiff) error {
+	identityRaw := d.Get("identity").([]interface{})
+	if len(identityRaw) == 0 || identityRaw[0] == nil {
+		return nil
+	}
+
+	identityMap := identityRaw[0].(map[string]interface{})
+	identityType := identityMap["type"].(string)
+	if !strings.Contains(identityType, string(identity.TypeUserAssigned)) {
+		return nil
+	}
+
+	customerManagedKeyRaw := d.Get("customer_managed_key").([]interface{})
+	if len(customerManagedKeyRaw) == 0 || customerManagedKeyRaw[0] == nil {
+		return nil
+	}
+
+	customerManagedKey := customerManagedKeyRaw[0].(map[string]interface{})
+	if customerManagedKey["user_assigned_identity_id"].(string) == "" {
+		return fmt.Errorf("`customer_managed_key.0.user_assigned_identity_id` must be specified when `identity` is `UserAssigned`")
+	}
 
 	return nil
 }

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2521,8 +2521,8 @@ func expandAccountCustomerManagedKey(d *pluginsdk.ResourceData, ctx context.Cont
 		return nil, fmt.Errorf("customer managed key can only be used with account kind `StorageV2` or account tier `Premium`")
 	}
 
-	if expandedIdentity.Type != identity.TypeUserAssigned && expandedIdentity.Type != identity.TypeSystemAssignedUserAssigned {
-		return nil, fmt.Errorf("customer managed key can only be configured when the storage account uses a `UserAssigned` or `SystemAssigned, UserAssigned` managed identity but got %q", string(expandedIdentity.Type))
+	if expandedIdentity.Type != identity.TypeUserAssigned && expandedIdentity.Type != identity.TypeSystemAssignedUserAssigned && expandedIdentity.Type != identity.TypeSystemAssigned {
+		return nil, fmt.Errorf("customer managed key can only be configured when the storage account uses a `SystemAssigned`, `UserAssigned` or `SystemAssigned, UserAssigned` managed identity but got %q", string(expandedIdentity.Type))
 	}
 
 	v := input[0].(map[string]interface{})

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -268,7 +268,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 
 						"user_assigned_identity_id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 						},
 					},

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2479,19 +2479,25 @@ func validateCustomerManagedKeyUserAssignedIdentity(d *pluginsdk.ResourceDiff) e
 		return nil
 	}
 
-	identityMap := identityRaw[0].(map[string]interface{})
-	identityType := identityMap["type"].(string)
+	identityType := identityRaw[0].(map[string]interface{})["type"].(string)
 	if !strings.Contains(identityType, string(identity.TypeUserAssigned)) {
 		return nil
 	}
 
-	customerManagedKeyRaw := d.Get("customer_managed_key").([]interface{})
-	if len(customerManagedKeyRaw) == 0 || customerManagedKeyRaw[0] == nil {
+	cmkRaw, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("customer_managed_key"))
+	if diags.HasError() || !cmkRaw.IsKnown() || cmkRaw.IsNull() || cmkRaw.LengthInt() == 0 {
 		return nil
 	}
 
-	customerManagedKey := customerManagedKeyRaw[0].(map[string]interface{})
-	if customerManagedKey["user_assigned_identity_id"].(string) == "" {
+	uaiRaw, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("customer_managed_key.0.user_assigned_identity_id"))
+	if diags.HasError() {
+		return nil
+	}
+	// Defer to apply time when the value is unknown (e.g. a reference to another resource).
+	if !uaiRaw.IsKnown() {
+		return nil
+	}
+	if uaiRaw.IsNull() || uaiRaw.AsString() == "" {
 		return fmt.Errorf("`customer_managed_key.0.user_assigned_identity_id` must be specified when `identity` is `UserAssigned`")
 	}
 

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1533,19 +1533,6 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	queueEncryptionKeyType := storageaccounts.KeyType(d.Get("queue_encryption_key_type").(string))
 	tableEncryptionKeyType := storageaccounts.KeyType(d.Get("table_encryption_key_type").(string))
 
-	// Validate required fields before expanding customer_managed_key
-	identityType := d.Get("identity").(string)
-	cmkCount := d.Get("customer_managed_key.#").(int)
-
-	// If the identity is "UserAssigned" and customer_managed_key is defined,
-	// ensure that user_assigned_identity_id is specified.
-	if strings.Contains(identityType, "UserAssigned") && cmkCount > 0 {
-		userAssignedIdentityID := d.Get("customer_managed_key.0.user_assigned_identity_id").(string)
-		if userAssignedIdentityID == "" {
-			return fmt.Errorf("`customer_managed_key.0.user_assigned_identity_id` must be specified when `identity` is `UserAssigned`")
-		}
-	}
-
 	encryptionRaw := d.Get("customer_managed_key").([]interface{})
 	encryption, err := expandAccountCustomerManagedKey(d, ctx, keyVaultClient, id.SubscriptionId, encryptionRaw, accountTier, accountKind, *expandedIdentity, queueEncryptionKeyType, tableEncryptionKeyType)
 	if err != nil {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1532,6 +1532,20 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// See: https://docs.microsoft.com/en-gb/azure/storage/common/account-encryption-key-create?tabs=portal
 	queueEncryptionKeyType := storageaccounts.KeyType(d.Get("queue_encryption_key_type").(string))
 	tableEncryptionKeyType := storageaccounts.KeyType(d.Get("table_encryption_key_type").(string))
+
+	// Validate required fields before expanding customer_managed_key
+	identityType := d.Get("identity").(string)
+	cmkCount := d.Get("customer_managed_key.#").(int)
+
+	// If the identity is "SystemAssigned" and customer_managed_key is defined,
+	// ensure that user_assigned_identity_id is specified.
+	if identityType == "UserAssigned" && cmkCount > 0 {
+		userAssignedIdentityID := d.Get("customer_managed_key.0.user_assigned_identity_id").(string)
+		if userAssignedIdentityID == "" {
+			return fmt.Errorf("`customer_managed_key.0.user_assigned_identity_id` must be specified when `identity` is `UserAssigned`")
+		}
+	}
+
 	encryptionRaw := d.Get("customer_managed_key").([]interface{})
 	encryption, err := expandAccountCustomerManagedKey(d, ctx, keyVaultClient, id.SubscriptionId, encryptionRaw, accountTier, accountKind, *expandedIdentity, queueEncryptionKeyType, tableEncryptionKeyType)
 	if err != nil {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1537,9 +1537,9 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	identityType := d.Get("identity").(string)
 	cmkCount := d.Get("customer_managed_key.#").(int)
 
-	// If the identity is "SystemAssigned" and customer_managed_key is defined,
+	// If the identity is "UserAssigned" and customer_managed_key is defined,
 	// ensure that user_assigned_identity_id is specified.
-	if identityType == "UserAssigned" && cmkCount > 0 {
+	if strings.Contains(identityType, "UserAssigned") && cmkCount > 0 {
 		userAssignedIdentityID := d.Get("customer_managed_key.0.user_assigned_identity_id").(string)
 		if userAssignedIdentityID == "" {
 			return fmt.Errorf("`customer_managed_key.0.user_assigned_identity_id` must be specified when `identity` is `UserAssigned`")

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1604,6 +1604,21 @@ func TestAccStorageAccount_customerManagedKeyForHSM(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_customerManagedKeySystemAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.customerManagedKeySystemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageAccount_edgeZone(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -5653,4 +5668,34 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) customerManagedKeySystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  identity {
+    type = "SystemAssigned"
+  }
+
+  customer_managed_key {
+    key_vault_key_id = azurerm_key_vault_key.test.id
+  }
+
+  infrastructure_encryption_enabled = true
+  table_encryption_key_type         = "Account"
+  queue_encryption_key_type         = "Account"
+
+  tags = {
+    environment = "production"
+  }
+}
+`, r.cmkTemplate(data), data.RandomString)
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1613,6 +1613,7 @@ func TestAccStorageAccount_customerManagedKeySystemAssignedIdentity(t *testing.T
 			Config: r.systemAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
 			),
 		},
     data.ImportStep(),
@@ -1622,22 +1623,21 @@ func TestAccStorageAccount_customerManagedKeySystemAssignedIdentity(t *testing.T
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
 	})
 }
 
 func (r StorageAccountResource) customerManagedKeySystemAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy    = false
-      recover_soft_deleted_key_vaults = true
-    }
-  }
+  features {}
 }
 
 data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
 
 resource "azurerm_key_vault" "test" {
   name                     = "acctestkv%s"
@@ -1648,25 +1648,13 @@ resource "azurerm_key_vault" "test" {
   purge_protection_enabled = true
 }
 
-resource "azurerm_key_vault_access_policy" "client" {
+resource "azurerm_key_vault_access_policy" "storage_client" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
-}
-
-resource "azurerm_key_vault_key" "test" {
-  name         = "first"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
-
-  depends_on = [
-    azurerm_key_vault_access_policy.client
-  ]
 }
 
 resource "azurerm_storage_account" "test" {
@@ -1680,8 +1668,10 @@ resource "azurerm_storage_account" "test" {
     type = "SystemAssigned"
   }
 
-  customer_managed_key {
-    key_vault_key_id = azurerm_key_vault_key.test.id
+  lifecycle {
+    ignore_changes = [
+      customer_managed_key,
+    ]
   }
 }
 
@@ -1693,7 +1683,30 @@ resource "azurerm_key_vault_access_policy" "storage_system" {
   key_permissions    = ["Get", "Create", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
   secret_permissions = ["Get"]
 }
-`, data.RandomString, data.RandomString)
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "first"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.storage_client,
+    azurerm_key_vault_access_policy.storage_system
+  ]
+}
+
+resource "azurerm_storage_account_customer_managed_key" "test" {
+  storage_account_id = azurerm_storage_account.test.id
+  key_vault_id       = azurerm_key_vault.test.id
+  key_name           = azurerm_key_vault_key.test.name
+
+  depends_on = [
+    azurerm_key_vault_key.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
 
 func TestAccStorageAccount_edgeZone(t *testing.T) {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1616,7 +1616,7 @@ func TestAccStorageAccount_customerManagedKeySystemAssignedIdentity(t *testing.T
 				check.That(data.ResourceName).Key("identity.0.type").HasValue("SystemAssigned"),
 			),
 		},
-    data.ImportStep(),
+		data.ImportStep(),
 		{
 			Config: r.customerManagedKeySystemAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -1658,7 +1658,7 @@ resource "azurerm_key_vault_access_policy" "storage_client" {
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "unlikely23exst2acct%s"
+  name                     = "acctestsa%s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -1685,7 +1685,7 @@ resource "azurerm_key_vault_access_policy" "storage_system" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "first"
+  name         = "acctest%s"
   key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
@@ -1706,7 +1706,7 @@ resource "azurerm_storage_account_customer_managed_key" "test" {
     azurerm_key_vault_key.test
   ]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString)
 }
 
 func TestAccStorageAccount_edgeZone(t *testing.T) {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1610,6 +1610,13 @@ func TestAccStorageAccount_customerManagedKeySystemAssignedIdentity(t *testing.T
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+    data.ImportStep(),
+		{
 			Config: r.customerManagedKeySystemAssignedIdentity(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -1617,6 +1624,76 @@ func TestAccStorageAccount_customerManagedKeySystemAssignedIdentity(t *testing.T
 		},
 		data.ImportStep(),
 	})
+}
+
+func (r StorageAccountResource) customerManagedKeySystemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = false
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "acctestkv%s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  purge_protection_enabled = true
+}
+
+resource "azurerm_key_vault_access_policy" "client" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
+  secret_permissions = ["Get"]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "first"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.client
+  ]
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  customer_managed_key {
+    key_vault_key_id = azurerm_key_vault_key.test.id
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "storage_system" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_storage_account.test.identity.0.principal_id
+
+  key_permissions    = ["Get", "Create", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  secret_permissions = ["Get"]
+}
+`, data.RandomString, data.RandomString)
 }
 
 func TestAccStorageAccount_edgeZone(t *testing.T) {
@@ -5668,34 +5745,4 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
-}
-
-func (r StorageAccountResource) customerManagedKeySystemAssignedIdentity(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_storage_account" "test" {
-  name                     = "unlikely23exst2acct%s"
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "StorageV2"
-  identity {
-    type = "SystemAssigned"
-  }
-
-  customer_managed_key {
-    key_vault_key_id = azurerm_key_vault_key.test.id
-  }
-
-  infrastructure_encryption_enabled = true
-  table_encryption_key_type         = "Account"
-  queue_encryption_key_type         = "Account"
-
-  tags = {
-    environment = "production"
-  }
-}
-`, r.cmkTemplate(data), data.RandomString)
 }

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -257,9 +257,9 @@ A `customer_managed_key` block supports the following:
 
 * `key_vault_key_id` - (Optional) The ID of the Key Vault Key, supplying a version-less key ID will enable auto-rotation of this key.
 
-* `user_assigned_identity_id` - (Required) The ID of a user assigned identity.
+* `user_assigned_identity_id` - (Optional) The ID of a user assigned identity.
 
-~> **Note:** `customer_managed_key` can only be set when the `account_kind` is set to `StorageV2` or `account_tier` set to `Premium`, and the identity type is `UserAssigned`.
+~> **Note:** `customer_managed_key` can only be set when the `account_kind` is set to `StorageV2` or `account_tier` set to `Premium`. `user_assigned_identity_id` is required when the identity type is `UserAssigned`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

By making key_vault_key_id a required parameter and user_assigned_identity_id optional, it becomes possible to assign a CMK with a SystemAssigned identity via terraform apply.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28296


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
