### PR TITLE
tests - skip managed HSM CMK tests unless env var is set

### DIFF
--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
@@ -6,6 +6,7 @@ package mssql_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -36,6 +37,10 @@ func TestAccMsSqlServerTransparentDataEncryption_keyVault(t *testing.T) {
 }
 
 func TestAccMsSqlServerTransparentDataEncryption_managedHSM(t *testing.T) {
+	if os.Getenv("ARM_TEST_HSM_KEY") == "" {
+		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server_transparent_data_encryption", "test")
 	r := MsSqlServerTransparentDataEncryptionResource{}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
@@ -6,6 +6,7 @@ package mssqlmanagedinstance_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -83,6 +84,10 @@ func TestAccMsSqlManagedInstanceTransparentDataEncryption_systemManaged(t *testi
 }
 
 func TestAccMsSqlManagedInstanceTransparentDataEncryption_managedHSM(t *testing.T) {
+	if os.Getenv("ARM_TEST_HSM_KEY") == "" {
+		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_mssql_managed_instance_transparent_data_encryption", "test")
 	r := MsSqlManagedInstanceTransparentDataEncryptionResource{}
 

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -458,6 +458,10 @@ func TestAccMySqlFlexibleServer_updateToCustomerManagedKey(t *testing.T) {
 }
 
 func TestAccMySqlFlexibleServer_createWithHsmCustomerManagedKey(t *testing.T) {
+	if os.Getenv("ARM_TEST_HSM_KEY") == "" {
+		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_mysql_flexible_server", "test")
 	r := MySqlFlexibleServerResource{}
 


### PR DESCRIPTION
These tests are extremely expensive to run and should only be run when there are changes to the CMK functionality.