### PR TITLE
Add germany c5 and hitrust compliance standards for azure databricks

### DIFF
--- a/examples/databricks/enhanced-security-compliance/main.tf
+++ b/examples/databricks/enhanced-security-compliance/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_databricks_workspace" "example" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = true
     compliance_security_profile_enabled   = true
-    compliance_security_profile_standards = ["HIPAA", "PCI_DSS"]
+    compliance_security_profile_standards = ["HIPAA", "PCI_DSS", "GERMANY_C5", "HITRUST"]
     enhanced_security_monitoring_enabled  = true
   }
 }

--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -260,7 +260,7 @@ resource "azurerm_databricks_workspace" "test" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = true
     compliance_security_profile_enabled   = true
-    compliance_security_profile_standards = ["PCI_DSS", "HIPAA"]
+    compliance_security_profile_standards = ["PCI_DSS", "HIPAA", "GERMANY_C5", "HITRUST"]
     enhanced_security_monitoring_enabled  = true
   }
 }

--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -358,6 +358,8 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 								ValidateFunc: validation.StringInSlice([]string{
 									string(workspaces.ComplianceStandardHIPAA),
 									string(workspaces.ComplianceStandardPCIDSS),
+									string(workspaces.ComplianceStandardGERMANYC5),
+									string(workspaces.ComplianceStandardHITRUST),
 								}, false),
 							},
 						},

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -431,7 +431,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurity(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA"}, true),
+			Config: r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "GERMANY_C5", "HITRUST"}, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -473,7 +473,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidStandardSku
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "standard", true, true, []string{"PCI_DSS", "HIPAA"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "standard", true, true, []string{"PCI_DSS", "HIPAA", "GERMANY_C5", "HITRUST"}, true),
 			ExpectError: regexp.MustCompile("enhanced_security_compliance.*are only available with a `premium`"),
 		},
 	})
@@ -485,7 +485,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithoutEnhancedSecurit
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA"}, false),
+			Config:      r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "GERMANY_C5", "HITRUST"}, false),
 			ExpectError: regexp.MustCompile("`enhanced_security_monitoring_enabled` must be set to true when `compliance_security_profile_enabled` is set to true"),
 		},
 	})
@@ -497,7 +497,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithoutAutomaticCluste
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", false, true, []string{"PCI_DSS", "HIPAA"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "premium", false, true, []string{"PCI_DSS", "HIPAA", "GERMANY_C5", "HITRUST"}, true),
 			ExpectError: regexp.MustCompile("`automatic_cluster_update_enabled` .* must be set to true when `compliance_security_profile_enabled` is set to true"),
 		},
 	})
@@ -509,7 +509,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidComplianceS
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", true, false, []string{"PCI_DSS", "HIPAA"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "premium", true, false, []string{"PCI_DSS", "HIPAA", "GERMANY_C5", "HITRUST"}, true),
 			ExpectError: regexp.MustCompile("`compliance_security_profile_standards` cannot be set when `compliance_security_profile_enabled` is false"),
 		},
 	})

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2024-05-01/workspaces/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2024-05-01/workspaces/constants.go
@@ -97,6 +97,8 @@ const (
 	ComplianceStandardHIPAA  ComplianceStandard = "HIPAA"
 	ComplianceStandardNONE   ComplianceStandard = "NONE"
 	ComplianceStandardPCIDSS ComplianceStandard = "PCI_DSS"
+	ComplianceStandardGERMANYC5 ComplianceStandard = "GERMANY_C5"
+	ComplianceStandardHITRUST ComplianceStandard = "HITRUST"
 )
 
 func PossibleValuesForComplianceStandard() []string {
@@ -104,6 +106,8 @@ func PossibleValuesForComplianceStandard() []string {
 		string(ComplianceStandardHIPAA),
 		string(ComplianceStandardNONE),
 		string(ComplianceStandardPCIDSS),
+		string(ComplianceStandardGERMANYC5),
+		string(ComplianceStandardHITRUST),
 	}
 }
 
@@ -125,6 +129,8 @@ func parseComplianceStandard(input string) (*ComplianceStandard, error) {
 		"hipaa":   ComplianceStandardHIPAA,
 		"none":    ComplianceStandardNONE,
 		"pci_dss": ComplianceStandardPCIDSS,
+		"germany_c5": ComplianceStandardGERMANYC5,
+		"hitrust": ComplianceStandardHITRUST,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -136,7 +136,7 @@ An `enhanced_security_compliance` block supports the following:
 
 ~> **Note:** The attributes `automatic_cluster_update_enabled` and `enhanced_security_monitoring_enabled` must be set to `true` in order to set `compliance_security_profile_enabled` to `true`.
 
-* `compliance_security_profile_standards` - (Optional) A list of standards to enforce on this workspace. Possible values include `HIPAA` and `PCI_DSS`.
+* `compliance_security_profile_standards` - (Optional) A list of standards to enforce on this workspace. Possible values include `HIPAA`, `PCI_DSS`, `GERMANY_C5` and `HITRUST`.
 
 ~> **Note:** `compliance_security_profile_enabled` must be set to `true` in order to use `compliance_security_profile_standards`.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
* Please vote on this PR by adding a :thumbsup: reaction to help the community and maintainers prioritise for review  
* Please do not leave comments along the lines of “+1”, “me too” or “any updates”, they generate extra noise for PR followers and do not help prioritise for review  

## Description
This PR adds support for the **GERMANY_C5** and **HITRUST** compliance standards in the `enhanced_security_compliance` block of the `azurerm_databricks_workspace` resource.

Previously the provider only allowed the values `HIPAA` and `PCI_DSS`. With this change, Terraform users can now configure the `compliance_security_profile_standards` list to include `GERMANY_C5` and `HITRUST`. The underlying constants and parsing logic have been updated, along with validation logic, tests, example configurations, and documentation.

### What this PR is doing
- Extends the string validation for `compliance_security_profile_standards` to allow the additional values `GERMANY_C5` and `HITRUST`.  
- Adds constants for `ComplianceStandardGERMANYC5` and `ComplianceStandardHITRUST` in the SDK constants file.  
- Updates `PossibleValuesForComplianceStandard()` and the parsing logic (`parseComplianceStandard`) to include the new values.  
- Updates examples (e.g., `examples/databricks/enhanced-security-compliance/main.tf`) to demonstrate using the full list of standards including `GERMANY_C5` and `HITRUST`.  
- Updates tests (resource, data source, and acceptance tests) to cover scenarios with the new values and ensure validation behaves correctly.  
- Updates documentation (`website/docs/r/databricks_workspace.html.markdown`) to reflect that the `compliance_security_profile_standards` list may include `GERMANY_C5` and `HITRUST`.  

### Why this change is needed  
The underlying service (Azure Databricks) supports the compliance frameworks HITRUST and Germany C5 as part of its enhanced security / compliance profile. Cloud-service customers who require those frameworks were unable to specify them through the Terraform provider and would receive validation errors even though the platform supports them. This change ensures the provider remains aligned with platform capabilities and supports broader compliance use-cases.

### Does this introduce a breaking change?  
No — this is an **enhancement**/extension of existing functionality. It does *not* remove or alter existing valid values (`HIPAA`, `PCI_DSS` remain unchanged), nor does it change default behaviour. Users who are currently only specifying those will see no change. Users who need `GERMANY_C5` or `HITRUST` now gain new capability.

## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).  
- [x] I have checked to ensure there aren’t other open Pull Requests for the same update/change.  
- [x] I have checked if my changes close any open issues. If so, I included appropriate [closing keywords] below.  
- [x] I have updated/added documentation as required, in a helpful and kind way to assist users.  
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.  
  - Suggested title: `azurerm_databricks_workspace – support for GERMANY_C5 and HITRUST compliance standards`  
- [ ] If listed, I will update/verify relevant changelog entries.

## Changes to existing Resource / Data Source
- In `azurerm_databricks_workspace`, updated the `enhanced_security_compliance` block to support the new standards.  
- Added new constants in the SDK for `GERMANY_C5` and `HITRUST`.  
- Updated unit tests, acceptance tests and examples relevant to `enhanced_security_compliance`.  
- Updated documentation describing the `compliance_security_profile_standards` parameter and its valid values.

## Testing
- Not run the tests

## Change Log  
Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format](../blob/main/contributing/topics/maintainer-merging.md).  

- azurerm_databricks_workspace - added support for the compliance standards GERMANY_C5 and HITRUST in the enhanced_security_compliance block. [GH-XXXX]

## This is a (please select all that apply):
- [ ] Bug Fix  
- [x] New Feature (i.e. adding support for new compliance standards)  
- [x] Enhancement  
- [ ] Breaking Change  

## Rollback Plan  
If any issue arises, revert the changes by publishing an updated version of the provider with this enhancement removed.

## Changes to Security Controls  
No changes to access controls, encryption, logging or other security controls beyond the compliance-standards support.
