### PR TITLE
`azurerm_shared_image_gallery` - add support for Resource Identity

### DIFF
--- a/internal/services/compute/shared_image_gallery_resource.go
+++ b/internal/services/compute/shared_image_gallery_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
@@ -24,16 +25,19 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name shared_image_gallery -service-package-name compute -properties "gallery_name:name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceSharedImageGallery() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceSharedImageGalleryCreate,
-		Read:   resourceSharedImageGalleryRead,
-		Update: resourceSharedImageGalleryUpdate,
-		Delete: resourceSharedImageGalleryDelete,
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := commonids.ParseSharedImageGalleryID(id)
-			return err
-		}),
+		Create:   resourceSharedImageGalleryCreate,
+		Read:     resourceSharedImageGalleryRead,
+		Update:   resourceSharedImageGalleryUpdate,
+		Delete:   resourceSharedImageGalleryDelete,
+		Importer: pluginsdk.ImporterValidatingIdentity(&commonids.SharedImageGalleryId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&commonids.SharedImageGalleryId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -224,7 +228,7 @@ func resourceSharedImageGalleryRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceSharedImageGalleryUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/compute/shared_image_gallery_resource_identity_gen_test.go
+++ b/internal/services/compute/shared_image_gallery_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+package compute_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccSharedImageGallery_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image_gallery", "test")
+	r := SharedImageGalleryResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_shared_image_gallery.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
```
--- PASS: TestAccSharedImageGallery_resourceIdentity (119.25s)
```