### PR TITLE
New Data Source: `azurerm_postgresql_flexible_server_active_directory_administrator`

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_data_source.go
+++ b/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_data_source.go
@@ -1,0 +1,113 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/administrators"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/servers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PostgresqlFlexibleServerActiveDirectoryAdministratorDataSourceModel struct {
+	ServerId      string `tfschema:"server_id"`
+	ObjectId      string `tfschema:"object_id"`
+	PrincipalName string `tfschema:"principal_name"`
+	PrincipalType string `tfschema:"principal_type"`
+	TenantId      string `tfschema:"tenant_id"`
+}
+
+type PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource struct{}
+
+var _ sdk.DataSource = PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource{}
+
+func (d PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"server_id": commonschema.ResourceIDReferenceRequired(&servers.FlexibleServerId{}),
+
+		"object_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+	}
+}
+
+func (d PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"principal_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"principal_type": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tenant_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (d PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource) ModelObject() interface{} {
+	return &PostgresqlFlexibleServerActiveDirectoryAdministratorDataSourceModel{}
+}
+
+func (d PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource) ResourceType() string {
+	return "azurerm_postgresql_flexible_server_active_directory_administrator"
+}
+
+func (d PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Postgres.FlexibleServerAdministratorsClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state PostgresqlFlexibleServerActiveDirectoryAdministratorDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			serverId, err := servers.ParseFlexibleServerID(state.ServerId)
+			if err != nil {
+				return err
+			}
+
+			id := administrators.NewAdministratorID(subscriptionId, serverId.ResourceGroupName, serverId.FlexibleServerName, state.ObjectId)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			state.ServerId = servers.NewFlexibleServerID(id.SubscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID()
+			state.ObjectId = id.ObjectId
+
+			if model := resp.Model; model != nil {
+				state.PrincipalName = pointer.From(model.Properties.PrincipalName)
+				state.PrincipalType = string(pointer.From(model.Properties.PrincipalType))
+				state.TenantId = pointer.From(model.Properties.TenantId)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_data_source_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_data_source_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package postgres_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource struct{}
+
+func TestAccPostgresqlFlexibleServerActiveDirectoryAdministratorDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_postgresql_flexible_server_active_directory_administrator", "test")
+	r := PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("server_id").Exists(),
+				check.That(data.ResourceName).Key("object_id").Exists(),
+				check.That(data.ResourceName).Key("principal_name").Exists(),
+				check.That(data.ResourceName).Key("principal_type").Exists(),
+				check.That(data.ResourceName).Key("tenant_id").Exists(),
+			),
+		},
+	})
+}
+
+func (PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_postgresql_flexible_server_active_directory_administrator" "test" {
+  server_id = azurerm_postgresql_flexible_server.test.id
+  object_id = azurerm_postgresql_flexible_server_active_directory_administrator.test.object_id
+}
+`, PostgresqlFlexibleServerAdministratorResource{}.basic(data))
+}

--- a/internal/services/postgres/registration.go
+++ b/internal/services/postgres/registration.go
@@ -76,5 +76,7 @@ func (r Registration) Resources() []sdk.Resource {
 }
 
 func (r Registration) DataSources() []sdk.DataSource {
-	return []sdk.DataSource{}
+	return []sdk.DataSource{
+		PostgresqlFlexibleServerActiveDirectoryAdministratorDataSource{},
+	}
 }

--- a/website/docs/d/postgresql_flexible_server_active_directory_administrator.html.markdown
+++ b/website/docs/d/postgresql_flexible_server_active_directory_administrator.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_postgresql_flexible_server_active_directory_administrator"
+description: |-
+  Gets information about an existing PostgreSQL Flexible Server Active Directory Administrator.
+---
+
+# Data Source: azurerm_postgresql_flexible_server_active_directory_administrator
+
+Use this data source to access information about an existing PostgreSQL Flexible Server Active Directory Administrator.
+
+## Example Usage
+
+```hcl
+data "azurerm_postgresql_flexible_server_active_directory_administrator" "example" {
+  server_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforPostgreSQL/flexibleServers/myserver1"
+  object_id = "00000000-0000-0000-0000-000000000000"
+}
+
+output "principal_name" {
+  value = data.azurerm_postgresql_flexible_server_active_directory_administrator.example.principal_name
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `server_id` - (Required) The ID of the PostgreSQL Flexible Server on which to set the administrator.
+
+* `object_id` - (Required) The object ID of a user, service principal or security group in the Azure Active Directory tenant set as the Flexible Server Admin.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the PostgreSQL Flexible Server Active Directory Administrator.
+
+* `principal_name` - The name of Azure Active Directory principal.
+
+* `principal_type` - The type of Azure Active Directory principal.
+
+* `tenant_id` - The Azure Tenant ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Flexible Server Active Directory Administrator.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.DBforPostgreSQL` - 2024-08-01


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR is to support new data source `azurerm_postgresql_flexible_server_active_directory_administrator`.
<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccPostgresqlFlexibleServerActiveDirectoryAdministratorDataSource_basic (439.73s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Data Source: `azurerm_postgresql_flexible_server_active_directory_administrator`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/31169


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
