### PR TITLE
[TestCase] `azurerm_log_analytics_storage_insights` - Mark `storage_account_id` as `ForceNew`

### DIFF
--- a/internal/services/loganalytics/log_analytics_storage_insights_resource.go
+++ b/internal/services/loganalytics/log_analytics_storage_insights_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -191,6 +192,7 @@ func resourceLogAnalyticsStorageInsightsSchema() map[string]*pluginsdk.Schema {
 		"storage_account_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
+			ForceNew:     features.FivePointOh(),
 			ValidateFunc: commonids.ValidateStorageAccountID,
 		},
 

--- a/internal/services/loganalytics/log_analytics_storage_insights_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_storage_insights_resource_test.go
@@ -100,7 +100,7 @@ func TestAccLogAnalyticsStorageInsights_updateStorageAccount(t *testing.T) {
 		},
 		data.ImportStep("storage_account_key"),
 		{
-			Config: r.updateStorageAccount(data),
+			Config: r.updateStorageAccountKey(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -201,18 +201,9 @@ resource "azurerm_log_analytics_storage_insights" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r LogAnalyticsStorageInsightsResource) updateStorageAccount(data acceptance.TestData) string {
+func (r LogAnalyticsStorageInsightsResource) updateStorageAccountKey(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-resource "azurerm_storage_account" "test2" {
-  name                = "acctestsads%s"
-  resource_group_name = azurerm_resource_group.test.name
-
-  location                 = azurerm_resource_group.test.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
 
 resource "azurerm_log_analytics_storage_insights" "test" {
   name                = "acctest-la-%d"
@@ -222,8 +213,8 @@ resource "azurerm_log_analytics_storage_insights" "test" {
   blob_container_names = ["wad-iis-logfiles"]
   table_names          = ["WADWindowsEventLogsTable", "LinuxSyslogVer2v0"]
 
-  storage_account_id  = azurerm_storage_account.test2.id
-  storage_account_key = azurerm_storage_account.test2.primary_access_key
+  storage_account_id  = azurerm_storage_account.test.id
+  storage_account_key = azurerm_storage_account.test.secondary_access_key
 }
-`, r.template(data), data.RandomStringOfLength(6), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -281,6 +281,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `workspace_resource_id` property has been removed and superseded by the `workspace_id` property.
 
+### `azurerm_log_analytics_storage_insights`
+
+* The `storage_account_id` property is marked as `ForceNew`.
+
 ### `azurerm_log_analytics_workspace`
 
 * The deprecated `local_authentication_disabled` property has been removed in favour of the `local_authentication_enabled` property.


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently I noticed that TestAccLogAnalyticsStorageInsights_updateStorageAccount failed on teamcity daily run. After I checked, I found service api doesn't allow to update storageAccountId anymore. So, I added forcenew for this property.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccLogAnalyticsStorageInsights_updateStorageAccount (359.21s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [TestCase] `azurerm_log_analytics_storage_insights` - Mark `storage_account_id` as `ForceNew`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
