### PR TITLE
`azurerm_container_app` - rename TCP scaling rule param `concurrent_requests` to `concurrent_connections`

### DIFF
--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -3297,7 +3297,7 @@ func HTTPScaleRuleSchema() *pluginsdk.Schema {
 				"concurrent_requests": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
-					ValidateFunc: validate.ContainerAppScaleRuleConcurrentRequests,
+					ValidateFunc: validate.ContainerAppScaleRuleConcurrentRequestsAndConnections,
 				},
 
 				"authentication": {
@@ -3364,9 +3364,9 @@ func HTTPScaleRuleSchemaComputed() *pluginsdk.Schema {
 }
 
 type TCPScaleRule struct {
-	Name               string                    `tfschema:"name"`
-	ConcurrentRequests string                    `tfschema:"concurrent_requests"`
-	Authentications    []ScaleRuleAuthentication `tfschema:"authentication"`
+	Name                  string                    `tfschema:"name"`
+	ConcurrentConnections string                    `tfschema:"concurrent_connections"`
+	Authentications       []ScaleRuleAuthentication `tfschema:"authentication"`
 }
 
 func TCPScaleRuleSchema() *pluginsdk.Schema {
@@ -3381,10 +3381,10 @@ func TCPScaleRuleSchema() *pluginsdk.Schema {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 
-				"concurrent_requests": {
+				"concurrent_connections": {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
-					ValidateFunc: validate.ContainerAppScaleRuleConcurrentRequests,
+					ValidateFunc: validate.ContainerAppScaleRuleConcurrentRequestsAndConnections,
 				},
 
 				"authentication": {
@@ -3423,7 +3423,7 @@ func TCPScaleRuleSchemaComputed() *pluginsdk.Schema {
 					Computed: true,
 				},
 
-				"concurrent_requests": {
+				"concurrent_connections": {
 					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
@@ -3532,7 +3532,7 @@ func (c *ContainerTemplate) expandContainerAppScaleRules() []containerapps.Scale
 
 	for _, v := range c.TCPScaleRules {
 		metaData := make(map[string]string, 0)
-		metaData["concurrentRequests"] = v.ConcurrentRequests
+		metaData["concurrentConnections"] = v.ConcurrentConnections
 		r := containerapps.ScaleRule{
 			Name: pointer.To(v.Name),
 			Tcp: &containerapps.TcpScaleRule{
@@ -3641,15 +3641,15 @@ func (c *ContainerTemplate) flattenContainerAppScaleRules(input *[]containerapps
 
 			if r := v.Tcp; r != nil {
 				metaData := pointer.From(r.Metadata)
-				concurrentReqs := ""
+				concurrentConnections := ""
 
-				if m, ok := metaData["concurrentRequests"]; ok {
-					concurrentReqs = m
+				if m, ok := metaData["concurrentConnections"]; ok {
+					concurrentConnections = m
 				}
 
 				rule := TCPScaleRule{
-					Name:               pointer.From(v.Name),
-					ConcurrentRequests: concurrentReqs,
+					Name:                  pointer.From(v.Name),
+					ConcurrentConnections: concurrentConnections,
 				}
 
 				authentications := make([]ScaleRuleAuthentication, 0)

--- a/internal/services/containerapps/validate/validate.go
+++ b/internal/services/containerapps/validate/validate.go
@@ -173,7 +173,7 @@ func LowerCaseAlphaNumericWithHyphensAndPeriods(i interface{}, k string) (warnin
 	return
 }
 
-func ContainerAppScaleRuleConcurrentRequests(i interface{}, k string) (warnings []string, errors []error) {
+func ContainerAppScaleRuleConcurrentRequestsAndConnections(i interface{}, k string) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))

--- a/internal/services/containerapps/validate/validate_test.go
+++ b/internal/services/containerapps/validate/validate_test.go
@@ -279,7 +279,7 @@ func TestValidateInitTimeout(t *testing.T) {
 	}
 }
 
-func TestContainerAppScaleRuleConcurrentRequests(t *testing.T) {
+func TestContainerAppScaleRuleConcurrentRequestsAndConnections(t *testing.T) {
 	cases := []struct {
 		Input string
 		Valid bool
@@ -316,7 +316,7 @@ func TestContainerAppScaleRuleConcurrentRequests(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Logf("[DEBUG] Testing Value %s", tc.Input)
-		_, errors := ContainerAppScaleRuleConcurrentRequests(tc.Input, "test")
+		_, errors := ContainerAppScaleRuleConcurrentRequestsAndConnections(tc.Input, "test")
 		valid := len(errors) == 0
 
 		if tc.Valid != valid {

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -172,7 +172,7 @@ A `tcp_scale_rule` block supports the following:
 
 * `name` - (Required) The name of the Scaling Rule
 
-* `concurrent_requests` - (Required) - The number of concurrent requests to trigger scaling.
+* `concurrent_connections` - (Required) - The number of concurrent connections to trigger scaling.
 
 * `authentication` - (Optional) Zero or more `authentication` blocks as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The current metadata parameter of `concurrentRequests` is valid to the API Spec, however the correct parameter for TCP scaling rules is `concurrentConnections`

Feature announcement and how it is configured: https://github.com/microsoft/azure-container-apps/issues/375
Similar bug in AZ CLI: https://github.com/Azure/azure-cli-extensions/pull/7584


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azurerm_container_app - rename TCP scaling rule param `concurrent_requests` to `concurrent_connections`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #29644


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
