### PR TITLE
azurerm_data_factory_linked_service_cosmosdb - support for the credential authentication method

### DIFF
--- a/website/docs/r/data_factory_linked_service_cosmosdb.html.markdown
+++ b/website/docs/r/data_factory_linked_service_cosmosdb.html.markdown
@@ -65,6 +65,8 @@ The following supported arguments are specific to CosmosDB Linked Service:
 
 * `account_key` - (Optional) The account key of the Azure Cosmos DB account. Required if `connection_string` is unspecified.
 
+* `credential_name` - (Optional) The name of the Data Factory credential to use for authentication. Cannot be specified if `account_key` or `account_endpoint` are provided.
+
 * `database` - (Optional) The name of the database. Required if `connection_string` is unspecified.
 
 * `connection_string` - (Optional) The connection string. Required if `account_endpoint`, `account_key`, and `database` are unspecified.


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adding Credential Authentication support for the Data Factory Linked Service Cosmos DB.
This allows Data Factory to connect to Cosmos DB using managed/user identities which can already be provisioned using the `azurerm_data_factory_credential_*` resources.
This is relevant for organisations that block the usage of AccountKeys for connecting different Azure services.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
> My organisation has restricted my Azure subscription using Azure Policy.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_data_factory_linked_service_cosmosdb` - support for the `credential_name` property

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

> I have used GitHub co-pilot for line-completion in documentation, the test and the implementation.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.