### PR TITLE
`azurerm_security_center_subscription_pricing` - add support for `AI` as option for `resource_type`

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -61,6 +61,7 @@ func resourceSecurityCenterSubscriptionPricing() *pluginsdk.Resource {
 				Optional: true,
 				Default:  "VirtualMachines",
 				ValidateFunc: validation.StringInSlice([]string{
+					"AI",
 					"Api",
 					"AppServices",
 					"ContainerRegistry",

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
 
-* `resource_type` - (Optional) The resource type this setting affects. Possible values are `Api`, `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
+* `resource_type` - (Optional) The resource type this setting affects. Possible values are `AI`, `Api`, `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
 
 * `subplan` - (Optional) Resource type pricing subplan. Contact your MSFT representative for possible values. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Adds `AI` as option for `azurerm_security_center_subscription_pricing.resource_type` as it is generally available on Azure, but not yet available in this provider.

The corresponding ARM looks like this:
```
{
  "id": "/subscriptions/XXXX/providers/Microsoft.Security/pricings/AI",
  "name": "AI",
  "type": "Microsoft.Security/pricings",
  "properties": {
    "extensions": [
      {
        "name": "AIPromptEvidence",
        "isEnabled": "True"
      },
      {
        "name": "AIPromptSharingWithPurview",
        "isEnabled": "False"
      }
    ]
  }
}
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_security_center_subscription_pricing` - support for the `resource_type` value `AI`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
-

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
