### PR TITLE
Docs: add missing deprecations to upgrade guide for `azurerm_key_vault`

### DIFF
--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -251,6 +251,11 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The deprecated `private_link_fast_path_enabled` property has been removed as it is no longer supported by the resource.
 
+### `azurerm_key_vault`
+
+* The deprecated `contact` property has been removed as it is no longer supported by the resource.
+* The deprecated `enable_rbac_authorization` property has been removed in favour of the `rbac_authorization_enabled` property.
+
 ### `azurerm_kubernetes_cluster`
 
 * The deprecated `default_node_pool.linux_os_config.transparent_huge_page_enabled` property has been removed in favour of the `default_node_pool.linux_os_config.transparent_huge_page` property.


### PR DESCRIPTION
Deprecated in #29886, missing from guide