### PR TITLE
[Bug:] `azurerm_mssql_server_vulnerability_assessment` - remove validation for `storage_account_access_key` and `storage_container_sas_key` being set

### DIFF
--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -117,21 +117,21 @@ func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData,
 
 	alertResult, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving mssql server security alert policy: %+v", err)
+		return fmt.Errorf("retrieving security alert policy for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	model := alertResult.Model
 	if model == nil {
-		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
+		return fmt.Errorf("security alert policy for SQL server %q returned empty response", serverId.ServerName)
 	}
 
 	alertProps := model.Properties
 	if alertProps == nil {
-		return fmt.Errorf("retrieving mssql server security alert policy properties %s: properties was nil", serverId)
+		return fmt.Errorf("security alert policy for SQL server %q has no properties", serverId.ServerName)
 	}
 
 	if alertProps.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
-		return fmt.Errorf("mssql server security alert policy is not 'enabled'")
+		return fmt.Errorf("security alert policy for SQL server %q must be enabled before configuring vulnerability assessment", serverId.ServerName)
 	}
 
 	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
@@ -188,7 +188,7 @@ func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData,
 
 	result, err := client.CreateOrUpdate(ctx, serverId, payload)
 	if err != nil || result.Model == nil || result.Model.Id == nil {
-		return fmt.Errorf("creating mssql server vulnerability assessment %s : %v", id, err)
+		return fmt.Errorf("creating vulnerability assessment for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	d.SetId(id.ID())
@@ -214,27 +214,27 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 	vulnerability, err := client.Get(ctx, serverId)
 	if err != nil {
 		if response.WasNotFound(vulnerability.HttpResponse) {
-			log.Printf("[WARN] mssql server vulnerability assessment %s: not found", id)
+			log.Printf("[WARN] vulnerability assessment for SQL server %q was not found", serverId.ServerName)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("retrieving mssql server vulnerability assessment %s: %+v", *id, err)
+		return fmt.Errorf("retrieving vulnerability assessment for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	alert, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving mssql server security alert policy by ID: %+v", err)
+		return fmt.Errorf("retrieving security alert policy for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	model := alert.Model
 
 	if model == nil {
-		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
+		return fmt.Errorf("security alert policy for SQL server %q returned empty response", serverId.ServerName)
 	}
 
 	if model.Id == nil {
-		return fmt.Errorf("retrieving mssql server security alert policy %s: Id was nil", serverId)
+		return fmt.Errorf("security alert policy for SQL server %q has no resource ID", serverId.ServerName)
 	}
 
 	recurringScans := make([]interface{}, 0)
@@ -303,38 +303,37 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 
 	alert, err := alertClient.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving mssql server security alert policy: %+v", err)
+		return fmt.Errorf("retrieving security alert policy for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	if alert.Model == nil {
-		return fmt.Errorf("retrieving mssql server security alert policy %s: model was nil", serverId)
+		return fmt.Errorf("security alert policy for SQL server %q returned empty response", serverId.ServerName)
 	}
 
 	if alert.Model.Properties == nil {
-		return fmt.Errorf("retrieving mssql server security alert policy properties %s: properties was nil", serverId)
+		return fmt.Errorf("security alert policy for SQL server %q has no properties", serverId.ServerName)
 	}
 
 	if alert.Model.Properties.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
-		return fmt.Errorf("mssql server security alert policy is not 'enabled'")
+		return fmt.Errorf("security alert policy for SQL server %q must be enabled before updating vulnerability assessment", serverId.ServerName)
 	}
 
 	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment update")
 
 	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
-
 	result, err := client.Get(ctx, serverId)
 	if err != nil {
-		return fmt.Errorf("retrieving mssql server vulnerability assessment policy: %+v", err)
+		return fmt.Errorf("retrieving existing vulnerability assessment for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	if result.Model == nil {
-		return fmt.Errorf("retrieving mssql server vulnerability assessment policy %s: model was nil", serverId)
+		return fmt.Errorf("vulnerability assessment for SQL server %q returned empty response", serverId.ServerName)
 	}
 
 	props := result.Model.Properties
 
 	if props == nil {
-		return fmt.Errorf("retrieving mssql server vulnerability assessment policy %s: properties was nil", serverId)
+		return fmt.Errorf("vulnerability assessment for SQL server %q has no properties", serverId.ServerName)
 	}
 
 	if d.HasChange("storage_container_path") {
@@ -394,7 +393,7 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 
 	update, err := client.CreateOrUpdate(ctx, serverId, payload)
 	if err != nil || update.Model == nil || update.Model.Id == nil {
-		return fmt.Errorf("updating mssql server vulnerability assessment %s : %v", id, err)
+		return fmt.Errorf("updating vulnerability assessment for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	return resourceMsSqlServerVulnerabilityAssessmentRead(d, meta)
@@ -415,7 +414,7 @@ func resourceMsSqlServerVulnerabilityAssessmentDelete(d *pluginsdk.ResourceData,
 	serverId := commonids.NewSqlServerID(id.SubscriptionId, id.ResourceGroup, id.ServerName)
 
 	if _, err = client.Delete(ctx, serverId); err != nil {
-		return fmt.Errorf("deleting mssql server vulnerability assessment %s: %v", *id, err)
+		return fmt.Errorf("deleting vulnerability assessment for SQL server %q: %w", serverId.ServerName, err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

When the storage account is secured behind a `virtual network` or `firewall`, it is valid for both `storage_container_access_key` and `storage_container_sas_key` to be unset. Accordingly, I am removing the validation logic that enforces the presence of at least one of these fields.

### **Error Message Consistency Across CRUD Operations:**
All CRUD operations (Create, Read, Update, Delete) now have consistent error message patterns:

* Clear operation description
* Specific resource identification
* Proper error wrapping
* Actionable context when possible

### **Go Error Message Standards Compliance:**
* **Lowercase**: All error messages now start with lowercase letters (unless they begin with proper nouns like "SQL")
* **No punctuation**: Removed periods and unnecessary punctuation from error messages
* **Error wrapping**: Used `%w` verb for proper error wrapping instead of `%+v` or `%v`

The error messages are now more professional, easier to understand for users, and follow Go's official error handling guidelines while maintaining the functional behavior.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_server_vulnerability_assessment` - remove validation for `storage_account_access_key` and `storage_container_sas_key` fields being set [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29767

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
