### PR TITLE
Revert "`azurerm_site_recovery_replicated_vm` - deprecate `network_interace.target_*` property, add `network_interface.ip_configuration.*`"

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
@@ -42,7 +41,7 @@ import (
 )
 
 func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceSiteRecoveryReplicatedItemCreate,
 		Read:   resourceSiteRecoveryReplicatedItemRead,
 		Update: resourceSiteRecoveryReplicatedItemUpdate,
@@ -295,7 +294,7 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			},
 
 			"network_interface": {
-				Type:       pluginsdk.TypeList,
+				Type:       pluginsdk.TypeSet, // use set to avoid diff caused by different orders.
 				Optional:   true,
 				Computed:   true,
 				ConfigMode: pluginsdk.SchemaConfigModeAttr,
@@ -303,12 +302,10 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func networkInterfaceResource() *pluginsdk.Resource {
-	nicSchema := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Schema: map[string]*pluginsdk.Schema{
 			"source_network_interface_id": {
 				Type:         pluginsdk.TypeString,
@@ -317,143 +314,61 @@ func networkInterfaceResource() *pluginsdk.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
-			"ip_configuration": {
-				Type:       pluginsdk.TypeList,
-				Optional:   true,
-				ConfigMode: pluginsdk.SchemaConfigModeAttr,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"name": {
-							Type:     pluginsdk.TypeString,
-							Required: true,
-						},
+			"failover_test_static_ip": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 
-						"failover_test_static_ip": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
+			"target_static_ip": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 
-						"target_static_ip": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
+			"failover_test_subnet_name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 
-						"failover_test_subnet_name": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
+			"target_subnet_name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 
-						"target_subnet_name": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
+			"failover_test_public_ip_address_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     false,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
-						"failover_test_public_ip_address_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: azure.ValidateResourceID,
-						},
-
-						"recovery_load_balancer_backend_address_pool_ids": {
-							Type:     pluginsdk.TypeSet,
-							Optional: true,
-							Elem: &pluginsdk.Schema{
-								Type:         pluginsdk.TypeString,
-								ValidateFunc: loadbalancers.ValidateLoadBalancerBackendAddressPoolID,
-							},
-						},
-
-						"recovery_public_ip_address_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: azure.ValidateResourceID,
-						},
-
-						"is_primary": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-						},
-					},
+			"recovery_load_balancer_backend_address_pool_ids": {
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: loadbalancers.ValidateLoadBalancerBackendAddressPoolID,
 				},
+			},
+
+			"recovery_public_ip_address_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: azure.ValidateResourceID,
 			},
 		},
 	}
-
-	if !features.FivePointOh() {
-		nicSchema.Schema["ip_configuration"].Computed = true
-
-		nicSchema.Schema["failover_test_static_ip"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		}
-
-		nicSchema.Schema["target_static_ip"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		}
-
-		nicSchema.Schema["failover_test_subnet_name"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		}
-
-		nicSchema.Schema["failover_test_subnet_name"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		}
-
-		nicSchema.Schema["target_subnet_name"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		}
-
-		nicSchema.Schema["failover_test_public_ip_address_id"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: azure.ValidateResourceID,
-		}
-
-		nicSchema.Schema["recovery_load_balancer_backend_address_pool_ids"] = &pluginsdk.Schema{
-			Deprecated: "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:       pluginsdk.TypeSet,
-			Optional:   true,
-			Computed:   true,
-			Elem: &pluginsdk.Schema{
-				Type:         pluginsdk.TypeString,
-				ValidateFunc: loadbalancers.ValidateLoadBalancerBackendAddressPoolID,
-			},
-		}
-
-		nicSchema.Schema["recovery_public_ip_address_id"] = &pluginsdk.Schema{
-			Deprecated:   "this property has been deprecated in favour of `network_interface.ip_configuration`",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			Computed:     true,
-			ValidateFunc: azure.ValidateResourceID,
-		}
-	}
-	return nicSchema
 }
 
 func diskEncryptionResource() *pluginsdk.Resource {
@@ -639,16 +554,39 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 		targetAvailabilitySetID = nil
 	}
 
-	nicList := d.Get("network_interface").([]interface{})
+	nicList := d.Get("network_interface").(*pluginsdk.Set).List()
 	vmNics := make([]replicationprotecteditems.VMNicInputDetails, 0, len(nicList))
 	for _, raw := range nicList {
 		vmNicInput := raw.(map[string]interface{})
 		sourceNicId := vmNicInput["source_network_interface_id"].(string)
+		targetStaticIp := vmNicInput["target_static_ip"].(string)
+		targetSubnetName := vmNicInput["target_subnet_name"].(string)
+		recoveryPublicIPAddressID := vmNicInput["recovery_public_ip_address_id"].(string)
+		testStaticIp := vmNicInput["failover_test_static_ip"].(string)
+		testSubNetName := vmNicInput["failover_test_subnet_name"].(string)
+		testPublicIpAddressID := vmNicInput["failover_test_public_ip_address_id"].(string)
+
+		var recoveryLoadBalancerBackendPoolIds *[]string
+		if ids, ok := vmNicInput["recovery_load_balancer_backend_address_pool_ids"].(*schema.Set); ok && ids.Len() > 0 {
+			recoveryLoadBalancerBackendPoolIds = utils.ExpandStringSlice(ids.List())
+		}
+
 		nicId := findNicId(state, sourceNicId)
 		if nicId == nil {
 			return fmt.Errorf("updating replicated vm %s (vault %s): Trying to update NIC that is not known by Azure %s", name, vaultName, sourceNicId)
 		}
-		ipConfig := expandSiteRecoveryReplicatedVMIPConfig(vmNicInput)
+		ipConfig := []replicationprotecteditems.IPConfigInputDetails{
+			{
+				RecoverySubnetName:              &targetSubnetName,
+				RecoveryStaticIPAddress:         &targetStaticIp,
+				RecoveryLBBackendAddressPoolIds: recoveryLoadBalancerBackendPoolIds,
+				RecoveryPublicIPAddressId:       &recoveryPublicIPAddressID,
+				TfoStaticIPAddress:              &testStaticIp,
+				TfoPublicIPAddressId:            &testPublicIpAddressID,
+				TfoSubnetName:                   &testSubNetName,
+				IsPrimary:                       utils.Bool(true), // currently we can only set one IPconfig for a nic, so we dont need to expose this to users.
+			},
+		}
 		vmNics = append(vmNics, replicationprotecteditems.VMNicInputDetails{
 			NicId:     nicId,
 			IPConfigs: &ipConfig,
@@ -973,38 +911,32 @@ func resourceSiteRecoveryReplicatedItemRead(d *pluginsdk.ResourceData, meta inte
 						nicOutput["source_network_interface_id"] = *nic.SourceNicArmId
 					}
 					if nic.IPConfigs != nil && len(*(nic.IPConfigs)) > 0 {
-						nicOutput["ip_configuration"] = flattenSiteRecoveryReplicatedVMIPConfig(nic.IPConfigs)
-						if !features.FivePointOh() {
-							ipConfig := (*(nic.IPConfigs))[0]
-							if ipConfig.RecoveryStaticIPAddress != nil {
-								nicOutput["target_static_ip"] = *ipConfig.RecoveryStaticIPAddress
-							}
-							if ipConfig.RecoverySubnetName != nil {
-								nicOutput["target_subnet_name"] = *ipConfig.RecoverySubnetName
-							}
-							if ipConfig.RecoveryLBBackendAddressPoolIds != nil {
-								nicOutput["recovery_load_balancer_backend_address_pool_ids"] = schema.NewSet(schema.HashString, utils.FlattenStringSlice(ipConfig.RecoveryLBBackendAddressPoolIds))
-							}
-							if ipConfig.RecoveryPublicIPAddressId != nil {
-								nicOutput["recovery_public_ip_address_id"] = *ipConfig.RecoveryPublicIPAddressId
-							}
-							if ipConfig.TfoStaticIPAddress != nil {
-								nicOutput["failover_test_static_ip"] = *ipConfig.TfoStaticIPAddress
-							}
-							if ipConfig.TfoSubnetName != nil {
-								nicOutput["failover_test_subnet_name"] = *ipConfig.TfoSubnetName
-							}
-							if ipConfig.TfoPublicIPAddressId != nil {
-								nicOutput["failover_test_public_ip_address_id"] = *ipConfig.TfoPublicIPAddressId
-							}
+						ipConfig := (*(nic.IPConfigs))[0]
+						if ipConfig.RecoveryStaticIPAddress != nil {
+							nicOutput["target_static_ip"] = *ipConfig.RecoveryStaticIPAddress
+						}
+						if ipConfig.RecoverySubnetName != nil {
+							nicOutput["target_subnet_name"] = *ipConfig.RecoverySubnetName
+						}
+						if ipConfig.RecoveryLBBackendAddressPoolIds != nil {
+							nicOutput["recovery_load_balancer_backend_address_pool_ids"] = schema.NewSet(schema.HashString, utils.FlattenStringSlice(ipConfig.RecoveryLBBackendAddressPoolIds))
+						}
+						if ipConfig.RecoveryPublicIPAddressId != nil {
+							nicOutput["recovery_public_ip_address_id"] = *ipConfig.RecoveryPublicIPAddressId
+						}
+						if ipConfig.TfoStaticIPAddress != nil {
+							nicOutput["failover_test_static_ip"] = *ipConfig.TfoStaticIPAddress
+						}
+						if ipConfig.TfoSubnetName != nil {
+							nicOutput["failover_test_subnet_name"] = *ipConfig.TfoSubnetName
+						}
+						if ipConfig.TfoPublicIPAddressId != nil {
+							nicOutput["failover_test_public_ip_address_id"] = *ipConfig.TfoPublicIPAddressId
 						}
 					}
 					nicsOutput = append(nicsOutput, nicOutput)
 				}
-
-				if err := d.Set("network_interface", nicsOutput); err != nil {
-					return fmt.Errorf("setting `network_interface`: %v", err)
-				}
+				d.Set("network_interface", pluginsdk.NewSet(pluginsdk.HashResource(networkInterfaceResource()), nicsOutput))
 			}
 		}
 	}
@@ -1125,84 +1057,6 @@ func waitForReplicationToBeHealthyRefreshFunc(d *pluginsdk.ResourceData, meta in
 		}
 		return *resp.Model, *resp.Model.Properties.ReplicationHealth, nil
 	}
-}
-
-func expandSiteRecoveryReplicatedVMIPConfig(nicInput map[string]interface{}) []replicationprotecteditems.IPConfigInputDetails {
-	output := []replicationprotecteditems.IPConfigInputDetails{}
-	ipConfigs := nicInput["ip_configuration"].([]interface{})
-	if len(ipConfigs) > 0 {
-		for _, ipConfig := range ipConfigs {
-			ipConfig := ipConfig.(map[string]interface{})
-			var recoveryLoadBalancerBackendPoolIds *[]string
-			if ids, ok := nicInput["recovery_load_balancer_backend_address_pool_ids"].(*schema.Set); ok && ids.Len() > 0 {
-				recoveryLoadBalancerBackendPoolIds = utils.ExpandStringSlice(ids.List())
-			}
-			output = append(output, replicationprotecteditems.IPConfigInputDetails{
-				IPConfigName:                    pointer.To(ipConfig["name"].(string)),
-				RecoverySubnetName:              pointer.To(ipConfig["target_subnet_name"].(string)),
-				RecoveryStaticIPAddress:         pointer.To(ipConfig["target_static_ip"].(string)),
-				RecoveryLBBackendAddressPoolIds: recoveryLoadBalancerBackendPoolIds,
-				RecoveryPublicIPAddressId:       pointer.To(ipConfig["recovery_public_ip_address_id"].(string)),
-				TfoStaticIPAddress:              pointer.To(ipConfig["failover_test_static_ip"].(string)),
-				TfoSubnetName:                   pointer.To(ipConfig["failover_test_subnet_name"].(string)),
-				TfoPublicIPAddressId:            pointer.To(ipConfig["failover_test_public_ip_address_id"].(string)),
-				IsPrimary:                       pointer.To(ipConfig["is_primary"].(bool)),
-			})
-		}
-		return output
-	}
-
-	if !features.FivePointOh() {
-		targetStaticIp := nicInput["target_static_ip"].(string)
-		targetSubnetName := nicInput["target_subnet_name"].(string)
-		recoveryPublicIPAddressID := nicInput["recovery_public_ip_address_id"].(string)
-		testStaticIp := nicInput["failover_test_static_ip"].(string)
-		testSubNetName := nicInput["failover_test_subnet_name"].(string)
-		testPublicIpAddressID := nicInput["failover_test_public_ip_address_id"].(string)
-
-		var recoveryLoadBalancerBackendPoolIds *[]string
-		if ids, ok := nicInput["recovery_load_balancer_backend_address_pool_ids"].(*schema.Set); ok && ids.Len() > 0 {
-			recoveryLoadBalancerBackendPoolIds = utils.ExpandStringSlice(ids.List())
-		}
-
-		if targetStaticIp != "" || targetSubnetName != "" || recoveryPublicIPAddressID != "" || testSubNetName != "" || testStaticIp != "" || testPublicIpAddressID != "" {
-			return append(output, replicationprotecteditems.IPConfigInputDetails{
-				RecoverySubnetName:              &targetSubnetName,
-				RecoveryStaticIPAddress:         &targetStaticIp,
-				RecoveryLBBackendAddressPoolIds: recoveryLoadBalancerBackendPoolIds,
-				RecoveryPublicIPAddressId:       &recoveryPublicIPAddressID,
-				TfoStaticIPAddress:              &testStaticIp,
-				TfoPublicIPAddressId:            &testPublicIpAddressID,
-				TfoSubnetName:                   &testSubNetName,
-				IsPrimary:                       utils.Bool(true),
-			})
-		}
-	}
-	return output
-}
-
-func flattenSiteRecoveryReplicatedVMIPConfig(ipConfigs *[]replicationprotecteditems.IPConfigDetails) []interface{} {
-	outputs := make([]interface{}, 0)
-
-	if ipConfigs != nil {
-		for _, ipConfig := range *ipConfigs {
-			output := map[string]interface{}{
-				"name":                               pointer.From(ipConfig.Name),
-				"is_primary":                         pointer.From(ipConfig.IsPrimary),
-				"target_static_ip":                   pointer.From(ipConfig.RecoveryStaticIPAddress),
-				"target_subnet_name":                 pointer.From(ipConfig.RecoverySubnetName),
-				"recovery_public_ip_address_id":      pointer.From(ipConfig.RecoveryPublicIPAddressId),
-				"failover_test_static_ip":            pointer.From(ipConfig.TfoStaticIPAddress),
-				"failover_test_subnet_name":          pointer.From(ipConfig.TfoSubnetName),
-				"failover_test_public_ip_address_id": pointer.From(ipConfig.TfoPublicIPAddressId),
-			}
-			if ipConfig.RecoveryLBBackendAddressPoolIds != nil {
-				output["recovery_load_balancer_backend_address_pool_ids"] = utils.FlattenStringSlice(ipConfig.RecoveryLBBackendAddressPoolIds)
-			}
-			outputs = append(outputs, output)
-		}
-	}
-	return outputs
 }
 
 func expandDiskEncryption(diskEncryptionInfoList []interface{}) *replicationprotecteditems.DiskEncryptionInfo {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -401,14 +401,6 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The property `minimum_tls_version` no longer accepts `1.0` or `1.1` as a value.
 
-### `azurerm_site_recovery_replicated_vm`
-
-* The property `network_interface.target_static_ip` has been removed in favour of the `network_interface.ip_configuration.target_statc_ip` property.
-* The property `network_interface.target_subnet_name` has been removed in favour of the `network_interface.ip_configuration.target_static_ip` property.
-* The property `network_interface.recovery_load_balancer_backend_address_pool_ids` has been removed in favour of the `network_interface.ip_configuration.recovery_load_balancer_backend_address_pool_ids` property.
-* The property `network_interface.recovery_public_ip_address_id` has been removed in favour of the `network_interface.ip_configuration.recovery_public_ip_address_id` property.
-* The property `network_interface.ip_configuration.name` is a new required property, it must be as same as the name of the ip configuration of network interface from the source VM.
-
 ### `azurerm_storage_account`
 
 * The deprecated `queue_properties` block has been removed and superseded by the `azurerm_storage_account_queue_properties` resource.

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -196,6 +196,7 @@ resource "azurerm_site_recovery_replicated_vm" "vm-replication" {
   target_resource_group_id                = azurerm_resource_group.secondary.id
   target_recovery_fabric_id               = azurerm_site_recovery_fabric.secondary.id
   target_recovery_protection_container_id = azurerm_site_recovery_protection_container.secondary.id
+
   managed_disk {
     disk_id                    = azurerm_virtual_machine.vm.storage_os_disk[0].managed_disk_id
     staging_storage_account_id = azurerm_storage_account.primary.id
@@ -203,13 +204,11 @@ resource "azurerm_site_recovery_replicated_vm" "vm-replication" {
     target_disk_type           = "Premium_LRS"
     target_replica_disk_type   = "Premium_LRS"
   }
+
   network_interface {
-    source_network_interface_id = azurerm_network_interface.vm.id
-    ip_configuration {
-      name                          = "vm"
-      target_subnet_name            = azurerm_subnet.secondary.name
-      recovery_public_ip_address_id = azurerm_public_ip.secondary.id
-    }
+    source_network_interface_id   = azurerm_network_interface.vm.id
+    target_subnet_name            = azurerm_subnet.secondary.name
+    recovery_public_ip_address_id = azurerm_public_ip.secondary.id
   }
 
   depends_on = [
@@ -306,16 +305,6 @@ A `unmanaged_disk` block supports the following:
 A `network_interface` block supports the following:
 
 * `source_network_interface_id` - (Optional) (Required if the network_interface block is specified) Id source network interface.
-
-* `ip_configuration` - (Optional) IP configuration to assign when a failover is done. One or more `ip_configuration` block as defined below.
-
----
-
-The `ip_configuration` block supports the following:
-
-* `name` - (Required) Name of the IP configuration, must be consistent with the name of IP configuration of source VM.
-
-* `is_primary` - (Optional) Whether this IP configuration is primary? Must be specified if there is more than 1 `ip_configuration`.
 
 * `target_static_ip` - (Optional) Static IP to assign when a failover is done.
 


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-azurerm#28833

We're unable to find testing evidence of this running in 5.0 beta mode and the deprecation messages are incomplete.

As discussed internally, we're going to revert this until after today's release out of an abundance of caution.