### PR TITLE
`azurerm_mssql_job_step` - nil check `ExecutionOptions` before accessing nested fields

### DIFF
--- a/internal/services/mssql/mssql_job_step_resource.go
+++ b/internal/services/mssql/mssql_job_step_resource.go
@@ -281,21 +281,23 @@ func (r MsSqlJobStepResource) Read() sdk.ResourceFunc {
 						state.JobCredentialID = credentialID.ID()
 					}
 
-					state.JobStepIndex = pointer.From(props.StepId)
-					state.JobTargetGroupID = props.TargetGroup
-					state.SqlScript = props.Action.Value
-					state.InitialRetryIntervalSeconds = pointer.From(props.ExecutionOptions.InitialRetryIntervalSeconds)
-					state.MaximumRetryIntervalSeconds = pointer.From(props.ExecutionOptions.MaximumRetryIntervalSeconds)
-
 					target, err := flattenOutputTarget(props.Output)
 					if err != nil {
 						return fmt.Errorf("flattening `output_target`: %+v", err)
 					}
 					state.OutputTarget = target
 
-					state.RetryAttempts = pointer.From(props.ExecutionOptions.RetryAttempts)
-					state.RetryIntervalBackoffMultiplier = pointer.From(props.ExecutionOptions.RetryIntervalBackoffMultiplier)
-					state.TimeoutSeconds = pointer.From(props.ExecutionOptions.TimeoutSeconds)
+					state.JobStepIndex = pointer.From(props.StepId)
+					state.JobTargetGroupID = props.TargetGroup
+					state.SqlScript = props.Action.Value
+
+					if exec := props.ExecutionOptions; exec != nil {
+						state.InitialRetryIntervalSeconds = pointer.From(exec.InitialRetryIntervalSeconds)
+						state.MaximumRetryIntervalSeconds = pointer.From(exec.MaximumRetryIntervalSeconds)
+						state.RetryAttempts = pointer.From(exec.RetryAttempts)
+						state.RetryIntervalBackoffMultiplier = pointer.From(exec.RetryIntervalBackoffMultiplier)
+						state.TimeoutSeconds = pointer.From(exec.TimeoutSeconds)
+					}
 				}
 			}
 


### PR DESCRIPTION
`ExecutionOptions` wasn't nil checked before accessing nested fields which could lead to a panic.

<img width="336" height="137" alt="image" src="https://github.com/user-attachments/assets/b6b4b47a-9478-4809-8eb1-bf7b1f5a1deb" />
