### PR TITLE
azurerm_monitor_scheduled_query_rules_alert_v2: add support for email_subject within action block

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -48,6 +48,7 @@ type ScheduledQueryRulesAlertV2Model struct {
 type ScheduledQueryRulesAlertV2ActionsModel struct {
 	ActionGroups     []string          `tfschema:"action_groups"`
 	CustomProperties map[string]string `tfschema:"custom_properties"`
+	EmailSubject     string            `tfschema:"email_subject"`
 }
 
 type ScheduledQueryRulesAlertV2CriteriaModel struct {
@@ -293,6 +294,11 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 						Elem: &pluginsdk.Schema{
 							Type: pluginsdk.TypeString,
 						},
+					},
+					"email_subject": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
 					},
 				},
 			},
@@ -763,6 +769,16 @@ func expandScheduledQueryRulesAlertV2ActionsModel(inputList []ScheduledQueryRule
 		CustomProperties: &input.CustomProperties,
 	}
 
+	if input.EmailSubject != "" {
+		m := map[string]string{
+			"Email.Subject": input.EmailSubject,
+		}
+		output.ActionProperties = &m
+	} else {
+		m := map[string]string{}
+		output.ActionProperties = &m
+	}
+
 	return &output
 }
 
@@ -842,6 +858,12 @@ func flattenScheduledQueryRulesAlertV2ActionsModel(input *scheduledqueryrules.Ac
 
 	if input.CustomProperties != nil {
 		output.CustomProperties = *input.CustomProperties
+	}
+
+	if input.ActionProperties != nil {
+		if s, ok := (*input.ActionProperties)["Email.Subject"]; ok {
+			output.EmailSubject = s
+		}
 	}
 
 	return append(outputList, output)

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
@@ -55,6 +55,7 @@ func TestAccMonitorScheduledQueryRulesAlertV2_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("action.0.email_subject").HasValue("acctest subject v1"),
 			),
 		},
 		data.ImportStep(),
@@ -69,6 +70,7 @@ func TestAccMonitorScheduledQueryRulesAlertV2_update(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("action.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -76,6 +78,7 @@ func TestAccMonitorScheduledQueryRulesAlertV2_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("action.0.email_subject").HasValue("acctest subject v1"),
 			),
 		},
 		data.ImportStep(),
@@ -83,6 +86,7 @@ func TestAccMonitorScheduledQueryRulesAlertV2_update(t *testing.T) {
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("action.0.email_subject").HasValue("acctest subject v2"),
 			),
 		},
 		data.ImportStep(),
@@ -305,6 +309,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "test" {
     custom_properties = {
       key = "value"
     }
+    email_subject = "acctest subject v1"
   }
 
   tags = {
@@ -363,6 +368,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "test" {
       key  = "value"
       key2 = "value2"
     }
+    email_subject = "acctest subject v2"
   }
 
   tags = {

--- a/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
@@ -87,6 +87,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "example" {
       key  = "value"
       key2 = "value2"
     }
+    email_subject = "Email Header"
   }
 
   identity {
@@ -163,6 +164,8 @@ An `action` block supports the following:
 * `action_groups` - (Optional) List of Action Group resource IDs to invoke when the alert fires.
 
 * `custom_properties` - (Optional) Specifies the properties of an alert payload.
+
+* `email_subject` - (Optional) Custom subject override for all email ids in Azure action group.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR adds support for setting a custom `email_subject` inside the `action` block of the `azurerm_monitor_scheduled_query_rules_alert_v2` resource.

This enhancement allows users to customize the subject line of alert emails, aligning the Terraform resource with Azure Monitor’s capability to override the default subject. Without this property, all alerts sent by Azure Monitor use a generic subject line, making it more difficult for teams to triage multiple alerts efficiently.

Reference: [Azure Monitor documentation on customizing email subject lines](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-customize-email-subject-how-to#sample-template)

This is a **non-breaking enhancement**:
- The argument is optional.
- Default behavior remains unchanged if the property is not set.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added documentation as required, including an example of using `email_subject` inside the `action` block.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

**Acceptance Testing**
Acceptance tests were run locally:

```go
make testacc TEST="./internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go"
```
**Results:**
All tests passed successfully. Key scenarios covered include:
- Creating a scheduled query rule with a custom `email_subject`.
- Updating the `email_subject` to a new value.
- Removing the `email_subject` to verify default behavior is restored.

This ensures the new argument is handled correctly across create, update, and delete operations.

**Evidence:**
A full test run log has been attached: [test.log](https://github.com/user-attachments/files/22289164/test.log)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_scheduled_query_rules_alert_v2` – add support for `email_subject` within `action` block [GH-30540]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Enhancement


## Related Issue(s)
Fixes #30540

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
