### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert` - add support for Resource Identity

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_data_source_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_data_source_test.go
@@ -52,7 +52,7 @@ data "azurerm_monitor_scheduled_query_rules_alert" "test" {
   name                = basename(azurerm_monitor_scheduled_query_rules_alert.test.id)
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, MonitorScheduledQueryRulesResource{}.AlertingActionConfigBasic(data, ts))
+`, MonitorScheduledQueryRulesAlertResource{}.AlertingActionConfigBasic(data, ts))
 }
 
 func (MonitorScheduledQueryRulesDataSource) AlertingActionCrossResourceConfig(data acceptance.TestData) string {
@@ -63,5 +63,5 @@ data "azurerm_monitor_scheduled_query_rules_alert" "test" {
   name                = basename(azurerm_monitor_scheduled_query_rules_alert.test.id)
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, MonitorScheduledQueryRulesResource{}.AlertingActionCrossResourceConfig(data))
+`, MonitorScheduledQueryRulesAlertResource{}.AlertingActionCrossResourceConfig(data))
 }

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -26,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name monitor_scheduled_query_rules_alert -service-package-name monitor -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary" -test-name "AlertingActionConfigComplete"
+
 func resourceMonitorScheduledQueryRulesAlert() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceMonitorScheduledQueryRulesAlertCreateUpdate,
@@ -33,10 +36,11 @@ func resourceMonitorScheduledQueryRulesAlert() *pluginsdk.Resource {
 		Update: resourceMonitorScheduledQueryRulesAlertCreateUpdate,
 		Delete: resourceMonitorScheduledQueryRulesAlertDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := scheduledqueryrules.ParseScheduledQueryRuleID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&scheduledqueryrules.ScheduledQueryRuleId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&scheduledqueryrules.ScheduledQueryRuleId{}),
+		},
 
 		SchemaVersion: 1,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
@@ -367,7 +371,7 @@ func resourceMonitorScheduledQueryRulesAlertRead(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceMonitorScheduledQueryRulesAlertDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_identity_gen_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package monitor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccMonitorScheduledQueryRulesAlert_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
+	r := MonitorScheduledQueryRulesAlertResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.AlertingActionConfigComplete(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_test.go
@@ -18,11 +18,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type MonitorScheduledQueryRulesResource struct{}
+type MonitorScheduledQueryRulesAlertResource struct{}
 
 func TestAccMonitorScheduledQueryRules_AlertingActionBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
-	r := MonitorScheduledQueryRulesResource{}
+	r := MonitorScheduledQueryRulesAlertResource{}
 	ts := time.Now().Format(time.RFC3339)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -38,7 +38,7 @@ func TestAccMonitorScheduledQueryRules_AlertingActionBasic(t *testing.T) {
 
 func TestAccMonitorScheduledQueryRules_AlertingActionQueryTypeNumber(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
-	r := MonitorScheduledQueryRulesResource{}
+	r := MonitorScheduledQueryRulesAlertResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -53,7 +53,7 @@ func TestAccMonitorScheduledQueryRules_AlertingActionQueryTypeNumber(t *testing.
 
 func TestAccMonitorScheduledQueryRules_AlertingActionUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
-	r := MonitorScheduledQueryRulesResource{}
+	r := MonitorScheduledQueryRulesAlertResource{}
 	ts := time.Now().Format(time.RFC3339)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -76,7 +76,7 @@ func TestAccMonitorScheduledQueryRules_AlertingActionUpdate(t *testing.T) {
 
 func TestAccMonitorScheduledQueryRules_AlertingActionComplete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
-	r := MonitorScheduledQueryRulesResource{}
+	r := MonitorScheduledQueryRulesAlertResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -91,7 +91,7 @@ func TestAccMonitorScheduledQueryRules_AlertingActionComplete(t *testing.T) {
 
 func TestAccMonitorScheduledQueryRules_AlertingActionCrossResource(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
-	r := MonitorScheduledQueryRulesResource{}
+	r := MonitorScheduledQueryRulesAlertResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -106,7 +106,7 @@ func TestAccMonitorScheduledQueryRules_AlertingActionCrossResource(t *testing.T)
 
 func TestAccMonitorScheduledQueryRules_AutoMitigate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
-	r := MonitorScheduledQueryRulesResource{}
+	r := MonitorScheduledQueryRulesAlertResource{}
 	ts := time.Now().Format(time.RFC3339)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -134,7 +134,7 @@ func TestAccMonitorScheduledQueryRules_AutoMitigate(t *testing.T) {
 	})
 }
 
-func (MonitorScheduledQueryRulesResource) AlertingActionAutoMitigate(data acceptance.TestData, ts string, autoMitigate bool) string {
+func (MonitorScheduledQueryRulesAlertResource) AlertingActionAutoMitigate(data acceptance.TestData, ts string, autoMitigate bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -178,7 +178,7 @@ QUERY
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, ts, ts, strconv.FormatBool(autoMitigate))
 }
 
-func (MonitorScheduledQueryRulesResource) AlertingActionQueryTypeNumber(data acceptance.TestData) string {
+func (MonitorScheduledQueryRulesAlertResource) AlertingActionQueryTypeNumber(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -225,7 +225,7 @@ QUERY
 }`, data.RandomInteger, data.Locations.Primary)
 }
 
-func (MonitorScheduledQueryRulesResource) AlertingActionConfigBasic(data acceptance.TestData, ts string) string {
+func (MonitorScheduledQueryRulesAlertResource) AlertingActionConfigBasic(data acceptance.TestData, ts string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -276,7 +276,7 @@ QUERY
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, ts, ts)
 }
 
-func (MonitorScheduledQueryRulesResource) AlertingActionConfigUpdate(data acceptance.TestData, ts string) string {
+func (MonitorScheduledQueryRulesAlertResource) AlertingActionConfigUpdate(data acceptance.TestData, ts string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -330,7 +330,7 @@ QUERY
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, ts, ts)
 }
 
-func (MonitorScheduledQueryRulesResource) AlertingActionConfigComplete(data acceptance.TestData) string {
+func (MonitorScheduledQueryRulesAlertResource) AlertingActionConfigComplete(data acceptance.TestData) string {
 	ts := time.Now().Format(time.RFC3339)
 
 	return fmt.Sprintf(`
@@ -396,7 +396,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, ts, ts)
 }
 
-func (MonitorScheduledQueryRulesResource) AlertingActionCrossResourceConfig(data acceptance.TestData) string {
+func (MonitorScheduledQueryRulesAlertResource) AlertingActionCrossResourceConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -468,7 +468,7 @@ QUERY
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (t MonitorScheduledQueryRulesResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (t MonitorScheduledQueryRulesAlertResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := scheduledqueryrules.ParseScheduledQueryRuleID(state.ID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
--- PASS: TestAccMonitorScheduledQueryRulesAlert_resourceIdentity (164.85s)
```