### PR TITLE
`azurerm_bot_web_app` - fix acctest, add support for `microsoft_app_type`, `microsoft_app_tenant_id`, microsoft_app_user_assigned_identity_id`

### DIFF
--- a/internal/services/bot/bot_web_app_resource.go
+++ b/internal/services/bot/bot_web_app_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -26,7 +27,7 @@ import (
 )
 
 func resourceBotWebApp() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceBotWebAppCreate,
 		Read:   resourceBotWebAppRead,
 		Update: resourceBotWebAppUpdate,
@@ -93,23 +94,22 @@ func resourceBotWebApp() *pluginsdk.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 
-			"microsoft_app_tenant_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsUUID,
-			},
-
 			"microsoft_app_type": {
 				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(botservice.MsaAppTypeMultiTenant),
 					string(botservice.MsaAppTypeSingleTenant),
 					string(botservice.MsaAppTypeUserAssignedMSI),
 				}, false),
-				Default: string(botservice.MsaAppTypeMultiTenant),
+			},
+
+			"microsoft_app_tenant_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"microsoft_app_user_assigned_identity_id": {
@@ -170,6 +170,23 @@ func resourceBotWebApp() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["microsoft_app_type"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			// Note: O+C because Azure sets a value for this if omitted
+			Computed: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(botservice.MsaAppTypeMultiTenant),
+				string(botservice.MsaAppTypeSingleTenant),
+				string(botservice.MsaAppTypeUserAssignedMSI),
+			}, false),
+		}
+	}
+
+	return r
 }
 
 func resourceBotWebAppCreate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -110,14 +110,16 @@ resource "azuread_application_registration" "test" {
 }
 
 resource "azurerm_bot_web_app" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "F0"
-  microsoft_app_id    = azuread_application_registration.test.client_id
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "F0"
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 
   tags = {
-    environment = "production"
+    environment = "Test"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -142,14 +144,16 @@ resource "azuread_application_registration" "test" {
 }
 
 resource "azurerm_bot_web_app" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "F0"
-  microsoft_app_id    = azuread_application_registration.test.client_id
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "F0"
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 
   tags = {
-    environment = "production"
+    environment = "Test2"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -187,11 +191,13 @@ resource "azuread_application_registration" "test" {
 }
 
 resource "azurerm_bot_web_app" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  microsoft_app_id    = azuread_application_registration.test.client_id
-  sku                 = "F0"
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
+  sku                     = "F0"
 
   endpoint                              = "https://example.com"
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key
@@ -199,7 +205,7 @@ resource "azurerm_bot_web_app" "test" {
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 
   tags = {
-    environment = "production"
+    environment = "Test"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -77,7 +77,22 @@ func TestAccBotWebApp_complete(t *testing.T) {
 	})
 }
 
-func (t BotWebAppResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func TestAccBotWebApp_userAssignedMSI(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.userAssignedMSI(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r BotWebAppResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.BotServiceID(state.ID)
 	if err != nil {
 		return nil, err
@@ -91,26 +106,16 @@ func (t BotWebAppResource) Exists(ctx context.Context, clients *clients.Client, 
 	return pointer.To(resp.Properties != nil), nil
 }
 
-func (BotWebAppResource) basicConfig(data acceptance.TestData) string {
+func (r BotWebAppResource) basicConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azuread_application_registration" "test" {
-  display_name = "acctestReg-%d"
-}
+%[1]s
 
 resource "azurerm_bot_web_app" "test" {
-  name                    = "acctestdf%d"
+  name                    = "acctestdf%[2]d"
   location                = "global"
   resource_group_name     = azurerm_resource_group.test.name
   sku                     = "F0"
@@ -122,29 +127,19 @@ resource "azurerm_bot_web_app" "test" {
     environment = "Test"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (BotWebAppResource) updateConfig(data acceptance.TestData) string {
+func (r BotWebAppResource) updateConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azuread_application_registration" "test" {
-  display_name = "acctestReg-%d"
-}
+%[1]s
 
 resource "azurerm_bot_web_app" "test" {
-  name                    = "acctestdf%d"
+  name                    = "acctestdf%[2]d"
   location                = "global"
   resource_group_name     = azurerm_resource_group.test.name
   sku                     = "F0"
@@ -156,42 +151,32 @@ resource "azurerm_bot_web_app" "test" {
     environment = "Test2"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (BotWebAppResource) completeConfig(data acceptance.TestData) string {
+func (r BotWebAppResource) completeConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_application_insights" "test" {
-  name                = "acctestappinsights-%d"
+  name                = "acctestappinsights-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   application_type    = "web"
 }
 
 resource "azurerm_application_insights_api_key" "test" {
-  name                    = "acctestappinsightsapikey-%d"
+  name                    = "acctestappinsightsapikey-%[2]d"
   application_insights_id = azurerm_application_insights.test.id
   read_permissions        = ["aggregate", "api", "draft", "extendqueries", "search"]
 }
 
-resource "azuread_application_registration" "test" {
-  display_name = "acctestReg-%d"
-}
-
 resource "azurerm_bot_web_app" "test" {
-  name                    = "acctestdf%d"
+  name                    = "acctestdf%[2]d"
   location                = "global"
   resource_group_name     = azurerm_resource_group.test.name
   microsoft_app_id        = azuread_application_registration.test.client_id
@@ -208,5 +193,48 @@ resource "azurerm_bot_web_app" "test" {
     environment = "Test"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
+}
+
+func (r BotWebAppResource) userAssignedMSI(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_bot_web_app" "test" {
+  name                = "acctestdf%[2]d"
+  location            = "global"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "F0"
+
+  microsoft_app_id                        = azuread_application_registration.test.client_id
+  microsoft_app_type                      = "UserAssignedMSI"
+  microsoft_app_tenant_id                 = data.azurerm_client_config.current.tenant_id
+  microsoft_app_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r BotWebAppResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azuread_application_registration" "test" {
+  display_name = "acctestReg-%[1]d"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -300,15 +300,19 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `certificate` property has been removed.
 
-### `azurem_bot_service_azure_bot`
-
-* The `microsoft_app_type` property is now required.
-
 ### `azurerm_bot_channel_ms_teams`
 
 * The deprecated `enable_calling` property has been removed in favour of the `calling_enabled` property.
 
 ### `azurerm_bot_channels_registration`
+
+* The `microsoft_app_type` property is now required.
+
+### `azurem_bot_service_azure_bot`
+
+* The `microsoft_app_type` property is now required.
+
+### `azurerm_bot_web_app`
 
 * The `microsoft_app_type` property is now required.
 

--- a/website/docs/r/bot_web_app.html.markdown
+++ b/website/docs/r/bot_web_app.html.markdown
@@ -21,11 +21,13 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_bot_web_app" "example" {
-  name                = "example"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.example.name
-  sku                 = "F0"
-  microsoft_app_id    = data.azurerm_client_config.current.client_id
+  name                    = "example"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.example.name
+  sku                     = "F0"
+  microsoft_app_id        = data.azurerm_client_config.current.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 }
 ```
 
@@ -42,6 +44,16 @@ The following arguments are supported:
 * `sku` - (Required) The SKU of the Web App Bot. Valid values include `F0` or `S1`. Changing this forces a new resource to be created.
 
 * `microsoft_app_id` - (Required) The Microsoft Application ID for the Web App Bot. Changing this forces a new resource to be created.
+
+* `microsoft_app_type` - (Optional) The Microsoft Application Type for the Bot Channels Registration. Possible values are `MultiTenant`, `SingleTenant` and `UserAssignedMSI`. Defaults to `MultiTenant`. Changing this forces a new resource to be created.
+
+~> **Note:** The `MultiTenant` bot creation is deprecated by service API. Please use `SingleTenant` or `UserAssignedMSI`.
+
+~> **Note:** The `MultiTenant` bot which is already created will continue to function as normal.
+
+* `microsoft_app_tenant_id` - (Optional) The Microsoft Application Tenant ID for the Bot Channels Registration. Changing this forces a new resource to be created.
+
+* `microsoft_app_user_assigned_identity_id` - (Optional) The ID of Microsoft Application User Assigned Identity for the Bot Channels Registration. Changing this forces a new resource to be created.
 
 * `display_name` - (Optional) The name of the Web App Bot will be displayed as. This defaults to `name` if not specified.
 

--- a/website/docs/r/bot_web_app.html.markdown
+++ b/website/docs/r/bot_web_app.html.markdown
@@ -45,11 +45,11 @@ The following arguments are supported:
 
 * `microsoft_app_id` - (Required) The Microsoft Application ID for the Web App Bot. Changing this forces a new resource to be created.
 
+---
+
 * `microsoft_app_type` - (Optional) The Microsoft Application Type for the Bot Channels Registration. Possible values are `MultiTenant`, `SingleTenant` and `UserAssignedMSI`. Defaults to `MultiTenant`. Changing this forces a new resource to be created.
 
-~> **Note:** The `MultiTenant` bot creation is deprecated by service API. Please use `SingleTenant` or `UserAssignedMSI`.
-
-~> **Note:** The `MultiTenant` bot which is already created will continue to function as normal.
+~> **Note:** Creation of `azurerm_bot_web_app` resources using the `MultiTenant` type is no longer supported by Azure, existing resources can continue using this type.
 
 * `microsoft_app_tenant_id` - (Optional) The Microsoft Application Tenant ID for the Bot Channels Registration. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Recently we noticed that test cases related with BOT RP are failed on Teamcity Daily Run. Service team confirmed that they have deprecated enum value "MultiTenant" of the property "MsaAppType". So I submitted this PR to resolve this issue.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
<img width="257" height="54" alt="image" src="https://github.com/user-attachments/assets/eab31d2f-3cca-4c3c-99e3-a0ba86465019" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [TestCase] azurerm_bot_web_app - fix acctest


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
