### PR TITLE
`azurerm_monitor_activity_log_alert` - enhance validate `criteria.level` for Resource Health alert

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -425,13 +425,18 @@ func resourceMonitorActivityLogAlertCreateUpdate(d *pluginsdk.ResourceData, meta
 	actionRaw := d.Get("action").([]interface{})
 
 	t := d.Get("tags").(map[string]interface{})
+	criteria, err := expandMonitorActivityLogAlertCriteria(criteriaRaw)
+	if err != nil {
+		return fmt.Errorf("expanding `criteria`: %+v", err)
+	}
+
 	parameters := activitylogalertsapis.ActivityLogAlertResource{
 		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &activitylogalertsapis.AlertRuleProperties{
 			Enabled:     utils.Bool(enabled),
 			Description: utils.String(description),
 			Scopes:      expandStringValues(scopesRaw),
-			Condition:   expandMonitorActivityLogAlertCriteria(criteriaRaw),
+			Condition:   *criteria,
 			Actions:     expandMonitorActivityLogAlertAction(actionRaw),
 		},
 		Tags: utils.ExpandPtrMapStringString(t),
@@ -517,11 +522,12 @@ func resourceMonitorActivityLogAlertDelete(d *pluginsdk.ResourceData, meta inter
 	return nil
 }
 
-func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalertsapis.AlertRuleAllOfCondition {
+func expandMonitorActivityLogAlertCriteria(input []interface{}) (*activitylogalertsapis.AlertRuleAllOfCondition, error) {
 	conditions := make([]activitylogalertsapis.AlertRuleAnyOfOrLeafCondition, 0)
 	v := input[0].(map[string]interface{})
 
-	if category := v["category"].(string); category != "" {
+	category := v["category"].(string)
+	if category != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("category"),
 			Equals: utils.String(category),
@@ -543,6 +549,9 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 	}
 
 	if level := v["level"].(string); level != "" {
+		if strings.EqualFold(category, "ResourceHealth") && !strings.EqualFold(level, "Critical") && !strings.EqualFold(level, "Informational") {
+			return nil, fmt.Errorf("invalid `level` for Resource Health alert criteria: must be `Critical` or `Informational`, got `%v`", level)
+		}
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("level"),
 			Equals: utils.String(level),
@@ -550,6 +559,13 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 	}
 
 	if levels := v["levels"].([]interface{}); len(levels) > 0 {
+		if strings.EqualFold(category, "ResourceHealth") {
+			for _, level := range levels {
+				if !strings.EqualFold(level.(string), "Critical") && !strings.EqualFold(level.(string), "Informational") {
+					return nil, fmt.Errorf("invalid `levels` for Resource Health alert criteria: must be `Critical` or 'Informational`, got `%v`", level)
+				}
+			}
+		}
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			AnyOf: expandAnyOfCondition(levels, "level"),
 		})
@@ -662,9 +678,9 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 		conditions = expandServiceHealth(serviceHealth, conditions)
 	}
 
-	return activitylogalertsapis.AlertRuleAllOfCondition{
+	return &activitylogalertsapis.AlertRuleAllOfCondition{
 		AllOf: conditions,
-	}
+	}, nil
 }
 
 func expandAnyOfCondition(input []interface{}, field string) *[]activitylogalertsapis.AlertRuleLeafCondition {

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -108,8 +108,9 @@ A `criteria` block supports the following:
 
 ~> **Note:** `resource_id` and `resource_ids` are mutually exclusive.
 
-* `level` - (Optional) The severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
-* `levels` - (Optional) A list of severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
+* `level` - (Optional) The severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`. If `category` is set to `ResourceHealth`, supported values are `Informational` and `Critical`.
+
+* `levels` - (Optional) A list of severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`. If `category` is set to `ResourceHealth`, supported values are `Informational` and `Critical`.
 
 ~> **Note:** `level` and `levels` are mutually exclusive.
 
@@ -122,7 +123,7 @@ A `criteria` block supports the following:
 * `sub_statuses` - (Optional) A list of sub status of the event.
 
 ~> **Note:** `sub_status` and `sub_statuses` are mutually exclusive.
- 
+
 * `recommendation_type` - (Optional) The recommendation type of the event. It is only allowed when `category` is `Recommendation`.
 * `recommendation_category` - (Optional) The recommendation category of the event. Possible values are `Cost`, `Reliability`, `OperationalExcellence`, `HighAvailability` and `Performance`. It is only allowed when `category` is `Recommendation`.
 * `recommendation_impact` - (Optional) The recommendation impact of the event. Possible values are `High`, `Medium` and `Low`. It is only allowed when `category` is `Recommendation`.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
If `category` is set to `ResourceHealth`, supported values for `criteria.level` or `criteria.levels` are `Informational` and `Critical`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
![Uploading image.png…]()


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_activity_log_alert` - enhance validate `level` for Resource Health alert [GH-29613]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/29540


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
