### PR TITLE
`azurerm_private_endpoint` - Fix `TestAccPrivateEndpoint_privateDnsZone*` failures due to inconsistent resource application 

### DIFF
--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -674,22 +674,15 @@ resource "azurerm_subnet" "endpoint" {
   private_endpoint_network_policies = "Disabled"
 }
 
-resource "azurerm_postgresql_server" "test" {
-  name                = "acctest-pe-server-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku_name = "GP_Gen5_4"
-
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  auto_grow_enabled            = true
-
-  administrator_login          = "psqladmin"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "9.5"
-  ssl_enforcement_enabled      = true
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  version                = "12"
+  sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
 }
 
 resource "azurerm_private_dns_zone" "finance" {
@@ -705,7 +698,7 @@ resource "azurerm_private_endpoint" "test" {
 
   private_service_connection {
     name                           = "acctest-privatelink-psc-%d"
-    private_connection_resource_id = azurerm_postgresql_server.test.id
+    private_connection_resource_id = azurerm_postgresql_flexible_server.test.id
     subresource_names              = ["postgresqlServer"]
     is_manual_connection           = false
   }
@@ -749,22 +742,15 @@ resource "azurerm_subnet" "endpoint" {
   private_endpoint_network_policies = "Disabled"
 }
 
-resource "azurerm_postgresql_server" "test" {
-  name                = "acctest-pe-server-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku_name = "GP_Gen5_4"
-
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  auto_grow_enabled            = true
-
-  administrator_login          = "psqladmin"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "9.5"
-  ssl_enforcement_enabled      = true
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  version                = "12"
+  sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
 }
 
 resource "azurerm_private_dns_zone" "finance" {
@@ -790,7 +776,7 @@ resource "azurerm_private_endpoint" "test" {
 
   private_service_connection {
     name                           = "acctest-privatelink-psc-%d"
-    private_connection_resource_id = azurerm_postgresql_server.test.id
+    private_connection_resource_id = azurerm_postgresql_flexible_server.test.id
     subresource_names              = ["postgresqlServer"]
     is_manual_connection           = false
   }
@@ -834,22 +820,15 @@ resource "azurerm_subnet" "endpoint" {
   private_endpoint_network_policies = "Disabled"
 }
 
-resource "azurerm_postgresql_server" "test" {
-  name                = "acctest-pe-server-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku_name = "GP_Gen5_4"
-
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  auto_grow_enabled            = true
-
-  administrator_login          = "psqladmin"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "9.5"
-  ssl_enforcement_enabled      = true
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  version                = "12"
+  sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
 }
 
 resource "azurerm_resource_group" "test2" {
@@ -875,7 +854,7 @@ resource "azurerm_private_endpoint" "test" {
 
   private_service_connection {
     name                           = "acctest-privatelink-psc-%d"
-    private_connection_resource_id = azurerm_postgresql_server.test.id
+    private_connection_resource_id = azurerm_postgresql_flexible_server.test.id
     subresource_names              = ["postgresqlServer"]
     is_manual_connection           = false
   }
@@ -943,22 +922,15 @@ resource "azurerm_subnet" "endpoint" {
   private_endpoint_network_policies = "Disabled"
 }
 
-resource "azurerm_postgresql_server" "test" {
-  name                = "acctest-pe-server-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku_name = "GP_Gen5_4"
-
-  storage_mb                   = 5120
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  auto_grow_enabled            = true
-
-  administrator_login          = "psqladmin"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "9.5"
-  ssl_enforcement_enabled      = true
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  version                = "12"
+  sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
 }
 
 resource "azurerm_private_dns_zone" "finance" {
@@ -979,7 +951,7 @@ resource "azurerm_private_endpoint" "test" {
 
   private_service_connection {
     name                           = "acctest-privatelink-psc-%d"
-    private_connection_resource_id = azurerm_postgresql_server.test.id
+    private_connection_resource_id = azurerm_postgresql_flexible_server.test.id
     subresource_names              = ["postgresqlServer"]
     is_manual_connection           = false
   }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccPrivateEndpoint_privateDnsZone*` acceptance tests of `azurerm_private_endpoint` resource fail as shown in the log below.

```
    testcase.go:173: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_private_endpoint.test' - expected action to not be Replace, path: [[private_service_connection 0 private_connection_resource_id]] tried to update a value that is ForceNew
```

The error is due to the inconsistent application of `azurerm_postgresql_server` and `azurerm_postgresql_flexible_server` on `azurerm_private_endpoint` `private_connection_resource_id`. As `azurerm_postgresql_server` has been retired according to [Azure updates](https://azure.microsoft.com/en-us/updates?id=azure-database-for-postgresql-single-server-will-be-retired-migrate-to-flexible-server-by-28-march-2025), all `azurerm_postgresql_server` are replaced with `azurerm_postgresql_flexible_server`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORK/544257?buildTab=overview
<img width="947" height="637" alt="image" src="https://github.com/user-attachments/assets/d19a9bcd-d47b-49c2-9fe3-abbfddbca575" />

The failed tests are due to other issues which will be addressed in different PRs.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [BUG FIXES] `azurerm_private_endpoint` - fix `TestAccPrivateEndpoint_privateDnsZone*`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
