### PR TITLE
`azurerm_route_map` - add support for Resource Identity

### DIFF
--- a/internal/services/network/route_map_resource.go
+++ b/internal/services/network/route_map_resource.go
@@ -10,12 +10,15 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_map -service-package-name network -properties "route_map_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id" -test-params "ident"
 
 type RouteMapModel struct {
 	Name         string `tfschema:"name"`
@@ -51,9 +54,14 @@ type Criterion struct {
 type RouteMapResource struct{}
 
 var (
+	_ sdk.ResourceWithIdentity      = RouteMapResource{}
 	_ sdk.ResourceWithUpdate        = RouteMapResource{}
 	_ sdk.ResourceWithCustomizeDiff = RouteMapResource{}
 )
+
+func (r RouteMapResource) Identity() resourceids.ResourceId {
+	return &virtualwans.RouteMapId{}
+}
 
 func (r RouteMapResource) ResourceType() string {
 	return "azurerm_route_map"
@@ -326,6 +334,10 @@ func (r RouteMapResource) Read() sdk.ResourceFunc {
 				if props := model.Properties; props != nil {
 					state.Rules = flattenRules(props.Rules)
 				}
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/network/route_map_resource_identity_gen_test.go
+++ b/internal/services/network/route_map_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccRouteMap_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_route_map", "test")
+	r := RouteMapResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data, "ident"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_map.test", tfjsonpath.New("route_map_name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
--- PASS: TestAccRouteMap_resourceIdentity (2637.08s)