### PR TITLE
`azurerm_storage_share` - Support `rbac_scope_id`

### DIFF
--- a/internal/services/storage/storage_share_data_source.go
+++ b/internal/services/storage/storage_share_data_source.go
@@ -79,6 +79,11 @@ func dataSourceStorageShare() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
 			},
+
+			"rbac_scope_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 
@@ -173,6 +178,7 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 			resourceManagerId := parse.NewStorageShareResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, "default", shareName)
 			d.Set("resource_manager_id", resourceManagerId.ID())
+			d.Set("rbac_scope_id", resourceManagerId.ID())
 
 			return nil
 		}
@@ -204,6 +210,8 @@ func dataSourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) err
 	if !features.FivePointOh() {
 		d.Set("resource_manager_id", id.ID())
 	}
+
+	d.Set("rbac_scope_id", parse.NewStorageShareResourceManagerID(id.SubscriptionId, id.ResourceGroupName, id.StorageAccountName, "default", id.ShareName).ID())
 
 	d.SetId(id.ID())
 

--- a/internal/services/storage/storage_share_data_source_test.go
+++ b/internal/services/storage/storage_share_data_source_test.go
@@ -5,6 +5,7 @@ package storage_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -29,6 +30,7 @@ func TestAccDataSourceStorageShare_basicDeprecated(t *testing.T) {
 				check.That(data.ResourceName).Key("metadata.%").HasValue("2"),
 				check.That(data.ResourceName).Key("metadata.k1").HasValue("v1"),
 				check.That(data.ResourceName).Key("metadata.k2").HasValue("v2"),
+				check.That(data.ResourceName).Key("rbac_scope_id").MatchesRegex(regexp.MustCompile(`/fileshares/`)),
 			),
 		},
 	})
@@ -45,6 +47,7 @@ func TestAccStorageShareDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("metadata.%").HasValue("2"),
 				check.That(data.ResourceName).Key("metadata.hello").HasValue("world"),
 				check.That(data.ResourceName).Key("metadata.foo").HasValue("bar"),
+				check.That(data.ResourceName).Key("rbac_scope_id").MatchesRegex(regexp.MustCompile(`/fileshares/`)),
 			),
 		},
 	})

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -154,6 +154,11 @@ func resourceStorageShare() *pluginsdk.Resource {
 						string(shares.TransactionOptimizedAccessTier),
 					}, false),
 			},
+
+			"rbac_scope_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 
@@ -401,6 +406,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 		resourceManagerId := parse.NewStorageShareResourceManagerID(account.StorageAccountId.SubscriptionId, account.StorageAccountId.ResourceGroupName, account.StorageAccountId.StorageAccountName, "default", id.ShareName)
 		d.Set("resource_manager_id", resourceManagerId.ID())
+		d.Set("rbac_scope_id", resourceManagerId.ID())
 
 		return nil
 	}
@@ -478,6 +484,7 @@ func resourceStorageShareRead(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 
 	d.Set("url", shares.NewShareID(*accountId, id.ShareName).ID())
+	d.Set("rbac_scope_id", parse.NewStorageShareResourceManagerID(id.SubscriptionId, id.ResourceGroupName, id.StorageAccountName, "default", id.ShareName).ID())
 
 	return nil
 }

--- a/internal/services/storage/storage_share_resource_test.go
+++ b/internal/services/storage/storage_share_resource_test.go
@@ -35,6 +35,7 @@ func TestAccStorageShare_basicDeprecated(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("enabled_protocol").HasValue("SMB"),
+				check.That(data.ResourceName).Key("rbac_scope_id").MatchesRegex(regexp.MustCompile(`/fileshares/`)),
 			),
 		},
 		data.ImportStep(),
@@ -50,6 +51,7 @@ func TestAccStorageShare_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("rbac_scope_id").MatchesRegex(regexp.MustCompile(`/fileshares/`)),
 			),
 		},
 		data.ImportStep(),

--- a/website/docs/d/storage_share.html.markdown
+++ b/website/docs/d/storage_share.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `rbac_scope_id` - The ID that is supposed to be used as the `scope` of an `azurerm_role_assignmet` for this File Share.
 
-~>**Note:** Due to historical reason of the File Share service, the `scope` to be used in an `azurerm_role_assignmet` is different than its Resource Manager ID. See: https://github.com/Azure/azure-rest-api-specs/issues/24568.
+~> **Note:** Due to historical reason of the File Share service, the `scope` to be used in an `azurerm_role_assignmet` is different than its Resource Manager ID. See: https://github.com/Azure/azure-rest-api-specs/issues/24568.
 
 ---
 

--- a/website/docs/d/storage_share.html.markdown
+++ b/website/docs/d/storage_share.html.markdown
@@ -49,6 +49,10 @@ The following arguments are supported:
 
 * `acl` - One or more acl blocks as defined below.
 
+* `rbac_scope_id` - The ID that is supposed to be used as the `scope` of an `azurerm_role_assignmet` for this File Share.
+
+~>**Note:** Due to historical reason of the File Share service, the `scope` to be used in an `azurerm_role_assignmet` is different than its Resource Manager ID. See: https://github.com/Azure/azure-rest-api-specs/issues/24568.
+
 ---
 
 A `acl` block has the following attributes:

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -107,7 +107,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `rbac_scope_id` - The ID that is supposed to be used as the `scope` of an `azurerm_role_assignmet` for this File Share.
 
-~>**Note:** Due to historical reason of the File Share service, the `scope` to be used in an `azurerm_role_assignmet` is different than its Resource Manager ID. See: https://github.com/Azure/azure-rest-api-specs/issues/24568.
+~> **Note:** Due to historical reason of the File Share service, the `scope` to be used in an `azurerm_role_assignmet` is different than its Resource Manager ID. See: https://github.com/Azure/azure-rest-api-specs/issues/24568.
 
 * `resource_manager_id` - The Resource Manager ID of this File Share.
 

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -105,6 +105,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the File Share.
 
+* `rbac_scope_id` - The ID that is supposed to be used as the `scope` of an `azurerm_role_assignmet` for this File Share.
+
+~>**Note:** Due to historical reason of the File Share service, the `scope` to be used in an `azurerm_role_assignmet` is different than its Resource Manager ID. See: https://github.com/Azure/azure-rest-api-specs/issues/24568.
+
 * `resource_manager_id` - The Resource Manager ID of this File Share.
 
 * `url` - The URL of the File Share


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR introduces a new computed attribute `rbac_scope_id` for the managed resource and data source of `azurerm_storage_share`. This new attribute is to expose the correct id format to be used as the `scope` of the `azurerm_role_assignment`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

**Without ARM_FIVEPOINTZERO_BETA=true**

```shell
💤 TF_ACC=1 go test -v -timeout=20h -run='TestAccStorageShare(DataSource)?_basic' ./internal/services/storage
=== RUN   TestAccStorageShareDataSource_basic
=== PAUSE TestAccStorageShareDataSource_basic
=== RUN   TestAccStorageShare_basicDeprecated
=== PAUSE TestAccStorageShare_basicDeprecated
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== CONT  TestAccStorageShareDataSource_basic
=== CONT  TestAccStorageShare_basic
=== CONT  TestAccStorageShare_basicDeprecated
--- PASS: TestAccStorageShareDataSource_basic (159.54s)
--- PASS: TestAccStorageShare_basicDeprecated (173.40s)
--- PASS: TestAccStorageShare_basic (174.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage     174.100s
```

**With ARM_FIVEPOINTZERO_BETA=true**

```shell
💤 TF_ACC=1 go test -v -timeout=20h -run='TestAccStorageShare(DataSource)?_basic' ./internal/services/storage
=== RUN   TestAccStorageShareDataSource_basic
=== PAUSE TestAccStorageShareDataSource_basic
=== RUN   TestAccStorageShare_basicDeprecated
    storage_share_resource_test.go:27: skipping as not valid in 5.0
--- SKIP: TestAccStorageShare_basicDeprecated (0.00s)
=== RUN   TestAccStorageShare_basic
=== PAUSE TestAccStorageShare_basic
=== CONT  TestAccStorageShareDataSource_basic
=== CONT  TestAccStorageShare_basic
--- PASS: TestAccStorageShareDataSource_basic (94.24s)
--- PASS: TestAccStorageShare_basic (120.27s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage    120.295s

```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #28832


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
