### PR TITLE
azurerm_backup_policy_vm_workload - support for the tiering_policy property

### DIFF
--- a/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
@@ -410,7 +410,7 @@ func (r BackupProtectionPolicyVMWorkloadResource) Arguments() map[string]*plugin
 											"duration": {
 												Type:         pluginsdk.TypeInt,
 												Optional:     true,
-												ValidateFunc: validation.IntAtLeast(3),
+												ValidateFunc: validation.IntAtLeast(45),
 											},
 
 											"duration_type": {

--- a/internal/services/recoveryservices/backup_policy_vm_workload_resource_test.go
+++ b/internal/services/recoveryservices/backup_policy_vm_workload_resource_test.go
@@ -65,7 +65,7 @@ func TestAccBackupProtectionPolicyVMWorkload_tieringPolicy(t *testing.T) {
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("protection_policy.0.tiering_policy.0.archived_restore_point.0.mode").HasValue("TierAfter"),
-				check.That(data.ResourceName).Key("protection_policy.0.tiering_policy.0.archived_restore_point.0.duration").HasValue("30"),
+				check.That(data.ResourceName).Key("protection_policy.0.tiering_policy.0.archived_restore_point.0.duration").HasValue("45"),
 				check.That(data.ResourceName).Key("protection_policy.0.tiering_policy.0.archived_restore_point.0.duration_type").HasValue("Days"),
 			),
 		},
@@ -385,7 +385,7 @@ resource "azurerm_backup_policy_vm_workload" "test" {
     tiering_policy {
       archived_restore_point {
         mode          = "TierAfter"
-        duration      = 30
+        duration      = 45
         duration_type = "Days"
       }
     }

--- a/website/docs/r/backup_policy_vm_workload.html.markdown
+++ b/website/docs/r/backup_policy_vm_workload.html.markdown
@@ -53,7 +53,7 @@ resource "azurerm_backup_policy_vm_workload" "example" {
     tiering_policy {
       archived_restore_point {
         mode          = "TierAfter"
-        duration      = 30
+        duration      = 45
         duration_type = "Days"
       }
     }
@@ -127,9 +127,11 @@ The `archived_restore_point` block supports the following:
 
 * `mode` - (Required) The tiering mode for the archived restore point. Possible values are `TierAfter` and `TierRecommended`.
 
-* `duration` - (Optional) The duration after which the restore point will be archived. Required when `mode` is `TierAfter`.
+* `duration` - (Optional) The duration after which the restore point will be archived. Must be at least `45` days. Required when `mode` is `TierAfter`.
 
 * `duration_type` - (Optional) The duration type for the archived restore point. Possible values are `Days`, `Weeks`, `Months`, and `Years`. Required when `mode` is `TierAfter`.
+
+~> **Note:** When using `TierAfter` mode, at least one retention policy for full backup (daily, weekly, monthly, or yearly) must be set to a duration of at least 180 days longer than the `duration` value. For example, if `duration` is set to 45 days, at least one full backup retention policy must be configured for 225 days or more (45 + 180).
 
 ---
 


### PR DESCRIPTION
### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

### PR Checklist

- [x] Have you followed the guidelines in our [Contributing Documentation](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/hashicorp/terraform-provider-azurerm/pulls) for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?

### Changes to existing Resource

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your resource changes?
- [x] Have you successfully run tests with your changes locally?

### Documentation Changes

- [x] Documentation is written in International English.
- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource.

### Description

This PR adds support for the `tiering_policy` property to the `azurerm_backup_policy_vm_workload` resource, enabling users to configure archive tiering for SQL Database and SAP HANA backup policies.

Note: This is for the **VM Workload** resource (SQL/SAP HANA), which is separate from `azurerm_backup_policy_vm` (which already has tiering support via #26263).

The Azure SDK supports this functionality via the `TieringPolicy` field in the `SubProtectionPolicy` struct (2024-10-01 API). This implementation follows the same pattern as the existing tiering policy support in `azurerm_backup_policy_vm`.

**What's New:**
- Added `tiering_policy` block with `archived_restore_point` sub-block to the resource schema
- Supports `TierAfter` and `TierRecommended` tiering modes
- Enforces minimum duration of 45 days (as required by Azure for SQL/SAP HANA workloads)
- Allows configuration of duration and duration_type for automatic archival
- Implemented expand/flatten functions for bidirectional conversion
- Updated Create, Read, and Update functions to handle tiering policy
- Added comprehensive acceptance test: `TestAccBackupProtectionPolicyVMWorkload_tieringPolicy`
- Updated documentation with examples, complete argument reference, and Azure requirements note

**Azure Requirements:**
Per [Azure documentation](https://learn.microsoft.com/en-us/azure/backup/use-archive-tier-support), SQL/SAP HANA workload backups require:
- Minimum `TierAfter` duration: 45 days
- At least one retention policy must be configured for (TierAfter + 180) days or more

**Example Usage:**
```hcl
protection_policy {
  policy_type = "Full"

  backup {
    frequency = "Daily"
    time      = "15:00"
  }

  retention_daily {
    count = 225  # Must be at least 45 + 180 = 225 days
  }

  tiering_policy {
    archived_restore_point {
      mode          = "TierAfter"
      duration      = 45
      duration_type = "Days"
    }
  }
}
```

### Change Log

* `azurerm_backup_policy_vm_workload` - support for the `tiering_policy` property

- [x] New Feature

<!-- gk-ai-analysis-start:e721d866b2c8ae8f2298d1d059f732ba03a472c3 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBzdXBwb3J0IGZvciB0aGUgYHRpZXJpbmdfcG9saWN5YCBibG9jayB0byB0aGUgYGF6dXJlcm1fYmFja3VwX3BvbGljeV92bV93b3JrbG9hZGAgcmVzb3VyY2UsIGVuYWJsaW5nIGFyY2hpdmUgdGllcmluZyBmb3IgU1FMIERhdGFiYXNlIGFuZCBTQVAgSEFOQSBiYWNrdXAgcG9saWNpZXMuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiTmV3IHRpZXJpbmdfcG9saWN5IHNjaGVtYSBibG9jayIsImRlc2NyaXB0aW9uIjoiSW50cm9kdWNlcyB0aGUgYHRpZXJpbmdfcG9saWN5YCBibG9jayB3aXRoIGFuIGBhcmNoaXZlZF9yZXN0b3JlX3BvaW50YCBzdWItYmxvY2sgdG8gY29uZmlndXJlIGF1dG9tYXRpYyBhcmNoaXZhbCB0aWVyaW5nIG1vZGUsIGR1cmF0aW9uLCBhbmQgZHVyYXRpb24gdHlwZS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiaW50ZXJuYWwvc2VydmljZXMvcmVjb3ZlcnlzZXJ2aWNlcy9iYWNrdXBfcG9saWN5X3ZtX3dvcmtsb2FkX3Jlc291cmNlLmdvIiwibGluZVN0YXJ0IjozODl9LHsidGl0bGUiOiJBUEkgY29udmVyc2lvbnMgZm9yIHRpZXJpbmcgcG9saWN5IiwiZGVzY3JpcHRpb24iOiJBZGRzIGV4cGFuZCBhbmQgZmxhdHRlbiBvcGVyYXRpb25zIHRvIHRyYW5zbGF0ZSB0aGUgYHRpZXJpbmdfcG9saWN5YCBibG9jayB0byBhbmQgZnJvbSBBenVyZSdzIGBTdWJQcm90ZWN0aW9uUG9saWN5LlRpZXJpbmdQb2xpY3lgIEFQSSBzdHJ1Y3R1cmUuIiwic2V2ZXJpdHkiOiJtZWRpdW0iLCJmaWxlUGF0aCI6ImludGVybmFsL3NlcnZpY2VzL3JlY292ZXJ5c2VydmljZXMvYmFja3VwX3BvbGljeV92bV93b3JrbG9hZF9yZXNvdXJjZS5nbyIsImxpbmVTdGFydCI6NzEyfV0sImlzc3VlcyI6W3sidGl0bGUiOiJJbmNvcnJlY3QgdmFsaWRhdGlvbiBvbiBgZHVyYXRpb25gIHByZXZlbnRzIHZhbGlkIG5vbi1EYXlzIGR1cmF0aW9uIHR5cGVzIiwiZGVzY3JpcHRpb24iOiJUaGUgYFZhbGlkYXRlRnVuYzogdmFsaWRhdGlvbi5JbnRBdExlYXN0KDQ1KWAgb24gdGhlIGBkdXJhdGlvbmAgZmllbGQgcmVzdHJpY3RzIHRoZSByYXcgaW50ZWdlciB0byBiZSBhdCBsZWFzdCA0NS4gSWYgYSB1c2VyIHZhbGlkbHkgc3BlY2lmaWVzIGBkdXJhdGlvbl90eXBlYCBhcyBgV2Vla3NgLCBgTW9udGhzYCwgb3IgYFllYXJzYCAoZS5nLiwgYGR1cmF0aW9uID0gMmAsIGBkdXJhdGlvbl90eXBlID0gXCJNb250aHNcImApLCB0aGlzIHZhbGlkYXRpb24gd2lsbCBlcnJvbmVvdXNseSBmYWlsIGRlc3BpdGUgdGhlIGFjdHVhbCB0aW1lZnJhbWUgZXhjZWVkaW5nIDQ1IGRheXMuIENvbnNpZGVyIHJlbW92aW5nIHRoaXMgc3BlY2lmaWMgc2NoZW1hIHZhbGlkYXRpb24gYW5kIHJlbHlpbmcgb24gdGhlIEFQSSwgb3IgdXNpbmcgYSBgQ3VzdG9taXplRGlmZmAgdmFsaWRhdGlvbiB0byBjYWxjdWxhdGUgdGhlIGNvbWJpbmVkIHRvdGFsIGRheXMuIiwic2V2ZXJpdHkiOiJoaWdoIiwiZmlsZVBhdGgiOiJpbnRlcm5hbC9zZXJ2aWNlcy9yZWNvdmVyeXNlcnZpY2VzL2JhY2t1cF9wb2xpY3lfdm1fd29ya2xvYWRfcmVzb3VyY2UuZ28iLCJsaW5lU3RhcnQiOjQwOH0seyJ0aXRsZSI6IkFjY2VwdGFuY2UgdGVzdCB1c2VzIGludmFsaWQgcmV0ZW50aW9uIGNvdW50IHRoYXQgdmlvbGF0ZXMgQXp1cmUgcmVxdWlyZW1lbnRzIiwiZGVzY3JpcHRpb24iOiJUaGUgdGVzdCBjb25maWd1cmVzIGByZXRlbnRpb25fZGFpbHkuY291bnQgPSA4YCB3aGlsZSB1c2luZyBgbW9kZSA9IFwiVGllckFmdGVyXCJgIHdpdGggYSA0NS1kYXkgZHVyYXRpb24uIEFjY29yZGluZyB0byB0aGUgUFIgZG9jdW1lbnRhdGlvbiwgQXp1cmUgcmVxdWlyZXMgcmV0ZW50aW9uIHRvIGJlIGF0IGxlYXN0IDE4MCBkYXlzIGxvbmdlciB0aGFuIHRoZSB0aWVyaW5nIGR1cmF0aW9uIChpLmUuLCBhdCBsZWFzdCAyMjUgZGF5cykuIFRoaXMgd2lsbCBsaWtlbHkgY2F1c2UgdGhlIGFjY2VwdGFuY2UgdGVzdCB0byBmYWlsIGFnYWluc3QgdGhlIGxpdmUgQXp1cmUgQVBJLiIsInNldmVyaXR5IjoiaGlnaCIsImZpbGVQYXRoIjoiaW50ZXJuYWwvc2VydmljZXMvcmVjb3ZlcnlzZXJ2aWNlcy9iYWNrdXBfcG9saWN5X3ZtX3dvcmtsb2FkX3Jlc291cmNlX3Rlc3QuZ28iLCJsaW5lU3RhcnQiOjM3OH1dLCJzdWdnZXN0aW9ucyI6W3sidGl0bGUiOiJFbmZvcmNlIGNyb3NzLWZpZWxkIGRlcGVuZGVuY2llcyBmb3IgbW9kZSBhbmQgZHVyYXRpb24iLCJkZXNjcmlwdGlvbiI6IlRoZSBgZHVyYXRpb25gIGFuZCBgZHVyYXRpb25fdHlwZWAgZmllbGRzIGFyZSBkb2N1bWVudGVkIGFzIHJlcXVpcmVkIHdoZW4gYG1vZGVgIGlzIGBUaWVyQWZ0ZXJgLCBidXQgdGhleSBhcmUgbWFya2VkIGBPcHRpb25hbDogdHJ1ZWAgd2l0aG91dCBzY2hlbWEtbGV2ZWwgY2hlY2tzLiBDb25zaWRlciBpbXBsZW1lbnRpbmcgY3Jvc3MtZmllbGQgdmFsaWRhdGlvbiAoZS5nLiwgdXNpbmcgYSBgQ3VzdG9taXplRGlmZmAgZnVuY3Rpb24pIHRvIGVuc3VyZSB0aGV5IGFyZSBleHBsaWNpdGx5IHByb3ZpZGVkIGZvciBgVGllckFmdGVyYCBhbmQgb21pdHRlZCBmb3IgYFRpZXJSZWNvbW1lbmRlZGAuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6ImludGVybmFsL3NlcnZpY2VzL3JlY292ZXJ5c2VydmljZXMvYmFja3VwX3BvbGljeV92bV93b3JrbG9hZF9yZXNvdXJjZS5nbyIsImxpbmVTdGFydCI6NDA4fV0sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:e721d866b2c8ae8f2298d1d059f732ba03a472c3 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/hashicorp/terraform-provider-azurerm/pull/31151">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->