### PR TITLE
`azurerm_eventhub_namespace` - `maximum_throughput_units` can be set to `0` when `auto_inflate_enabled` is disabled

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // Default Authorization Rule/Policy created by Azure, used to populate the
@@ -328,19 +327,19 @@ func resourceEventHubNamespaceCreate(d *pluginsdk.ResourceData, meta interface{}
 				v := namespaces.SkuTier(sku)
 				return &v
 			}(),
-			Capacity: utils.Int64(int64(capacity)),
+			Capacity: pointer.To(int64(capacity)),
 		},
 		Identity: identity,
 		Properties: &namespaces.EHNamespaceProperties{
-			IsAutoInflateEnabled: utils.Bool(autoInflateEnabled),
-			DisableLocalAuth:     utils.Bool(disableLocalAuth),
+			IsAutoInflateEnabled: pointer.To(autoInflateEnabled),
+			DisableLocalAuth:     pointer.To(disableLocalAuth),
 			PublicNetworkAccess:  &publicNetworkEnabled,
 		},
 		Tags: tags.Expand(t),
 	}
 
 	if v := d.Get("dedicated_cluster_id").(string); v != "" {
-		parameters.Properties.ClusterArmId = utils.String(v)
+		parameters.Properties.ClusterArmId = pointer.To(v)
 	}
 
 	if tlsValue := d.Get("minimum_tls_version").(string); tlsValue != "" {
@@ -349,7 +348,7 @@ func resourceEventHubNamespaceCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("maximum_throughput_units"); ok {
-		parameters.Properties.MaximumThroughputUnits = utils.Int64(int64(v.(int)))
+		parameters.Properties.MaximumThroughputUnits = pointer.To(int64(v.(int)))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
@@ -421,19 +420,19 @@ func resourceEventHubNamespaceUpdate(d *pluginsdk.ResourceData, meta interface{}
 				v := namespaces.SkuTier(sku)
 				return &v
 			}(),
-			Capacity: utils.Int64(int64(capacity)),
+			Capacity: pointer.To(int64(capacity)),
 		},
 		Identity: identity,
 		Properties: &namespaces.EHNamespaceProperties{
-			IsAutoInflateEnabled: utils.Bool(autoInflateEnabled),
-			DisableLocalAuth:     utils.Bool(disableLocalAuth),
+			IsAutoInflateEnabled: pointer.To(autoInflateEnabled),
+			DisableLocalAuth:     pointer.To(disableLocalAuth),
 			PublicNetworkAccess:  &publicNetworkEnabled,
 		},
 		Tags: tags.Expand(t),
 	}
 
 	if v := d.Get("dedicated_cluster_id").(string); v != "" {
-		parameters.Properties.ClusterArmId = utils.String(v)
+		parameters.Properties.ClusterArmId = pointer.To(v)
 	}
 
 	if tlsValue := d.Get("minimum_tls_version").(string); tlsValue != "" {
@@ -441,8 +440,8 @@ func resourceEventHubNamespaceUpdate(d *pluginsdk.ResourceData, meta interface{}
 		parameters.Properties.MinimumTlsVersion = &minimumTls
 	}
 
-	if v, ok := d.GetOk("maximum_throughput_units"); ok {
-		parameters.Properties.MaximumThroughputUnits = utils.Int64(int64(v.(int)))
+	if d.HasChange("maximum_throughput_units") {
+		parameters.Properties.MaximumThroughputUnits = pointer.To(int64(d.Get("maximum_throughput_units").(int)))
 	}
 
 	// @favoretti: if we are downgrading from Standard to Basic SKU and namespace had both autoInflate enabled and
@@ -451,7 +450,7 @@ func resourceEventHubNamespaceUpdate(d *pluginsdk.ResourceData, meta interface{}
 	// See: https://github.com/hashicorp/terraform-provider-azurerm/issues/10244
 	//
 	if *parameters.Sku.Tier == namespaces.SkuTierBasic && !autoInflateEnabled {
-		parameters.Properties.MaximumThroughputUnits = utils.Int64(0)
+		parameters.Properties.MaximumThroughputUnits = pointer.To(int64(0))
 	}
 
 	if _, err = client.Update(ctx, id, parameters); err != nil {
@@ -634,7 +633,7 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 	}
 
 	if v, ok := block["trusted_service_access_enabled"]; ok {
-		ruleset.TrustedServiceAccessEnabled = utils.Bool(v.(bool))
+		ruleset.TrustedServiceAccessEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := block["virtual_network_rule"]; ok {
@@ -645,9 +644,9 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 				rblock := r.(map[string]interface{})
 				rules = append(rules, networkrulesets.NWRuleSetVirtualNetworkRules{
 					Subnet: &networkrulesets.Subnet{
-						Id: utils.String(rblock["subnet_id"].(string)),
+						Id: pointer.To(rblock["subnet_id"].(string)),
 					},
-					IgnoreMissingVnetServiceEndpoint: utils.Bool(rblock["ignore_missing_virtual_network_service_endpoint"].(bool)),
+					IgnoreMissingVnetServiceEndpoint: pointer.To(rblock["ignore_missing_virtual_network_service_endpoint"].(bool)),
 				})
 			}
 
@@ -661,7 +660,7 @@ func expandEventHubNamespaceNetworkRuleset(input []interface{}) *networkrulesets
 			for _, r := range v {
 				rblock := r.(map[string]interface{})
 				rules = append(rules, networkrulesets.NWRuleSetIPRules{
-					IPMask: utils.String(rblock["ip_mask"].(string)),
+					IPMask: pointer.To(rblock["ip_mask"].(string)),
 					Action: func() *networkrulesets.NetworkRuleIPAction {
 						v := networkrulesets.NetworkRuleIPAction(rblock["action"].(string))
 						return &v

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -453,6 +453,26 @@ func TestAccEventHubNamespace_maximumThroughputUnitsUpdate(t *testing.T) {
 	})
 }
 
+func TestAccEventHubNamespace_maximumThroughputUnitsDisable(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
+	r := EventHubNamespaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.maximumThroughputUnits(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.maximumThroughputUnitsDisable(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccEventHubNamespace_publicNetworkAccessUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
 	r := EventHubNamespaceResource{}
@@ -1086,6 +1106,29 @@ resource "azurerm_eventhub_namespace" "test" {
   capacity                 = 1
   auto_inflate_enabled     = true
   maximum_throughput_units = 1
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (EventHubNamespaceResource) maximumThroughputUnitsDisable(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-eh-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                     = "acctesteventhubnamespace-%d"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  sku                      = "Standard"
+  capacity                 = 1
+  auto_inflate_enabled     = false
+  maximum_throughput_units = 0
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Fixes #25786