### PR TITLE
Machine learning - Fix TeamCity acceptance test rate limit issue

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -123,7 +123,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "logic" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false)),
 
         // Rotate machinelearning acctest across supported-but-less-frequently-used locations to prevent quota and rate limiting
-        "machinelearning" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "northeurope", "uksouth", true)),
+        "machinelearning" to testConfiguration(locationOverride = LocationConfiguration("westus3", "northeurope", "uksouth", true)),
 
         // Managed Redis is only available in certain locations, and has limited quota
         "managedredis" to testConfiguration(locationOverride = LocationConfiguration("uksouth", "westus3", "southcentralus", true)),


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Machine learning acceptance tests can occasionally fail due to rate limiting error as shown below:

```
testcase.go:173: Step 1/3 error: Error running apply: exit status 1
        Error: creating Workspace (Subscription: "*******"
        Resource Group Name: "_REDACTED_"
        Workspace Name: "_REDACTED_"): polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
        Status: "TooManyRequests"
        Code: ""
        Message: "Received too many requests in a short amount of time. Retry again after 11 seconds."
        Activity Id: ""
        ---
        API Response:
        ----[start]----
        {
          "status": "Failed",
          "error": {
            "code": "TooManyRequests",
            "message": "Received too many requests in a short amount of time. Retry again after 11 seconds."
          }
        }
        -----[end]-----
          with azurerm_machine_learning_workspace.test,
          on terraform_plugin_test.tf line 77, in resource "azurerm_machine_learning_workspace" "test":
          77: resource "azurerm_machine_learning_workspace" "test" {
```

To solve the issue, the tests are run in less frequently used regions with dynamic rotation enabled.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MACHINELEARNING/539662
<img width="1468" height="637" alt="image" src="https://github.com/user-attachments/assets/9f4c6d73-bceb-4bb9-b32a-32a1e6fbf41c" />
`TestAccMachineLearningWorkspaceNetworkOutboundRulePrivateEndpoint_internetOutbound` and `TestAccMachineLearningWorkspaceNetworkOutboundRulePrivateEndpoint_redis` failure are fixed in [this PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/31165) while `TestAccInferenceCluster_identity` fails due to a different error which will be dealt with in other PR.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

N/A, no user visible changes, only acctest fixes.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
