### PR TITLE
docs: add missing `## Example Usage` mark in documents

### DIFF
--- a/website/docs/r/container_registry_scope_map.html.markdown
+++ b/website/docs/r/container_registry_scope_map.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages an Azure Container Registry scope map.  For more information on scope maps see the [product documentation](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions).
 
+## Example Usage
+
 ```hcl
 resource "azurerm_resource_group" "example" {
   name     = "example-resource-group"

--- a/website/docs/r/container_registry_token.html.markdown
+++ b/website/docs/r/container_registry_token.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages an Azure Container Registry token associated to a scope map. For more information on scope maps and their tokens see the [product documentation](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions).
 
+## Example Usage
+
 ```hcl
 resource "azurerm_resource_group" "example" {
   name     = "example-resource-group"

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -22,6 +22,8 @@ Manages the Custom HTTPS Configuration for an Azure Front Door (classic) Fronten
 
 !> **Note:** On `1 April 2025`, Azure Front Door (classic) will be retired for the public cloud, existing Azure Front Door (classic) resources must be migrated out of Azure Front Door (classic) to Azure Front Door Standard/Premium before `1 October 2025` to avoid potential disruptions in service.
 
+## Example Usage
+
 ```hcl
 resource "azurerm_resource_group" "example" {
   name     = "FrontDoorExampleResourceGroup"

--- a/website/docs/r/healthcare_medtech_service_fhir_destination.html.markdown
+++ b/website/docs/r/healthcare_medtech_service_fhir_destination.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Healthcare Med Tech Service Fhir Destination.
 
+## Example Usage
+
 ```hcl
 resource "azurerm_resource_group" "example" {
   name     = "example-rg"

--- a/website/docs/r/key_vault_managed_hardware_security_module_key.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_key.html.markdown
@@ -12,6 +12,8 @@ Manages a Key Vault Managed Hardware Security Module Key.
 
 ~> **Note:** The Azure Provider includes a Feature Toggle which will purge a Key Vault Managed Hardware Security Module Key resource on destroy, rather than the default soft-delete. See [`purge_soft_deleted_hardware_security_modules_on_destroy`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#purge_soft_deleted_hardware_security_module_keys_on_destroy) for more information.
 
+## Example Usage
+
 ```hcl
 data "azurerm_client_config" "current" {}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

These documents miss the Example Usage title which cause some analysis tools to not recognize the example usage section.