### PR TITLE
`keyvault`: use alt keyvault dataplane client with new inited transport for key vault nested resource creation

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -278,7 +278,7 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 
 func resourceKeyVaultKeyCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	keyVaultsClient := meta.(*clients.Client).KeyVault
-	client := meta.(*clients.Client).KeyVault.ManagementClient
+	client := meta.(*clients.Client).KeyVault.DataPlaneClientAlt
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -470,7 +470,7 @@ func resourceKeyVaultKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	keyVaultsClient := meta.(*clients.Client).KeyVault
-	client := meta.(*clients.Client).KeyVault.ManagementClient
+	client := meta.(*clients.Client).KeyVault.DataPlaneClientAlt
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -238,9 +238,9 @@ func TestAccKeyVaultKey_update(t *testing.T) {
 
 func TestAccKeyVaultKey_withPrivateEndpoint(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
-	subnetIDStr := os.Getenv("ACC_AZURE_SUBNET_ID")
+	subnetIDStr := os.Getenv("ACC_PRIVATE_ENDPOINT_AZURE_SUBNET_ID")
 	if subnetIDStr == "" {
-		t.Skip(`Skipping test: ACC_AZURE_SUBNET_ID is not set. This test has to be run in an Azure Virtual Machine and to set ACC_AZURE_SUBNET_ID to the subnet id of the virtual machine where the test is running`)
+		t.Skip(`Skipping test: ACC_PRIVATE_ENDPOINT_AZURE_SUBNET_ID is not set. This test has to be run in an Azure Virtual Machine and to set ACC_PRIVATE_ENDPOINT_AZURE_SUBNET_ID to the subnet id of the virtual machine where the test is running`)
 	}
 
 	subnetID, err := commonids.ParseSubnetIDInsensitively(subnetIDStr)
@@ -735,8 +735,8 @@ data "azurerm_subnet" "test" {
 
 resource "azurerm_key_vault" "test" {
   name                          = "acckv%[4]d"
-  resource_group_name           = data.azurerm_resource_group.test.name
-  location                      = data.azurerm_resource_group.test.location
+  resource_group_name           = data.azurerm_resource_group.rg.name
+  location                      = data.azurerm_resource_group.rg.location
   tenant_id                     = data.azurerm_client_config.current.tenant_id
   sku_name                      = "standard"
   public_network_access_enabled = false
@@ -756,12 +756,12 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_private_dns_zone" "test" {
   name                = "privatelink.vaultcore.azure.net"
-  resource_group_name = data.azurerm_resource_group.test.name
+  resource_group_name = data.azurerm_resource_group.rg.name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "test" {
   name                  = "xuwu1-kv-pe-dns-link"
-  resource_group_name   = data.azurerm_resource_group.test.name
+  resource_group_name   = data.azurerm_resource_group.rg.name
   private_dns_zone_name = azurerm_private_dns_zone.test.name
   virtual_network_id    = data.azurerm_virtual_network.test.id
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

as disccussed in issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/27840#issuecomment-2735532410 we need a new http.Client to void the cached connection to key vault data plane API which is required when creating keyvault with a private endpoint, so this PR is to add a separate client for data plane resource creation. currently only used to key_vault_key resource, if it looks good to you, I'll apply it to secret, certificate and key vault storage account.

this PR proposes a method to workaround the data plane resource to work with private endpoint, so it may also can address similar issues to storage related resources.

I tested locally several times, it works fine.  it's not possible to run an acceptance test for it in local or TeamCity, but only in a Azure Virtual Machine, I added a such test and run in azure vm, which will skip it if specific environment variable is not set:

```sh
adminuser@xuwu1-vm-kv-pe:~/azurerm/terraform-provider-azurerm$ ./keyvault.test -test.v -test.run ^TestAccKeyVaultKey_withPrivateEndpoint$
=== RUN   TestAccKeyVaultKey_withPrivateEndpoint
=== PAUSE TestAccKeyVaultKey_withPrivateEndpoint
=== CONT  TestAccKeyVaultKey_withPrivateEndpoint
--- PASS: TestAccKeyVaultKey_withPrivateEndpoint (772.03s)
PASS
adminuser@xuwu1-vm-kv-pe:~/azurerm/terraform-provider-azurerm$ echo $ACC_AZURE_SUBNET_ID 
/subscriptions/xxxx/resourceGroups/xuwu1-rg-kv-pe/providers/Microsoft.Network/virtualNetworks/xuwu1-vnet-kv-pe/subnets/xuwu1-subnet-kv-pe
```


as all senders in autorest are initialized from below code, so we can safely convert it back to `*http.Client` in this PR:

https://github.com/hashicorp/terraform-provider-azurerm/blob/ac2b077aab403e343c9392bb308ce67cf804435a/vendor/github.com/Azure/go-autorest/autorest/sender.go#L155-L158


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="709" height="476" alt="image" src="https://github.com/user-attachments/assets/23e2b323-2246-4dc5-a3ac-2ddecfc857dc" />

The failed test is not related to this PR:

<img width="671" height="594" alt="image" src="https://github.com/user-attachments/assets/15c2441c-e348-4fec-a295-b2faed361e37" />



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault_key` - support for the creation with private endpoint [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #27840
fixes #9738
fixes #18659
fixes #19730

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
