### PR TITLE
Framework - fix an issue that caused `Value Conversion` errors

### DIFF
--- a/internal/sdk/framework_resource_wrapper.go
+++ b/internal/sdk/framework_resource_wrapper.go
@@ -143,14 +143,14 @@ func (r *FrameworkResourceWrapper) Update(ctx context.Context, request resource.
 		plan := r.FrameworkWrappedResource.ModelObject()
 		state := r.FrameworkWrappedResource.ModelObject()
 
-		r.ResourceMetadata.DecodeUpdate(ctx, request, response, &plan, &state)
+		r.ResourceMetadata.DecodeUpdate(ctx, request, response, plan, state)
 		if response.Diagnostics.HasError() {
 			return
 		}
 
 		fr.Update(ctx, request, response, r.ResourceMetadata, plan, state)
 
-		r.ResourceMetadata.EncodeUpdate(ctx, response, state)
+		r.ResourceMetadata.EncodeUpdate(ctx, response, plan)
 
 		return
 	} else {


### PR DESCRIPTION
Fixes:
- `Value Conversion` error during updates
- `Provider produced inconsistent result after apply` errors during updates