### PR TITLE
`azurerm_virtual_hub_route_table` - add support for Resource Identity

### DIFF
--- a/internal/services/network/virtual_hub_route_table_resource.go
+++ b/internal/services/network/virtual_hub_route_table_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-05-01/virtualwans"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -21,6 +22,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name virtual_hub_route_table -service-package-name network -properties "hub_route_table_name:name" -compare-values "subscription_id:virtual_hub_id,resource_group_name:virtual_hub_id,virtual_hub_name:virtual_hub_id"
 
 func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -36,10 +39,11 @@ func resourceVirtualHubRouteTable() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := virtualwans.ParseHubRouteTableID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&virtualwans.HubRouteTableId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&virtualwans.HubRouteTableId{}),
+		},
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -243,7 +247,7 @@ func resourceVirtualHubRouteTableRead(d *pluginsdk.ResourceData, meta interface{
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceVirtualHubRouteTableDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/network/virtual_hub_route_table_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_route_table_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package network_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccVirtualHubRouteTable_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_route_table", "test")
+	r := VirtualHubRouteTableResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("hub_route_table_name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
--- PASS: TestAccVirtualHubRouteTable_resourceIdentity (2304.30s)