### PR TITLE
make `role_definition_id` of `data.azurerm_role_definition` return GUID

### DIFF
--- a/internal/services/authorization/role_definition_data_source.go
+++ b/internal/services/authorization/role_definition_data_source.go
@@ -218,8 +218,8 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := RoleDefinitionDataSourceModel{
-				Scope:            id.Scope,
-				RoleDefinitionId: defId,
+				Scope:            config.Scope,
+				RoleDefinitionId: pointer.From(role.Name),
 			}
 			if props := role.Properties; props != nil {
 				state.Name = pointer.From(props.RoleName)

--- a/internal/services/authorization/role_definition_data_source.go
+++ b/internal/services/authorization/role_definition_data_source.go
@@ -192,8 +192,8 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 						return pluginsdk.NonRetryableError(fmt.Errorf("loading Role Definition List: values[0].NameD is nil '%s'", config.Name))
 					}
 
-					defId = *(*roleDefinitions.Model)[0].Id
-					id = roledefinitions.NewScopedRoleDefinitionID(config.Scope, *(*roleDefinitions.Model)[0].Name)
+					defId = *(*roleDefinitions.Model)[0].Name
+					id = roledefinitions.NewScopedRoleDefinitionID(config.Scope, defId)
 					return nil
 				})
 				if err != nil {
@@ -218,8 +218,8 @@ func (a RoleDefinitionDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := RoleDefinitionDataSourceModel{
-				Scope:            config.Scope,
-				RoleDefinitionId: pointer.From(role.Name),
+				Scope:            id.Scope,
+				RoleDefinitionId: defId,
 			}
 			if props := role.Properties; props != nil {
 				state.Name = pointer.From(props.RoleName)

--- a/internal/services/authorization/role_definition_data_source_test.go
+++ b/internal/services/authorization/role_definition_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccRoleDefinitionDataSource_basic(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.basic(id, data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -46,6 +47,7 @@ func TestAccRoleDefinitionDataSource_basicByName(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.byName(id, data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -68,6 +70,7 @@ func TestAccRoleDefinitionDataSource_builtIn_contributor(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.builtIn("Contributor"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -95,6 +98,7 @@ func TestAccRoleDefinitionDataSource_builtIn_owner(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.builtIn("Owner"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -114,6 +118,7 @@ func TestAccRoleDefinitionDataSource_builtIn_reader(t *testing.T) {
 			Config: RoleDefinitionDataSource{}.builtIn("Reader"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
@@ -133,6 +138,7 @@ func TestAccRoleDefinitionDataSource_builtIn_virtualMachineContributor(t *testin
 			Config: RoleDefinitionDataSource{}.builtIn("Virtual Machine Contributor"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").HasValue("/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c"),
+				check.That(data.ResourceName).Key("role_definition_id").IsUUID(),
 				check.That(data.ResourceName).Key("description").Exists(),
 				check.That(data.ResourceName).Key("type").Exists(),
 				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR reintroduces the fix of `data.azurerm_role_definition.role_definition_id`, which should return a GUID as per documentation.

It's a BREAKING CHANGE. For users relying on the property having a fully-qualified ID should switch to the property `id`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)

Fixes #28501


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
