### PR TITLE
replace all references to `azurerm_storage_container.*.resource_manager_id` with `id`

### DIFF
--- a/internal/services/applicationinsights/application_insights_workbook_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource_test.go
@@ -264,7 +264,7 @@ resource "azurerm_application_insights_workbook" "test" {
   source_id            = lower(azurerm_resource_group.test.id)
   category             = "workbook1"
   description          = "description1"
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
 
   identity {
     type = "UserAssigned"
@@ -339,7 +339,7 @@ resource "azurerm_application_insights_workbook" "test" {
   source_id            = "azure monitor"
   category             = "workbook2"
   description          = "description2"
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
 
   identity {
     type = "UserAssigned"

--- a/internal/services/costmanagement/billing_account_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/billing_account_cost_management_export_resource_test.go
@@ -145,7 +145,7 @@ resource "azurerm_billing_account_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
 
@@ -193,7 +193,7 @@ resource "azurerm_billing_account_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root/updated"
   }
 
@@ -218,7 +218,7 @@ resource "azurerm_billing_account_cost_management_export" "import" {
   recurrence_period_end_date   = azurerm_billing_account_cost_management_export.test.recurrence_period_start_date
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
 

--- a/internal/services/costmanagement/resource_group_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/resource_group_cost_management_export_resource_test.go
@@ -129,7 +129,7 @@ resource "azurerm_resource_group_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
   export_data_options {
@@ -174,7 +174,7 @@ resource "azurerm_resource_group_cost_management_export" "test" {
   file_format                  = "Csv"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
   export_data_options {
@@ -198,7 +198,7 @@ resource "azurerm_resource_group_cost_management_export" "import" {
   recurrence_period_end_date   = azurerm_resource_group_cost_management_export.test.recurrence_period_start_date
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
 

--- a/internal/services/costmanagement/subscription_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/subscription_cost_management_export_resource_test.go
@@ -134,7 +134,7 @@ resource "azurerm_subscription_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
 
@@ -184,7 +184,7 @@ resource "azurerm_subscription_cost_management_export" "test" {
   recurrence_period_end_date   = "%sT00:00:00Z"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
 
@@ -209,7 +209,7 @@ resource "azurerm_subscription_cost_management_export" "import" {
   recurrence_period_end_date   = azurerm_subscription_cost_management_export.test.recurrence_period_start_date
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.test.resource_manager_id
+    container_id     = azurerm_storage_container.test.id
     root_folder_path = "/root"
   }
 

--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource_test.go
@@ -147,7 +147,7 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_machine_learning_datastore_blobstorage" "test" {
   name                 = "accdatastore%[2]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
   account_key          = azurerm_storage_account.test.primary_access_key
 }
 `, template, data.RandomInteger)
@@ -167,7 +167,7 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_machine_learning_datastore_blobstorage" "test" {
   name                       = "accdatastore%[2]d"
   workspace_id               = azurerm_machine_learning_workspace.test.id
-  storage_container_id       = azurerm_storage_container.test.resource_manager_id
+  storage_container_id       = azurerm_storage_container.test.id
   service_data_auth_identity = "WorkspaceSystemAssignedIdentity"
 }
 `, template, data.RandomInteger)
@@ -223,7 +223,7 @@ data "azurerm_storage_account_sas" "test" {
 resource "azurerm_machine_learning_datastore_blobstorage" "test" {
   name                       = "accdatastore%[2]d"
   workspace_id               = azurerm_machine_learning_workspace.test.id
-  storage_container_id       = azurerm_storage_container.test.resource_manager_id
+  storage_container_id       = azurerm_storage_container.test.id
   service_data_auth_identity = "WorkspaceUserAssignedIdentity"
   shared_access_signature    = data.azurerm_storage_account_sas.test.sas
   account_key                = azurerm_storage_account.test.primary_access_key
@@ -280,7 +280,7 @@ data "azurerm_storage_account_sas" "test" {
 resource "azurerm_machine_learning_datastore_blobstorage" "test" {
   name                    = "accdatastore%[2]d"
   workspace_id            = azurerm_machine_learning_workspace.test.id
-  storage_container_id    = azurerm_storage_container.test.resource_manager_id
+  storage_container_id    = azurerm_storage_container.test.id
   shared_access_signature = data.azurerm_storage_account_sas.test.sas
 }
 `, template, data.RandomInteger)

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
@@ -138,7 +138,7 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_machine_learning_datastore_datalake_gen2" "test" {
   name                 = "accdatastore%[2]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
 }
 `, template, data.RandomInteger)
 }
@@ -168,7 +168,7 @@ resource "azuread_service_principal_password" "test" {
 resource "azurerm_machine_learning_datastore_datalake_gen2" "test" {
   name                 = "accdatastore%[2]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
   tenant_id            = azuread_service_principal.test.application_tenant_id
   client_id            = azuread_service_principal.test.client_id
   client_secret        = azuread_service_principal_password.test.value
@@ -190,7 +190,7 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_machine_learning_datastore_datalake_gen2" "test" {
   name                 = "acctestdatastore%[2]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
 }
 
 provider "azurerm-alt" {
@@ -229,7 +229,7 @@ resource "azurerm_storage_container" "testalt" {
 resource "azurerm_machine_learning_datastore_datalake_gen2" "crosssub" {
   name                 = "acctestdcrosssub%[5]d"
   workspace_id         = azurerm_machine_learning_workspace.test.id
-  storage_container_id = azurerm_storage_container.testalt.resource_manager_id
+  storage_container_id = azurerm_storage_container.testalt.id
 }
 	`, template, data.RandomInteger, os.Getenv("ARM_SUBSCRIPTION_ID_ALT"), data.Locations.Primary, data.RandomIntOfLength(10))
 }

--- a/internal/services/storage/storage_container_immutability_policy_resource_test.go
+++ b/internal/services/storage/storage_container_immutability_policy_resource_test.go
@@ -134,7 +134,7 @@ func (r StorageContainerImmutabilityPolicyResource) basic(data acceptance.TestDa
 %[1]s
 
 resource "azurerm_storage_container_immutability_policy" "test" {
-  storage_container_resource_manager_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_resource_manager_id = azurerm_storage_container.test.id
   immutability_period_in_days           = 1
 }
 `, template)
@@ -146,7 +146,7 @@ func (r StorageContainerImmutabilityPolicyResource) completeUnlocked(data accept
 %[1]s
 
 resource "azurerm_storage_container_immutability_policy" "test" {
-  storage_container_resource_manager_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_resource_manager_id = azurerm_storage_container.test.id
   immutability_period_in_days           = 2
   protected_append_writes_all_enabled   = false
   protected_append_writes_enabled       = true
@@ -160,7 +160,7 @@ func (r StorageContainerImmutabilityPolicyResource) completeLocked(data acceptan
 %[1]s
 
 resource "azurerm_storage_container_immutability_policy" "test" {
-  storage_container_resource_manager_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_resource_manager_id = azurerm_storage_container.test.id
   immutability_period_in_days           = 2
   protected_append_writes_all_enabled   = true
   protected_append_writes_enabled       = false

--- a/internal/services/storagecache/hpc_cache_blob_target_resource_test.go
+++ b/internal/services/storagecache/hpc_cache_blob_target_resource_test.go
@@ -137,7 +137,7 @@ resource "azurerm_hpc_cache_blob_target" "test" {
   name                 = "acctest-HPCCTGT-%s"
   resource_group_name  = azurerm_resource_group.test.name
   cache_name           = azurerm_hpc_cache.test.name
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
   namespace_path       = "/blob_storage1"
   access_policy_name   = "default"
 }
@@ -152,7 +152,7 @@ resource "azurerm_hpc_cache_blob_target" "test" {
   name                 = "acctest-HPCCTGT-%s"
   resource_group_name  = azurerm_resource_group.test.name
   cache_name           = azurerm_hpc_cache.test.name
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
   namespace_path       = "/blob_storage2"
 }
 `, r.cacheTemplate(data), data.RandomString)
@@ -181,7 +181,7 @@ resource "azurerm_hpc_cache_blob_target" "test" {
   name                 = "acctest-HPCCTGT-%s"
   resource_group_name  = azurerm_resource_group.test.name
   cache_name           = azurerm_hpc_cache.test.name
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
   namespace_path       = "/blob_storage1"
   access_policy_name   = azurerm_hpc_cache_access_policy.test.name
 }
@@ -212,7 +212,7 @@ resource "azurerm_hpc_cache_blob_target" "test" {
   name                 = "acctest-HPCCTGT-%s"
   resource_group_name  = azurerm_resource_group.test.name
   cache_name           = azurerm_hpc_cache.test.name
-  storage_container_id = azurerm_storage_container.test.resource_manager_id
+  storage_container_id = azurerm_storage_container.test.id
   namespace_path       = "/blob_storage1"
   access_policy_name   = azurerm_hpc_cache_access_policy.test.name
 }

--- a/internal/services/storagecache/managed_lustre_file_system_resource_test.go
+++ b/internal/services/storagecache/managed_lustre_file_system_resource_test.go
@@ -342,8 +342,8 @@ resource "azurerm_managed_lustre_file_system" "test" {
   }
 
   hsm_setting {
-    container_id         = azurerm_storage_container.test.resource_manager_id
-    logging_container_id = azurerm_storage_container.test2.resource_manager_id
+    container_id         = azurerm_storage_container.test.id
+    logging_container_id = azurerm_storage_container.test2.id
     import_prefix        = "/"
   }
 
@@ -433,8 +433,8 @@ resource "azurerm_managed_lustre_file_system" "test" {
   }
 
   hsm_setting {
-    container_id         = azurerm_storage_container.test.resource_manager_id
-    logging_container_id = azurerm_storage_container.test2.resource_manager_id
+    container_id         = azurerm_storage_container.test.id
+    logging_container_id = azurerm_storage_container.test2.id
     import_prefix        = "/"
   }
 

--- a/website/docs/r/billing_account_cost_management_export.html.markdown
+++ b/website/docs/r/billing_account_cost_management_export.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_billing_account_cost_management_export" "example" {
   file_format                  = "Csv"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.example.resource_manager_id
+    container_id     = azurerm_storage_container.example.id
     root_folder_path = "/root/updated"
   }
 

--- a/website/docs/r/hpc_cache_blob_target.html.markdown
+++ b/website/docs/r/hpc_cache_blob_target.html.markdown
@@ -78,7 +78,7 @@ resource "azurerm_hpc_cache_blob_target" "example" {
   name                 = "examplehpccblobtarget"
   resource_group_name  = azurerm_resource_group.example.name
   cache_name           = azurerm_hpc_cache.example.name
-  storage_container_id = azurerm_storage_container.example.resource_manager_id
+  storage_container_id = azurerm_storage_container.example.id
   namespace_path       = "/blob_storage"
 }
 ```

--- a/website/docs/r/machine_learning_datastore_blobstorage.html.markdown
+++ b/website/docs/r/machine_learning_datastore_blobstorage.html.markdown
@@ -69,7 +69,7 @@ resource "azurerm_storage_container" "example" {
 resource "azurerm_machine_learning_datastore_blobstorage" "example" {
   name                 = "example-datastore"
   workspace_id         = azurerm_machine_learning_workspace.example.id
-  storage_container_id = azurerm_storage_container.example.resource_manager_id
+  storage_container_id = azurerm_storage_container.example.id
   account_key          = azurerm_storage_account.example.primary_access_key
 }
 ```

--- a/website/docs/r/machine_learning_datastore_datalake_gen2.html.markdown
+++ b/website/docs/r/machine_learning_datastore_datalake_gen2.html.markdown
@@ -69,7 +69,7 @@ resource "azurerm_storage_container" "example" {
 resource "azurerm_machine_learning_datastore_datalake_gen2" "example" {
   name                 = "example-datastore"
   workspace_id         = azurerm_machine_learning_workspace.example.id
-  storage_container_id = azurerm_storage_container.example.resource_manager_id
+  storage_container_id = azurerm_storage_container.example.id
 }
 ```
 

--- a/website/docs/r/resource_group_cost_management_export.html.markdown
+++ b/website/docs/r/resource_group_cost_management_export.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_resource_group_cost_management_export" "example" {
   file_format                  = "Csv"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.example.resource_manager_id
+    container_id     = azurerm_storage_container.example.id
     root_folder_path = "/root/updated"
   }
 

--- a/website/docs/r/storage_container_immutability_policy.html.markdown
+++ b/website/docs/r/storage_container_immutability_policy.html.markdown
@@ -37,7 +37,7 @@ resource "azurerm_storage_container" "example" {
 }
 
 resource "azurerm_storage_container_immutability_policy" "example" {
-  storage_container_resource_manager_id = azurerm_storage_container.example.resource_manager_id
+  storage_container_resource_manager_id = azurerm_storage_container.example.id
   immutability_period_in_days           = 14
   protected_append_writes_all_enabled   = false
   protected_append_writes_enabled       = true

--- a/website/docs/r/subscription_cost_management_export.html.markdown
+++ b/website/docs/r/subscription_cost_management_export.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_subscription_cost_management_export" "example" {
   file_format                  = "Csv"
 
   export_data_storage_location {
-    container_id     = azurerm_storage_container.example.resource_manager_id
+    container_id     = azurerm_storage_container.example.id
     root_folder_path = "/root/updated"
   }
 


### PR DESCRIPTION
`resource_manager_id` is deprecated in favour of `id`

fixes #30629