### PR TITLE
Fix 400 error when removing auth_settings_v2 block from App Service resources

### DIFF
--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -1790,3 +1790,24 @@ func DefaultAuthSettingsProperties() *webapps.SiteAuthSettingsProperties {
 		TwitterConsumerSecretSettingName:        pointer.To(""),
 	}
 }
+
+// DefaultAuthV2SettingsProperties returns a `SiteAuthSettingsV2Properties` struct populated with "empty" and default values to clear previous configuration.
+func DefaultAuthV2SettingsProperties() *webapps.SiteAuthSettingsV2Properties {
+	return &webapps.SiteAuthSettingsV2Properties{
+		Platform: &webapps.AuthPlatform{
+			Enabled: pointer.To(false),
+		},
+		GlobalValidation: &webapps.GlobalValidation{
+			RequireAuthentication: pointer.To(false),
+		},
+		IdentityProviders: &webapps.IdentityProviders{},
+		Login: &webapps.Login{
+			TokenStore: &webapps.TokenStore{
+				Enabled: pointer.To(false),
+			},
+		},
+		HTTPSettings: &webapps.HTTPSettings{
+			RequireHTTPS: pointer.To(false),
+		},
+	}
+}

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1157,6 +1157,10 @@ func (r LinuxFunctionAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+				}
 				if _, err := client.UpdateAuthSettingsV2(ctx, *id, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
 				}

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -1073,6 +1073,10 @@ func (r LinuxFunctionAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+				}
 				if _, err := client.UpdateAuthSettingsV2Slot(ctx, *id, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
 				}

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -940,6 +940,11 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+					updateLogs = true
+				}
 				if _, err := client.UpdateAuthSettingsV2(ctx, *id, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
 				}

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -893,6 +893,10 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+				}
 				if _, err := client.UpdateAuthSettingsV2Slot(ctx, *id, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
 				}

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -1167,6 +1167,10 @@ func (r WindowsFunctionAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+				}
 				if _, err := client.UpdateAuthSettingsV2(ctx, *id, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Windows %s: %+v", id, err)
 				}

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -1088,6 +1088,10 @@ func (r WindowsFunctionAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+				}
 				if _, err := client.UpdateAuthSettingsV2Slot(ctx, *id, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Windows %s: %+v", id, err)
 				}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -978,8 +978,13 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+					updateLogs = true
+				}
 				if _, err := client.UpdateAuthSettingsV2(ctx, *id, *authV2Update); err != nil {
-					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
+					return fmt.Errorf("updating AuthV2 Settings for Windows %s: %+v", id, err)
 				}
 				updateLogs = true
 			}

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -940,8 +940,12 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authV2Update.Properties == nil {
+					authV2Update.Properties = helpers.DefaultAuthV2SettingsProperties()
+				}
 				if _, err := client.UpdateAuthSettingsV2Slot(ctx, *id, *authV2Update); err != nil {
-					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", *id, err)
+					return fmt.Errorf("updating AuthV2 Settings for Windows %s: %+v", *id, err)
 				}
 				updateLogs = true
 			}


### PR DESCRIPTION
- Added DefaultAuthV2SettingsProperties helper to reset auth settings to disabled state
- Applied default properties when auth_settings_v2 block is removed across all app service resources
- Corrected error message for Windows web app slot to reference correct OS type

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR fixes a bug where removing the `auth_settings_v2` block from Azure App Service resources causes a 400 Bad Request error from the Azure API.

**Issue:** When users remove the `auth_settings_v2` block from their Terraform configuration, the provider sends an API request with `Properties = nil` to Azure, which Azure rejects with error code `BadRequest` stating "The parameter properties has an invalid value."

**Root Cause:** The `auth_settings` block had logic to handle removal by sending default/disabled values, but `auth_settings_v2` was missing this same pattern. When the block is removed, [ExpandAuthV2Settings()](cci:1://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers/auth_v2_schema.go:2055:0-2117:1) returns an empty struct with `Properties = nil`.

**Solution:** 
1. Created [DefaultAuthV2SettingsProperties()](cci:1://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers/shared_schema.go:1793:0-1812:1) helper function that returns a properly structured `SiteAuthSettingsV2Properties` with authentication disabled
2. Updated all 8 App Service resources to check if `Properties == nil` and apply default values before sending to Azure
3. Fixed error message in Windows web app slot to correctly reference "Windows" instead of "Linux"

This follows the same pattern already established for `auth_settings` removal.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

**Manual Testing Performed:**
1. Created a Linux Web App with `auth_settings_v2` block configured with Active Directory authentication
2. Applied configuration successfully
3. Commented out the entire `auth_settings_v2` block
4. Ran `terraform apply` - previously resulted in 400 error, now succeeds
5. Verified in Azure Portal that authentication settings were properly disabled
6. Tested with provider built locally using `make build` and dev overrides

**Note on automated tests:** The existing acceptance tests for `auth_settings_v2` (e.g., `TestAccLinuxWebApp_authV2Update`) already test adding/updating auth settings. The removal scenario was not previously covered because it would fail. The fix enables this scenario to work, and the existing test infrastructure validates the auth settings expansion/flattening logic remains correct.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

- azurerm_linux_web_app - fix 400 error when removing auth_settings_v2 block
- azurerm_windows_web_app - fix 400 error when removing auth_settings_v2 block
- azurerm_linux_function_app - fix 400 error when removing auth_settings_v2 block
- azurerm_windows_function_app - fix 400 error when removing auth_settings_v2 block
- azurerm_linux_web_app_slot - fix 400 error when removing auth_settings_v2 block
- azurerm_windows_web_app_slot - fix 400 error when removing auth_settings_v2 block and correct error message
- azurerm_linux_function_app_slot - fix 400 error when removing auth_settings_v2 block
- azurerm_windows_function_app_slot - fix 400 error when removing auth_settings_v2 block

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes - #31080 


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used for:
- Code generation for the fix implementation across all 8 resource files
- Identifying the pattern from existing `auth_settings` handling

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. This fix ensures that authentication settings can be properly disabled/removed, which is the expected behavior when users remove the `auth_settings_v2` configuration block. The fix sends explicit "disabled" values to Azure rather than invalid empty values.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.

