### PR TITLE
`azurerm_search_service` - implement plan time error when `local_authentication_enabled = false` and `authentication_failure_mode` is set

### DIFF
--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -5,7 +5,6 @@ package search
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -289,10 +288,6 @@ func resourceSearchServiceCreate(d *pluginsdk.ResourceData, meta interface{}) er
 		return err
 	}
 
-	if !localAuthenticationEnabled && authenticationFailureMode != "" {
-		return errors.New("'authentication_failure_mode' cannot be defined if 'local_authentication_enabled' has been set to 'false'")
-	}
-
 	// API Only Mode (Default) (e.g. localAuthenticationEnabled = true)...
 	authenticationOptions := pointer.To(services.DataPlaneAuthOptions{
 		ApiKeyOnly: pointer.To(apiKeyOnly),
@@ -444,9 +439,6 @@ func resourceSearchServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	if d.HasChanges("authentication_failure_mode", "local_authentication_enabled") {
 		authenticationFailureMode := d.Get("authentication_failure_mode").(string)
 		localAuthenticationEnabled := d.Get("local_authentication_enabled").(bool)
-		if !localAuthenticationEnabled && authenticationFailureMode != "" {
-			return fmt.Errorf("'authentication_failure_mode' cannot be defined if 'local_authentication_enabled' has been set to 'false'")
-		}
 
 		var apiKeyOnly interface{} = make(map[string]interface{}, 0)
 

--- a/internal/services/search/search_service_resource_test.go
+++ b/internal/services/search/search_service_resource_test.go
@@ -584,6 +584,10 @@ func TestAccSearchService_apiAccessControlUpdate(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config:      r.apiAccessControlBoth(data, false, "http401WithBearerChallenge"),
+			ExpectError: regexp.MustCompile("cannot be defined"),
+		},
+		{
 			Config: r.basic(data, "standard"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

In #30871 it was identified that an improvement to the plan time error checking when `local_authentication_enabled = false` and `authentication_failure_mode` is set could be implemented. This PR implements that check.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

Closes #30880 

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing 

No new tests required. Running existing tests shows a dramatic change in test run time for the case where the error would be seen (which is expected).

Relevant test output before change:

```bash
make acctests SERVICE='search' TESTARGS='-run=TestAccSearchService_apiAccessControlRbacError' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/search -run=TestAccSearchService_apiAccessControlRbacError -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSearchService_apiAccessControlRbacError
=== PAUSE TestAccSearchService_apiAccessControlRbacError
=== CONT  TestAccSearchService_apiAccessControlRbacError
--- PASS: TestAccSearchService_apiAccessControlRbacError (37.23s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/search        37.276s
```

After the change: 

```bash
$make acctests SERVICE='search' TESTARGS='-run=TestAccSearchService_apiAccessControlRbacError' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/search -run=TestAccSearchService_apiAccessControlRbacError -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSearchService_apiAccessControlRbacError
=== PAUSE TestAccSearchService_apiAccessControlRbacError
=== CONT  TestAccSearchService_apiAccessControlRbacError
--- PASS: TestAccSearchService_apiAccessControlRbacError (11.68s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/search        11.709s
```

Testing the non-error case:

```bash
$ make acctests SERVICE='search' TESTARGS='-run=TestAccSearchService_apiAccessControlUpdate' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/search -run=TestAccSearchService_apiAccessControlUpdate -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccSearchService_apiAccessControlUpdate
=== PAUSE TestAccSearchService_apiAccessControlUpdate
=== CONT  TestAccSearchService_apiAccessControlUpdate
--- PASS: TestAccSearchService_apiAccessControlUpdate (245.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/search        245.073s
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_search_service` - implement plan time error when `local_authentication_enabled = false` and `authentication_failure_mode` is set [GH-30880]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30880 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
