### PR TITLE
EventGrid functions: Use pointer.To instead of utils.X functions.

### DIFF
--- a/internal/services/eventgrid/event_subscription_funcs.go
+++ b/internal/services/eventgrid/event_subscription_funcs.go
@@ -76,11 +76,11 @@ func expandEventGridEventSubscriptionWebhookEndpoint(input []interface{}, delive
 	}
 
 	if v, ok := config["active_directory_tenant_id"]; ok && v != "" {
-		props.AzureActiveDirectoryTenantId = utils.String(v.(string))
+		props.AzureActiveDirectoryTenantId = pointer.To(v.(string))
 	}
 
 	if v, ok := config["active_directory_app_id_or_uri"]; ok && v != "" {
-		props.AzureActiveDirectoryApplicationIdOrUri = utils.String(v.(string))
+		props.AzureActiveDirectoryApplicationIdOrUri = pointer.To(v.(string))
 	}
 
 	return webhookDestination
@@ -92,7 +92,7 @@ func expandEventSubscriptionDestinationAzureFunction(input []interface{}, delive
 		DeliveryAttributeMappings: &deliveryMappings,
 	}
 	if v, ok := item["function_id"]; ok && v != "" {
-		props.ResourceId = utils.String(v.(string))
+		props.ResourceId = pointer.To(v.(string))
 	}
 	if v, ok := item["max_events_per_batch"]; ok && v != 0 {
 		props.MaxEventsPerBatch = pointer.To(int64(v.(int)))
@@ -230,17 +230,17 @@ func expandEventSubscriptionDeliveryAttributeMappings(input []interface{}) []eve
 		switch mappingBlock["type"].(string) {
 		case "Static":
 			output = append(output, eventsubscriptions.StaticDeliveryAttributeMapping{
-				Name: utils.String(mappingBlock["header_name"].(string)),
+				Name: pointer.To(mappingBlock["header_name"].(string)),
 				Properties: &eventsubscriptions.StaticDeliveryAttributeMappingProperties{
-					Value:    utils.String(mappingBlock["value"].(string)),
-					IsSecret: utils.Bool(mappingBlock["secret"].(bool)),
+					Value:    pointer.To(mappingBlock["value"].(string)),
+					IsSecret: pointer.To(mappingBlock["secret"].(bool)),
 				},
 			})
 		case "Dynamic":
 			output = append(output, eventsubscriptions.DynamicDeliveryAttributeMapping{
-				Name: utils.String(mappingBlock["header_name"].(string)),
+				Name: pointer.To(mappingBlock["header_name"].(string)),
 				Properties: &eventsubscriptions.DynamicDeliveryAttributeMappingProperties{
-					SourceField: utils.String(mappingBlock["source_field"].(string)),
+					SourceField: pointer.To(mappingBlock["source_field"].(string)),
 				},
 			})
 		}
@@ -613,7 +613,7 @@ func expandEventSubscriptionFilter(d *pluginsdk.ResourceData) (*eventsubscriptio
 	}
 
 	if v, ok := d.GetOk("advanced_filtering_on_arrays_enabled"); ok {
-		filter.EnableAdvancedFilteringOnArrays = utils.Bool(v.(bool))
+		filter.EnableAdvancedFilteringOnArrays = pointer.To(v.(bool))
 	}
 
 	return filter, nil

--- a/internal/services/eventgrid/eventgrid_domain_resource.go
+++ b/internal/services/eventgrid/eventgrid_domain_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceEventGridDomain() *pluginsdk.Resource {
@@ -237,9 +236,9 @@ func resourceEventGridDomainCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	domain := domains.Domain{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &domains.DomainProperties{
-			AutoCreateTopicWithFirstSubscription: utils.Bool(d.Get("auto_create_topic_with_first_subscription").(bool)),
-			AutoDeleteTopicWithLastSubscription:  utils.Bool(d.Get("auto_delete_topic_with_last_subscription").(bool)),
-			DisableLocalAuth:                     utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			AutoCreateTopicWithFirstSubscription: pointer.To(d.Get("auto_create_topic_with_first_subscription").(bool)),
+			AutoDeleteTopicWithLastSubscription:  pointer.To(d.Get("auto_delete_topic_with_last_subscription").(bool)),
+			DisableLocalAuth:                     pointer.To(!d.Get("local_auth_enabled").(bool)),
 			InboundIPRules:                       inboundIPRules,
 			InputSchema:                          pointer.To(domains.InputSchema(d.Get("input_schema").(string))),
 			InputSchemaMapping:                   expandDomainInputMapping(d),

--- a/internal/services/eventgrid/eventgrid_domain_topic_resource_test.go
+++ b/internal/services/eventgrid/eventgrid_domain_topic_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/domaintopics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventGridDomainTopicResource struct{}
@@ -62,7 +62,7 @@ func (EventGridDomainTopicResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventGridDomainTopicResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventgrid/eventgrid_topic_resource.go
+++ b/internal/services/eventgrid/eventgrid_topic_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceEventGridTopic() *pluginsdk.Resource {
@@ -231,7 +230,7 @@ func resourceEventGridTopicCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			InputSchema:         pointer.To(topics.InputSchema(d.Get("input_schema").(string))),
 			PublicNetworkAccess: pointer.To(publicNetworkAccess),
 			InboundIPRules:      inboundIPRules,
-			DisableLocalAuth:    utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			DisableLocalAuth:    pointer.To(!d.Get("local_auth_enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -605,7 +604,7 @@ func expandTopicInboundIPRules(input []interface{}) *[]topics.InboundIPRule {
 		rawRule := item.(map[string]interface{})
 		rules = append(rules, topics.InboundIPRule{
 			Action: pointer.To(topics.IPActionType(rawRule["action"].(string))),
-			IPMask: utils.String(rawRule["ip_mask"].(string)),
+			IPMask: pointer.To(rawRule["ip_mask"].(string)),
 		})
 	}
 	return &rules

--- a/internal/services/eventgrid/eventgrid_topic_resource_test.go
+++ b/internal/services/eventgrid/eventgrid_topic_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/topics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventGridTopicResource struct{}
@@ -206,7 +206,7 @@ func (EventGridTopicResource) Exists(ctx context.Context, clients *clients.Clien
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventGridTopicResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `utils.Bool`, `utils.String` and a few more have been deprecated in favor of `pointer.To`. I noticed it since I already work in this directory/service folder. 

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change
- [X] Maintenance

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
