### PR TITLE
New Resource: `azurerm_kubernetes_cluster_connection`

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -309,7 +309,7 @@ service/service-bus:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_servicebus_((.|\n)*)###'
 
 service/service-connector:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(app_service_connection|function_app_connection|spring_cloud_connection)((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(app_service_connection|function_app_connection|kubernetes_cluster_connection|spring_cloud_connection)((.|\n)*)###'
 
 service/service-fabric:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_service_fabric_cluster((.|\n)*)###'

--- a/internal/services/serviceconnector/kubernetes_cluster_connection_resource.go
+++ b/internal/services/serviceconnector/kubernetes_cluster_connection_resource.go
@@ -1,0 +1,312 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package serviceconnector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2024-04-01/servicelinker"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+var _ sdk.ResourceWithUpdate = KubernetesClusterConnectorResource{}
+
+type KubernetesClusterConnectorResource struct{}
+
+type KubernetesClusterConnectorResourceModel struct {
+	Name                string             `tfschema:"name"`
+	KubernetesClusterId string             `tfschema:"kubernetes_cluster_id"`
+	TargetResourceId    string             `tfschema:"target_resource_id"`
+	ClientType          string             `tfschema:"client_type"`
+	AuthInfo            []AuthInfoModel    `tfschema:"authentication"`
+	VnetSolution        string             `tfschema:"vnet_solution"`
+	SecretStore         []SecretStoreModel `tfschema:"secret_store"`
+}
+
+func (r KubernetesClusterConnectorResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"kubernetes_cluster_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateKubernetesClusterID,
+		},
+
+		"target_resource_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
+
+		"client_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(servicelinker.ClientTypeNone),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(servicelinker.ClientTypeNone),
+				string(servicelinker.ClientTypeDotnet),
+				string(servicelinker.ClientTypeJava),
+				string(servicelinker.ClientTypePython),
+				string(servicelinker.ClientTypeGo),
+				string(servicelinker.ClientTypePhp),
+				string(servicelinker.ClientTypeRuby),
+				string(servicelinker.ClientTypeDjango),
+				string(servicelinker.ClientTypeNodejs),
+				string(servicelinker.ClientTypeSpringBoot),
+			}, false),
+		},
+
+		"secret_store": secretStoreSchema(),
+
+		"vnet_solution": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(servicelinker.VNetSolutionTypeServiceEndpoint),
+				string(servicelinker.VNetSolutionTypePrivateLink),
+			}, false),
+		},
+
+		"authentication": authInfoSchema(),
+	}
+}
+
+func (r KubernetesClusterConnectorResource) Attributes() map[string]*schema.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r KubernetesClusterConnectorResource) ModelObject() interface{} {
+	return &KubernetesClusterConnectorResourceModel{}
+}
+
+func (r KubernetesClusterConnectorResource) ResourceType() string {
+	return "azurerm_kubernetes_cluster_connection"
+}
+
+func (r KubernetesClusterConnectorResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model KubernetesClusterConnectorResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			client := metadata.Client.ServiceConnector.ServiceLinkerClient
+
+			id := servicelinker.NewScopedLinkerID(model.KubernetesClusterId, model.Name)
+			existing, err := client.LinkerGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			authInfo, err := expandServiceConnectorAuthInfoForCreate(model.AuthInfo)
+			if err != nil {
+				return fmt.Errorf("expanding `authentication`: %+v", err)
+			}
+
+			serviceConnectorProperties := servicelinker.LinkerProperties{
+				AuthInfo: authInfo,
+			}
+
+			if storageAccountId, err := commonids.ParseStorageAccountID(model.TargetResourceId); err == nil {
+				targetResourceId := fmt.Sprintf("%s/blobServices/default", storageAccountId.ID())
+				serviceConnectorProperties.TargetService = servicelinker.AzureResource{
+					Id: &targetResourceId,
+				}
+			} else {
+				serviceConnectorProperties.TargetService = servicelinker.AzureResource{
+					Id: &model.TargetResourceId,
+				}
+			}
+
+			if model.SecretStore != nil {
+				secretStore := expandSecretStore(model.SecretStore)
+				serviceConnectorProperties.SecretStore = secretStore
+			}
+
+			if model.ClientType != "" {
+				clientType := servicelinker.ClientType(model.ClientType)
+				serviceConnectorProperties.ClientType = &clientType
+			}
+
+			if model.VnetSolution != "" {
+				vNetSolutionType := servicelinker.VNetSolutionType(model.VnetSolution)
+				vNetSolution := servicelinker.VNetSolution{
+					Type: &vNetSolutionType,
+				}
+				serviceConnectorProperties.VNetSolution = &vNetSolution
+			}
+
+			props := servicelinker.LinkerResource{
+				Id:         pointer.To(id.ID()),
+				Name:       pointer.To(model.Name),
+				Properties: serviceConnectorProperties,
+			}
+
+			if err := client.LinkerCreateOrUpdateThenPoll(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r KubernetesClusterConnectorResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ServiceConnector.ServiceLinkerClient
+			id, err := servicelinker.ParseScopedLinkerID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.LinkerGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			pwd := metadata.ResourceData.Get("authentication.0.secret").(string)
+
+			if model := resp.Model; model != nil {
+				props := model.Properties
+				if props.AuthInfo == nil || props.TargetService == nil {
+					return nil
+				}
+
+				state := KubernetesClusterConnectorResourceModel{
+					Name:                id.LinkerName,
+					KubernetesClusterId: id.ResourceUri,
+					TargetResourceId:    flattenTargetService(props.TargetService),
+					AuthInfo:            flattenServiceConnectorAuthInfo(props.AuthInfo, pwd),
+				}
+
+				if props.ClientType != nil {
+					state.ClientType = string(*props.ClientType)
+				}
+
+				if props.VNetSolution != nil && props.VNetSolution.Type != nil {
+					state.VnetSolution = string(*props.VNetSolution.Type)
+				}
+
+				if props.SecretStore != nil {
+					state.SecretStore = flattenSecretStore(*props.SecretStore)
+				}
+
+				return metadata.Encode(&state)
+			}
+			return nil
+		},
+	}
+}
+
+func (r KubernetesClusterConnectorResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ServiceConnector.LinksClient
+			id, err := links.ParseScopedLinkerID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting %s", *id)
+
+			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r KubernetesClusterConnectorResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ServiceConnector.LinksClient
+			id, err := links.ParseScopedLinkerID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var state KubernetesClusterConnectorResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			d := metadata.ResourceData
+			linkerProps := links.LinkerProperties{}
+
+			if d.HasChange("client_type") {
+				clientType := links.ClientType(state.ClientType)
+				linkerProps.ClientType = &clientType
+			}
+
+			if d.HasChange("vnet_solution") {
+				vnetSolutionType := links.VNetSolutionType(state.VnetSolution)
+				vnetSolution := links.VNetSolution{
+					Type: &vnetSolutionType,
+				}
+				linkerProps.VNetSolution = &vnetSolution
+			}
+
+			if d.HasChange("secret_store") {
+				linkerProps.SecretStore = pointer.To(links.SecretStore{KeyVaultId: expandSecretStore(state.SecretStore).KeyVaultId})
+			}
+
+			if d.HasChange("authentication") {
+				authInfo, err := expandServiceConnectorAuthInfoForUpdate(state.AuthInfo)
+				if err != nil {
+					return fmt.Errorf("expanding `authentication`: %+v", err)
+				}
+
+				linkerProps.AuthInfo = authInfo
+			}
+
+			props := links.LinkerPatch{
+				Properties: &linkerProps,
+			}
+
+			if err := client.LinkerUpdateThenPoll(ctx, *id, props); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r KubernetesClusterConnectorResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return servicelinker.ValidateScopedLinkerID
+}

--- a/internal/services/serviceconnector/kubernetes_cluster_connection_resource_test.go
+++ b/internal/services/serviceconnector/kubernetes_cluster_connection_resource_test.go
@@ -1,0 +1,462 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package serviceconnector_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2024-04-01/servicelinker"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ServiceConnectorKubernetesClusterResource struct{}
+
+func (r ServiceConnectorKubernetesClusterResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := servicelinker.ParseScopedLinkerID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ServiceConnector.ServiceLinkerClient.LinkerGet(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func TestAccServiceConnectorKubernetesClusterCosmosdb_secretAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_connection", "test")
+	r := ServiceConnectorKubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cosmosdbWithSecretAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("authentication"),
+	})
+}
+
+func TestAccServiceConnectorKubernetesClusterCosmosdb_servicePrincipalSecretAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_connection", "test")
+	r := ServiceConnectorKubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cosmosdbWithServicePrincipalSecretAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("authentication"),
+	})
+}
+
+func TestAccServiceConnectorKubernetesClusterCosmosdb_userAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_connection", "test")
+	r := ServiceConnectorKubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cosmosdbWithUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("authentication"),
+	})
+}
+
+func TestAccServiceConnectorKubernetesClusterStorageBlob_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_connection", "test")
+	r := ServiceConnectorKubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageBlob(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServiceConnectorKubernetesClusterStorageBlob_secretStore(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_connection", "test")
+	r := ServiceConnectorKubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.secretStore(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServiceConnectorKubernetesCluster_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_connection", "test")
+	r := ServiceConnectorKubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ServiceConnectorKubernetesClusterResource) storageBlob(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[3]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[3]d"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "standard_a2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_connection" "test" {
+  name                  = "acctestserviceconnector%[3]d"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  target_resource_id    = azurerm_storage_account.test.id
+  authentication {
+    type   = "secret"
+    name   = "foo"
+    secret = "bar"
+  }
+}
+`, data.Locations.Primary, data.RandomString, data.RandomInteger)
+}
+
+func (r ServiceConnectorKubernetesClusterResource) cosmosdbWithSecretAuth(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_kubernetes_cluster_connection" "test" {
+  name                  = "acctestserviceconnector%[2]d"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  target_resource_id    = azurerm_cosmosdb_sql_database.test.id
+  authentication {
+    type   = "secret"
+    name   = "foo"
+    secret = "bar"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ServiceConnectorKubernetesClusterResource) cosmosdbWithServicePrincipalSecretAuth(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%[2]s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_kubernetes_cluster_connection" "test" {
+  name                  = "acctestserviceconnector%[3]d"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  target_resource_id    = azurerm_cosmosdb_sql_database.test.id
+  authentication {
+    type         = "servicePrincipalSecret"
+    client_id    = "someclientid"
+    principal_id = azurerm_user_assigned_identity.test.principal_id
+    secret       = "somesecret"
+  }
+}
+`, template, data.RandomString, data.RandomInteger)
+}
+
+func (r ServiceConnectorKubernetesClusterResource) cosmosdbWithUserAssignedIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+data "azurerm_subscription" "test" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%[2]s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_kubernetes_cluster_connection" "test" {
+  name                  = "acctestserviceconnector%[3]d"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  target_resource_id    = azurerm_cosmosdb_sql_database.test.id
+  authentication {
+    type            = "userAssignedIdentity"
+    subscription_id = data.azurerm_subscription.test.subscription_id
+    client_id       = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, template, data.RandomString, data.RandomInteger)
+}
+
+func (r ServiceConnectorKubernetesClusterResource) secretStore(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults    = false
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[4]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "standard_a2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  name                     = "accAKV-%[4]s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "standard"
+  purge_protection_enabled = true
+}
+
+resource "azurerm_kubernetes_cluster_connection" "test" {
+  name                  = "acctestserviceconnector%[3]d"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  target_resource_id    = azurerm_storage_account.test.id
+  client_type           = "java"
+
+  secret_store {
+    key_vault_id = azurerm_key_vault.test.id
+  }
+  authentication {
+    type   = "secret"
+    name   = "foo"
+    secret = "bar"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString)
+}
+
+func (r ServiceConnectorKubernetesClusterResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctestacc%[4]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  consistency_policy {
+    consistency_level       = "BoundedStaleness"
+    max_interval_in_seconds = 10
+    max_staleness_prefix    = 200
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "cosmos-sql-db"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  throughput          = 400
+}
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "example-container"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_paths = ["/definition"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "standard_a2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_connection" "test" {
+  name                  = "acctestserviceconnector%[3]d"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  target_resource_id    = azurerm_cosmosdb_sql_database.test.id
+  client_type           = "java"
+  vnet_solution         = "privateLink"
+  authentication {
+    type   = "secret"
+    name   = "foo"
+    secret = "bar"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString)
+}
+
+func (r ServiceConnectorKubernetesClusterResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctestacc%[4]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  consistency_policy {
+    consistency_level       = "BoundedStaleness"
+    max_interval_in_seconds = 10
+    max_staleness_prefix    = 200
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "cosmos-sql-db"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  throughput          = 400
+}
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "example-container"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_paths = ["/definition"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "standard_a2_v2"
+
+    upgrade_settings {
+      max_surge                     = "10%%"
+      drain_timeout_in_minutes      = 0
+      node_soak_duration_in_minutes = 0
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString)
+}

--- a/internal/services/serviceconnector/registration.go
+++ b/internal/services/serviceconnector/registration.go
@@ -28,6 +28,7 @@ func (r Registration) Resources() []sdk.Resource {
 		AppServiceConnectorResource{},
 		SpringCloudConnectorResource{},
 		FunctionAppConnectorResource{},
+		KubernetesClusterConnectorResource{},
 	}
 }
 

--- a/website/docs/r/kubernetes_cluster_connection.html.markdown
+++ b/website/docs/r/kubernetes_cluster_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Container (Kubernetes)"
+subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_cluster_connection"
 description: |-

--- a/website/docs/r/kubernetes_cluster_connection.html.markdown
+++ b/website/docs/r/kubernetes_cluster_connection.html.markdown
@@ -147,3 +147,9 @@ Service Connector for kubernetes cluster can be imported using the `resource id`
 ```shell
 terraform import azurerm_kubernetes_cluster_connection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/providers/Microsoft.ServiceLinker/linkers/link1
 ```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.ServiceLinker` - 2024-04-01, 2022-05-01

--- a/website/docs/r/kubernetes_cluster_connection.html.markdown
+++ b/website/docs/r/kubernetes_cluster_connection.html.markdown
@@ -1,0 +1,149 @@
+---
+subcategory: "Container (Kubernetes)"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_kubernetes_cluster_connection"
+description: |-
+  Manages a service connector for kubernetes cluster.
+---
+
+# azurerm_kubernetes_cluster_connection
+
+Manages a service connector for kubernetes cluster.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_cosmosdb_account" "example" {
+  name                = "example-cosmosdb-account"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  consistency_policy {
+    consistency_level       = "BoundedStaleness"
+    max_interval_in_seconds = 10
+    max_staleness_prefix    = 200
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.example.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "example" {
+  name                = "cosmos-sql-db"
+  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
+  account_name        = azurerm_cosmosdb_account.example.name
+  throughput          = 400
+}
+
+resource "azurerm_cosmosdb_sql_container" "example" {
+  name                = "example-container"
+  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
+  account_name        = azurerm_cosmosdb_account.example.name
+  database_name       = azurerm_cosmosdb_sql_database.example.name
+  partition_key_path  = "/definition"
+}
+
+resource "azurerm_kubernetes_cluster" "example" {
+  name                = "example-aks-cluster"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  dns_prefix          = "exampleaks"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_connection" "example" {
+  name                  = "example-serviceconnector"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  target_resource_id    = azurerm_cosmosdb_sql_database.example.id
+  authentication {
+    type   = "secret"
+    name   = "foo"
+    secret = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the service connection. Changing this forces a new resource to be created.
+
+* `kubernetes_cluster_id` - (Required) The ID of the kubernetes cluster. Changing this forces a new resource to be created.
+
+* `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible target resources are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`. The integration guide can be found [here](https://learn.microsoft.com/en-us/azure/service-connector/how-to-integrate-postgres).
+
+* `authentication` - (Required) The authentication info. An `authentication` block as defined below.
+
+* `client_type` - (Optional) The application client type. Possible values are `none`, `dotnet`, `java`, `python`, `go`, `php`, `ruby`, `django`, `nodejs` and `springBoot`. Defaults to `none`.
+
+* `vnet_solution` - (Optional) The type of VNet solution. Possible values are `serviceEndpoint`, `privateLink`.
+
+* `secret_store` - (Optional) An option to store secret value in secure place. An `secret_store` block as defined below.
+
+-> **Note:** If a Managed Identity is used, this will need to be configured on the Kubernetes Cluster.
+
+---
+
+An `authentication` block supports the following:
+
+* `type` - (Required) The authentication type. Possible values are `userAssignedIdentity`, `servicePrincipalSecret`, `servicePrincipalCertificate`, `secret`. Changing this forces a new resource to be created.
+
+* `certificate` - (Optional) The certificate for `servicePrincipalCertificate` authentication. Should be specified when `type` is set to `servicePrincipalCertificate`.
+
+* `client_id` - (Optional) The client ID for `userAssignedIdentity` or `servicePrincipalSecret` authentication. Should be specified when `type` is set to `servicePrincipalSecret` or `userAssignedIdentity`.
+
+* `name` - (Optional) The name of the secret for `secret` authentication. Should be specified when `type` is set to `secret`.
+
+* `principal_id` - (Optional) The principal ID for `servicePrincipalSecret` authentication. Should be specified when `type` is set to `servicePrincipalSecret`.
+
+* `secret` - (Optional) The secret for `secret` or `servicePrincipalSecret` authentication. Should be specified when `type` is set to `secret` or `servicePrincipalSecret`.
+
+* `subscription_id` - (Optional) The subscription ID for `userAssignedIdentity` authentication. Should be specified when `type` is set to `userAssignedIdentity`.
+
+---
+
+An `secret_store` block supports the following:
+
+* `key_vault_id` - (Required) The key vault id to store secret.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the service connector.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Service Connector.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Service Connector.
+* `update` - (Defaults to 30 minutes) Used when updating the Service Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Service Connector.
+
+## Import
+
+Service Connector for kubernetes cluster can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_kubernetes_cluster_connection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/providers/Microsoft.ServiceLinker/linkers/link1
+```

--- a/website/docs/r/kubernetes_cluster_connection.html.markdown
+++ b/website/docs/r/kubernetes_cluster_connection.html.markdown
@@ -105,19 +105,17 @@ The following arguments are supported:
 
 An `authentication` block supports the following:
 
-* `type` - (Required) The authentication type. Possible values are `userAssignedIdentity`, `servicePrincipalSecret`, `servicePrincipalCertificate`, `secret`. Changing this forces a new resource to be created.
+* `type` - (Required) The authentication type. Possible values are `systemAssignedIdentity`, `servicePrincipalSecret`, `servicePrincipalCertificate`, `secret`. Changing this forces a new resource to be created.
 
 * `certificate` - (Optional) The certificate for `servicePrincipalCertificate` authentication. Should be specified when `type` is set to `servicePrincipalCertificate`.
 
-* `client_id` - (Optional) The client ID for `userAssignedIdentity` or `servicePrincipalSecret` authentication. Should be specified when `type` is set to `servicePrincipalSecret` or `userAssignedIdentity`.
+* `client_id` - (Optional) The client ID for `servicePrincipalSecret` authentication. Should be specified when `type` is set to `servicePrincipalSecret`.
 
 * `name` - (Optional) The name of the secret for `secret` authentication. Should be specified when `type` is set to `secret`.
 
 * `principal_id` - (Optional) The principal ID for `servicePrincipalSecret` authentication. Should be specified when `type` is set to `servicePrincipalSecret`.
 
 * `secret` - (Optional) The secret for `secret` or `servicePrincipalSecret` authentication. Should be specified when `type` is set to `secret` or `servicePrincipalSecret`.
-
-* `subscription_id` - (Optional) The subscription ID for `userAssignedIdentity` authentication. Should be specified when `type` is set to `userAssignedIdentity`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28579 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
