### PR TITLE
azurerm_key_vault - validate name against ARM-enforced hyphen conditions

### DIFF
--- a/internal/services/keyvault/validate/vault_name.go
+++ b/internal/services/keyvault/validate/vault_name.go
@@ -6,12 +6,21 @@ package validate
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 func VaultName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 	if matched := regexp.MustCompile(`^[a-zA-Z0-9-]{3,24}$`).Match([]byte(value)); !matched {
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes and must be between 3-24 chars", k))
+	}
+
+	if matched2 := regexp.MustCompile(`^[a-zA-Z].*[a-zA-Z0-9]$`).Match([]byte(value)); !matched2 {
+		errors = append(errors, fmt.Errorf("%q must start with a letter and end with a letter or number", k))
+	}
+
+	if strings.Contains(value, "--") {
+		errors = append(errors, fmt.Errorf("%q cannot contain consecutive hyphens (\"--\")", k))
 	}
 
 	return warnings, errors

--- a/internal/services/keyvault/validate/vault_name_test.go
+++ b/internal/services/keyvault/validate/vault_name_test.go
@@ -42,14 +42,34 @@ func TestValidateVaultName(t *testing.T) {
 		},
 		{
 			Input:       "20202020",
-			ExpectError: false,
+			ExpectError: true,
 		},
 		{
 			Input:       "ABC123!@£",
 			ExpectError: true,
 		},
 		{
+			Input:       "abcdefghijklmnopqrstuvwx",
+			ExpectError: false,
+		},
+		{
 			Input:       "abcdefghijklmnopqrstuvwxyz",
+			ExpectError: true,
+		},
+		{
+			Input:       "hello-",
+			ExpectError: true,
+		},
+		{
+			Input:       "hello--world",
+			ExpectError: true,
+		},
+		{
+			Input:       "-hello",
+			ExpectError: true,
+		},
+		{
+			Input:       "123hello",
 			ExpectError: true,
 		},
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

[Microsoft's documentation for key vaults](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftkeyvault) clearly specifies that vault names may contain:
> 	Alphanumerics and hyphens
>     Start with a letter. End with letter or number. Can't contain consecutive hyphens.

Up to now, terraform only enforced the first condition during plan, and would fail on scenarios failing the second during apply.



## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Assists with https://github.com/Azure/terraform-azurerm-naming/issues/37

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->