### PR TITLE
List - remove redundant context instantiation from list resources

### DIFF
--- a/internal/services/network/network_interface_resource_list.go
+++ b/internal/services/network/network_interface_resource_list.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -35,9 +34,6 @@ func (r NetworkInterfaceListResource) ResourceFunc() *pluginsdk.Resource {
 
 func (r NetworkInterfaceListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
 	client := metadata.Client.Network.NetworkInterfaces
-
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*60)
-	defer cancel()
 
 	var data NetworkInterfaceListModel
 	diags := request.Config.Get(ctx, &data)

--- a/internal/services/network/network_profile_resource_list.go
+++ b/internal/services/network/network_profile_resource_list.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -29,9 +28,6 @@ func (r NetworkProfileListResource) Metadata(_ context.Context, _ resource.Metad
 
 func (r NetworkProfileListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
 	client := metadata.Client.Network.NetworkProfiles
-
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*60)
-	defer cancel()
 
 	var data sdk.DefaultListModel
 	diags := request.Config.Get(ctx, &data)

--- a/internal/services/network/network_security_group_resource_list.go
+++ b/internal/services/network/network_security_group_resource_list.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -29,9 +28,6 @@ func (r NetworkSecurityGroupListResource) Metadata(_ context.Context, _ resource
 
 func (r NetworkSecurityGroupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
 	client := metadata.Client.Network.NetworkSecurityGroups
-
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*60)
-	defer cancel()
 
 	var data sdk.DefaultListModel
 	diags := request.Config.Get(ctx, &data)

--- a/internal/services/network/route_table_resource_list.go
+++ b/internal/services/network/route_table_resource_list.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -29,9 +28,6 @@ func (r RouteTableListResource) Metadata(_ context.Context, _ resource.MetadataR
 
 func (r RouteTableListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
 	client := metadata.Client.Network.RouteTables
-
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*60)
-	defer cancel()
 
 	var data sdk.DefaultListModel
 	diags := request.Config.Get(ctx, &data)


### PR DESCRIPTION
Clean up leftovers from refactor. A timeout is already added to the context in the [list resource wrapper](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/sdk/list_resource.go#L68-L71).