### PR TITLE
data_protection_backup_policy_blob_storage: fix docs retention_rule block

### DIFF
--- a/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_blob_storage.html.markdown
@@ -61,8 +61,6 @@ A `retention_rule` block supports the following:
 
 * `name` - (Required) The name which should be used for this retention rule. Changing this forces a new Backup Policy Blob Storage to be created.
 
-* `duration` - (Required) Duration after which the backup is deleted. It should follow `ISO 8601` duration format. Changing this forces a new Backup Policy Blob Storage to be created.
-
 * `criteria` - (Required) A `criteria` block as defined below. Changing this forces a new Backup Policy Blob Storage to be created.
 
 * `life_cycle` - (Required) A `life_cycle` block as defined below. Changing this forces a new Backup Policy Blob Storage to be created.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Currently, the docs show `duration` as required twice. First within a `retention_rule` block, and then also within a `life_cycle` sub-block. However, only the latter is valid according to the provider schema:
https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource.go#L202

The test below further reinforces this:
https://github.com/hashicorp/terraform-provider-azurerm/blob/v4.29.0/internal/services/dataprotection/data_protection_backup_policy_blob_storage_resource_test.go#L129

This PR will remove the first instance of `duration` nested immediately under a `retention_rule` block.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

