### PR TITLE
mongo_cluster_resource - added support for MongoDB 8.0 - resolves #39726

### DIFF
--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -190,6 +190,7 @@ func (r MongoClusterResource) Arguments() map[string]*pluginsdk.Schema {
 				"5.0",
 				"6.0",
 				"7.0",
+				"8.0",
 			}, false),
 		},
 	}

--- a/internal/services/mongocluster/mongo_cluster_resource_test.go
+++ b/internal/services/mongocluster/mongo_cluster_resource_test.go
@@ -41,7 +41,8 @@ func testAccMongoCluster_basic(t *testing.T) {
 						data.RandomInteger)),
 				check.That(data.ResourceName).Key("connection_strings.1.value").HasValue(
 					fmt.Sprintf(`mongodb+srv://adminTerraform:QAZwsx123basic@acctest-mc%d.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000`,
-						data.RandomInteger)),
+						data.RandomInteger),
+				),
 			),
 		},
 		data.ImportStep("administrator_password", "create_mode", "connection_strings.0.value", "connection_strings.1.value"),
@@ -150,7 +151,7 @@ resource "azurerm_mongo_cluster" "test" {
   compute_tier           = "Free"
   high_availability_mode = "Disabled"
   storage_size_in_gb     = "32"
-  version                = "6.0"
+  version                = "7.0"
 }
 `, r.template(data, data.Locations.Ternary), data.RandomInteger)
 }
@@ -170,7 +171,7 @@ resource "azurerm_mongo_cluster" "test" {
   high_availability_mode = "ZoneRedundantPreferred"
   public_network_access  = "Disabled"
   storage_size_in_gb     = "64"
-  version                = "7.0"
+  version                = "8.0"
 
   tags = {
     environment = "test"
@@ -193,7 +194,7 @@ resource "azurerm_mongo_cluster" "test" {
   shard_count            = "1"
   compute_tier           = "M30"
   storage_size_in_gb     = "64"
-  version                = "7.0"
+  version                = "8.0"
 }
 `, r.template(data, data.Locations.Primary), data.RandomInteger)
 }
@@ -232,7 +233,7 @@ resource "azurerm_mongo_cluster" "test" {
   high_availability_mode = "ZoneRedundantPreferred"
   storage_size_in_gb     = "64"
   preview_features       = ["GeoReplicas"]
-  version                = "7.0"
+  version                = "8.0"
 }
 `, r.template(data, data.Locations.Primary), data.RandomInteger)
 }

--- a/website/docs/r/mongo_cluster.html.markdown
+++ b/website/docs/r/mongo_cluster.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the MongoDB Cluster.
 
-* `version` - (Optional) The version for the MongoDB Cluster. Possibles values are `5.0`, `6.0` and `7.0`.
+* `version` - (Optional) The version for the MongoDB Cluster. Possibles values are `5.0`, `6.0`, `7.0` and `8.0`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Issue raised on [#29726](https://github.com/hashicorp/terraform-provider-azurerm/issues/29726), added support for MongoDB version 8.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
$ make acctests SERVICE='mongocluster' TESTARGS='-run=TestAccMongoClusterFreeTier'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/mongocluster -run=TestAccMongoClusterFreeTier -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMongoClusterFreeTier
=== RUN   TestAccMongoClusterFreeTier/freeTier
=== RUN   TestAccMongoClusterFreeTier/freeTier/basic
=== RUN   TestAccMongoClusterFreeTier/freeTier/update
=== RUN   TestAccMongoClusterFreeTier/freeTier/import

--- PASS: TestAccMongoClusterFreeTier (4052.06s)
    --- PASS: TestAccMongoClusterFreeTier/freeTier (4052.06s)
        --- PASS: TestAccMongoClusterFreeTier/freeTier/basic (931.14s)
        --- PASS: TestAccMongoClusterFreeTier/freeTier/update (2356.15s)
        --- PASS: TestAccMongoClusterFreeTier/freeTier/import (764.77s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mongocluster  4071.666s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes [#29726](https://github.com/hashicorp/terraform-provider-azurerm/issues/29726)


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
