### PR TITLE
`azurerm_lb_rule` - updated docs to fix formatting for `load_distribution` property

### DIFF
--- a/website/docs/r/lb_rule.html.markdown
+++ b/website/docs/r/lb_rule.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `probe_id` - (Optional) A reference to a Probe used by this Load Balancing Rule.
 * `floating_ip_enabled` - (Optional) Are the Floating IPs enabled for this Load Balancer Rule? A "floating" IP is reassigned to a secondary server in case the primary server fails. Required to configure a SQL AlwaysOn Availability Group. Defaults to `false`.
 * `idle_timeout_in_minutes` - (Optional) Specifies the idle timeout in minutes for TCP connections. Valid values are between `4` and `100` minutes. Defaults to `4` minutes.
-* `load_distribution` - (Optional) Specifies the load balancing distribution type to be used by the Load Balancer. Possible values are:  
+* `load_distribution` - (Optional) Specifies the load balancing distribution type to be used by the Load Balancer. Possible values are `Default`, `SourceIP` and `SourceIPProtocol`. Defaults to `Default.`
   * `Default` – The load balancer is configured to use a 5 tuple hash to map traffic to available servers.  
   * `SourceIP` – The load balancer is configured to use a 2 tuple hash to map traffic to available servers.  
   * `SourceIPProtocol` – The load balancer is configured to use a 3 tuple hash to map traffic to available servers.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change

## Overview

This is a simple PR to fix how the docs render for `azurerm_lb_rule` . It currently renders as one big block
<img width="846" height="261" alt="image" src="https://github.com/user-attachments/assets/bcd51b92-8a80-4600-b177-4fa6cfa95f6b" />

and this PR makes it easier to read

<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/c889e6dc-956a-446b-9cef-1e4b344774f6" />



## AI Assistance Disclosure

None

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
