### PR TITLE
`azurerm_storage_encryption_scope` - add support for Resource Identity

### DIFF
--- a/internal/services/storage/storage_encryption_scope_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_encryption_scope_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageEncryptionScope_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_encryption_scope", "test")
+	r := StorageEncryptionScopeResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.keyVaultKey(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("encryption_scope_name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
```
--- PASS: TestAccStorageEncryptionScope_resourceIdentity (310.79s)
```