### PR TITLE
azurerm_nginx_deployment: Deprecate diagnose_support_enabled in v5.0

### DIFF
--- a/internal/services/nginx/nginx_api_key_resource_test.go
+++ b/internal/services/nginx/nginx_api_key_resource_test.go
@@ -175,12 +175,11 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_nginx_deployment" "test" {
-  name                     = "acctest-%[1]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "standardv3_Monthly"
-  capacity                 = 10
-  location                 = azurerm_resource_group.test.location
-  diagnose_support_enabled = false
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "standardv3_Monthly"
+  capacity            = 10
+  location            = azurerm_resource_group.test.location
 
   frontend_public {
     ip_address = [azurerm_public_ip.test.id]

--- a/internal/services/nginx/nginx_certificate_resource_test.go
+++ b/internal/services/nginx/nginx_certificate_resource_test.go
@@ -223,12 +223,11 @@ resource "azurerm_user_assigned_identity" "test" {
 
 
 resource "azurerm_nginx_deployment" "test" {
-  name                     = "acctest-%[1]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "standardv3_Monthly"
-  capacity                 = 10
-  location                 = azurerm_resource_group.test.location
-  diagnose_support_enabled = false
+  name                = "acctest-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "standardv3_Monthly"
+  capacity            = 10
+  location            = azurerm_resource_group.test.location
 
   identity {
     type         = "UserAssigned"

--- a/internal/services/nginx/nginx_configuration_resource_test.go
+++ b/internal/services/nginx/nginx_configuration_resource_test.go
@@ -289,8 +289,6 @@ resource "azurerm_nginx_deployment" "test" {
   capacity            = 10
   location            = azurerm_resource_group.test.location
 
-  diagnose_support_enabled = false
-
   frontend_public {
     ip_address = [azurerm_public_ip.test.id]
   }

--- a/internal/services/nginx/nginx_deployment_data_source.go
+++ b/internal/services/nginx/nginx_deployment_data_source.go
@@ -29,7 +29,7 @@ type DeploymentDataSourceModel struct {
 	Location               string                                     `tfschema:"location"`
 	Capacity               int64                                      `tfschema:"capacity"`
 	AutoScaleProfile       []AutoScaleProfile                         `tfschema:"auto_scale_profile"`
-	DiagnoseSupportEnabled bool                                       `tfschema:"diagnose_support_enabled"`
+	DiagnoseSupportEnabled bool                                       `tfschema:"diagnose_support_enabled, removedInNextMajorVersion"`
 	Email                  string                                     `tfschema:"email"`
 	IpAddress              string                                     `tfschema:"ip_address"`
 	LoggingStorageAccount  []LoggingStorageAccount                    `tfschema:"logging_storage_account,removedInNextMajorVersion"`
@@ -105,11 +105,6 @@ func (m DeploymentDataSource) Attributes() map[string]*pluginsdk.Schema {
 					},
 				},
 			},
-		},
-
-		"diagnose_support_enabled": {
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
 		},
 
 		"email": {
@@ -232,6 +227,12 @@ func (m DeploymentDataSource) Attributes() map[string]*pluginsdk.Schema {
 				},
 			},
 		}
+
+		dataSource["diagnose_support_enabled"] = &pluginsdk.Schema{
+			Deprecated: "this property is deprecated and will be removed in v5.0, metrics are enabled by default.",
+			Type:       pluginsdk.TypeBool,
+			Computed:   true,
+		}
 	}
 	return dataSource
 }
@@ -323,7 +324,6 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 					output.IpAddress = pointer.From(props.IPAddress)
 					output.NginxVersion = pointer.From(props.NginxVersion)
 					output.DataplaneAPIEndpoint = pointer.From(props.DataplaneApiEndpoint)
-					output.DiagnoseSupportEnabled = pointer.From(props.EnableDiagnosticsSupport)
 
 					if !features.FivePointOh() {
 						if props.Logging != nil && props.Logging.StorageAccount != nil {
@@ -334,6 +334,7 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 								},
 							}
 						}
+						output.DiagnoseSupportEnabled = pointer.From(props.EnableDiagnosticsSupport)
 					}
 
 					if profile := props.NetworkProfile; profile != nil {

--- a/internal/services/nginx/nginx_deployment_resource_test.go
+++ b/internal/services/nginx/nginx_deployment_resource_test.go
@@ -175,7 +175,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_public {
@@ -208,7 +207,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_private {
@@ -243,7 +241,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_public {
@@ -286,7 +283,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_public {
@@ -325,11 +321,10 @@ func (a DeploymentResource) update(data acceptance.TestData) string {
 %s
 
 resource "azurerm_nginx_deployment" "test" {
-  name                     = "acctest-%[2]d"
-  resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "standardv3_Monthly"
-  location                 = azurerm_resource_group.test.location
-  diagnose_support_enabled = false
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "standardv3_Monthly"
+  location            = azurerm_resource_group.test.location
 
   frontend_public {
     ip_address = [azurerm_public_ip.test.id]
@@ -361,7 +356,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_private {
@@ -396,7 +390,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_private {
@@ -431,7 +424,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_public {
@@ -530,7 +522,6 @@ resource "azurerm_nginx_deployment" "test" {
   resource_group_name       = azurerm_resource_group.test.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.test.location
-  diagnose_support_enabled  = false
   automatic_upgrade_channel = "stable"
 
   frontend_public {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -397,6 +397,7 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `logging_storage_account` block has been removed in favour of the `azurerm_monitor_diagnostic_setting` resource.
 * The deprecated `managed_resource_group` property has been removed.
+* The deprecated `diagnose_support_enabled` property has been removed.
 
 ### `azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack`
 
@@ -568,6 +569,7 @@ Please follow the format in the example below for listing breaking changes in da
 
 * The deprecated `logging_storage_account` block has been removed.
 * The deprecated `managed_resource_group` property has been removed.
+* The deprecated `diagnose_support_enabled` property has been removed.
 
 ### `azurerm_servicebus_namespace_disaster_recovery_config`
 

--- a/website/docs/d/nginx_deployment.html.markdown
+++ b/website/docs/d/nginx_deployment.html.markdown
@@ -41,8 +41,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `auto_scale_profile` - An `auto_scale_profile` block as defined below.
 
-* `diagnose_support_enabled` - Whether metrics are exported to Azure Monitor.
-
 * `email` - Preferred email associated with the NGINX Deployment.
 
 * `frontend_private` - A `frontend_private` block as defined below.

--- a/website/docs/r/nginx_certificate.html.markdown
+++ b/website/docs/r/nginx_certificate.html.markdown
@@ -55,13 +55,11 @@ resource "azurerm_subnet" "example" {
 }
 
 resource "azurerm_nginx_deployment" "example" {
-  name                     = "example-nginx"
-  resource_group_name      = azurerm_resource_group.example.name
-  sku                      = "publicpreview_Monthly_gmz7xq9ge3py"
-  location                 = azurerm_resource_group.example.location
-  managed_resource_group   = "example"
-  diagnose_support_enabled = true
-
+  name                   = "example-nginx"
+  resource_group_name    = azurerm_resource_group.example.name
+  sku                    = "publicpreview_Monthly_gmz7xq9ge3py"
+  location               = azurerm_resource_group.example.location
+  managed_resource_group = "example"
   frontend_public {
     ip_address = [azurerm_public_ip.example.id]
   }

--- a/website/docs/r/nginx_configuration.html.markdown
+++ b/website/docs/r/nginx_configuration.html.markdown
@@ -55,11 +55,10 @@ resource "azurerm_subnet" "example" {
 }
 
 resource "azurerm_nginx_deployment" "example" {
-  name                     = "example-nginx"
-  resource_group_name      = azurerm_resource_group.example.name
-  sku                      = "publicpreview_Monthly_gmz7xq9ge3py"
-  location                 = azurerm_resource_group.example.location
-  diagnose_support_enabled = true
+  name                = "example-nginx"
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "publicpreview_Monthly_gmz7xq9ge3py"
+  location            = azurerm_resource_group.example.location
 
   frontend_public {
     ip_address = [azurerm_public_ip.example.id]

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -59,7 +59,6 @@ resource "azurerm_nginx_deployment" "example" {
   resource_group_name       = azurerm_resource_group.example.name
   sku                       = "standardv3_Monthly"
   location                  = azurerm_resource_group.example.location
-  diagnose_support_enabled  = true
   automatic_upgrade_channel = "stable"
 
   frontend_public {
@@ -98,8 +97,6 @@ The following arguments are supported:
 -> **Note:** For more information on NGINX capacity units, please refer to the [NGINX scaling guidance documentation](https://docs.nginx.com/nginxaas/azure/quickstart/scaling/)
 
 * `auto_scale_profile` - (Optional) An `auto_scale_profile` block as defined below.
-
-* `diagnose_support_enabled` - (Optional) Should the metrics be exported to Azure Monitor?
 
 * `email` - (Optional) Specify the preferred support contact email address for receiving alerts and notifications.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

NGINXaaS is deprecating the diagnose_support_enabled field. Metrics will be enabled by default on all deployments and doesn't need to be explicity enabled via this field.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [x] Breaking Change


## Related Issue(s)
Fixes #0000

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
