### PR TITLE
`azurerm_key_vault*` - can now set `not_before_date` and `expiration_date` as empty

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -544,13 +544,17 @@ func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	}
 
 	if attributes := resp.Attributes; attributes != nil {
+		notBeforeDate := ""
 		if v := attributes.NotBefore; v != nil {
-			d.Set("not_before_date", time.Time(*v).Format(time.RFC3339))
+			notBeforeDate = time.Time(*v).Format(time.RFC3339)
 		}
+		d.Set("not_before_date", notBeforeDate)
 
+		expirationDate := ""
 		if v := attributes.Expires; v != nil {
-			d.Set("expiration_date", time.Time(*v).Format(time.RFC3339))
+			expirationDate = time.Time(*v).Format(time.RFC3339)
 		}
+		d.Set("expiration_date", expirationDate)
 	}
 
 	// Computed

--- a/internal/services/keyvault/key_vault_secret_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_data_source.go
@@ -122,12 +122,17 @@ func dataSourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("version", secretId.Version)
 	d.Set("content_type", resp.ContentType)
 	if attributes := resp.Attributes; attributes != nil {
-		if notBefore := attributes.NotBefore; notBefore != nil {
-			d.Set("not_before_date", time.Time(*notBefore).Format(time.RFC3339))
+		notBeforeDate := ""
+		if v := attributes.NotBefore; v != nil {
+			notBeforeDate = time.Time(*v).Format(time.RFC3339)
 		}
-		if expires := attributes.Expires; expires != nil {
-			d.Set("expiration_date", time.Time(*expires).Format(time.RFC3339))
+		d.Set("not_before_date", notBeforeDate)
+
+		expirationDate := ""
+		if v := attributes.Expires; v != nil {
+			expirationDate = time.Time(*v).Format(time.RFC3339)
 		}
+		d.Set("expiration_date", expirationDate)
 	}
 	d.Set("versionless_id", secretId.VersionlessID())
 

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -401,13 +401,17 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("value_wo_version", d.Get("value_wo_version").(int))
 
 	if attributes := resp.Attributes; attributes != nil {
+		notBeforeDate := ""
 		if v := attributes.NotBefore; v != nil {
-			d.Set("not_before_date", time.Time(*v).Format(time.RFC3339))
+			notBeforeDate = time.Time(*v).Format(time.RFC3339)
 		}
+		d.Set("not_before_date", notBeforeDate)
 
+		expirationDate := ""
 		if v := attributes.Expires; v != nil {
-			d.Set("expiration_date", time.Time(*v).Format(time.RFC3339))
+			expirationDate = time.Time(*v).Format(time.RFC3339)
 		}
+		d.Set("expiration_date", expirationDate)
 	}
 
 	d.Set("resource_id", parse.NewSecretID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroupName, keyVaultId.VaultName, id.Name, id.Version).ID())


### PR DESCRIPTION
This PR fixes an issue where `not_before_date` and `expiration_date` were set in state and then removed outside of Terraform and subsequent Terraform runs would not recognize that change. 

`azurerm_key_vault` - `not_before_date` and `expiration_date` can now be set into state as empty
`azurerm_key_vault_secret` - `not_before_date` and `expiration_date` can now be set into state as empty
