### PR TITLE
azurerm_postgresql_flexible_server: Fix database name validation

### DIFF
--- a/internal/services/postgres/validate/flexible_server_database_name.go
+++ b/internal/services/postgres/validate/flexible_server_database_name.go
@@ -35,7 +35,7 @@ func FlexibleServerDatabaseName(i interface{}, k string) (warnings []string, err
 		return
 	}
 
-	if !regexp.MustCompile(`^[a-zA-Z0-9-_]+$`).MatchString(v) {
+	if !regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q must only contains numbers, characters and `-`, `_`, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_database_name_test.go
+++ b/internal/services/postgres/validate/flexible_server_database_name_test.go
@@ -50,8 +50,13 @@ func TestFlexibleServerDatabaseName(t *testing.T) {
 			valid: true,
 		},
 		{
-			name:  "Valid",
+			name:  "Invalid character: `-`",
 			input: "flexdb-1-test",
+			valid: false,
+		},
+		{
+			name:  "Valid",
+			input: "flexdb_1_test",
 			valid: true,
 		},
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

According to the official [Postgres documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS): "SQL identifiers and key words must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($). Note that dollar signs are not allowed in identifiers according to the letter of the SQL standard, so their use might render applications less portable." 

The current validations allows `-` characters as well without any warning.
This is problematic, because incorrect database names don't pass validation where a valid postgres database name is expected, e.g: `cron.database_name` server parameter. 

![image](https://github.com/user-attachments/assets/ae1e6e44-a736-4cd2-bc83-3edb97676bf4)


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

