### PR TITLE
`azurerm_pim_active_role_assignment` `azurerm_pim_eligible_role_assignment`- add validation for `role_definition_id` field

### DIFF
--- a/internal/services/authorization/pim_active_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource_test.go
@@ -188,24 +188,6 @@ data "azurerm_role_definition" "test" {
 
 %[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[2]d"
-  location = "%[3]s"
-}
-
-resource "azurerm_role_management_policy" "test" {
-  scope              = azurerm_resource_group.test.id
-  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-
-  active_assignment_rules {
-    expiration_required = false
-  }
-
-  eligible_assignment_rules {
-    expiration_required = false
-  }
-}
-
 resource "azurerm_pim_active_role_assignment" "test" {
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
@@ -217,10 +199,8 @@ resource "azurerm_pim_active_role_assignment" "test" {
     number = "1"
     system = "example ticket system"
   }
-
-  depends_on = [azurerm_role_management_policy.test]
 }
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, r.template(data))
 }
 
 func (PimActiveRoleAssignmentResource) expirationByDurationHours(data acceptance.TestData) string {

--- a/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
@@ -204,26 +204,8 @@ data "azurerm_role_definition" "test" {
 
 %[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%[2]d"
-  location = "%[3]s"
-}
-
-resource "azurerm_role_management_policy" "test" {
-  scope              = azurerm_resource_group.test.id
-  role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-
-  active_assignment_rules {
-    expiration_required = false
-  }
-
-  eligible_assignment_rules {
-    expiration_required = false
-  }
-}
-
 resource "azurerm_pim_eligible_role_assignment" "test" {
-  scope              = azurerm_resource_group.test.id
+  scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
   principal_id       = azuread_user.test.object_id
 
@@ -233,10 +215,8 @@ resource "azurerm_pim_eligible_role_assignment" "test" {
     number = "1"
     system = "example ticket system"
   }
-
-  depends_on = [azurerm_role_management_policy.test]
 }
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, r.template(data))
 }
 
 func (r PimEligibleRoleAssignmentResource) expirationByDurationHours(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Validate the `role_definition_id` to ensure it accepts ScopedRoleDefinitionID, like `/subscriptions/44444444-4444-4444-4444-444444444444/providers/Microsoft.Authorization/roleDefinitions/44444444-4444-d261-98c2-2c2ebb6639d2`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Most tests are passing, but 3 of them are also failing on the Main branch.
<img width="763" height="550" alt="image" src="https://github.com/user-attachments/assets/46969fff-173f-4393-90db-d0f922128370" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_pim_active_role_assignment` `azurerm_pim_eligible_role_assignment`- add validation for `role_definition_id` field [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30437

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
