### PR TITLE
`azurerm_key_vault` - add new feature schema `check_public_availability`

### DIFF
--- a/internal/features/defaults.go
+++ b/internal/features/defaults.go
@@ -21,6 +21,7 @@ func Default() UserFeatures {
 			PurgeSoftDeleteOnDestroy: true,
 		},
 		KeyVault: KeyVaultFeatures{
+			CheckPublicAvailability:          true,
 			PurgeSoftDeleteOnDestroy:         true,
 			PurgeSoftDeletedKeysOnDestroy:    true,
 			PurgeSoftDeletedCertsOnDestroy:   true,

--- a/internal/features/user_flags.go
+++ b/internal/features/user_flags.go
@@ -44,6 +44,7 @@ type VirtualMachineScaleSetFeatures struct {
 }
 
 type KeyVaultFeatures struct {
+	CheckPublicAvailability          bool
 	PurgeSoftDeleteOnDestroy         bool
 	PurgeSoftDeletedKeysOnDestroy    bool
 	PurgeSoftDeletedCertsOnDestroy   bool

--- a/internal/provider/features.go
+++ b/internal/provider/features.go
@@ -94,6 +94,12 @@ func schemaFeatures(supportLegacyTestSuite bool) *pluginsdk.Schema {
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
+					"check_public_availability": {
+						Description: "When enabled the provider will check for the public availability of `azurerm_key_vault` after creation when `public_network_access_enabled` is set to `true`.",
+						Type:        pluginsdk.TypeBool,
+						Optional:    true,
+						Default:     true,
+					},
 					"purge_soft_delete_on_destroy": {
 						Description: "When enabled soft-deleted `azurerm_key_vault` resources will be permanently deleted (e.g purged), when destroyed",
 						Type:        pluginsdk.TypeBool,
@@ -523,6 +529,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		items := raw.([]interface{})
 		if len(items) > 0 && items[0] != nil {
 			keyVaultRaw := items[0].(map[string]interface{})
+			if v, ok := keyVaultRaw["check_public_availability"]; ok {
+				featuresMap.KeyVault.CheckPublicAvailability = v.(bool)
+			}
 			if v, ok := keyVaultRaw["purge_soft_delete_on_destroy"]; ok {
 				featuresMap.KeyVault.PurgeSoftDeleteOnDestroy = v.(bool)
 			}

--- a/internal/provider/features_test.go
+++ b/internal/provider/features_test.go
@@ -36,6 +36,7 @@ func TestExpandFeatures(t *testing.T) {
 					PurgeSoftDeleteOnDestroy: true,
 				},
 				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          true,
 					PurgeSoftDeletedCertsOnDestroy:   true,
 					PurgeSoftDeletedKeysOnDestroy:    true,
 					PurgeSoftDeletedSecretsOnDestroy: true,
@@ -128,6 +129,7 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"key_vault": []interface{}{
 						map[string]interface{}{
+							"check_public_availability":                                   true,
 							"purge_soft_deleted_certificates_on_destroy":                  true,
 							"purge_soft_deleted_keys_on_destroy":                          true,
 							"purge_soft_deleted_secrets_on_destroy":                       true,
@@ -237,6 +239,7 @@ func TestExpandFeatures(t *testing.T) {
 					PurgeSoftDeleteOnDestroy: true,
 				},
 				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          true,
 					PurgeSoftDeletedCertsOnDestroy:   true,
 					PurgeSoftDeletedKeysOnDestroy:    true,
 					PurgeSoftDeletedSecretsOnDestroy: true,
@@ -329,6 +332,7 @@ func TestExpandFeatures(t *testing.T) {
 					},
 					"key_vault": []interface{}{
 						map[string]interface{}{
+							"check_public_availability":                                   false,
 							"purge_soft_deleted_certificates_on_destroy":                  false,
 							"purge_soft_deleted_keys_on_destroy":                          false,
 							"purge_soft_deleted_secrets_on_destroy":                       false,
@@ -438,6 +442,7 @@ func TestExpandFeatures(t *testing.T) {
 					PurgeSoftDeleteOnDestroy: false,
 				},
 				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          false,
 					PurgeSoftDeletedCertsOnDestroy:   false,
 					PurgeSoftDeletedKeysOnDestroy:    false,
 					PurgeSoftDeletedSecretsOnDestroy: false,
@@ -799,6 +804,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          true,
 					PurgeSoftDeletedCertsOnDestroy:   true,
 					PurgeSoftDeletedKeysOnDestroy:    true,
 					PurgeSoftDeletedSecretsOnDestroy: true,
@@ -819,6 +825,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 				map[string]interface{}{
 					"key_vault": []interface{}{
 						map[string]interface{}{
+							"check_public_availability":                                   true,
 							"purge_soft_deleted_certificates_on_destroy":                  true,
 							"purge_soft_deleted_keys_on_destroy":                          true,
 							"purge_soft_deleted_secrets_on_destroy":                       true,
@@ -836,6 +843,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          true,
 					PurgeSoftDeletedCertsOnDestroy:   true,
 					PurgeSoftDeletedKeysOnDestroy:    true,
 					PurgeSoftDeletedSecretsOnDestroy: true,
@@ -856,6 +864,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 				map[string]interface{}{
 					"key_vault": []interface{}{
 						map[string]interface{}{
+							"check_public_availability":                                   true,
 							"purge_soft_deleted_certificates_on_destroy":                  false,
 							"purge_soft_deleted_keys_on_destroy":                          false,
 							"purge_soft_deleted_secrets_on_destroy":                       false,
@@ -873,6 +882,7 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 			},
 			Expected: features.UserFeatures{
 				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          true,
 					PurgeSoftDeletedCertsOnDestroy:   false,
 					PurgeSoftDeletedKeysOnDestroy:    false,
 					PurgeSoftDeletedSecretsOnDestroy: false,
@@ -884,6 +894,45 @@ func TestExpandFeaturesKeyVault(t *testing.T) {
 					RecoverSoftDeletedKeys:           false,
 					RecoverSoftDeletedSecrets:        false,
 					RecoverSoftDeletedHSMKeys:        false,
+				},
+			},
+		},
+		{
+			Name: "Disable public availability check and Purge Soft Delete On Destroy and Recover Soft Deleted Key Vaults Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"key_vault": []interface{}{
+						map[string]interface{}{
+							"check_public_availability":                                   false,
+							"purge_soft_deleted_certificates_on_destroy":                  true,
+							"purge_soft_deleted_keys_on_destroy":                          true,
+							"purge_soft_deleted_secrets_on_destroy":                       true,
+							"purge_soft_deleted_hardware_security_modules_on_destroy":     true,
+							"purge_soft_deleted_hardware_security_module_keys_on_destroy": true,
+							"purge_soft_delete_on_destroy":                                true,
+							"recover_soft_deleted_certificates":                           true,
+							"recover_soft_deleted_keys":                                   true,
+							"recover_soft_deleted_key_vaults":                             true,
+							"recover_soft_deleted_secrets":                                true,
+							"recover_soft_deleted_hardware_security_module_keys":          true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				KeyVault: features.KeyVaultFeatures{
+					CheckPublicAvailability:          false,
+					PurgeSoftDeletedCertsOnDestroy:   true,
+					PurgeSoftDeletedKeysOnDestroy:    true,
+					PurgeSoftDeletedSecretsOnDestroy: true,
+					PurgeSoftDeleteOnDestroy:         true,
+					PurgeSoftDeletedHSMsOnDestroy:    true,
+					PurgeSoftDeletedHSMKeysOnDestroy: true,
+					RecoverSoftDeletedCerts:          true,
+					RecoverSoftDeletedKeyVaults:      true,
+					RecoverSoftDeletedKeys:           true,
+					RecoverSoftDeletedSecrets:        true,
+					RecoverSoftDeletedHSMKeys:        true,
 				},
 			},
 		},

--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -221,7 +221,10 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 			if diags.HasError() {
 				return
 			}
-
+			f.KeyVault.CheckPublicAvailability = true
+			if !feature[0].CheckPublicAvailability.IsNull() && !feature[0].CheckPublicAvailability.IsUnknown() {
+				f.KeyVault.CheckPublicAvailability = feature[0].CheckPublicAvailability.ValueBool()
+			}
 			f.KeyVault.PurgeSoftDeleteOnDestroy = true
 			if !feature[0].PurgeSoftDeleteOnDestroy.IsNull() && !feature[0].PurgeSoftDeleteOnDestroy.IsUnknown() {
 				f.KeyVault.PurgeSoftDeleteOnDestroy = feature[0].PurgeSoftDeleteOnDestroy.ValueBool()
@@ -277,6 +280,7 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 				f.KeyVault.RecoverSoftDeletedHSMKeys = feature[0].RecoverSoftDeletedHSMKeys.ValueBool()
 			}
 		} else {
+			f.KeyVault.CheckPublicAvailability = true
 			f.KeyVault.PurgeSoftDeleteOnDestroy = true
 			f.KeyVault.PurgeSoftDeletedCertsOnDestroy = true
 			f.KeyVault.PurgeSoftDeletedKeysOnDestroy = true

--- a/internal/provider/framework/config_test.go
+++ b/internal/provider/framework/config_test.go
@@ -242,6 +242,7 @@ func defaultFeaturesList() types.List {
 	cognitiveAccountList, _ := basetypes.NewListValue(types.ObjectType{}.WithAttributeTypes(CognitiveAccountAttributes), []attr.Value{cognitiveAccount})
 
 	keyVault, _ := basetypes.NewObjectValueFrom(context.Background(), KeyVaultAttributes, map[string]attr.Value{
+		"check_public_availability":                               basetypes.NewBoolNull(),
 		"purge_soft_delete_on_destroy":                            basetypes.NewBoolNull(),
 		"purge_soft_deleted_certificates_on_destroy":              basetypes.NewBoolNull(),
 		"purge_soft_deleted_keys_on_destroy":                      basetypes.NewBoolNull(),

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -125,6 +125,7 @@ var CognitiveAccountAttributes = map[string]attr.Type{
 }
 
 type KeyVault struct {
+	CheckPublicAvailability                              types.Bool `tfsdk:"check_public_availability"`
 	PurgeSoftDeleteOnDestroy                             types.Bool `tfsdk:"purge_soft_delete_on_destroy"`
 	PurgeSoftDeletedCertificatesOnDestroy                types.Bool `tfsdk:"purge_soft_deleted_certificates_on_destroy"`
 	PurgeSoftDeletedKeysOnDestroy                        types.Bool `tfsdk:"purge_soft_deleted_keys_on_destroy"`
@@ -139,6 +140,7 @@ type KeyVault struct {
 }
 
 var KeyVaultAttributes = map[string]attr.Type{
+	"check_public_availability":                                   types.BoolType,
 	"purge_soft_delete_on_destroy":                                types.BoolType,
 	"purge_soft_deleted_certificates_on_destroy":                  types.BoolType,
 	"purge_soft_deleted_keys_on_destroy":                          types.BoolType,

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -292,6 +292,10 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 						"key_vault": schema.ListNestedBlock{
 							NestedObject: schema.NestedBlockObject{
 								Attributes: map[string]schema.Attribute{
+									"check_public_availability": schema.BoolAttribute{
+										Description: "When enabled the provider will check for the public availability of `azurerm_key_vault` after creation when `public_network_access_enabled` is set to `true`.",
+										Optional:    true,
+									},
 									"purge_soft_delete_on_destroy": schema.BoolAttribute{
 										Description: "When enabled soft-deleted `azurerm_key_vault` resources will be permanently deleted (e.g purged), when destroyed",
 										Optional:    true,

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -436,7 +436,8 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	//
 	// As such we poll to check the Key Vault is available, if it's public, to ensure that downstream
 	// operations can succeed.
-	if isPublic {
+
+	if isPublic && meta.(*clients.Client).Features.KeyVault.CheckPublicAvailability {
 		log.Printf("[DEBUG] Waiting for %s to become available", id)
 		deadline, ok := ctx.Deadline()
 		if !ok {
@@ -782,7 +783,7 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	// to ignore the error if the data plane call fails.
 	contacts, err := managementClient.GetCertificateContacts(ctx, vaultUri)
 	if err != nil {
-		if publicNetworkAccessEnabled && (!utils.ResponseWasForbidden(contacts.Response) && !utils.ResponseWasNotFound(contacts.Response)) {
+		if publicNetworkAccessEnabled && meta.(*clients.Client).Features.KeyVault.CheckPublicAvailability && (!utils.ResponseWasForbidden(contacts.Response) && !utils.ResponseWasNotFound(contacts.Response)) {
 			return fmt.Errorf("retrieving `contact` for KeyVault: %+v", err)
 		}
 	}

--- a/website/docs/guides/features-block.html.markdown
+++ b/website/docs/guides/features-block.html.markdown
@@ -50,6 +50,7 @@ provider "azurerm" {
     }
 
     key_vault {
+      check_public_availability       = true
       purge_soft_delete_on_destroy    = true
       recover_soft_deleted_key_vaults = true
     }
@@ -186,6 +187,8 @@ The `databricks_workspace` block supports the following:
 ---
 
 The `key_vault` block supports the following:
+
+* `check_public_availability` - (Optional) When enabled the provider will check for the public availability of `azurerm_key_vault` after creation when `public_network_access_enabled` is set to `true`. Defaults to `true`.
 
 * `purge_soft_delete_on_destroy` - (Optional) Should the `azurerm_key_vault` resource be permanently deleted (e.g. purged) when destroyed? Defaults to `true`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Provide an option to disable public availability check when `public_network_access_enabled` is true.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_key_vault` - support for the `check_public_availability` feature [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #30716

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
