### PR TITLE
`azurerm_kubernetes_cluster` - add support for `node_provisioning_profile`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -604,6 +604,23 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"node_provisioning_profile": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"default_node_pool": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"oidc_issuer_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
@@ -822,6 +839,11 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 			networkProfile := flattenKubernetesClusterDataSourceNetworkProfile(props.NetworkProfile)
 			if err := d.Set("network_profile", networkProfile); err != nil {
 				return fmt.Errorf("setting `network_profile`: %+v", err)
+			}
+
+			nodeProvisioningProfile := flattenKubernetesClusterDataSourceNodeProvisioningProfile(props.NodeProvisioningProfile)
+			if err := d.Set("node_provisioning_profile", nodeProvisioningProfile); err != nil {
+				return fmt.Errorf("setting `node_provisioning_profile`: %+v", err)
 			}
 
 			oidcIssuerEnabled := false
@@ -1463,4 +1485,17 @@ func flattenKubernetesClusterDataSourceUpgradeSettings(input *managedclusters.Ag
 	}
 
 	return []interface{}{values}
+}
+
+func flattenKubernetesClusterDataSourceNodeProvisioningProfile(input *managedclusters.ManagedClusterNodeProvisioningProfile) []interface{} {
+	if input == nil || input.Mode == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"default_node_pool": pointer.From(input.DefaultNodePools),
+			"mode":              pointer.From(input.Mode),
+		},
+	}
 }

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -650,6 +650,21 @@ func TestAccDataSourceKubernetesCluster_serviceMeshRevisions(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceKubernetesCluster_nodeProvisioningProfileAuto(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.nodeProvisioningProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("node_provisioning_profile.0.default_node_pool").HasValue("Auto"),
+				check.That(data.ResourceName).Key("node_provisioning_profile.0.mode").HasValue("Auto"),
+			),
+		},
+	})
+}
+
 func (KubernetesClusterDataSource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -995,4 +1010,14 @@ data "azurerm_kubernetes_cluster" "test" {
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
 `, KubernetesClusterResource{}.addonProfileServiceMeshProfileRevisionsConfig(data, revisions))
+}
+
+func (KubernetesClusterDataSource) nodeProvisioningProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+data "azurerm_kubernetes_cluster" "test" {
+  name                = azurerm_kubernetes_cluster.test.name
+  resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
+}
+`, KubernetesClusterResource{}.nodeProvisioningProfile(data))
 }

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -98,6 +98,8 @@ The following attributes are exported:
 
 * `network_profile` - A `network_profile` block as documented below.
 
+* `node_provisioning_profile` - A `node_provisioning_profile` block as documented below.
+
 * `node_resource_group` - Auto-generated Resource Group containing AKS Cluster resources.
 
 * `node_resource_group_id` - The ID of the Resource Group containing the resources for this Managed Kubernetes Cluster.
@@ -395,6 +397,15 @@ A `certificate_authority` block exports the following:
 * `key_object_name` - The intermediate certificate private key object name in Azure Key Vault.
 
 ---
+
+The `node_provisioning_profile` block exports the following:
+
+* `mode` - Mode of node provisioning. Possible values are `Manual` and `Auto`.
+
+* `default_node_pool` - Whether default autoprovisioning node pools are created. This attribute is not applicable unless `mode` is `Auto`. Possible values are `None` and `Auto`.
+
+---
+
 
 ## Timeouts
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -163,6 +163,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 -> **Note:** `node_os_upgrade_channel` must be set to `NodeImage` if `automatic_upgrade_channel` has been set to `node-image`
 
+* `node_provisioning_profile` - (Optional) A `node_provisioning_profile` block as defined below. For more details about the node provisioning profile, see [Node Auto Provisioning](https://learn.microsoft.com/en-us/azure/aks/node-autoprovision) for more information.
+
 * `node_resource_group` - (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created.
 
 -> **Note:** Azure requires that a new, non-existent Resource Group is used, as otherwise, the provisioning of the Kubernetes Service will fail.
@@ -1148,6 +1150,17 @@ The `web_app_routing_identity` block exports the following:
 * `user_assigned_identity_id` - The ID of the User Assigned Identity used for Web App Routing.
 
 ---
+
+The `node_provisioning_profile` block supports the following:
+
+* `mode` - (Optional) Mode to use for node provisioning. Currently supported values are `Manual` and `Auto`. Defaults to `Manual`.
+
+* `default_node_pool` - (Optional) Whether to create default autoprovisioning node pools. This attribute has no effect unless `mode` is `Auto`. Possible values are `None` and `Auto`. Defaults to `Auto`.
+
+-> **Note:** Changing this from Auto to None on an existing cluster will cause the default node pools to be deleted, which will drain and delete the nodes associated with those pools.
+
+---
+
 
 ## Timeouts
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for `node_provisioning_profile` in azurerm_kubernetes_cluster. This allows for the use of the Node Autoprovisioning feature in AKS which was recently stablised.

Based on https://github.com/hashicorp/terraform-provider-azurerm/pull/25084

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster` - support for `node_provisioning_profile` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30190

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
