### PR TITLE
`azurerm_data_factory_dataset_binary_resource`/`azurerm_data_factory_dataset_json_resource` - support dynamic compression values

### DIFF
--- a/internal/services/datafactory/data_factory_dataset_binary_resource_test.go
+++ b/internal/services/datafactory/data_factory_dataset_binary_resource_test.go
@@ -137,6 +137,15 @@ func TestAccDataFactoryDatasetBinary_compression(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.dynamicCompression(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("compression.#").HasValue("1"),
+				check.That(data.ResourceName).Key("compression.0.type").HasValue("@concat('Tar', 'GZip')"),
+				check.That(data.ResourceName).Key("compression.0.level").HasValue("@dataset().level"),
+			),
+		},
 	})
 }
 
@@ -491,6 +500,57 @@ resource "azurerm_data_factory_dataset_binary" "test" {
   compression {
     type  = "GZip"
     level = "Fastest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (DatasetBinaryResource) dynamicCompression(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_sftp" "test" {
+  name                = "acctestlssftp%[1]d"
+  data_factory_id     = azurerm_data_factory.test.id
+  authentication_type = "Basic"
+  host                = "http://www.bing.com"
+  port                = 22
+  username            = "foo"
+  password            = "bar"
+}
+
+resource "azurerm_data_factory_dataset_binary" "test" {
+  name                = "acctestds%[1]d"
+  data_factory_id     = azurerm_data_factory.test.id
+  linked_service_name = azurerm_data_factory_linked_service_sftp.test.name
+
+  sftp_server_location {
+    path     = "/test/"
+    filename = "**"
+  }
+
+  parameters = {
+    level = "Optimal"
+  }
+
+  compression {
+    dynamic_type_enabled  = true
+    type                  = "@concat('Tar', 'GZip')"
+    dynamic_level_enabled = true
+    level                 = "@dataset().level"
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/datafactory/data_factory_test.go
+++ b/internal/services/datafactory/data_factory_test.go
@@ -3,7 +3,10 @@
 
 package datafactory
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestDataFactoryLinkedServiceConnectionStringDiff(t *testing.T) {
 	cases := []struct {
@@ -121,26 +124,38 @@ func TestNormalizeJSON(t *testing.T) {
 func TestExpandCompressionType(t *testing.T) {
 	cases := []struct {
 		input          string
-		expectedOutput string
+		isDynamic      bool
+		expectedOutput interface{}
 	}{
 		{
 			input:          "Gzip",
+			isDynamic:      false,
 			expectedOutput: "gzip",
 		},
 		{
 			input:          "gzip",
+			isDynamic:      false,
 			expectedOutput: "gzip",
 		},
 		{
 			input:          "TarGZip",
+			isDynamic:      false,
 			expectedOutput: "TarGZip",
+		},
+		{
+			input:     "@concat('Tar', 'GZip')",
+			isDynamic: true,
+			expectedOutput: map[string]string{
+				"type":  "Expression",
+				"value": "@concat('Tar', 'GZip')",
+			},
 		},
 	}
 
 	for _, tc := range cases {
-		output := expandCompressionType(tc.input)
+		output := expandCompressionType(tc.input, tc.isDynamic)
 
-		if output != tc.expectedOutput {
+		if !reflect.DeepEqual(output, tc.expectedOutput) {
 			t.Fatalf("Expected expandCompressionType to be '%s' for '%s' - got '%s'", tc.expectedOutput, tc.input, output)
 		}
 	}

--- a/website/docs/r/data_factory_dataset_binary.html.markdown
+++ b/website/docs/r/data_factory_dataset_binary.html.markdown
@@ -85,7 +85,11 @@ A `compression` block supports the following:
 
 * `type` - (Required) The type of compression used during transport. Possible values are `BZip2`, `Deflate`, `GZip`, `Tar`, `TarGZip` and `ZipDeflate`.
 
+* `dynamic_type_enabled` - (Optional) Is the `type` using dynamic expression, function or system variables? Defaults to `false`.
+
 * `level` - (Optional) The level of compression. Possible values are `Fastest` and `Optimal`.
+
+* `dynamic_level_enabled` - (Optional) Is the `level` using dynamic expression, function or system variables? Defaults to `false`.
 
 ---
 

--- a/website/docs/r/data_factory_dataset_json.html.markdown
+++ b/website/docs/r/data_factory_dataset_json.html.markdown
@@ -79,6 +79,8 @@ The following supported arguments are specific to Delimited Text Dataset:
 
 * `encoding` - (Optional) The encoding format for the file.
 
+* `compression` - (Optional) A `compression` block as defined below.
+
 ---
 
 A `schema_column` block supports the following:
@@ -118,6 +120,20 @@ A `azure_blob_storage_location` block supports the following:
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 
 * `dynamic_filename_enabled` - (Optional) Is the `filename` using dynamic expression, function or system variables? Defaults to `false`.
+
+---
+
+A `compression` block supports the following:
+
+* `type` - (Required) The type of compression used during transport. Possible values are `BZip2`, `Deflate`, `GZip`, `Tar`, `TarGZip`, `ZipDeflate`, `snappy` and `lz4`.
+
+* `dynamic_type_enabled` - (Optional) Is the `type` using dynamic expression, function or system variables? Defaults to `false`.
+
+* `level` - (Optional) The level of compression. Possible values are `Fastest` and `Optimal`.
+
+* `dynamic_level_enabled` - (Optional) Is the `level` using dynamic expression, function or system variables? Defaults to `false`.
+
+---
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Adding `compression` support in `azurerm_data_factory_dataset_json_resource`. 
I noticed that `azurerm_data_factory_dataset_binary_resource` already has partial support for this however does not support dynamic expressions so I've added that too.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1485" height="875" alt="image" src="https://github.com/user-attachments/assets/07a7061f-fcdf-4186-93b3-4e9e9a7410d7" />

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_DATAFACTORY/412614?buildTab=tests

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_dataset_binary_resource` - add support for dynamic expressions in `compression` properties [GH-29880]
* `azurerm_data_factory_dataset_json_resource`  - add support for `compression` property [GH-29880]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #29880

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
