### PR TITLE
authorization: remove atScope() filter from pim_eligible_role_assignment

### DIFF
--- a/internal/services/authorization/pim_eligible_role_assignment_resource.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource.go
@@ -685,7 +685,7 @@ func findRoleEligibilitySchedule(ctx context.Context, client *roleeligibilitysch
 	}
 
 	schedulesResult, err := client.ListForScopeComplete(ctx, *scopeId, roleeligibilityschedules.ListForScopeOperationOptions{
-		Filter: pointer.To(fmt.Sprintf("(principalId eq '%s') and atScope()", id.PrincipalId)),
+		Filter: pointer.To(fmt.Sprintf("(principalId eq '%s')", id.PrincipalId)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("listing Role Eligiblity Schedules for %s: %+v", scopeId, err)
@@ -731,7 +731,7 @@ func findRoleEligibilityScheduleRequest(ctx context.Context, client *roleeligibi
 		}
 
 		requestsResult, err := client.ListForScopeComplete(ctx, *scopeId, roleeligibilityschedulerequests.ListForScopeOperationOptions{
-			Filter: pointer.To(fmt.Sprintf("principalId eq '%s' and atScope()", *principalId)),
+			Filter: pointer.To(fmt.Sprintf("principalId eq '%s'", *principalId)),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("listing Role Eligibility Requests for principal_id %q: %+v", *principalId, err)


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `atScope()` filter in the Azure API has eventual consistency issues where newly created role eligibility schedules may not immediately appear in filtered results. This causes `terraform apply` to timeout with "waiting for state to become 'Exists'" even though the resource was successfully created in Azure.

This PR removes `atScope()` from filters in [findRoleEligibilitySchedule](cci:1://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/pim_eligible_role_assignment_resource.go:680:0-705:1) and [findRoleEligibilityScheduleRequest](cci:1://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/pim_eligible_role_assignment_resource.go:707:0-750:1) functions. This aligns with how [pim_active_role_assignment_resource.go](cci:7://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/pim_active_role_assignment_resource.go:0:0-0:0) handles the same scenario (it does not use `atScope()`). The scope validation is already performed in code via `strings.EqualFold(*props.Scope, scopeId.ID())`, making the `atScope()` filter redundant.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

**Testing Note:** Unable to run acceptance tests locally as PIM requires Microsoft Entra ID P2 license. The fix is straightforward - it removes `atScope()` from API filters to align with how [pim_active_role_assignment_resource.go](cci:7://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/pim_active_role_assignment_resource.go:0:0-0:0) already handles this (which does not have this timeout issue).


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Unable to run tests locally - PIM requires Microsoft Entra ID P2 or Microsoft Entra ID Governance license which is not available in my test environment. No new tests are needed as this is a bug fix to existing functionality. Existing tests should continue to pass.


## Change Log

* `azurerm_pim_eligible_role_assignment` - fix timeout when waiting for role eligibility schedule to appear by removing `atScope()` filter [GH-31180]


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31180


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI assistance was used to help identify the root cause by comparing [pim_eligible_role_assignment_resource.go](cci:7://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/pim_eligible_role_assignment_resource.go:0:0-0:0) with [pim_active_role_assignment_resource.go](cci:7://file:///Users/jhern/go/src/github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/pim_active_role_assignment_resource.go:0:0-0:0) and identifying that `atScope()` was the differentiating factor causing eventual consistency issues.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.