### PR TITLE
`azurerm_mssql_failover_group` : support for the `secondary_type` property

### DIFF
--- a/internal/services/mssql/mssql_failover_group_resource.go
+++ b/internal/services/mssql/mssql_failover_group_resource.go
@@ -25,14 +25,14 @@ import (
 )
 
 type MsSqlFailoverGroupModel struct {
-	Databases                            []string             `tfschema:"databases"`
-	Name                                 string               `tfschema:"name"`
-	PartnerServers                       []PartnerServerModel `tfschema:"partner_server"`
-	ReadonlyEndpointFailurePolicyEnabled bool                 `tfschema:"readonly_endpoint_failover_policy_enabled"`
-	ServerId                             string               `tfschema:"server_id"`
-	Tags                                 map[string]string    `tfschema:"tags"`
-
-	ReadWriteEndpointFailurePolicy []ReadWriteEndpointFailurePolicyModel `tfschema:"read_write_endpoint_failover_policy"`
+	Databases                            []string                              `tfschema:"databases"`
+	Name                                 string                                `tfschema:"name"`
+	PartnerServers                       []PartnerServerModel                  `tfschema:"partner_server"`
+	ReadonlyEndpointFailurePolicyEnabled bool                                  `tfschema:"readonly_endpoint_failover_policy_enabled"`
+	ServerId                             string                                `tfschema:"server_id"`
+	Tags                                 map[string]string                     `tfschema:"tags"`
+	SecondaryType                        string                                `tfschema:"secondary_type"`
+	ReadWriteEndpointFailurePolicy       []ReadWriteEndpointFailurePolicyModel `tfschema:"read_write_endpoint_failover_policy"`
 }
 
 type PartnerServerModel struct {
@@ -141,6 +141,13 @@ func (r MsSqlFailoverGroupResource) Arguments() map[string]*pluginsdk.Schema {
 			},
 		},
 
+		"secondary_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice(
+				failovergroups.PossibleValuesForFailoverGroupDatabasesSecondaryType(), false),
+		},
+
 		"tags": commonschema.Tags(),
 	}
 }
@@ -223,6 +230,10 @@ func (r MsSqlFailoverGroupResource) Create() sdk.ResourceFunc {
 				Tags: pointer.To(model.Tags),
 			}
 
+			if model.SecondaryType != "" {
+				properties.Properties.SecondaryType = pointer.To(failovergroups.FailoverGroupDatabasesSecondaryType(model.SecondaryType))
+			}
+
 			if rwPolicy := model.ReadWriteEndpointFailurePolicy; len(rwPolicy) > 0 {
 				properties.Properties.ReadWriteEndpoint.FailoverPolicy = failovergroups.ReadWriteEndpointFailoverPolicy(rwPolicy[0].Mode)
 				if rwPolicy[0].Mode == string(failovergroups.ReadWriteEndpointFailoverPolicyAutomatic) {
@@ -283,6 +294,10 @@ func (r MsSqlFailoverGroupResource) Update() sdk.ResourceFunc {
 				properties.Properties.ReadWriteEndpoint.FailoverWithDataLossGracePeriodMinutes = pointer.To(state.ReadWriteEndpointFailurePolicy[0].GraceMinutes)
 			}
 
+			if state.SecondaryType != "" {
+				properties.Properties.SecondaryType = pointer.To(failovergroups.FailoverGroupDatabasesSecondaryType(state.SecondaryType))
+			}
+
 			// client.Update doesn't support changing the PartnerServers
 			err = client.CreateOrUpdateThenPoll(ctx, *id, properties)
 			if err != nil {
@@ -341,6 +356,10 @@ func (r MsSqlFailoverGroupResource) Read() sdk.ResourceFunc {
 					}}
 
 					model.ReadWriteEndpointFailurePolicy[0].GraceMinutes = pointer.From(props.ReadWriteEndpoint.FailoverWithDataLossGracePeriodMinutes)
+
+					// The API does not return the value of secondary_type.
+					// Tracking issue:https://github.com/Azure/azure-rest-api-specs/issues/35500
+					model.SecondaryType = metadata.ResourceData.Get("secondary_type").(string)
 				}
 			}
 

--- a/website/docs/r/mssql_failover_group.html.markdown
+++ b/website/docs/r/mssql_failover_group.html.markdown
@@ -88,6 +88,8 @@ The following arguments are supported:
 
 * `read_write_endpoint_failover_policy` - (Required) A `read_write_endpoint_failover_policy` block as defined below.
 
+* `secondary_type` - (Optional) Specifies the type of secondary replica to be used on the partner server. Possible values are `Geo` and `Standby`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support for the `secondary_type` property.

Swagger: https://github.com/Azure/azure-rest-api-specs/blob/fa1c574f05a6e43791c10752c321cbdf8ad2ec78/specification/sql/resource-manager/Microsoft.Sql/preview/2023-08-01-preview/FailoverGroups.json#L596C8-L596C25

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Test Results:
![image](https://github.com/user-attachments/assets/3d447216-a821-4f05-93a1-60e5dea766ff)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_failover_group` - support for the `secondary_type` property [GH-29987]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29987

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
