### PR TITLE
`azurerm_postgres_flexible_server` - change validation for the `customer_managed_key.[geo_backup_]key_vault_key_id` properties to allow managed hsm keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/go-azure-helpers v0.74.0
+	github.com/hashicorp/go-azure-helpers v0.75.1
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20251114.1193342
 	github.com/hashicorp/go-azure-sdk/sdk v0.20251114.1193342
 	github.com/hashicorp/go-cty v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-azure-helpers v0.74.0 h1:4zF2Fn/LVlSwZ+wYQ3zqVf8k/x4f2OKXKsVOFRfsFHg=
-github.com/hashicorp/go-azure-helpers v0.74.0/go.mod h1:tAUWC+kwZQsuNAHEIlnbojMMcC6SWQb6W1HfIeluv1E=
+github.com/hashicorp/go-azure-helpers v0.75.1 h1:trQTCMvBkuBWl5ltPQpGDw/Xe4oepz0enaUeVS0Op3M=
+github.com/hashicorp/go-azure-helpers v0.75.1/go.mod h1:tAUWC+kwZQsuNAHEIlnbojMMcC6SWQb6W1HfIeluv1E=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20251114.1193342 h1:Z5/KIHFp++Rh36aRggvqwvuD3J28U/dlHpbjoLN3XJM=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20251114.1193342/go.mod h1:Nwl+RqMd4KysUTcJdSp4dHTu+BzRtQn0Uvc1kT7TwAg=
 github.com/hashicorp/go-azure-sdk/sdk v0.20251114.1193342 h1:uKtbwoGRSzx9OgHzbuqvBnz3HnR0xFYz9Ns5LzJSm5Q=

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault/constants.go
@@ -1,0 +1,27 @@
+package keyvault
+
+type NestedItemType string
+
+const (
+	NestedItemTypeAny         NestedItemType = "any"
+	NestedItemTypeCertificate NestedItemType = "certificates"
+	NestedItemTypeKey         NestedItemType = "keys"
+	NestedItemTypeSecret      NestedItemType = "secrets"
+)
+
+// PossibleNestedItemTypeValues returns a string slice of possible "NestedItemType" values.
+func PossibleNestedItemTypeValues() []string {
+	return []string{
+		string(NestedItemTypeCertificate),
+		string(NestedItemTypeKey),
+		string(NestedItemTypeSecret),
+	}
+}
+
+type VersionType int
+
+const (
+	VersionTypeAny = iota
+	VersionTypeVersioned
+	VersionTypeVersionless
+)

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault/nested_item.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault/nested_item.go
@@ -1,0 +1,166 @@
+package keyvault
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+type NestedItemID struct {
+	KeyVaultBaseURL string
+	NestedItemType  NestedItemType
+	Name            string
+	Version         string
+}
+
+func NewNestedItemID(keyVaultBaseURL string, nestedItemType NestedItemType, name string, version string) (*NestedItemID, error) {
+	if keyVaultBaseURL == "" {
+		return nil, errors.New("expected a non-empty value for `keyVaultBaseURL`")
+	}
+
+	if name == "" {
+		return nil, errors.New("expected a non-empty value for `name`")
+	}
+
+	if nestedItemType == NestedItemTypeAny {
+		return nil, fmt.Errorf("`NestedItemTypeAny` is not valid when creating a new nested item ID, please specify one of %s", strings.Join(PossibleNestedItemTypeValues(), ", "))
+	}
+
+	keyVaultUrl, err := url.Parse(keyVaultBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing `%s`: %w", keyVaultBaseURL, err)
+	}
+
+	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
+		keyVaultUrl.Host = hostParts[0]
+	}
+
+	return &NestedItemID{
+		KeyVaultBaseURL: strings.TrimSuffix(keyVaultUrl.String(), "/"),
+		NestedItemType:  nestedItemType,
+		Name:            name,
+		Version:         version,
+	}, nil
+}
+
+func (id NestedItemID) ID() string {
+	segments := []string{
+		id.KeyVaultBaseURL,
+		string(id.NestedItemType),
+		id.Name,
+	}
+
+	if id.Version != "" {
+		segments = append(segments, id.Version)
+	}
+
+	return strings.Join(segments, "/")
+}
+
+func (id NestedItemID) VersionlessID() string {
+	segments := []string{
+		id.KeyVaultBaseURL,
+		string(id.NestedItemType),
+		id.Name,
+	}
+
+	return strings.Join(segments, "/")
+}
+
+func (id NestedItemID) String() string {
+	components := []string{
+		fmt.Sprintf("Base URL %q", id.KeyVaultBaseURL),
+		fmt.Sprintf("Nested Item Type %q", string(id.NestedItemType)),
+		fmt.Sprintf("Name %q", id.Name),
+	}
+
+	if id.Version != "" {
+		components = append(components, fmt.Sprintf("Version %q", id.Version))
+	}
+
+	return fmt.Sprintf("Key Vault Nested Item (%s)", strings.Join(components, " / "))
+}
+
+func ParseNestedItemID(input string, versionType VersionType, nestedItemType NestedItemType) (*NestedItemID, error) {
+	id, err := parseNestedItemID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if versionType == VersionTypeVersioned && id.Version == "" {
+		return nil, fmt.Errorf("parsing `%s`: expected a versioned ID", input)
+	}
+
+	if versionType == VersionTypeVersionless && id.Version != "" {
+		return nil, fmt.Errorf("parsing `%s`: expected a versionless ID", input)
+	}
+
+	if nestedItemType == NestedItemTypeAny && !slices.Contains(PossibleNestedItemTypeValues(), string(id.NestedItemType)) {
+		return nil, fmt.Errorf("parsing `%s`: unexpected `NestedItemType` found (`%s`)", input, string(id.NestedItemType))
+	}
+
+	if nestedItemType != id.NestedItemType && nestedItemType != NestedItemTypeAny {
+		return nil, fmt.Errorf("parsing `%s`: expected `NestedItemType` to be `%s`, got `%s`", input, nestedItemType, id.NestedItemType)
+	}
+
+	return id, nil
+}
+
+func parseNestedItemID(input string) (*NestedItemID, error) {
+	inputUrl, err := url.Parse(input)
+	if err != nil {
+		return nil, err
+	}
+
+	path := strings.TrimSuffix(strings.TrimPrefix(inputUrl.Path, "/"), "/")
+	pathSegments := strings.Split(path, "/")
+
+	if l := len(pathSegments); l != 2 && l != 3 {
+		return nil, fmt.Errorf("expected 2 or 3 path segments, found %d segment(s) in `%s`", l, input)
+	}
+
+	var version string
+	if len(pathSegments) == 3 {
+		version = pathSegments[2]
+	}
+
+	return &NestedItemID{
+		KeyVaultBaseURL: fmt.Sprintf("%s://%s", inputUrl.Scheme, inputUrl.Host),
+		NestedItemType:  NestedItemType(pathSegments[0]),
+		Name:            pathSegments[1],
+		Version:         version,
+	}, nil
+}
+
+// ValidateNestedItemID validates the provided ID based on the provided `VersionType` and `NestedItemType` constants
+func ValidateNestedItemID(versionType VersionType, nestedItemType NestedItemType) func(input any, key string) (warnings []string, errors []error) {
+	return func(input any, key string) (warnings []string, errors []error) {
+		v, ok := input.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected `%s` to be a string", key))
+		}
+
+		if _, err := ParseNestedItemID(v, versionType, nestedItemType); err != nil {
+			errors = append(errors, err)
+		}
+
+		return
+	}
+}
+
+func ValidateNestedItemName(v interface{}, k string) (warnings []string, errors []error) {
+	if !regexp.MustCompile(`^[0-9a-zA-Z-]+$`).MatchString(v.(string)) {
+		errors = append(errors, fmt.Errorf("`%s` may only contain alphanumeric characters and dashes", k))
+	}
+
+	return warnings, errors
+}
+
+// IsManagedHSM is a helper to determine whether the key vault URL is for a Managed HSM vault.
+// This can be used to determine whether to set `managed_hsm_key_id` into state while this argument is in a deprecated state.
+func (id NestedItemID) IsManagedHSM() bool {
+	return strings.Contains(id.KeyVaultBaseURL, ".managedhsm.")
+}

--- a/vendor/golang.org/x/crypto/sha3/legacy_hash.go
+++ b/vendor/golang.org/x/crypto/sha3/legacy_hash.go
@@ -1,0 +1,263 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sha3
+
+// This implementation is only used for NewLegacyKeccak256 and
+// NewLegacyKeccak512, which are not implemented by crypto/sha3.
+// All other functions in this package are wrappers around crypto/sha3.
+
+import (
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+	"hash"
+	"unsafe"
+
+	"golang.org/x/sys/cpu"
+)
+
+const (
+	dsbyteKeccak = 0b00000001
+
+	// rateK[c] is the rate in bytes for Keccak[c] where c is the capacity in
+	// bits. Given the sponge size is 1600 bits, the rate is 1600 - c bits.
+	rateK256  = (1600 - 256) / 8
+	rateK512  = (1600 - 512) / 8
+	rateK1024 = (1600 - 1024) / 8
+)
+
+// NewLegacyKeccak256 creates a new Keccak-256 hash.
+//
+// Only use this function if you require compatibility with an existing cryptosystem
+// that uses non-standard padding. All other users should use New256 instead.
+func NewLegacyKeccak256() hash.Hash {
+	return &state{rate: rateK512, outputLen: 32, dsbyte: dsbyteKeccak}
+}
+
+// NewLegacyKeccak512 creates a new Keccak-512 hash.
+//
+// Only use this function if you require compatibility with an existing cryptosystem
+// that uses non-standard padding. All other users should use New512 instead.
+func NewLegacyKeccak512() hash.Hash {
+	return &state{rate: rateK1024, outputLen: 64, dsbyte: dsbyteKeccak}
+}
+
+// spongeDirection indicates the direction bytes are flowing through the sponge.
+type spongeDirection int
+
+const (
+	// spongeAbsorbing indicates that the sponge is absorbing input.
+	spongeAbsorbing spongeDirection = iota
+	// spongeSqueezing indicates that the sponge is being squeezed.
+	spongeSqueezing
+)
+
+type state struct {
+	a [1600 / 8]byte // main state of the hash
+
+	// a[n:rate] is the buffer. If absorbing, it's the remaining space to XOR
+	// into before running the permutation. If squeezing, it's the remaining
+	// output to produce before running the permutation.
+	n, rate int
+
+	// dsbyte contains the "domain separation" bits and the first bit of
+	// the padding. Sections 6.1 and 6.2 of [1] separate the outputs of the
+	// SHA-3 and SHAKE functions by appending bitstrings to the message.
+	// Using a little-endian bit-ordering convention, these are "01" for SHA-3
+	// and "1111" for SHAKE, or 00000010b and 00001111b, respectively. Then the
+	// padding rule from section 5.1 is applied to pad the message to a multiple
+	// of the rate, which involves adding a "1" bit, zero or more "0" bits, and
+	// a final "1" bit. We merge the first "1" bit from the padding into dsbyte,
+	// giving 00000110b (0x06) and 00011111b (0x1f).
+	// [1] http://csrc.nist.gov/publications/drafts/fips-202/fips_202_draft.pdf
+	//     "Draft FIPS 202: SHA-3 Standard: Permutation-Based Hash and
+	//      Extendable-Output Functions (May 2014)"
+	dsbyte byte
+
+	outputLen int             // the default output size in bytes
+	state     spongeDirection // whether the sponge is absorbing or squeezing
+}
+
+// BlockSize returns the rate of sponge underlying this hash function.
+func (d *state) BlockSize() int { return d.rate }
+
+// Size returns the output size of the hash function in bytes.
+func (d *state) Size() int { return d.outputLen }
+
+// Reset clears the internal state by zeroing the sponge state and
+// the buffer indexes, and setting Sponge.state to absorbing.
+func (d *state) Reset() {
+	// Zero the permutation's state.
+	for i := range d.a {
+		d.a[i] = 0
+	}
+	d.state = spongeAbsorbing
+	d.n = 0
+}
+
+func (d *state) clone() *state {
+	ret := *d
+	return &ret
+}
+
+// permute applies the KeccakF-1600 permutation.
+func (d *state) permute() {
+	var a *[25]uint64
+	if cpu.IsBigEndian {
+		a = new([25]uint64)
+		for i := range a {
+			a[i] = binary.LittleEndian.Uint64(d.a[i*8:])
+		}
+	} else {
+		a = (*[25]uint64)(unsafe.Pointer(&d.a))
+	}
+
+	keccakF1600(a)
+	d.n = 0
+
+	if cpu.IsBigEndian {
+		for i := range a {
+			binary.LittleEndian.PutUint64(d.a[i*8:], a[i])
+		}
+	}
+}
+
+// pads appends the domain separation bits in dsbyte, applies
+// the multi-bitrate 10..1 padding rule, and permutes the state.
+func (d *state) padAndPermute() {
+	// Pad with this instance's domain-separator bits. We know that there's
+	// at least one byte of space in the sponge because, if it were full,
+	// permute would have been called to empty it. dsbyte also contains the
+	// first one bit for the padding. See the comment in the state struct.
+	d.a[d.n] ^= d.dsbyte
+	// This adds the final one bit for the padding. Because of the way that
+	// bits are numbered from the LSB upwards, the final bit is the MSB of
+	// the last byte.
+	d.a[d.rate-1] ^= 0x80
+	// Apply the permutation
+	d.permute()
+	d.state = spongeSqueezing
+}
+
+// Write absorbs more data into the hash's state. It panics if any
+// output has already been read.
+func (d *state) Write(p []byte) (n int, err error) {
+	if d.state != spongeAbsorbing {
+		panic("sha3: Write after Read")
+	}
+
+	n = len(p)
+
+	for len(p) > 0 {
+		x := subtle.XORBytes(d.a[d.n:d.rate], d.a[d.n:d.rate], p)
+		d.n += x
+		p = p[x:]
+
+		// If the sponge is full, apply the permutation.
+		if d.n == d.rate {
+			d.permute()
+		}
+	}
+
+	return
+}
+
+// Read squeezes an arbitrary number of bytes from the sponge.
+func (d *state) Read(out []byte) (n int, err error) {
+	// If we're still absorbing, pad and apply the permutation.
+	if d.state == spongeAbsorbing {
+		d.padAndPermute()
+	}
+
+	n = len(out)
+
+	// Now, do the squeezing.
+	for len(out) > 0 {
+		// Apply the permutation if we've squeezed the sponge dry.
+		if d.n == d.rate {
+			d.permute()
+		}
+
+		x := copy(out, d.a[d.n:d.rate])
+		d.n += x
+		out = out[x:]
+	}
+
+	return
+}
+
+// Sum applies padding to the hash state and then squeezes out the desired
+// number of output bytes. It panics if any output has already been read.
+func (d *state) Sum(in []byte) []byte {
+	if d.state != spongeAbsorbing {
+		panic("sha3: Sum after Read")
+	}
+
+	// Make a copy of the original hash so that caller can keep writing
+	// and summing.
+	dup := d.clone()
+	hash := make([]byte, dup.outputLen, 64) // explicit cap to allow stack allocation
+	dup.Read(hash)
+	return append(in, hash...)
+}
+
+const (
+	magicKeccak = "sha\x0b"
+	// magic || rate || main state || n || sponge direction
+	marshaledSize = len(magicKeccak) + 1 + 200 + 1 + 1
+)
+
+func (d *state) MarshalBinary() ([]byte, error) {
+	return d.AppendBinary(make([]byte, 0, marshaledSize))
+}
+
+func (d *state) AppendBinary(b []byte) ([]byte, error) {
+	switch d.dsbyte {
+	case dsbyteKeccak:
+		b = append(b, magicKeccak...)
+	default:
+		panic("unknown dsbyte")
+	}
+	// rate is at most 168, and n is at most rate.
+	b = append(b, byte(d.rate))
+	b = append(b, d.a[:]...)
+	b = append(b, byte(d.n), byte(d.state))
+	return b, nil
+}
+
+func (d *state) UnmarshalBinary(b []byte) error {
+	if len(b) != marshaledSize {
+		return errors.New("sha3: invalid hash state")
+	}
+
+	magic := string(b[:len(magicKeccak)])
+	b = b[len(magicKeccak):]
+	switch {
+	case magic == magicKeccak && d.dsbyte == dsbyteKeccak:
+	default:
+		return errors.New("sha3: invalid hash state identifier")
+	}
+
+	rate := int(b[0])
+	b = b[1:]
+	if rate != d.rate {
+		return errors.New("sha3: invalid hash state function")
+	}
+
+	copy(d.a[:], b)
+	b = b[len(d.a):]
+
+	n, state := int(b[0]), spongeDirection(b[1])
+	if n > d.rate {
+		return errors.New("sha3: invalid hash state")
+	}
+	d.n = n
+	if state != spongeAbsorbing && state != spongeSqueezing {
+		return errors.New("sha3: invalid hash state")
+	}
+	d.state = state
+
+	return nil
+}

--- a/vendor/golang.org/x/crypto/sha3/legacy_keccakf.go
+++ b/vendor/golang.org/x/crypto/sha3/legacy_keccakf.go
@@ -1,0 +1,416 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sha3
+
+// This implementation is only used for NewLegacyKeccak256 and
+// NewLegacyKeccak512, which are not implemented by crypto/sha3.
+// All other functions in this package are wrappers around crypto/sha3.
+
+import "math/bits"
+
+// rc stores the round constants for use in the ι step.
+var rc = [24]uint64{
+	0x0000000000000001,
+	0x0000000000008082,
+	0x800000000000808A,
+	0x8000000080008000,
+	0x000000000000808B,
+	0x0000000080000001,
+	0x8000000080008081,
+	0x8000000000008009,
+	0x000000000000008A,
+	0x0000000000000088,
+	0x0000000080008009,
+	0x000000008000000A,
+	0x000000008000808B,
+	0x800000000000008B,
+	0x8000000000008089,
+	0x8000000000008003,
+	0x8000000000008002,
+	0x8000000000000080,
+	0x000000000000800A,
+	0x800000008000000A,
+	0x8000000080008081,
+	0x8000000000008080,
+	0x0000000080000001,
+	0x8000000080008008,
+}
+
+// keccakF1600 applies the Keccak permutation to a 1600b-wide
+// state represented as a slice of 25 uint64s.
+func keccakF1600(a *[25]uint64) {
+	// Implementation translated from Keccak-inplace.c
+	// in the keccak reference code.
+	var t, bc0, bc1, bc2, bc3, bc4, d0, d1, d2, d3, d4 uint64
+
+	for i := 0; i < 24; i += 4 {
+		// Combines the 5 steps in each round into 2 steps.
+		// Unrolls 4 rounds per loop and spreads some steps across rounds.
+
+		// Round 1
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[6] ^ d1
+		bc1 = bits.RotateLeft64(t, 44)
+		t = a[12] ^ d2
+		bc2 = bits.RotateLeft64(t, 43)
+		t = a[18] ^ d3
+		bc3 = bits.RotateLeft64(t, 21)
+		t = a[24] ^ d4
+		bc4 = bits.RotateLeft64(t, 14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i]
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc2 = bits.RotateLeft64(t, 3)
+		t = a[16] ^ d1
+		bc3 = bits.RotateLeft64(t, 45)
+		t = a[22] ^ d2
+		bc4 = bits.RotateLeft64(t, 61)
+		t = a[3] ^ d3
+		bc0 = bits.RotateLeft64(t, 28)
+		t = a[9] ^ d4
+		bc1 = bits.RotateLeft64(t, 20)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc4 = bits.RotateLeft64(t, 18)
+		t = a[1] ^ d1
+		bc0 = bits.RotateLeft64(t, 1)
+		t = a[7] ^ d2
+		bc1 = bits.RotateLeft64(t, 6)
+		t = a[13] ^ d3
+		bc2 = bits.RotateLeft64(t, 25)
+		t = a[19] ^ d4
+		bc3 = bits.RotateLeft64(t, 8)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc1 = bits.RotateLeft64(t, 36)
+		t = a[11] ^ d1
+		bc2 = bits.RotateLeft64(t, 10)
+		t = a[17] ^ d2
+		bc3 = bits.RotateLeft64(t, 15)
+		t = a[23] ^ d3
+		bc4 = bits.RotateLeft64(t, 56)
+		t = a[4] ^ d4
+		bc0 = bits.RotateLeft64(t, 27)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc3 = bits.RotateLeft64(t, 41)
+		t = a[21] ^ d1
+		bc4 = bits.RotateLeft64(t, 2)
+		t = a[2] ^ d2
+		bc0 = bits.RotateLeft64(t, 62)
+		t = a[8] ^ d3
+		bc1 = bits.RotateLeft64(t, 55)
+		t = a[14] ^ d4
+		bc2 = bits.RotateLeft64(t, 39)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		// Round 2
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[16] ^ d1
+		bc1 = bits.RotateLeft64(t, 44)
+		t = a[7] ^ d2
+		bc2 = bits.RotateLeft64(t, 43)
+		t = a[23] ^ d3
+		bc3 = bits.RotateLeft64(t, 21)
+		t = a[14] ^ d4
+		bc4 = bits.RotateLeft64(t, 14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+1]
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc2 = bits.RotateLeft64(t, 3)
+		t = a[11] ^ d1
+		bc3 = bits.RotateLeft64(t, 45)
+		t = a[2] ^ d2
+		bc4 = bits.RotateLeft64(t, 61)
+		t = a[18] ^ d3
+		bc0 = bits.RotateLeft64(t, 28)
+		t = a[9] ^ d4
+		bc1 = bits.RotateLeft64(t, 20)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc4 = bits.RotateLeft64(t, 18)
+		t = a[6] ^ d1
+		bc0 = bits.RotateLeft64(t, 1)
+		t = a[22] ^ d2
+		bc1 = bits.RotateLeft64(t, 6)
+		t = a[13] ^ d3
+		bc2 = bits.RotateLeft64(t, 25)
+		t = a[4] ^ d4
+		bc3 = bits.RotateLeft64(t, 8)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc1 = bits.RotateLeft64(t, 36)
+		t = a[1] ^ d1
+		bc2 = bits.RotateLeft64(t, 10)
+		t = a[17] ^ d2
+		bc3 = bits.RotateLeft64(t, 15)
+		t = a[8] ^ d3
+		bc4 = bits.RotateLeft64(t, 56)
+		t = a[24] ^ d4
+		bc0 = bits.RotateLeft64(t, 27)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc3 = bits.RotateLeft64(t, 41)
+		t = a[21] ^ d1
+		bc4 = bits.RotateLeft64(t, 2)
+		t = a[12] ^ d2
+		bc0 = bits.RotateLeft64(t, 62)
+		t = a[3] ^ d3
+		bc1 = bits.RotateLeft64(t, 55)
+		t = a[19] ^ d4
+		bc2 = bits.RotateLeft64(t, 39)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		// Round 3
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[11] ^ d1
+		bc1 = bits.RotateLeft64(t, 44)
+		t = a[22] ^ d2
+		bc2 = bits.RotateLeft64(t, 43)
+		t = a[8] ^ d3
+		bc3 = bits.RotateLeft64(t, 21)
+		t = a[19] ^ d4
+		bc4 = bits.RotateLeft64(t, 14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+2]
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc2 = bits.RotateLeft64(t, 3)
+		t = a[1] ^ d1
+		bc3 = bits.RotateLeft64(t, 45)
+		t = a[12] ^ d2
+		bc4 = bits.RotateLeft64(t, 61)
+		t = a[23] ^ d3
+		bc0 = bits.RotateLeft64(t, 28)
+		t = a[9] ^ d4
+		bc1 = bits.RotateLeft64(t, 20)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc4 = bits.RotateLeft64(t, 18)
+		t = a[16] ^ d1
+		bc0 = bits.RotateLeft64(t, 1)
+		t = a[2] ^ d2
+		bc1 = bits.RotateLeft64(t, 6)
+		t = a[13] ^ d3
+		bc2 = bits.RotateLeft64(t, 25)
+		t = a[24] ^ d4
+		bc3 = bits.RotateLeft64(t, 8)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc1 = bits.RotateLeft64(t, 36)
+		t = a[6] ^ d1
+		bc2 = bits.RotateLeft64(t, 10)
+		t = a[17] ^ d2
+		bc3 = bits.RotateLeft64(t, 15)
+		t = a[3] ^ d3
+		bc4 = bits.RotateLeft64(t, 56)
+		t = a[14] ^ d4
+		bc0 = bits.RotateLeft64(t, 27)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc3 = bits.RotateLeft64(t, 41)
+		t = a[21] ^ d1
+		bc4 = bits.RotateLeft64(t, 2)
+		t = a[7] ^ d2
+		bc0 = bits.RotateLeft64(t, 62)
+		t = a[18] ^ d3
+		bc1 = bits.RotateLeft64(t, 55)
+		t = a[4] ^ d4
+		bc2 = bits.RotateLeft64(t, 39)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		// Round 4
+		bc0 = a[0] ^ a[5] ^ a[10] ^ a[15] ^ a[20]
+		bc1 = a[1] ^ a[6] ^ a[11] ^ a[16] ^ a[21]
+		bc2 = a[2] ^ a[7] ^ a[12] ^ a[17] ^ a[22]
+		bc3 = a[3] ^ a[8] ^ a[13] ^ a[18] ^ a[23]
+		bc4 = a[4] ^ a[9] ^ a[14] ^ a[19] ^ a[24]
+		d0 = bc4 ^ (bc1<<1 | bc1>>63)
+		d1 = bc0 ^ (bc2<<1 | bc2>>63)
+		d2 = bc1 ^ (bc3<<1 | bc3>>63)
+		d3 = bc2 ^ (bc4<<1 | bc4>>63)
+		d4 = bc3 ^ (bc0<<1 | bc0>>63)
+
+		bc0 = a[0] ^ d0
+		t = a[1] ^ d1
+		bc1 = bits.RotateLeft64(t, 44)
+		t = a[2] ^ d2
+		bc2 = bits.RotateLeft64(t, 43)
+		t = a[3] ^ d3
+		bc3 = bits.RotateLeft64(t, 21)
+		t = a[4] ^ d4
+		bc4 = bits.RotateLeft64(t, 14)
+		a[0] = bc0 ^ (bc2 &^ bc1) ^ rc[i+3]
+		a[1] = bc1 ^ (bc3 &^ bc2)
+		a[2] = bc2 ^ (bc4 &^ bc3)
+		a[3] = bc3 ^ (bc0 &^ bc4)
+		a[4] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[5] ^ d0
+		bc2 = bits.RotateLeft64(t, 3)
+		t = a[6] ^ d1
+		bc3 = bits.RotateLeft64(t, 45)
+		t = a[7] ^ d2
+		bc4 = bits.RotateLeft64(t, 61)
+		t = a[8] ^ d3
+		bc0 = bits.RotateLeft64(t, 28)
+		t = a[9] ^ d4
+		bc1 = bits.RotateLeft64(t, 20)
+		a[5] = bc0 ^ (bc2 &^ bc1)
+		a[6] = bc1 ^ (bc3 &^ bc2)
+		a[7] = bc2 ^ (bc4 &^ bc3)
+		a[8] = bc3 ^ (bc0 &^ bc4)
+		a[9] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[10] ^ d0
+		bc4 = bits.RotateLeft64(t, 18)
+		t = a[11] ^ d1
+		bc0 = bits.RotateLeft64(t, 1)
+		t = a[12] ^ d2
+		bc1 = bits.RotateLeft64(t, 6)
+		t = a[13] ^ d3
+		bc2 = bits.RotateLeft64(t, 25)
+		t = a[14] ^ d4
+		bc3 = bits.RotateLeft64(t, 8)
+		a[10] = bc0 ^ (bc2 &^ bc1)
+		a[11] = bc1 ^ (bc3 &^ bc2)
+		a[12] = bc2 ^ (bc4 &^ bc3)
+		a[13] = bc3 ^ (bc0 &^ bc4)
+		a[14] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[15] ^ d0
+		bc1 = bits.RotateLeft64(t, 36)
+		t = a[16] ^ d1
+		bc2 = bits.RotateLeft64(t, 10)
+		t = a[17] ^ d2
+		bc3 = bits.RotateLeft64(t, 15)
+		t = a[18] ^ d3
+		bc4 = bits.RotateLeft64(t, 56)
+		t = a[19] ^ d4
+		bc0 = bits.RotateLeft64(t, 27)
+		a[15] = bc0 ^ (bc2 &^ bc1)
+		a[16] = bc1 ^ (bc3 &^ bc2)
+		a[17] = bc2 ^ (bc4 &^ bc3)
+		a[18] = bc3 ^ (bc0 &^ bc4)
+		a[19] = bc4 ^ (bc1 &^ bc0)
+
+		t = a[20] ^ d0
+		bc3 = bits.RotateLeft64(t, 41)
+		t = a[21] ^ d1
+		bc4 = bits.RotateLeft64(t, 2)
+		t = a[22] ^ d2
+		bc0 = bits.RotateLeft64(t, 62)
+		t = a[23] ^ d3
+		bc1 = bits.RotateLeft64(t, 55)
+		t = a[24] ^ d4
+		bc2 = bits.RotateLeft64(t, 39)
+		a[20] = bc0 ^ (bc2 &^ bc1)
+		a[21] = bc1 ^ (bc3 &^ bc2)
+		a[22] = bc2 ^ (bc4 &^ bc3)
+		a[23] = bc3 ^ (bc0 &^ bc4)
+		a[24] = bc4 ^ (bc1 &^ bc0)
+	}
+}

--- a/vendor/golang.org/x/net/http2/writesched_priority_rfc9218.go
+++ b/vendor/golang.org/x/net/http2/writesched_priority_rfc9218.go
@@ -1,0 +1,209 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package http2
+
+import (
+	"fmt"
+	"math"
+)
+
+type streamMetadata struct {
+	location *writeQueue
+	priority PriorityParam
+}
+
+type priorityWriteSchedulerRFC9218 struct {
+	// control contains control frames (SETTINGS, PING, etc.).
+	control writeQueue
+
+	// heads contain the head of a circular list of streams.
+	// We put these heads within a nested array that represents urgency and
+	// incremental, as defined in
+	// https://www.rfc-editor.org/rfc/rfc9218.html#name-priority-parameters.
+	// 8 represents u=0 up to u=7, and 2 represents i=false and i=true.
+	heads [8][2]*writeQueue
+
+	// streams contains a mapping between each stream ID and their metadata, so
+	// we can quickly locate them when needing to, for example, adjust their
+	// priority.
+	streams map[uint32]streamMetadata
+
+	// queuePool are empty queues for reuse.
+	queuePool writeQueuePool
+
+	// prioritizeIncremental is used to determine whether we should prioritize
+	// incremental streams or not, when urgency is the same in a given Pop()
+	// call.
+	prioritizeIncremental bool
+}
+
+func newPriorityWriteSchedulerRFC9218() WriteScheduler {
+	ws := &priorityWriteSchedulerRFC9218{
+		streams: make(map[uint32]streamMetadata),
+	}
+	return ws
+}
+
+func (ws *priorityWriteSchedulerRFC9218) OpenStream(streamID uint32, opt OpenStreamOptions) {
+	if ws.streams[streamID].location != nil {
+		panic(fmt.Errorf("stream %d already opened", streamID))
+	}
+	q := ws.queuePool.get()
+	ws.streams[streamID] = streamMetadata{
+		location: q,
+		priority: opt.priority,
+	}
+
+	u, i := opt.priority.urgency, opt.priority.incremental
+	if ws.heads[u][i] == nil {
+		ws.heads[u][i] = q
+		q.next = q
+		q.prev = q
+	} else {
+		// Queues are stored in a ring.
+		// Insert the new stream before ws.head, putting it at the end of the list.
+		q.prev = ws.heads[u][i].prev
+		q.next = ws.heads[u][i]
+		q.prev.next = q
+		q.next.prev = q
+	}
+}
+
+func (ws *priorityWriteSchedulerRFC9218) CloseStream(streamID uint32) {
+	metadata := ws.streams[streamID]
+	q, u, i := metadata.location, metadata.priority.urgency, metadata.priority.incremental
+	if q == nil {
+		return
+	}
+	if q.next == q {
+		// This was the only open stream.
+		ws.heads[u][i] = nil
+	} else {
+		q.prev.next = q.next
+		q.next.prev = q.prev
+		if ws.heads[u][i] == q {
+			ws.heads[u][i] = q.next
+		}
+	}
+	delete(ws.streams, streamID)
+	ws.queuePool.put(q)
+}
+
+func (ws *priorityWriteSchedulerRFC9218) AdjustStream(streamID uint32, priority PriorityParam) {
+	metadata := ws.streams[streamID]
+	q, u, i := metadata.location, metadata.priority.urgency, metadata.priority.incremental
+	if q == nil {
+		return
+	}
+
+	// Remove stream from current location.
+	if q.next == q {
+		// This was the only open stream.
+		ws.heads[u][i] = nil
+	} else {
+		q.prev.next = q.next
+		q.next.prev = q.prev
+		if ws.heads[u][i] == q {
+			ws.heads[u][i] = q.next
+		}
+	}
+
+	// Insert stream to the new queue.
+	u, i = priority.urgency, priority.incremental
+	if ws.heads[u][i] == nil {
+		ws.heads[u][i] = q
+		q.next = q
+		q.prev = q
+	} else {
+		// Queues are stored in a ring.
+		// Insert the new stream before ws.head, putting it at the end of the list.
+		q.prev = ws.heads[u][i].prev
+		q.next = ws.heads[u][i]
+		q.prev.next = q
+		q.next.prev = q
+	}
+
+	// Update the metadata.
+	ws.streams[streamID] = streamMetadata{
+		location: q,
+		priority: priority,
+	}
+}
+
+func (ws *priorityWriteSchedulerRFC9218) Push(wr FrameWriteRequest) {
+	if wr.isControl() {
+		ws.control.push(wr)
+		return
+	}
+	q := ws.streams[wr.StreamID()].location
+	if q == nil {
+		// This is a closed stream.
+		// wr should not be a HEADERS or DATA frame.
+		// We push the request onto the control queue.
+		if wr.DataSize() > 0 {
+			panic("add DATA on non-open stream")
+		}
+		ws.control.push(wr)
+		return
+	}
+	q.push(wr)
+}
+
+func (ws *priorityWriteSchedulerRFC9218) Pop() (FrameWriteRequest, bool) {
+	// Control and RST_STREAM frames first.
+	if !ws.control.empty() {
+		return ws.control.shift(), true
+	}
+
+	// On the next Pop(), we want to prioritize incremental if we prioritized
+	// non-incremental request of the same urgency this time. Vice-versa.
+	// i.e. when there are incremental and non-incremental requests at the same
+	// priority, we give 50% of our bandwidth to the incremental ones in
+	// aggregate and 50% to the first non-incremental one (since
+	// non-incremental streams do not use round-robin writes).
+	ws.prioritizeIncremental = !ws.prioritizeIncremental
+
+	// Always prioritize lowest u (i.e. highest urgency level).
+	for u := range ws.heads {
+		for i := range ws.heads[u] {
+			// When we want to prioritize incremental, we try to pop i=true
+			// first before i=false when u is the same.
+			if ws.prioritizeIncremental {
+				i = (i + 1) % 2
+			}
+			q := ws.heads[u][i]
+			if q == nil {
+				continue
+			}
+			for {
+				if wr, ok := q.consume(math.MaxInt32); ok {
+					if i == 1 {
+						// For incremental streams, we update head to q.next so
+						// we can round-robin between multiple streams that can
+						// immediately benefit from partial writes.
+						ws.heads[u][i] = q.next
+					} else {
+						// For non-incremental streams, we try to finish one to
+						// completion rather than doing round-robin. However,
+						// we update head here so that if q.consume() is !ok
+						// (e.g. the stream has no more frame to consume), head
+						// is updated to the next q that has frames to consume
+						// on future iterations. This way, we do not prioritize
+						// writing to unavailable stream on next Pop() calls,
+						// preventing head-of-line blocking.
+						ws.heads[u][i] = q
+					}
+					return wr, true
+				}
+				q = q.next
+				if q == ws.heads[u][i] {
+					break
+				}
+			}
+
+		}
+	}
+	return FrameWriteRequest{}, false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.74.0
+# github.com/hashicorp/go-azure-helpers v0.75.1
 ## explicit; go 1.24.1
 github.com/hashicorp/go-azure-helpers/eventhub
 github.com/hashicorp/go-azure-helpers/framework/commonschema
@@ -156,6 +156,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema
 github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones
 github.com/hashicorp/go-azure-helpers/resourcemanager/features
 github.com/hashicorp/go-azure-helpers/resourcemanager/identity
+github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault
 github.com/hashicorp/go-azure-helpers/resourcemanager/location
 github.com/hashicorp/go-azure-helpers/resourcemanager/recaser
 github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Changes validation to the new go-azure-helpers function, also allowing managed hsm keys

Note: I've left out a test specifically for managed HSM keys due to the cost associated with running these tests and the fact that the functionality (from a provider perspective) doesn't change between key vault and managed HSM key vaults.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

New failure due to a transient error

<img width="646" height="993" alt="image" src="https://github.com/user-attachments/assets/27c4044f-42bf-4d36-a29c-e964ff6cecb5" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #26338


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
