### PR TITLE
policy assignment - validate policy assignment name length

### DIFF
--- a/internal/services/policy/management_group_policy_assignment_resource.go
+++ b/internal/services/policy/management_group_policy_assignment_resource.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	managementGroupValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
@@ -31,8 +33,9 @@ func (r ManagementGroupAssignmentResource) Arguments() map[string]*pluginsdk.Sch
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				validation.StringDoesNotContainAny("/"),
-				validation.StringLenBetween(3, 24),
+				validation.StringDoesNotContainAny("#<>%&:\\?/"),
+				validation.StringLenBetween(1, 24),
+				validation.StringMatch(regexp.MustCompile("[^ .]$"), "The name cannot end with a period or space."),
 			),
 		},
 	}

--- a/internal/services/policy/resource_group_policy_assignment_resource.go
+++ b/internal/services/policy/resource_group_policy_assignment_resource.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
 	resourceValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
@@ -25,8 +27,9 @@ func (r ResourceGroupAssignmentResource) Arguments() map[string]*pluginsdk.Schem
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				validation.StringDoesNotContainAny("/"),
+				validation.StringDoesNotContainAny("#<>%&:\\?/"),
 				validation.StringLenBetween(1, 64),
+				validation.StringMatch(regexp.MustCompile("[^ .]$"), "The name cannot end with a period or space."),
 			),
 		},
 		"resource_group_id": {

--- a/internal/services/policy/resource_policy_assignment_resource.go
+++ b/internal/services/policy/resource_policy_assignment_resource.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -24,8 +26,9 @@ func (r ResourceAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				validation.StringDoesNotContainAny("/"),
+				validation.StringDoesNotContainAny("#<>%&:\\?/"),
 				validation.StringLenBetween(1, 64),
+				validation.StringMatch(regexp.MustCompile("[^ .]$"), "The name cannot end with a period or space."),
 			),
 		},
 		"resource_id": {

--- a/internal/services/policy/subscription_policy_assignment_resource.go
+++ b/internal/services/policy/subscription_policy_assignment_resource.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
@@ -25,8 +27,9 @@ func (r SubscriptionAssignmentResource) Arguments() map[string]*pluginsdk.Schema
 			ForceNew: true,
 			ValidateFunc: validation.All(
 				validation.StringIsNotWhiteSpace,
-				validation.StringDoesNotContainAny("/"),
+				validation.StringDoesNotContainAny("#<>%&:\\?/"),
 				validation.StringLenBetween(1, 64),
+				validation.StringMatch(regexp.MustCompile("[^ .]$"), "The name cannot end with a period or space."),
 			),
 		},
 		"subscription_id": {

--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `management_group_id` - (Required) The ID of the Management Group. Changing this forces a new Policy Assignment to be created.
 
-* `name` - (Required) The name which should be used for this Policy Assignment. Possible values must be between 3 and 24 characters in length. Changing this forces a new Policy Assignment to be created.
+* `name` - (Required) The name which should be used for this Policy Assignment. Cannot exceed 24 characters in length. Changing this forces a new Policy Assignment to be created.
 
 * `policy_definition_id` - (Required) The ID of the Policy Definition or Policy Definition Set. Changing this forces a new Policy Assignment to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Docs were added previously but the validation wasn't being enforced
https://github.com/hashicorp/terraform-provider-azurerm/pull/21549/files

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- (n/a) I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30081

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
