### PR TITLE
`azurerm_key_vault_secret` : remove nanosecond precision to prevent `expiration_date` parsing errors

### DIFF
--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -173,13 +173,17 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("not_before_date"); ok {
 		notBeforeDate, _ := time.Parse(time.RFC3339, v.(string)) // validated by schema
-		notBeforeUnixTime := date.UnixTime(notBeforeDate)
+		// Remove nanoseconds to avoid precision issues when converting to date.UnixTime
+		cleaned := time.Unix(notBeforeDate.Unix(), 0).UTC()
+		notBeforeUnixTime := date.UnixTime(cleaned)
 		parameters.SecretAttributes.NotBefore = &notBeforeUnixTime
 	}
 
 	if v, ok := d.GetOk("expiration_date"); ok {
 		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) // validated by schema
-		expirationUnixTime := date.UnixTime(expirationDate)
+		// Remove nanoseconds to avoid precision issues when converting to date.UnixTime
+		cleaned := time.Unix(expirationDate.Unix(), 0).UTC()
+		expirationUnixTime := date.UnixTime(cleaned)
 		parameters.SecretAttributes.Expires = &expirationUnixTime
 	}
 
@@ -277,13 +281,17 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("not_before_date"); ok {
 		notBeforeDate, _ := time.Parse(time.RFC3339, v.(string)) // validated by schema
-		notBeforeUnixTime := date.UnixTime(notBeforeDate)
+		// Remove nanoseconds to avoid precision issues when converting to date.UnixTime
+		cleaned := time.Unix(notBeforeDate.Unix(), 0).UTC()
+		notBeforeUnixTime := date.UnixTime(cleaned)
 		secretAttributes.NotBefore = &notBeforeUnixTime
 	}
 
 	if v, ok := d.GetOk("expiration_date"); ok {
 		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) // validated by schema
-		expirationUnixTime := date.UnixTime(expirationDate)
+		// Remove nanoseconds to avoid precision issues when converting to date.UnixTime
+		cleaned := time.Unix(expirationDate.Unix(), 0).UTC()
+		expirationUnixTime := date.UnixTime(cleaned)
 		secretAttributes.Expires = &expirationUnixTime
 	}
 

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -170,7 +170,7 @@ func TestAccKeyVaultSecret_complete(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("not_before_date").HasValue("2019-01-01T01:02:03Z"),
-				check.That(data.ResourceName).Key("expiration_date").HasValue("2020-01-01T01:02:03Z"),
+				check.That(data.ResourceName).Key("expiration_date").HasValue("2199-12-31T23:59:59Z"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
 				check.That(data.ResourceName).Key("versionless_id").HasValue(fmt.Sprintf("https://acctestkv-%s.vault.azure.net/secrets/secret-%s", data.RandomString, data.RandomString)),
@@ -466,8 +466,7 @@ resource "azurerm_key_vault_secret" "test" {
   key_vault_id    = azurerm_key_vault.test.id
   content_type    = "application/xml"
   not_before_date = "2019-01-01T01:02:03Z"
-  expiration_date = "2020-01-01T01:02:03Z"
-
+  expiration_date = "2199-12-31T23:59:59Z"
   tags = {
     "hello" = "world"
   }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Remove nanosecond precision to prevent `expiration_date` parsing errors.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

![image](https://github.com/user-attachments/assets/acb2766a-0f27-41a3-ad58-b7a2fd1e03ab)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_secret` - remove nanosecond precision to prevent `expiration_date` parsing errors [GH-30034]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30034

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
