### PR TITLE
`azurerm_storage_account` - Moving the `is_hns_enabled` validation from apply time to plan time

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1115,13 +1115,14 @@ func resourceStorageAccount() *pluginsdk.Resource {
 			pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
 				if d.HasChange("account_kind") {
 					accountKind, changedKind := d.GetChange("account_kind")
-
-					if accountKind != string(storageaccounts.KindStorage) && changedKind != string(storageaccounts.KindStorageVTwo) {
-						log.Printf("[DEBUG] recreate storage account, could't be migrated from %q to %q", accountKind, changedKind)
-						d.ForceNew("account_kind")
-						return nil
-					} else {
-						log.Printf("[DEBUG] storage account can be upgraded from %q to %q", accountKind, changedKind)
+					// Don't do the check for create case.
+					if accountKind != "" {
+						if accountKind != string(storageaccounts.KindStorage) && changedKind != string(storageaccounts.KindStorageVTwo) {
+							log.Printf("[DEBUG] recreate storage account, could't be migrated from %q to %q", accountKind, changedKind)
+							d.ForceNew("account_kind")
+						} else {
+							log.Printf("[DEBUG] storage account can be upgraded from %q to %q", accountKind, changedKind)
+						}
 					}
 				}
 
@@ -1177,7 +1178,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				accountKind := storageaccounts.Kind(d.Get("account_kind").(string))
 				if _, supportsHns := storageKindsSupportHns[accountKind]; !supportsHns && isHnsEnabled {
 					keys := sortedKeysFromSlice(storageKindsSupportHns)
-					return fmt.Errorf("`is_hns_enabled` can only be used for accounts with `kind` set to one of: %+v", strings.Join(keys, " / "))
+					return fmt.Errorf("`is_hns_enabled` can only be used for accounts with `account_kind` set to one of: %+v", strings.Join(keys, " / "))
 				}
 				return nil
 			}),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`azurerm_storage_account` - Moving the `is_hns_enabled` validation from apply time to plan time. This is because both the `is_hns_enabled` and `account_kind` are most likely know before apply, also it doesn't make a big difference to fail at runtime either by the previous check or by the API call.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
$ cat main.tf

...
resource "azurerm_storage_account" "test" {
  name                             = "testingasuiod1"
  resource_group_name              = azurerm_resource_group.test.name
  location                         = azurerm_resource_group.test.location
  account_kind                     = "StorageV2"
  account_tier                     = "Standard"
  account_replication_type         = "LRS"
  is_hns_enabled = true
}

$ tf plan

...
╷
│ Error: 1 error occurred:
│       * `is_hns_enabled` can only be used for accounts with `account_kind` set to one of: BlobStorage / BlockBlobStorage / StorageV2
│
│
│
│   with azurerm_storage_account.test,
│   on main.tf line 15, in resource "azurerm_storage_account" "test":
│   15: resource "azurerm_storage_account" "test" {
│
╵

💤  TF_ACC=1 go test -v -run=TestAccStorageAccount_basic ./internal/services/storage
=== RUN   TestAccStorageAccount_basic
=== PAUSE TestAccStorageAccount_basic
=== CONT  TestAccStorageAccount_basic
--- PASS: TestAccStorageAccount_basic (212.45s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       212.498s
```



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30530

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
