### PR TITLE
`azurerm_palo_alto_next_generation_firewall_*` - adding property `private_source_nat_rules_destination`

### DIFF
--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_resource_test.go
@@ -225,11 +225,12 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack
   plan_id              = "panw-cngfw-payg"
 
   network_profile {
-    virtual_hub_id               = azurerm_virtual_hub.test.id
-    network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.test.id
-    public_ip_address_ids        = [azurerm_public_ip.test.id]
-    egress_nat_ip_address_ids    = [azurerm_public_ip.egress.id]
-    trusted_address_ranges       = ["20.22.92.11"]
+    virtual_hub_id                       = azurerm_virtual_hub.test.id
+    network_virtual_appliance_id         = azurerm_palo_alto_virtual_network_appliance.test.id
+    public_ip_address_ids                = [azurerm_public_ip.test.id]
+    egress_nat_ip_address_ids            = [azurerm_public_ip.egress.id]
+    private_source_nat_rules_destination = ["10.0.0.1", "192.168.1.1"]
+    trusted_address_ranges               = ["20.22.92.11"]
   }
 
   dns_settings {

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_panorama_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_panorama_resource_test.go
@@ -172,11 +172,12 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama" "test
   panorama_base64_config = "%[3]s"
 
   network_profile {
-    virtual_hub_id               = azurerm_virtual_hub.test.id
-    network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.test.id
-    public_ip_address_ids        = [azurerm_public_ip.test.id]
-    egress_nat_ip_address_ids    = [azurerm_public_ip.egress.id]
-    trusted_address_ranges       = ["20.22.92.11"]
+    virtual_hub_id                       = azurerm_virtual_hub.test.id
+    network_virtual_appliance_id         = azurerm_palo_alto_virtual_network_appliance.test.id
+    public_ip_address_ids                = [azurerm_public_ip.test.id]
+    egress_nat_ip_address_ids            = [azurerm_public_ip.egress.id]
+    private_source_nat_rules_destination = ["10.0.0.1", "192.168.1.1"]
+    trusted_address_ranges               = ["20.22.92.11"]
   }
 
   dns_settings {

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource_test.go
@@ -241,7 +241,7 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rules
   network_profile {
     public_ip_address_ids                = [azurerm_public_ip.test.id]
     egress_nat_ip_address_ids            = [azurerm_public_ip.egress.id]
-    private_source_nat_rules_destination = ["10.0.0.0/16", "192.168.1.0/24"]
+    private_source_nat_rules_destination = ["10.0.0.1", "192.168.1.1"]
     trusted_address_ranges               = ["20.22.92.11", "20.23.92.11"]
 
     vnet_configuration {

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_panorama_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_panorama_resource_test.go
@@ -186,7 +186,7 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_network_panorama" "
   network_profile {
     public_ip_address_ids                = [azurerm_public_ip.test.id]
     egress_nat_ip_address_ids            = [azurerm_public_ip.egress.id]
-    private_source_nat_rules_destination = ["10.0.0.0/16", "192.168.1.0/24"]
+    private_source_nat_rules_destination = ["10.0.0.1", "192.168.1.1"]
     trusted_address_ranges               = ["20.22.92.11"]
 
     vnet_configuration {

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_hub_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_hub_local_rulestack.html.markdown
@@ -138,6 +138,8 @@ A `network_profile` block supports the following:
 
 * `egress_nat_ip_address_ids` - (Optional) Specifies a list of Public IP IDs to use for Egress NAT.
 
+* `private_source_nat_rules_destination` - (Optional) Specifies a list of destination addresses (IPv4 addresses or CIDR blocks) used for Private Source NAT Rules.
+
 * `trusted_address_ranges` - (Optional) Specifies a list of trusted ranges to use for the Network.
 
 ## Attributes Reference

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_hub_panorama.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_hub_panorama.html.markdown
@@ -143,6 +143,8 @@ A `network_profile` block supports the following:
 
 * `egress_nat_ip_address_ids` - (Optional) Specifies a list of Public IP IDs to use for Egress NAT.
 
+* `private_source_nat_rules_destination` - (Optional) Specifies a list of destination addresses (IPv4 addresses or CIDR blocks) used for Private Source NAT Rules.
+
 * `trusted_address_ranges` - (Optional) Specifies a list of trusted ranges to use for the Network.
 
 ## Attributes Reference

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
@@ -203,7 +203,7 @@ A `network_profile` block supports the following:
 
 * `egress_nat_ip_address_ids` - (Optional) Specifies a list of Azure Public IP Address IDs that can be used for Egress (Source) Network Address Translation.
 
-* `private_source_nat_rules_destination` - (Optional) Specifies a list of destination addresses (IPv4 addresses or CIDR blocks) used for Private Source NAT Rules.
+* `private_source_nat_rules_destination` - (Optional) Specifies a list of destination IPv4 addresses used for Private Source NAT Rules.
 
 * `trusted_address_ranges` - (Optional) Specifies a list of trusted ranges to use for the Network.
 

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
@@ -183,7 +183,7 @@ A `network_profile` block supports the following:
 
 * `egress_nat_ip_address_ids` - (Optional) Specifies a list of Azure Public IP Address IDs that can be used for Egress (Source) Network Address Translation.
 
-* `private_source_nat_rules_destination` - (Optional) Specifies a list of destination addresses (IPv4 addresses or CIDR blocks) used for Private Source NAT Rules.
+* `private_source_nat_rules_destination` - (Optional) Specifies a list of destination IPv4 addresses used for Private Source NAT Rules.
 
 * `trusted_address_ranges` - (Optional) Specifies a list of trusted ranges to use for the Network.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support `private_source_nat_rules_destination` for azurerm_palo_alto_next_generation_firewall_*.

https://learn.microsoft.com/en-us/rest/api/cloudngfw/firewalls/create-or-update?view=rest-cloudngfw-2025-10-08&tabs=HTTP#networkprofile


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="1470" height="782" alt="image" src="https://github.com/user-attachments/assets/f775b641-6657-4288-9565-5a6b56b4d745" />



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_palo_alto_next_generation_firewall_*` - support for the `private_source_nat_rules_destination` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30919 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
