### PR TITLE
`azurerm_linux_virtual_machine_scale_set`, `azurerm_orchestrated_virtual_machine_scale_set`, `azurerm_windows_virtual_machine_scale_set` - Fix potential nil panic caused by ommited `extensions_to_provision_after_vm_creation` block

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_extensions_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_extensions_test.go
@@ -1017,7 +1017,12 @@ resource "azurerm_service_fabric_cluster" "test" {
   reliability_level   = "Bronze"
   upgrade_mode        = "Automatic"
   vm_image            = "Linux"
-  management_endpoint = "http://example:80"
+  management_endpoint = "https://example:80"
+
+  certificate {
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    x509_store_name = "My"
+  }
 
   node_type {
     name                 = "backend"

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_network_test.go
@@ -525,8 +525,7 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-pubip-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  allocation_method   = "Dynamic"
-  sku                 = "Basic"
+  allocation_method   = "Static"
 }
 
 # since these variables are re-used - a locals block makes this more maintainable
@@ -545,8 +544,8 @@ resource "azurerm_application_gateway" "test" {
   location            = "${azurerm_resource_group.test.location}"
 
   sku {
-    name     = "Standard_Small"
-    tier     = "Standard"
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
     capacity = 2
   }
 
@@ -586,6 +585,7 @@ resource "azurerm_application_gateway" "test" {
 
   request_routing_rule {
     name                       = "${local.request_routing_rule_name}"
+    priority                   = 9
     rule_type                  = "Basic"
     http_listener_name         = "${local.listener_name}"
     backend_address_pool_name  = "${local.backend_address_pool_name}"

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -748,7 +748,7 @@ func TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.T)
 						return err
 					}
 
-					ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+					ctx2, cancel := context.WithTimeout(ctx, 60*time.Minute)
 					defer cancel()
 					options := virtualmachinescalesets.DefaultGetOperationOptions()
 					options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
@@ -2427,6 +2427,7 @@ resource "azurerm_public_ip" "test" {
   location                = azurerm_resource_group.test.location
   resource_group_name     = azurerm_resource_group.test.name
   allocation_method       = "Dynamic"
+  sku                     = "Basic"
   idle_timeout_in_minutes = 4
 }
 resource "azurerm_lb" "test" {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -1426,11 +1426,10 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 		autoUpgradeMinorVersion, _ := extensionRaw["auto_upgrade_minor_version_enabled"].(bool)
 
 		extensionProps := virtualmachinescalesets.VirtualMachineScaleSetExtensionProperties{
-			Publisher:                pointer.To(extensionRaw["publisher"].(string)),
-			Type:                     &extensionType,
-			TypeHandlerVersion:       pointer.To(extensionRaw["type_handler_version"].(string)),
-			AutoUpgradeMinorVersion:  pointer.To(autoUpgradeMinorVersion),
-			ProvisionAfterExtensions: utils.ExpandStringSlice(extensionRaw["extensions_to_provision_after_vm_creation"].([]interface{})),
+			Publisher:               pointer.To(extensionRaw["publisher"].(string)),
+			Type:                    &extensionType,
+			TypeHandlerVersion:      pointer.To(extensionRaw["type_handler_version"].(string)),
+			AutoUpgradeMinorVersion: pointer.To(autoUpgradeMinorVersion),
 		}
 
 		if extensionType == "ApplicationHealthLinux" || extensionType == "ApplicationHealthWindows" {
@@ -1452,6 +1451,10 @@ func expandOrchestratedVirtualMachineScaleSetExtensions(input []interface{}) (ex
 				return nil, false, fmt.Errorf("unmarshaling `settings`: %+v", err)
 			}
 			extensionProps.Settings = pointer.To(result)
+		}
+
+		if val, ok := extensionRaw["extensions_to_provision_after_vm_creation"]; ok && val != nil {
+			extensionProps.ProvisionAfterExtensions = utils.ExpandStringSlice(val.([]interface{}))
 		}
 
 		protectedSettingsFromKeyVault := expandProtectedSettingsFromKeyVaultVMSS(extensionRaw["protected_settings_from_key_vault"].([]interface{}))

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_network_test.go
@@ -523,8 +523,7 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-pubip-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  allocation_method   = "Dynamic"
-  sku                 = "Basic"
+  allocation_method   = "Static"
 }
 
 # since these variables are re-used - a locals block makes this more maintainable
@@ -543,8 +542,8 @@ resource "azurerm_application_gateway" "test" {
   location            = "${azurerm_resource_group.test.location}"
 
   sku {
-    name     = "Standard_Small"
-    tier     = "Standard"
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
     capacity = 2
   }
 
@@ -584,6 +583,7 @@ resource "azurerm_application_gateway" "test" {
 
   request_routing_rule {
     name                       = "${local.request_routing_rule_name}"
+    priority                   = 9
     rule_type                  = "Basic"
     http_listener_name         = "${local.listener_name}"
     backend_address_pool_name  = "${local.backend_address_pool_name}"

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -891,7 +891,7 @@ func TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades(t *testing.
 						return err
 					}
 
-					ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+					ctx2, cancel := context.WithTimeout(ctx, 60*time.Minute)
 					defer cancel()
 					options := virtualmachinescalesets.DefaultGetOperationOptions()
 					options.Expand = pointer.To(virtualmachinescalesets.ExpandTypesForGetVMScaleSetsUserData)
@@ -1346,6 +1346,7 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
+  default_outbound_access_enabled = false
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_other_test.go
@@ -1342,10 +1342,10 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "internal"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
+  name                            = "internal"
+  resource_group_name             = azurerm_resource_group.test.name
+  virtual_network_name            = azurerm_virtual_network.test.name
+  address_prefixes                = ["10.0.2.0/24"]
   default_outbound_access_enabled = false
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

I've fixed the following failed tests in this pr:

* `TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension`
* `TestAccLinuxVirtualMachineScaleSet_networkApplicationGateway`
* `TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades`
* `TestAccLinuxVirtualMachineScaleSet_otherAutomaticRepairsPolicy`
* `TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension`
* `TestAccWindowsVirtualMachineScaleSet_networkApplicationGateway`
* `TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades`
* `TestAccWindowsVirtualMachineScaleSet_otherEdgeZone`

But still got multiple failed tests, main reasons:

1. Lack of resource quota in my subscription
2. `expected action to not be Replace, path: xxx tried to update a value that is ForceNew`
  It seems like now the acc test framework doesn't allow ForceNew and replacement anymore.
3. `Resource not found in plan ResourceChanges`
  Some tests used empty config as startpoint:

```go
func TestAccLinuxVirtualMachineScaleSet_imagesPlan(t *testing.T) {
	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
	r := LinuxVirtualMachineScaleSetResource{}
	publisher := "cloudwhizsolutions"
	offer := "jenkins-with-centos-7-7-cw"
	sku := "jenkins-with-centos-77-cw"

	data.ResourceTest(t, r, []acceptance.TestStep{
		{
			Config: r.empty(),
			Check: acceptance.ComposeTestCheckFunc(
				data.CheckWithClientWithoutResource(r.cancelExistingAgreement(publisher, offer, sku)),
			),
		},
```
  It seems like the testing framework does not allow empty config anymore.

For reason 2 and 3, if you want me to remove them or fix them in a specified way, please let me know. Here's the test log:

=== RUN   TestAccLinuxVirtualMachineScaleSet_authPassword
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authPassword
=== CONT  TestAccLinuxVirtualMachineScaleSet_authPassword
--- PASS: TestAccLinuxVirtualMachineScaleSet_authPassword (825.73s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_authSSHKey
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authSSHKey
=== CONT  TestAccLinuxVirtualMachineScaleSet_authSSHKey
--- PASS: TestAccLinuxVirtualMachineScaleSet_authSSHKey (311.10s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_authSSHKeyAndPassword
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authSSHKeyAndPassword
=== CONT  TestAccLinuxVirtualMachineScaleSet_authSSHKeyAndPassword
--- PASS: TestAccLinuxVirtualMachineScaleSet_authSSHKeyAndPassword (324.26s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_authMultipleSSHKeys
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authMultipleSSHKeys
=== CONT  TestAccLinuxVirtualMachineScaleSet_authMultipleSSHKeys
--- PASS: TestAccLinuxVirtualMachineScaleSet_authMultipleSSHKeys (311.50s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_authUpdatingSSHKeys
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authUpdatingSSHKeys
=== CONT  TestAccLinuxVirtualMachineScaleSet_authUpdatingSSHKeys
--- PASS: TestAccLinuxVirtualMachineScaleSet_authUpdatingSSHKeys (409.82s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_authEd25519SSHKeys
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authEd25519SSHKeys
=== CONT  TestAccLinuxVirtualMachineScaleSet_authEd25519SSHKeys
--- PASS: TestAccLinuxVirtualMachineScaleSet_authEd25519SSHKeys (481.84s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_authDisablePasswordAuthUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_authDisablePasswordAuthUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_ 
    testcase.go:173: Step 4/9 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[admin_password]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_authDisablePasswordAuthUpdate (321.82s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskBasic (291.59s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskCaching (583.20s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet (1028.11s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskResizing (963.90s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskMultiple (295.67s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskRemove (969.53s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskScaling (738.79s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS (807.51s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS (798.63s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS (308.91s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS (308.10s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS (302.62s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS (452.11s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS (313.97s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS (814.04s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS (325.32s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS (316.73s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS (316.46s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220858947"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220858947"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Operation could not be completed as it results in exceeding approved standardMSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 8, (Minimum) New Limit Required: 8. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westeurope%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardMSFamily%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:8,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardMSFamily%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled (112.96s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskCaching
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskCaching
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskCaching
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskCaching (615.39s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskCustomSize
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskCustomSize
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskCustomSize
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskCustomSize (500.06s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet (570.81s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeral
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeral
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeral
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeral (303.76s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk (316.71s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS (302.94s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS (304.64s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS (300.66s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS (302.93s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS (303.33s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220854289"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220854289"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Operation could not be completed as it results in exceeding approved standardMSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 8, (Minimum) New Limit Required: 8. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westeurope%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardMSFamily%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:8,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardMSFamily%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled (116.28s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled (319.87s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled (319.90s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK
=== PAUSE TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK
=== CONT  TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK
--- PASS: TestAccLinuxVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK (564.24s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachines
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachines
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachines
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachines (783.34s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachinesUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachinesUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachinesUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionDoNotRunExtensionsOnOverProvisionedMachinesUpdate (467.64s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionBasic
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionBasic
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionBasic
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionBasic (308.60s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionOnlySettings
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionOnlySettings
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionOnlySettings
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionOnlySettings (337.37s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionForceUpdateTag
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionForceUpdateTag
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionForceUpdateTag
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionForceUpdateTag (477.19s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsMultiple
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsMultiple
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionsMultiple
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsMultiple (308.40s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionsUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsUpdate (633.17s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension (330.07s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension (317.37s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[rolling_upgrade_policy]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate (324.31s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudget
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudget
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudget
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudget (301.27s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudgetUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudgetUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudgetUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionWithTimeBudgetUpdate (641.69s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions (802.95s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate (587.52s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled (310.61s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionOperationsEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionOperationsEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionOperationsEnabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionOperationsEnabled (383.57s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionOperationsDisabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionOperationsDisabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionOperationsDisabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionOperationsDisabled (303.87s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
=== PAUSE TestAccLinuxVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
=== CONT  TestAccLinuxVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
--- PASS: TestAccLinuxVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault (705.57s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_identityNone
=== PAUSE TestAccLinuxVirtualMachineScaleSet_identityNone
=== CONT  TestAccLinuxVirtualMachineScaleSet_identityNone
--- PASS: TestAccLinuxVirtualMachineScaleSet_identityNone (792.85s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_identitySystemAssigned
=== PAUSE TestAccLinuxVirtualMachineScaleSet_identitySystemAssigned
=== CONT  TestAccLinuxVirtualMachineScaleSet_identitySystemAssigned
--- PASS: TestAccLinuxVirtualMachineScaleSet_identitySystemAssigned (492.05s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_identityUserAssigned
=== PAUSE TestAccLinuxVirtualMachineScaleSet_identityUserAssigned
=== CONT  TestAccLinuxVirtualMachineScaleSet_identityUserAssigned
--- PASS: TestAccLinuxVirtualMachineScaleSet_identityUserAssigned (1081.43s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_identitySystemAssignedUserAssigned
=== PAUSE TestAccLinuxVirtualMachineScaleSet_identitySystemAssignedUserAssigned
=== CONT  TestAccLinuxVirtualMachineScaleSet_identitySystemAssignedUserAssigned
--- PASS: TestAccLinuxVirtualMachineScaleSet_identitySystemAssignedUserAssigned (516.01s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesAutomaticUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesAutomaticUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesAutomaticUpdate
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesAutomaticUpdate (439.51s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesDisableAutomaticUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesDisableAutomaticUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesDisableAutomaticUpdate
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesDisableAutomaticUpdate (325.50s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage
    testcase.go:173: Step 1/9 error: Pre-apply plan check(s) failed:
        azurerm_linux_virtual_machine_scale_set.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage (21.58s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesManualUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesManualUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesManualUpdate
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesManualUpdate (308.17s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesManualUpdateExternalRoll
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesManualUpdateExternalRoll
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesManualUpdateExternalRoll
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesManualUpdateExternalRoll (304.33s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesRollingUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesRollingUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesRollingUpdate
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_linux_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesRollingUpdate (413.43s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_imagesPlan
=== PAUSE TestAccLinuxVirtualMachineScaleSet_imagesPlan
=== CONT  TestAccLinuxVirtualMachineScaleSet_imagesPlan
    testcase.go:173: Step 1/4 error: Pre-apply plan check(s) failed:
        azurerm_linux_virtual_machine_scale_set.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccLinuxVirtualMachineScaleSet_imagesPlan (16.42s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworking (306.37s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated (469.43s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkApplicationGateway
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkApplicationGateway        
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkApplicationGateway
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroup
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroup
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroup
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroup (294.75s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate (573.42s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkDNSServers
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkDNSServers
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkDNSServers
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkDNSServers (875.46s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkIPForwarding
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkIPForwarding
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkIPForwarding
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkIPForwarding (461.18s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkIPv6
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkIPv6
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkIPv6
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkIPv6 (102.45s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkLoadBalancer
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkLoadBalancer
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkLoadBalancer
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkLoadBalancer (376.82s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurations
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurations
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurations
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurations (300.62s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6 (305.26s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkMultipleNICs
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkMultipleNICs
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkMultipleNICs
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkMultipleNICs (794.10s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations (314.61s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs (297.04s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers (788.02s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroup
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroup
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroup
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroup (292.66s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate (542.76s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPrivate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkPrivate
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkPrivate
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkPrivate (788.41s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPublicIP
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkPublicIP
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkPublicIP
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkPublicIP (294.31s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPublicIPVersion
    linux_virtual_machine_scale_set_resource_network_test.go:389: Skipping test until api version is upgraded to 2022-03-01 with `network_interface.ip_configuration.public_ip_address.sku_name` added
--- SKIP: TestAccLinuxVirtualMachineScaleSet_networkPublicIPVersion (0.00s)

Test ignored.
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPublicIPDomainNameLabel
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkPublicIPDomainNameLabel
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkPublicIPDomainNameLabel
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkPublicIPDomainNameLabel (302.49s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkPublicIPFromPrefix (453.73s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_networkPublicIPTags
=== PAUSE TestAccLinuxVirtualMachineScaleSet_networkPublicIPTags
=== CONT  TestAccLinuxVirtualMachineScaleSet_networkPublicIPTags
--- PASS: TestAccLinuxVirtualMachineScaleSet_networkPublicIPTags (356.03s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherBootDiagnostics
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherBootDiagnostics
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherBootDiagnostics
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherBootDiagnostics (651.16s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherBootDiagnosticsManaged
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherBootDiagnosticsManaged
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherBootDiagnosticsManaged
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherBootDiagnosticsManaged (598.44s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefix
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefix
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefix
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefix (293.01s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefixInvalid
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefixInvalid
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefixInvalid
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherComputerNamePrefixInvalid (154.53s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherCustomData
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherCustomData
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherCustomData
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherCustomData (522.74s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherEdgeZone
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherEdgeZone
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherEdgeZone
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherEdgeZone (326.90s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherUserData
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherUserData
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherUserData
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherUserData (598.69s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherForceDelete
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherForceDelete
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherForceDelete
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherForceDelete (280.48s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDeallocate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDeallocate
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDeallocate
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220919043"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220919043"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDeallocate (128.82s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDelete
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDelete
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDelete
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220914397"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220914397"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotDelete (110.72s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice
    testcase.go:173: Step 1/6 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220918406"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220918406"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice (116.22s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherPriorityRegular
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherPriorityRegular
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherPriorityRegular
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherPriorityRegular (311.60s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherRequiresImport
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherRequiresImport
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherRequiresImport
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherRequiresImport (799.75s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherSecret
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherSecret
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherSecret
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherSecret (1220.89s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherSpotRestoreDefault
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherSpotRestoreDefault
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherSpotRestoreDefault
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220938464"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220938464"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_otherSpotRestoreDefault (113.50s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherSpotRestore
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherSpotRestore
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherSpotRestore
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Linux Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220930727"
        Virtual Machine Scale Set Name: "acctestvmss-250115131220930727"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_linux_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 65, in resource "azurerm_linux_virtual_machine_scale_set" "test":
          65: resource "azurerm_linux_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_otherSpotRestore (112.85s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_otherTags
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherTags
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherTags
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherTags (1014.60s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherVMAgent
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherVMAgent
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherVMAgent
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherVMAgent (794.88s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabled (309.53s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled (361.14s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherScaleIn
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherScaleIn
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherScaleIn
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherScaleIn (383.80s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherTerminationNotification
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherTerminationNotification
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherTerminationNotification
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherTerminationNotification (482.81s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherAutomaticRepairsPolicy
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherAutomaticRepairsPolicy
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherAutomaticRepairsPolicy (551.60s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherUpgradeMode
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherUpgradeMode
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherUpgradeMode
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherUpgradeMode (332.61s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHost
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHost
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHost
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHost (309.78s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostUpdate (469.83s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostWithCMK
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostWithCMK
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostWithCMK
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherEncryptionAtHostWithCMK (576.59s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherPlatformFaultDomainCount
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherPlatformFaultDomainCount
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherPlatformFaultDomainCount
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherPlatformFaultDomainCount (326.78s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate (557.88s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherHealthProbeUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherHealthProbeUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherHealthProbeUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherHealthProbeUpdate (490.37s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherSecureBootEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherSecureBootEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherSecureBootEnabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherSecureBootEnabled (321.31s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherVTpmEnabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherVTpmEnabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherVTpmEnabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherVTpmEnabled (305.94s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationBasic
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationBasic
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationBasic
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationBasic (1125.38s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationComplete
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationComplete
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationComplete
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherGalleryApplicationComplete (1141.16s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherCancelRollingUpgrades (1785.51s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_otherDisableReimageOnManualUpgrade
=== PAUSE TestAccLinuxVirtualMachineScaleSet_otherDisableReimageOnManualUpgrade
=== CONT  TestAccLinuxVirtualMachineScaleSet_otherDisableReimageOnManualUpgrade
--- PASS: TestAccLinuxVirtualMachineScaleSet_otherDisableReimageOnManualUpgrade (382.29s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingAutoScale
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingAutoScale
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingAutoScale
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingAutoScale (318.74s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingCapacityReservationGroupId (312.54s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount
=== PAUSE TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount
=== CONT  TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount
--- PASS: TestAccLinuxVirtualMachineScaleSet_defaultInstanceCount (203.83s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingHostGroupId
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingHostGroupId
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingHostGroupId
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Dedicated Host (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-vmss-250115131220968979"
        Host Group Name: "acctestDHG-250115131220968979"
        Host Name: "acctestDH-250115131220968979"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Operation could not be completed as it results in exceeding approved DedicatedVCpu quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 80, (Minimum) New Limit Required: 80. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/?#create/Microsoft.Support/Parameters/%7B%22subId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22pesId%22:%2206bfd9d3-516b-d5c6-5802-169c800dec89%22,%22supportTopicId%22:%22599a339a-a959-d783-24fc-81a42d3fd5fb%22%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests
        
          with azurerm_dedicated_host.test,
          on terraform_plugin_test.tf line 73, in resource "azurerm_dedicated_host" "test":
          73: resource "azurerm_dedicated_host" "test" {
        
--- FAIL: TestAccLinuxVirtualMachineScaleSet_scalingHostGroupId (104.68s)

=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingInstanceCount
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingInstanceCount
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingInstanceCount
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingInstanceCount (702.14s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingOverProvisionDisabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingOverProvisionDisabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingOverProvisionDisabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingOverProvisionDisabled (307.62s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingProximityPlacementGroup
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingProximityPlacementGroup
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingProximityPlacementGroup
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingProximityPlacementGroup (304.07s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled (330.86s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate (907.48s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingUpdateSku
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingUpdateSku
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingUpdateSku
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingUpdateSku (715.05s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingZonesSingle
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingZonesSingle
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingZonesSingle
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingZonesSingle (364.23s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingZonesMultiple
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingZonesMultiple
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingZonesMultiple
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingZonesMultiple (371.61s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingZonesUpdate
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingZonesUpdate
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingZonesUpdate
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingZonesUpdate (465.51s)
=== RUN   TestAccLinuxVirtualMachineScaleSet_scalingZonesBalance
=== PAUSE TestAccLinuxVirtualMachineScaleSet_scalingZonesBalance
=== CONT  TestAccLinuxVirtualMachineScaleSet_scalingZonesBalance
--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingZonesBalance (335.53s)


=== RUN   TestAccWindowsVirtualMachineScaleSet_authPassword
=== PAUSE TestAccWindowsVirtualMachineScaleSet_authPassword
=== CONT  TestAccWindowsVirtualMachineScaleSet_authPassword
--- PASS: TestAccWindowsVirtualMachineScaleSet_authPassword (409.14s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskBasic
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskBasic
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskBasic
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskBasic (303.46s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskCaching
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskCaching
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskCaching
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskCaching (602.06s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet (546.49s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskResizing
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskResizing
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskResizing
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskResizing (421.34s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskMultiple
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskMultiple
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskMultiple
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskMultiple (298.93s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskRemove
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskRemove
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskRemove
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskRemove (473.81s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskScaling
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskScaling
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskScaling
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskScaling (748.39s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS (300.52s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS (298.44s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS (292.06s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS (327.13s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS (331.45s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRSWithIOPSAndMBPS (438.95s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS (303.44s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS (303.03s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPS (314.48s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithMBPS (301.59s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRSWithIOPSAndMBPS (293.06s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059617651"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Operation could not be completed as it results in exceeding approved standardMSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 8, (Minimum) New Limit Required: 8. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westeurope%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardMSFamily%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:8,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardMSFamily%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_disksDataDiskWriteAcceleratorEnabled (85.58s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskCaching
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskCaching
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskCaching
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskCaching (584.63s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskCustomSize
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskCustomSize
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskCustomSize
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskCustomSize (561.20s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeral
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeral
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeral
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeral (307.35s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskEphemeralResourceDisk (307.99s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskDiskEncryptionSet (543.85s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS (296.71s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS (328.55s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS (386.96s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS (395.36s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS (417.68s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059620537"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Operation could not be completed as it results in exceeding approved standardMSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 8, (Minimum) New Limit Required: 8. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westeurope%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardMSFamily%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:8,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardMSFamily%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_disksOSDiskWriteAcceleratorEnabled (111.82s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootEnabled (373.89s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithGuestStateOnlySecureBootDisabled (351.22s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK
=== PAUSE TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK
=== CONT  TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK
--- PASS: TestAccWindowsVirtualMachineScaleSet_disksOSDiskConfidentialVmWithDiskAndVMGuestStateCMK (590.21s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionDoNotRunOnOverProvisionedMachines
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionDoNotRunOnOverProvisionedMachines
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionDoNotRunOnOverProvisionedMachines
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionDoNotRunOnOverProvisionedMachines (431.07s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionsDoNotRunOnOverProvisionedMachinesUpdate (467.33s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionBasic
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionBasic
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionBasic
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionBasic (340.01s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionForceUpdateTag
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionForceUpdateTag
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionForceUpdateTag
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionForceUpdateTag (556.93s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionMultiple
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionMultiple
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionMultiple
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionMultiple (329.31s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionOnlySettings
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionOnlySettings
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionOnlySettings
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionOnlySettings (323.29s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionUpdate (777.12s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionsRollingUpgradeWithHealthExtension (329.80s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithHealthExtension (361.94s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudget
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudget
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudget
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudget (376.95s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudgetUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudgetUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudgetUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionWithTimeBudgetUpdate (737.73s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensions (312.74s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionTimeBudgetWithoutExtensionsUpdate (553.76s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionsAutomaticUpgradeWithServiceFabricExtension (1166.09s)=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_windows_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[rolling_upgrade_policy]] tried to update a value that is ForceNew
--- FAIL: TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeUpdate (352.93s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionAutomaticUpgradeEnabled (334.29s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionOperationsEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionOperationsEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionOperationsEnabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionOperationsEnabled (381.43s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionOperationsDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionOperationsDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionOperationsDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionOperationsDisabled (303.98s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
=== PAUSE TestAccWindowsVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
=== CONT  TestAccWindowsVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
--- PASS: TestAccWindowsVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault (701.15s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_identityNone
=== PAUSE TestAccWindowsVirtualMachineScaleSet_identityNone
=== CONT  TestAccWindowsVirtualMachineScaleSet_identityNone
--- PASS: TestAccWindowsVirtualMachineScaleSet_identityNone (304.64s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_identitySystemAssigned
=== PAUSE TestAccWindowsVirtualMachineScaleSet_identitySystemAssigned
=== CONT  TestAccWindowsVirtualMachineScaleSet_identitySystemAssigned
--- PASS: TestAccWindowsVirtualMachineScaleSet_identitySystemAssigned (496.27s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_identityUserAssigned
=== PAUSE TestAccWindowsVirtualMachineScaleSet_identityUserAssigned
=== CONT  TestAccWindowsVirtualMachineScaleSet_identityUserAssigned
--- PASS: TestAccWindowsVirtualMachineScaleSet_identityUserAssigned (468.56s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_identitySystemAssignedUserAssigned
=== PAUSE TestAccWindowsVirtualMachineScaleSet_identitySystemAssignedUserAssigned
=== CONT  TestAccWindowsVirtualMachineScaleSet_identitySystemAssignedUserAssigned
--- PASS: TestAccWindowsVirtualMachineScaleSet_identitySystemAssignedUserAssigned (466.30s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesAutomaticUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesAutomaticUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesAutomaticUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_imagesAutomaticUpdate (925.04s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesDisableAutomaticUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesDisableAutomaticUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesDisableAutomaticUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_imagesDisableAutomaticUpdate (1059.43s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage
    testcase.go:173: Step 1/9 error: Pre-apply plan check(s) failed:
        azurerm_windows_virtual_machine_scale_set.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccWindowsVirtualMachineScaleSet_imagesFromCapturedVirtualMachineImage (8.53s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesManualUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesManualUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesManualUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_imagesManualUpdate (496.24s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesManualUpdateExternalRoll
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesManualUpdateExternalRoll
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesManualUpdateExternalRoll
--- PASS: TestAccWindowsVirtualMachineScaleSet_imagesManualUpdateExternalRoll (318.01s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesRollingUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesRollingUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesRollingUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_imagesRollingUpdate (442.63s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_imagesPlan
=== PAUSE TestAccWindowsVirtualMachineScaleSet_imagesPlan
=== CONT  TestAccWindowsVirtualMachineScaleSet_imagesPlan
    testcase.go:173: Step 1/4 error: Pre-apply plan check(s) failed:
        azurerm_windows_virtual_machine_scale_set.test - Resource not found in plan ResourceChanges
--- FAIL: TestAccWindowsVirtualMachineScaleSet_imagesPlan (4.97s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworking
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworking
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworking
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworking (300.15s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkAcceleratedNetworkingUpdated (391.41s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkApplicationGateway
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkApplicationGateway
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkApplicationGateway
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkApplicationGateway (1002.64s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroup
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroup
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroup
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroup (309.99s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkApplicationSecurityGroupUpdate (499.57s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkDNSServers
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkDNSServers
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkDNSServers
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkDNSServers (359.48s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkIPForwarding
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkIPForwarding
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkIPForwarding
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkIPForwarding (410.87s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkIPv6
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkIPv6
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkIPv6
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkIPv6 (123.05s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkLoadBalancer
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkLoadBalancer
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkLoadBalancer
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkLoadBalancer (951.98s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurations
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurations
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurations
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurations (300.22s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkMultipleIPConfigurationsIPv6 (295.32s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkMultipleNICs
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkMultipleNICs
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkMultipleNICs
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkMultipleNICs (309.13s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultipleIPConfigurations (307.52s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsMultiplePublicIPs (322.08s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkMultipleNICsWithDifferentDNSServers (303.00s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroup
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroup
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroup
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroup (326.83s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkNetworkSecurityGroupUpdate (471.26s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPrivate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkPrivate
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkPrivate
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkPrivate (303.05s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPublicIP
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkPublicIP
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkPublicIP
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkPublicIP (303.58s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPublicIPVersion
    windows_virtual_machine_scale_set_resource_network_test.go:389: Skipping test until api version is upgraded to 2022-03-01 with `network_interface.ip_configuration.public_ip_address.sku_name` added
--- SKIP: TestAccWindowsVirtualMachineScaleSet_networkPublicIPVersion (0.00s)

Test ignored.
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPublicIPDomainNameLabel
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkPublicIPDomainNameLabel
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkPublicIPDomainNameLabel
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkPublicIPDomainNameLabel (336.64s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkPublicIPFromPrefix (433.50s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_networkPublicIPTags
=== PAUSE TestAccWindowsVirtualMachineScaleSet_networkPublicIPTags
=== CONT  TestAccWindowsVirtualMachineScaleSet_networkPublicIPTags
--- PASS: TestAccWindowsVirtualMachineScaleSet_networkPublicIPTags (360.45s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent (334.46s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherBootDiagnostics
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherBootDiagnostics
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherBootDiagnostics
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherBootDiagnostics (679.78s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherBootDiagnosticsMananged
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherBootDiagnosticsMananged
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherBootDiagnosticsMananged
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherBootDiagnosticsMananged (628.41s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefix
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefix
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefix
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefix (320.33s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefixInvalid
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefixInvalid
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefixInvalid
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherComputerNamePrefixInvalid (91.78s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherCustomData
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherCustomData
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherCustomData
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherCustomData (498.72s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherEdgeZone
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherEdgeZone
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherEdgeZone
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherEdgeZone (321.93s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherUserData
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherUserData
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherUserData
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherUserData (592.15s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherForceDelete
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherForceDelete
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherForceDelete
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherForceDelete (265.32s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherEnableAutomaticUpdatesDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherEnableAutomaticUpdatesDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherEnableAutomaticUpdatesDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherEnableAutomaticUpdatesDisabled (392.73s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDeallocate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDeallocate
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDeallocate
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059663335"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDeallocate (106.20s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDelete
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDelete
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDelete
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059660408"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotDelete (109.91s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice
    testcase.go:173: Step 1/6 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059660480"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_otherPrioritySpotMaxBidPrice (93.05s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherPriorityRegular
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherPriorityRegular
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherPriorityRegular
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherPriorityRegular (300.54s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherRequiresImport
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherRequiresImport
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherRequiresImport
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherRequiresImport (295.69s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherSecret
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherSecret
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherSecret
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherSecret (1126.81s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherSpotRestoreDefault
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherSpotRestoreDefault
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherSpotRestoreDefault
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059679915"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_otherSpotRestoreDefault (87.78s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherSpotRestore
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherSpotRestore
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherSpotRestore
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Windows Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059673476"
        Virtual Machine Scale Set Name: "acctvm25"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: SkuNotAvailable: The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_F2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.
        
          with azurerm_windows_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 60, in resource "azurerm_windows_virtual_machine_scale_set" "test":
          60: resource "azurerm_windows_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_otherSpotRestore (85.55s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_otherTags
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherTags
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherTags
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherTags (406.50s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherTimeZone
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherTimeZone
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherTimeZone
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherTimeZone (318.04s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherVMAgent
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherVMAgent
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherVMAgent
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherVMAgent (361.47s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabled (302.89s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled (306.65s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTP
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTP
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTP
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTP (318.21s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTPS
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTPS
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTPS
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTPS (1090.49s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherUpgradeMode
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherUpgradeMode
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherUpgradeMode
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherUpgradeMode (305.81s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherScaleIn
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherScaleIn
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherScaleIn
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherScaleIn (355.93s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherTerminationNotification
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherTerminationNotification
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherTerminationNotification
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherTerminationNotification (396.09s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy (750.38s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabled (1036.20s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledUpdate (661.63s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledWithCMK
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledWithCMK
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledWithCMK
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherEncryptionAtHostEnabledWithCMK (546.39s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherSecureBootEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherSecureBootEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherSecureBootEnabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherSecureBootEnabled (308.82s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherVTpmEnabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherVTpmEnabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherVTpmEnabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherVTpmEnabled (301.79s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherPlatformFaultDomainCount
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherPlatformFaultDomainCount
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherPlatformFaultDomainCount
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherPlatformFaultDomainCount (296.62s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherRollingUpgradePolicyUpdate (512.46s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherHealthProbeUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherHealthProbeUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherHealthProbeUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherHealthProbeUpdate (464.20s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherLicenseTypeUpdated
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherLicenseTypeUpdated
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherLicenseTypeUpdated
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherLicenseTypeUpdated (399.86s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationBasic
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationBasic
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationBasic
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationBasic (1177.57s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationComplete
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationComplete
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationComplete
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherGalleryApplicationComplete (1134.42s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades
=== PAUSE TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades
=== CONT  TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades
--- PASS: TestAccWindowsVirtualMachineScaleSet_otherCancelRollingUpgrades (2267.50s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingAutoScale
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingAutoScale
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingAutoScale
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingAutoScale (315.23s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingCapacityReservationGroupId (316.42s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingHostGroupId
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingHostGroupId
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingHostGroupId
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Dedicated Host (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-250116164059704090"
        Host Group Name: "acctestDHG-250116164059704090"
        Host Name: "acctestDH-250116164059704090"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Operation could not be completed as it results in exceeding approved DedicatedVCpu quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 80, (Minimum) New Limit Required: 80. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/?#create/Microsoft.Support/Parameters/%7B%22subId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22pesId%22:%2206bfd9d3-516b-d5c6-5802-169c800dec89%22,%22supportTopicId%22:%22599a339a-a959-d783-24fc-81a42d3fd5fb%22%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests
        
          with azurerm_dedicated_host.test,
          on terraform_plugin_test.tf line 68, in resource "azurerm_dedicated_host" "test":
          68: resource "azurerm_dedicated_host" "test" {
        
--- FAIL: TestAccWindowsVirtualMachineScaleSet_scalingHostGroupId (80.34s)

=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingInstanceCount
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingInstanceCount
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingInstanceCount
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingInstanceCount (611.35s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionDisabled (297.61s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingOverProvisionUpdate (384.57s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingProximityPlacementGroup
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingProximityPlacementGroup
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingProximityPlacementGroup
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingProximityPlacementGroup (298.30s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabled (299.73s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingSinglePlacementGroupDisabledUpdate (350.42s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingUpdateSku
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingUpdateSku
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingUpdateSku
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingUpdateSku (756.97s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingZonesSingle
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingZonesSingle
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingZonesSingle
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingZonesSingle (321.72s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingZonesMultiple
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingZonesMultiple
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingZonesMultiple
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingZonesMultiple (304.99s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingZonesUpdate
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingZonesUpdate
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingZonesUpdate
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingZonesUpdate (418.56s)
=== RUN   TestAccWindowsVirtualMachineScaleSet_scalingZonesBalance
=== PAUSE TestAccWindowsVirtualMachineScaleSet_scalingZonesBalance
=== CONT  TestAccWindowsVirtualMachineScaleSet_scalingZonesBalance
--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingZonesBalance (302.83s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicLinux_managedDisk
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicLinux_managedDisk
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicLinux_managedDisk
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicLinux_managedDisk (291.14s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_importBasic_managedDisk_withZones
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_importBasic_managedDisk_withZones
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_importBasic_managedDisk_withZones
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_importBasic_managedDisk_withZones (256.46s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_loadBalancerManagedDataDisks
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_loadBalancerManagedDataDisks
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_loadBalancerManagedDataDisks
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_loadBalancerManagedDataDisks (251.26s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumLRS (237.10s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumV2LRS (257.13s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypePremiumZRS (266.44s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardLRS (229.83s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDLRS (241.01s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeStandardSSDZRS (232.90s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskStorageAccountTypeUltraSSDLRS (293.86s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskSizeFromMarketPlaceImage
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskSizeFromMarketPlaceImage
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskSizeFromMarketPlaceImage
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksDataDiskSizeFromMarketPlaceImage (299.57s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_orchestrated_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[os_disk 0 diff_disk_settings 0 placement]] tried to update a value that is ForceNew
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching (201.33s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumLRS (197.64s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypePremiumZRS (194.58s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardLRS (223.49s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDLRS (224.03s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStandardSSDZRS (229.27s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensions
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensions
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensions
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensions (154.41s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionsUpdate
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionsUpdate
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionsUpdate
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensionsUpdate (204.29s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple (152.42s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple_on_existing_OVMSS
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple_on_existing_OVMSS
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple_on_existing_OVMSS
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_orchestrated_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[network_interface 0 name]] tried to update a value that is ForceNew
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple_on_existing_OVMSS (263.19s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsEnabled
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsEnabled
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsEnabled
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsEnabled (155.63s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsDisabled
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsDisabled
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsDisabled
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensionOperationsDisabled (281.49s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionFailureSuppression
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionFailureSuppression
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionFailureSuppression
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensionFailureSuppression (198.71s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_extensionProtectedSettingsFromKeyVault (363.56s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_MSI_UserAssigned
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_MSI_UserAssigned
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_MSI_UserAssigned
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_MSI_UserAssigned (229.47s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_legacyBasicZonal
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_legacyBasicZonal
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_legacyBasicZonal
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_legacyBasicZonal (96.19s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_legacyUpdateZonal
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_legacyUpdateZonal
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_legacyUpdateZonal
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_legacyUpdateZonal (185.48s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_legacyBasicNonZonal
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_legacyBasicNonZonal
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_legacyBasicNonZonal
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_legacyBasicNonZonal (94.26s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_legacyRequiresImport
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_legacyRequiresImport
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_legacyRequiresImport
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_legacyRequiresImport (89.17s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_multipleNetworkProfiles
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_multipleNetworkProfiles
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_multipleNetworkProfiles
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_multipleNetworkProfiles (280.50s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_networkSecurityGroup
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_networkSecurityGroup
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_networkSecurityGroup
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_networkSecurityGroup (288.40s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworking
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworking
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworking
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworking (282.86s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworkingUpdated
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworkingUpdated
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworkingUpdated
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicAcceleratedNetworkingUpdated (370.84s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile_ipconfiguration_dns_name_label
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile_ipconfiguration_dns_name_label
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile_ipconfiguration_dns_name_label
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile_ipconfiguration_dns_name_label (217.66s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_updateNetworkProfile (238.83s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP_simpleUpdate
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP_simpleUpdate
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP_simpleUpdate
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP_simpleUpdate (217.85s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicPublicIP (278.20s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicIPForwarding
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicIPForwarding
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicIPForwarding
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicIPForwarding (288.56s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicDNSSettings
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicDNSSettings
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicDNSSettings
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicDNSSettings (275.13s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_loadBalancer
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_loadBalancer
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_loadBalancer
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_loadBalancer (272.90s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_publicIPSkuName
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_publicIPSkuName
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_publicIPSkuName
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_publicIPSkuName (188.38s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_networkPublicIPVersion
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_networkPublicIPVersion
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_networkPublicIPVersion
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_networkPublicIPVersion (201.42s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_priority
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_priority
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_priority
    testcase.go:173: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating Orchestrated Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521854005"
        Virtual Machine Scale Set Name: "acctestOVMSS-250117094521854005"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        
        Status: "SkuNotAvailable"
        Code: ""
        Message: "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details."
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----[start]----
        {
          "startTime": "2025-01-17T01:46:29.2885406+00:00",
          "endTime": "2025-01-17T01:46:29.9760493+00:00",
          "status": "Failed",
          "error": {
            "code": "SkuNotAvailable",
            "message": "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.",
            "target": "acctestOVMSS-250117094521854005_ef416553"
          },
          "name": "822e08db-542b-4f10-9633-546be20888be"
        }
        -----[end]-----
        
        
          with azurerm_orchestrated_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 82, in resource "azurerm_orchestrated_virtual_machine_scale_set" "test":
          82: resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
        
    panic.go:629: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Resource Group "acctestRG-OVMSS-250117094521854005": the Resource Group still contains Resources.
        
        Terraform is configured to check for Resources within the Resource Group when deleting the Resource Group - and
        raise an error if nested Resources still exist to avoid unintentionally deleting these Resources.
        
        Terraform has detected that the following Resources still exist within the Resource Group:
        
        * `/subscriptions/xxxxxxx/resourceGroups/acctestRG-OVMSS-250117094521854005/providers/Microsoft.Compute/virtualMachineScaleSets/acctestOVMSS-250117094521854005`
        
        This feature is intended to avoid the unintentional destruction of nested Resources provisioned through some
        other means (for example, an ARM Template Deployment) - as such you must either remove these Resources, or
        disable this behaviour using the feature flag `prevent_deletion_if_contains_resources` within the `features`
        block when configuring the Provider, for example:
        
        provider "azurerm" {
          features {
            resource_group {
              prevent_deletion_if_contains_resources = false
            }
          }
        }
        
        When that feature flag is set, Terraform will skip checking for any Resources within the Resource Group and
        delete this using the Azure API directly (which will clear up any nested resources).
        
        More information on the `features` block can be found in the documentation:
        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block
        
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_priority (732.09s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_zoneUpdate
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_zoneUpdate
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_zoneUpdate
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_zoneUpdate (103.85s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_NonStandardCasing
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_NonStandardCasing
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_NonStandardCasing
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_NonStandardCasing (243.90s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingLinux
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingLinux
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingLinux
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingLinux (153.59s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateLinux
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateLinux
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateLinux
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateLinux (242.47s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeLinux
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeLinux
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeLinux
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeLinux (150.02s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingWindows
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingWindows
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingWindows
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingWindows (155.43s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateWindows
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateWindows
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateWindows
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateWindows (238.75s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingHotpatchingEnabledWindows (196.70s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeWindows
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeWindows
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeWindows
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_PatchAssessmentModeWindows (154.91s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherAutomaticRepairsPolicy
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherAutomaticRepairsPolicy
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherAutomaticRepairsPolicy
    testcase.go:173: Step 4/15 error: Pre-apply plan check(s) failed:
        'azurerm_orchestrated_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_otherAutomaticRepairsPolicy (165.24s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherUltraSsd
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherUltraSsd
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherUltraSsd
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherUltraSsd (224.93s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherCapacityReservationGroupId
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherCapacityReservationGroupId
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherCapacityReservationGroupId
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherCapacityReservationGroupId (239.94s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabled
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabled
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabled
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabled (271.22s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherVMAgentDisabledWithExtensionDisabled (255.52s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherUserData
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherUserData
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherUserData
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherUserData (285.06s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroup
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroup
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroup
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroup (230.90s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupInvalid
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupInvalid
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupInvalid
    testcase.go:173: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1
        
        Error: creating Orchestrated Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521854999"
        Virtual Machine Scale Set Name: "acctestOVMSS-250117094521854999"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: Virtual Machine Scale Sets with Flexible Orchestration Mode cannot be created with VM Size 'Standard_D1_v2', if single placement group on such Virtual Machine Scale Sets is set to true.
        
          with azurerm_orchestrated_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 89, in resource "azurerm_orchestrated_virtual_machine_scale_set" "test":
          89: resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupInvalid (119.96s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullMSeriesVmSku
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullMSeriesVmSku
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullMSeriesVmSku
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Orchestrated Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521853206"
        Virtual Machine Scale Set Name: "acctestOVMSS-250117094521853206"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        
        Status: "OperationNotAllowed"
        Code: ""
        Message: "Operation could not be completed as it results in exceeding approved standardMSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 32, (Minimum) New Limit Required: 32. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westeurope%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardMSFamily%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:32,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardMSFamily%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests"
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----[start]----
        {
          "startTime": "2025-01-17T02:01:33.2357561+00:00",
          "endTime": "2025-01-17T02:01:34.0170018+00:00",
          "status": "Failed",
          "error": {
            "code": "OperationNotAllowed",
            "message": "Operation could not be completed as it results in exceeding approved standardMSFamily Cores quota. Additional details - Deployment Model: Resource Manager, Location: westeurope, Current Limit: 0, Current Usage: 0, Additional Required: 32, (Minimum) New Limit Required: 32. Setup Alerts when Quota reaches threshold. Learn more at https://aka.ms/quotamonitoringalerting . Submit a request for Quota increase at https://aka.ms/ProdportalCRP/#blade/Microsoft_Azure_Capacity/UsageAndQuota.ReactView/Parameters/%7B%22subscriptionId%22:%22f7a632a5-49db-4c5e-9828-cd62cb753971%22,%22command%22:%22openQuotaApprovalBlade%22,%22quotas%22:[%7B%22location%22:%22westeurope%22,%22providerId%22:%22Microsoft.Compute%22,%22resourceName%22:%22standardMSFamily%22,%22quotaRequest%22:%7B%22properties%22:%7B%22limit%22:32,%22unit%22:%22Count%22,%22name%22:%7B%22value%22:%22standardMSFamily%22%7D%7D%7D%7D]%7D by specifying parameters listed in the ‘Details’ section for deployment to succeed. Please read more about quota limits at https://docs.microsoft.com/en-us/azure/azure-supportability/per-vm-quota-requests",
            "target": "acctestOVMSS-250117094521853206_d0b2cd1b"
          },
          "name": "da97a71f-90c0-4119-b144-b96e03c4a033"
        }
        -----[end]-----
        
        
          with azurerm_orchestrated_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 89, in resource "azurerm_orchestrated_virtual_machine_scale_set" "test":
          89: resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
        
    panic.go:629: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Resource Group "acctestRG-OVMSS-250117094521853206": the Resource Group still contains Resources.
        
        Terraform is configured to check for Resources within the Resource Group when deleting the Resource Group - and
        raise an error if nested Resources still exist to avoid unintentionally deleting these Resources.
        
        Terraform has detected that the following Resources still exist within the Resource Group:
        
        * `/subscriptions/xxxxxxx/resourceGroups/acctestRG-OVMSS-250117094521853206/providers/Microsoft.Compute/virtualMachineScaleSets/acctestOVMSS-250117094521853206`
        
        This feature is intended to avoid the unintentional destruction of nested Resources provisioned through some
        other means (for example, an ARM Template Deployment) - as such you must either remove these Resources, or
        disable this behaviour using the feature flag `prevent_deletion_if_contains_resources` within the `features`
        block when configuring the Provider, for example:
        
        provider "azurerm" {
          features {
            resource_group {
              prevent_deletion_if_contains_resources = false
            }
          }
        }
        
        When that feature flag is set, Terraform will skip checking for any Resources within the Resource Group and
        delete this using the Azure API directly (which will clear up any nested resources).
        
        More information on the `features` block can be found in the documentation:
        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block
        
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullMSeriesVmSku (706.51s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullStandardVmSku
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullStandardVmSku
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullStandardVmSku
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherSinglePlacementGroupNullStandardVmSku (257.92s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basic
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basic
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basic
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basic (288.41s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_regression_15299
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_regression_15299
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_regression_15299
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_regression_15299 (478.26s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_requiresImport
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_requiresImport
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_requiresImport
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_requiresImport (240.92s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_evictionPolicyDelete
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_evictionPolicyDelete
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_evictionPolicyDelete
    testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Orchestrated Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521878772"
        Virtual Machine Scale Set Name: "acctestOVMSS-250117094521878772"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        
        Status: "SkuNotAvailable"
        Code: ""
        Message: "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details."
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----[start]----
        {
          "startTime": "2025-01-17T01:58:25.2994471+00:00",
          "endTime": "2025-01-17T01:58:26.2213148+00:00",
          "status": "Failed",
          "error": {
            "code": "SkuNotAvailable",
            "message": "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.",
            "target": "acctestOVMSS-250117094521878772_a370bdb0"
          },
          "name": "e17c6f3f-4d9f-4805-9b86-aa30a3efb2d8"
        }
        -----[end]-----
        
        
          with azurerm_orchestrated_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 82, in resource "azurerm_orchestrated_virtual_machine_scale_set" "test":
          82: resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
        
    panic.go:629: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Resource Group "acctestRG-OVMSS-250117094521878772": the Resource Group still contains Resources.
        
        Terraform is configured to check for Resources within the Resource Group when deleting the Resource Group - and
        raise an error if nested Resources still exist to avoid unintentionally deleting these Resources.
        
        Terraform has detected that the following Resources still exist within the Resource Group:
        
        * `/subscriptions/xxxxxxx/resourceGroups/acctestRG-OVMSS-250117094521878772/providers/Microsoft.Compute/virtualMachineScaleSets/acctestOVMSS-250117094521878772`
        
        This feature is intended to avoid the unintentional destruction of nested Resources provisioned through some
        other means (for example, an ARM Template Deployment) - as such you must either remove these Resources, or
        disable this behaviour using the feature flag `prevent_deletion_if_contains_resources` within the `features`
        block when configuring the Provider, for example:
        
        provider "azurerm" {
          features {
            resource_group {
              prevent_deletion_if_contains_resources = false
            }
          }
        }
        
        When that feature flag is set, Terraform will skip checking for any Resources within the Resource Group and
        delete this using the Azure API directly (which will clear up any nested resources).
        
        More information on the `features` block can be found in the documentation:
        https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block
        
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_evictionPolicyDelete (697.73s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_withPPG
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_withPPG
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_withPPG
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_withPPG (244.31s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_verify_key_data_changed
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_verify_key_data_changed
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_verify_key_data_changed
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_verify_key_data_changed (293.09s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_linux_ed25119_ssh_key
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_linux_ed25119_ssh_key
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_linux_ed25119_ssh_key
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_linux_ed25119_ssh_key (360.75s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicApplicationSecurity
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicApplicationSecurity
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicApplicationSecurity
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicApplicationSecurity (223.84s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_bootDiagnostic
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_bootDiagnostic
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_bootDiagnostic
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_bootDiagnostic (301.10s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_bootDiagnosticNoStorage
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_bootDiagnosticNoStorage
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_bootDiagnosticNoStorage
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_bootDiagnosticNoStorage (241.57s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicWindows
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicWindows
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicWindows
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicWindows (252.33s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_otherAdditionalUnattendContent
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_otherAdditionalUnattendContent
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_otherAdditionalUnattendContent
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_otherAdditionalUnattendContent (249.10s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicWindowsNoTimezone
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicWindowsNoTimezone
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicWindowsNoTimezone
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicWindowsNoTimezone (258.50s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_linuxUpdated
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_linuxUpdated
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_linuxUpdated
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_linuxUpdated (264.00s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_linuxInstances
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_linuxInstances
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_linuxInstances
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_linuxInstances (342.23s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_customDataUpdated
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_customDataUpdated
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_customDataUpdated
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_customDataUpdated (264.56s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_basicLinux_disappears
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_basicLinux_disappears
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_basicLinux_disappears
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_basicLinux_disappears (252.48s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_applicationGateway
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_applicationGateway
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_applicationGateway
    testcase.go:173: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating Application Gateway (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521877512"
        Application Gateway Name: "acctestgw-250117094521877512"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: AppGatewayV1SkuDeprecated: Application Gateway SKU tier Standard has been deprecated. Supported SKU tiers are Standard_v2,WAF_v2. Refer https://aka.ms/V1retirement.
        
          with azurerm_application_gateway.test,
          on terraform_plugin_test.tf line 144, in resource "azurerm_application_gateway" "test":
         144: resource "azurerm_application_gateway" "test" {
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_applicationGateway (116.58s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_importLinux
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_importLinux
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_importLinux
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_importLinux (248.11s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_skuProfileErrorConfiguration
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_skuProfileErrorConfiguration
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_skuProfileErrorConfiguration
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_skuProfileErrorConfiguration (7.01s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_skuProfile
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_skuProfile
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_skuProfile
--- PASS: TestAccOrchestratedVirtualMachineScaleSet_skuProfile (306.00s)
=== RUN   TestAccOrchestratedVirtualMachineScaleSet_priorityMixPolicy
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_priorityMixPolicy
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_priorityMixPolicy
    testcase.go:173: Step 1/1 error: Error running apply: exit status 1
        
        Error: creating Orchestrated Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521879234"
        Virtual Machine Scale Set Name: "acctestOVMSS-spotPriorityMixVMSS-250117094521879234"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        
        Status: "SkuNotAvailable"
        Code: ""
        Message: "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details."
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----[start]----
        {
          "startTime": "2025-01-17T01:54:38.254054+00:00",
          "endTime": "2025-01-17T01:55:59.4097646+00:00",
          "status": "Failed",
          "error": {
            "code": "SkuNotAvailable",
            "message": "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.",
            "target": "acctestOVMSS-spotPriorityMixVMSS-25_6c30452c"
          },
          "name": "28ea4ae4-5556-47c9-b9bd-f1d3a8f3b5e0"
        }
        -----[end]-----
        
        
          with azurerm_orchestrated_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 86, in resource "azurerm_orchestrated_virtual_machine_scale_set" "test":
          86: resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
        
    panic.go:629: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Subnet (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521879234"
        Virtual Network Name: "acctvn-250117094521879234"
        Subnet Name: "acctsub-250117094521879234"): performing Delete: unexpected status 400 (400 Bad Request) with error: InUseSubnetCannotBeDeleted: Subnet acctsub-250117094521879234 is in use by /subscriptions/xxxxxxx/resourceGroups/ACCTESTRG-OVMSS-250117094521879234/providers/Microsoft.Network/networkInterfaces/TESTNETWORKPROFILE-250117094521879234-6188DA40/ipConfigurations/TESTIPCONFIGURATION and cannot be deleted. In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_priorityMixPolicy (161.32s)

=== RUN   TestAccOrchestratedVirtualMachineScaleSet_updatePriorityMixPolicy
=== PAUSE TestAccOrchestratedVirtualMachineScaleSet_updatePriorityMixPolicy
=== CONT  TestAccOrchestratedVirtualMachineScaleSet_updatePriorityMixPolicy
    testcase.go:173: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating Orchestrated Virtual Machine Scale Set (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521873111"
        Virtual Machine Scale Set Name: "acctestOVMSS-spotPriorityMixVMSS-250117094521873111"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        
        Status: "SkuNotAvailable"
        Code: ""
        Message: "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details."
        Activity Id: ""
        
        ---
        
        API Response:
        
        ----[start]----
        {
          "startTime": "2025-01-17T01:54:33.6134626+00:00",
          "endTime": "2025-01-17T01:55:55.0347959+00:00",
          "status": "Failed",
          "error": {
            "code": "SkuNotAvailable",
            "message": "The requested VM size for resource 'Following SKUs have failed for Capacity Restrictions: Standard_D1_v2' is currently not available in location 'westeurope'. Please try another size or deploy to a different location or different zone. See https://aka.ms/azureskunotavailable for details.",
            "target": "acctestOVMSS-spotPriorityMixVMSS-25_0ab3f7dd"
          },
          "name": "a238d57b-9c53-4ac0-a86d-75c4cf54cc56"
        }
        -----[end]-----
        
        
          with azurerm_orchestrated_virtual_machine_scale_set.test,
          on terraform_plugin_test.tf line 86, in resource "azurerm_orchestrated_virtual_machine_scale_set" "test":
          86: resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
        
    panic.go:629: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Subnet (Subscription: "xxxxxxx"
        Resource Group Name: "acctestRG-OVMSS-250117094521873111"
        Virtual Network Name: "acctvn-250117094521873111"
        Subnet Name: "acctsub-250117094521873111"): performing Delete: unexpected status 400 (400 Bad Request) with error: InUseSubnetCannotBeDeleted: Subnet acctsub-250117094521873111 is in use by /subscriptions/xxxxxxx/resourceGroups/ACCTESTRG-OVMSS-250117094521873111/providers/Microsoft.Network/networkInterfaces/TESTNETWORKPROFILE-250117094521873111-A205CCB9/ipConfigurations/TESTIPCONFIGURATION and cannot be deleted. In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
        
--- FAIL: TestAccOrchestratedVirtualMachineScaleSet_updatePriorityMixPolicy (153.93s)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_linux_virtual_machine_scale_set`, `azurerm_orchestrated_virtual_machine_scale_set`, `azurerm_windows_virtual_machine_scale_set` - Fix potential nil panic caused by ommited `extensions_to_provision_after_vm_creation` block [GH-28417]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28417 


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
