### PR TITLE
services `A*` - deprecated function clean up

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_resource_test.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AadB2cDirectoryResource struct{}
@@ -109,12 +109,12 @@ func (r AadB2cDirectoryResource) Exists(ctx context.Context, client *clients.Cli
 	resp, err := client.AadB2c.Tenants.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AadB2cDirectoryResource) template(data acceptance.TestData) string {

--- a/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -11,12 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AnalysisServicesServerResource struct{}
@@ -508,7 +508,7 @@ func (t AnalysisServicesServerResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (t AnalysisServicesServerResource) suspend(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/apimanagement/api_management_data_source.go
+++ b/internal/services/apimanagement/api_management_data_source.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/tenantaccess"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2024-05-01/apimanagementservice"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/schemaz"
@@ -257,7 +256,7 @@ func dataSourceApiManagementRead(d *pluginsdk.ResourceData, meta interface{}) er
 	d.Set("resource_group_name", resourceGroup)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		identity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2024-05-01/apimanagementservice"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -767,7 +766,7 @@ func resourceApiManagementServiceCreate(d *pluginsdk.ResourceData, meta interfac
 		return tf.ImportAsExistsError("azurerm_api_management", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
 	publicIpAddressId := d.Get("public_ip_address_id").(string)
@@ -1290,7 +1289,7 @@ func resourceApiManagementServiceRead(d *pluginsdk.ResourceData, meta interface{
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 		identity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
 		if err != nil {
 			return fmt.Errorf("flattening `identity`: %+v", err)
@@ -1725,7 +1724,7 @@ func expandAzureRmApiManagementAdditionalLocations(d *pluginsdk.ResourceData, sk
 
 	for _, v := range inputLocations {
 		config := v.(map[string]interface{})
-		location := azure.NormalizeLocation(config["location"].(string))
+		location := location.Normalize(config["location"].(string))
 
 		if config["capacity"].(int) > 0 {
 			sku.Capacity = int64(config["capacity"].(int))

--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/appconfiguration/1.0/appconfiguration"
 )
 
@@ -262,7 +262,7 @@ func (t AppConfigurationFeatureResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("while checking for key's %q existence: %+v", nestedItemId.Key, err)
 	}
 
-	return utils.Bool(res.StatusCode == 200), nil
+	return pointer.To(res.StatusCode == 200), nil
 }
 
 func (t AppConfigurationFeatureResource) basic(data acceptance.TestData) string {

--- a/internal/services/appconfiguration/migration/feature_resource_v0_to_v1_test.go
+++ b/internal/services/appconfiguration/migration/feature_resource_v0_to_v1_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestFeatureResourceV0ToV1(t *testing.T) {
@@ -24,7 +24,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/keyName/Label/labelName",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label=labelName"),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label=labelName"),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -32,7 +32,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/key:name/test/Label/test:label/name",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2Fkey:name%2Ftest?label=test%3Alabel%2Fname"),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2Fkey:name%2Ftest?label=test%3Alabel%2Fname"),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -40,7 +40,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/keyName/Label/%00",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -48,7 +48,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/keyName/Label/\000",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -56,7 +56,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/.appconfig.featureflag%2FkeyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -64,7 +64,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.azure.cn/kv/.appconfig.featureflag%2FkeyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.azure.cn/kv/.appconfig.featureflag%2FkeyName?label="),
 			appConfigurationEnvironment: environments.AzureChina().AppConfiguration,
 		},
 		{
@@ -72,7 +72,7 @@ func TestFeatureResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationFeature/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.azure.us/kv/.appconfig.featureflag%2FkeyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.azure.us/kv/.appconfig.featureflag%2FkeyName?label="),
 			appConfigurationEnvironment: environments.AzureUSGovernment().AppConfiguration,
 		},
 	}

--- a/internal/services/appconfiguration/migration/key_resource_v0_to_v1_test.go
+++ b/internal/services/appconfiguration/migration/key_resource_v0_to_v1_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestKeyResourceV0ToV1(t *testing.T) {
@@ -21,28 +21,28 @@ func TestKeyResourceV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/labelName",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/labelName"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/labelName"),
 		},
 		{
 			name: "old id (encoded)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key%3Aname%2Ftest/Label/test%3Alabel%2Fname",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name"),
 		},
 		{
 			name: "old id (this is a bug and should be fixed in v1 to v2)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/%00",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/\000/AppConfigurationKey/keyName/Label/"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/\000/AppConfigurationKey/keyName/Label/"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/appconfiguration/migration/key_resource_v1_to_v2_test.go
+++ b/internal/services/appconfiguration/migration/key_resource_v1_to_v2_test.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestKeyResourceV1ToV2(t *testing.T) {
@@ -24,7 +24,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/labelName",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/keyName?label=labelName"),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/keyName?label=labelName"),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -32,7 +32,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/key:name%2Ftest?label=test%3Alabel%2Fname"),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/key:name%2Ftest?label=test%3Alabel%2Fname"),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -40,7 +40,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/%00",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/keyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/keyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -48,7 +48,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/\000",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/keyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/keyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -56,7 +56,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/keyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/keyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -64,7 +64,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/\000/AppConfigurationKey/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.io/kv/keyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.io/kv/keyName?label="),
 			appConfigurationEnvironment: environments.AzurePublic().AppConfiguration,
 		},
 		{
@@ -72,7 +72,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/\000/AppConfigurationKey/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.azure.cn/kv/keyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.azure.cn/kv/keyName?label="),
 			appConfigurationEnvironment: environments.AzureChina().AppConfiguration,
 		},
 		{
@@ -80,7 +80,7 @@ func TestKeyResourceV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/\000/AppConfigurationKey/keyName/Label/",
 			},
-			expected:                    utils.String("https://appConf1.azconfig.azure.us/kv/keyName?label="),
+			expected:                    pointer.To("https://appConf1.azconfig.azure.us/kv/keyName?label="),
 			appConfigurationEnvironment: environments.AzureUSGovernment().AppConfiguration,
 		},
 	}

--- a/internal/services/applicationinsights/application_insights_standard_web_test_resource.go
+++ b/internal/services/applicationinsights/application_insights_standard_web_test_resource.go
@@ -579,8 +579,8 @@ func expandApplicationInsightsStandardWebTestRequestHeaders(input []HeaderModel)
 
 	for _, v := range input {
 		h := webtests.HeaderField{
-			Key:   utils.String(v.Name),
-			Value: utils.String(v.Value),
+			Key:   pointer.To(v.Name),
+			Value: pointer.To(v.Value),
 		}
 		headers = append(headers, h)
 	}

--- a/internal/services/applicationinsights/application_insights_standard_web_test_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_standard_web_test_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	webtests "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApplicationInsightsStandardWebTestResource struct{}
@@ -127,7 +127,7 @@ func (ApplicationInsightsStandardWebTestResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil && resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model != nil && resp.Model.Properties != nil), nil
 }
 
 func (ApplicationInsightsStandardWebTestResource) sslCheckConfig(data acceptance.TestData) string {

--- a/internal/services/applicationinsights/application_insights_workbook_resource.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApplicationInsightsWorkbookModel struct {
@@ -137,7 +137,7 @@ func (r ApplicationInsightsWorkbookResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.AppInsights.WorkbookClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 			id := workbooks.NewWorkbookID(subscriptionId, model.ResourceGroupName, model.Name)
-			existing, err := client.WorkbooksGet(ctx, id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: utils.Bool(true)})
+			existing, err := client.WorkbooksGet(ctx, id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: pointer.To(true)})
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for existing %s: %+v", id, err)
 			}
@@ -200,7 +200,7 @@ func (r ApplicationInsightsWorkbookResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
-			resp, err := client.WorkbooksGet(ctx, *id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: utils.Bool(true)})
+			resp, err := client.WorkbooksGet(ctx, *id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: pointer.To(true)})
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
@@ -253,7 +253,7 @@ func (r ApplicationInsightsWorkbookResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			resp, err := client.WorkbooksGet(ctx, *id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: utils.Bool(true)})
+			resp, err := client.WorkbooksGet(ctx, *id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: pointer.To(true)})
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)

--- a/internal/services/applicationinsights/application_insights_workbook_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	workbooks "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApplicationInsightsWorkbookResource struct{}
@@ -122,14 +122,14 @@ func (r ApplicationInsightsWorkbookResource) Exists(ctx context.Context, clients
 	}
 
 	client := clients.AppInsights.WorkbookClient
-	resp, err := client.WorkbooksGet(ctx, *id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: utils.Bool(true)})
+	resp, err := client.WorkbooksGet(ctx, *id, workbooks.WorkbooksGetOperationOptions{CanFetchContent: pointer.To(true)})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ApplicationInsightsWorkbookResource) template(data acceptance.TestData) string {

--- a/internal/services/applicationinsights/application_insights_workbook_template_resource.go
+++ b/internal/services/applicationinsights/application_insights_workbook_template_resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApplicationInsightsWorkbookTemplateModel struct {
@@ -374,11 +374,11 @@ func expandWorkbookTemplateGalleryModel(inputList []WorkbookTemplateGalleryModel
 	outputList := make([]workbooktemplates.WorkbookTemplateGallery, 0, len(inputList))
 	for _, input := range inputList {
 		output := workbooktemplates.WorkbookTemplateGallery{
-			Category:     utils.String(input.Category),
-			Name:         utils.String(input.Name),
-			Order:        utils.Int64(input.Order),
-			ResourceType: utils.String(input.ResourceType),
-			Type:         utils.String(input.Type),
+			Category:     pointer.To(input.Category),
+			Name:         pointer.To(input.Name),
+			Order:        pointer.To(input.Order),
+			ResourceType: pointer.To(input.ResourceType),
+			Type:         pointer.To(input.Type),
 		}
 
 		outputList = append(outputList, output)

--- a/internal/services/applicationinsights/application_insights_workbook_template_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_template_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	workbooktemplates "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApplicationInsightsWorkbookTemplateResource struct{}
@@ -92,11 +92,11 @@ func (r ApplicationInsightsWorkbookTemplateResource) Exists(ctx context.Context,
 	resp, err := client.WorkbookTemplatesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ApplicationInsightsWorkbookTemplateResource) template(data acceptance.TestData) string {

--- a/internal/services/applicationinsights/migration/analytics_item_test.go
+++ b/internal/services/applicationinsights/migration/analytics_item_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestAnalyticsItemV0ToV1(t *testing.T) {
@@ -21,42 +21,42 @@ func TestAnalyticsItemV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/myanalyticsItems/item1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1"),
 		},
 		{
 			name: "old id - mixed case (shared)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/myanalyticsitems/item1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1"),
 		},
 		{
 			name: "new id (shared)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/myAnalyticsItems/item1"),
 		},
 		{
 			name: "old id (user)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/analyticsItems/item1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1"),
 		},
 		{
 			name: "old id - mixed case (user)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/analyticsitems/item1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1"),
 		},
 		{
 			name: "new id (user)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/analyticsItems/item1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/applicationinsights/migration/api_key_v0_to_v1_test.go
+++ b/internal/services/applicationinsights/migration/api_key_v0_to_v1_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestApiKeyV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestApiKeyV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/apikeys/key1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/Apikeys/key1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/applicationinsights/migration/api_key_v1_to_v2_test.go
+++ b/internal/services/applicationinsights/migration/api_key_v1_to_v2_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestApiKeyV1ToV2(t *testing.T) {
@@ -21,21 +21,21 @@ func TestApiKeyV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/apikeys/key1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1/Apikeys/key1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1/apiKeys/key1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/applicationinsights/migration/component_v0_to_v1_test.go
+++ b/internal/services/applicationinsights/migration/component_v0_to_v1_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestComponentV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestComponentV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/Components/component1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/applicationinsights/migration/component_v1_to_v2_test.go
+++ b/internal/services/applicationinsights/migration/component_v1_to_v2_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestComponentV1ToV2(t *testing.T) {
@@ -21,21 +21,21 @@ func TestComponentV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/components/component1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/Components/component1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/components/component1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/applicationinsights/migration/web_test_id_test.go
+++ b/internal/services/applicationinsights/migration/web_test_id_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestWebTestV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestWebTestV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/webtests/test1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/webtests/test1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/webTests/test1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/appservice/app_service_environment_v3_resource_test.go
+++ b/internal/services/appservice/app_service_environment_v3_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -177,12 +178,12 @@ func (AppServiceEnvironmentV3Resource) Exists(ctx context.Context, client *clien
 	resp, err := client.Web.AppServiceEnvironmentsClient.Get(ctx, id.ResourceGroup, id.HostingEnvironmentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Environment V3 %q (Resource Group %q): %+v", id.HostingEnvironmentName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceEnvironmentV3Resource) basic(data acceptance.TestData) string {

--- a/internal/services/appservice/app_service_source_control_resource_test.go
+++ b/internal/services/appservice/app_service_source_control_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // (@jackofallops) Note: Some tests require a valid GitHub token for ARM_GITHUB_ACCESS_TOKEN. This token needs the `repo` and `workflow` permissions to be applicable on the referenced repositories.
@@ -202,15 +202,15 @@ func (r AppServiceSourceControlResource) Exists(ctx context.Context, client *cli
 	resp, err := client.AppService.WebAppsClient.GetSourceControl(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Source Control for %s: %v", id, err)
 	}
 	if resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.RepoURL == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceSourceControlResource) windowsExternalGit(data acceptance.TestData) string {

--- a/internal/services/appservice/app_service_source_control_slot_resource.go
+++ b/internal/services/appservice/app_service_source_control_slot_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SourceControlSlotResource struct{}
@@ -201,11 +200,11 @@ func (r SourceControlSlotResource) Create() sdk.ResourceFunc {
 				}
 
 				if appSourceControlSlot.RepoURL != "" {
-					sourceControl.Properties.RepoURL = utils.String(appSourceControlSlot.RepoURL)
+					sourceControl.Properties.RepoURL = pointer.To(appSourceControlSlot.RepoURL)
 				}
 
 				if appSourceControlSlot.Branch != "" {
-					sourceControl.Properties.Branch = utils.String(appSourceControlSlot.Branch)
+					sourceControl.Properties.Branch = pointer.To(appSourceControlSlot.Branch)
 				}
 
 				if ghaConfig := expandGithubActionConfig(appSourceControlSlot.GithubActionConfiguration, usesLinux); ghaConfig != nil {

--- a/internal/services/appservice/app_service_source_control_slot_resource_test.go
+++ b/internal/services/appservice/app_service_source_control_slot_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // (@jackofallops) Note: Some tests require a valid GitHub token for ARM_GITHUB_ACCESS_TOKEN. This token needs the `repo` and `workflow` permissions to be applicable on the referenced repositories.
@@ -187,15 +187,15 @@ func (r SourceControlSlotResource) Exists(ctx context.Context, client *clients.C
 	resp, err := client.AppService.WebAppsClient.GetSourceControlSlot(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Source Control for %s: %v", id, err)
 	}
 	if resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.RepoURL == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SourceControlSlotResource) windowsExternalGit(data acceptance.TestData) string {

--- a/internal/services/appservice/function_app_function_resource_test.go
+++ b/internal/services/appservice/function_app_function_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FunctionAppFunctionResource struct{}
@@ -95,15 +95,15 @@ func (r FunctionAppFunctionResource) Exists(ctx context.Context, client *clients
 	resp, err := client.AppService.WebAppsClient.GetFunction(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 	if response.WasNotFound(resp.HttpResponse) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r FunctionAppFunctionResource) basic(data acceptance.TestData) string {

--- a/internal/services/appservice/function_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FunctionAppHybridConnectionResource struct{}
@@ -110,12 +110,12 @@ func (r FunctionAppHybridConnectionResource) Exists(ctx context.Context, clients
 	resp, err := clients.AppService.WebAppsClient.GetHybridConnection(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Windows %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r FunctionAppHybridConnectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/appservice/helpers/function_app_schema_test.go
+++ b/internal/services/appservice/helpers/function_app_schema_test.go
@@ -8,9 +8,9 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestMergeUserAppSettings(t *testing.T) {
@@ -22,8 +22,8 @@ func TestMergeUserAppSettings(t *testing.T) {
 		{
 			service: []webapps.NameValuePair{
 				{
-					Name:  utils.String("test"),
-					Value: utils.String("ServiceValue"),
+					Name:  pointer.To("test"),
+					Value: pointer.To("ServiceValue"),
 				},
 			},
 			user: map[string]string{
@@ -31,28 +31,28 @@ func TestMergeUserAppSettings(t *testing.T) {
 			},
 			expected: []webapps.NameValuePair{
 				{
-					Name:  utils.String("test"),
-					Value: utils.String("UserValue"),
+					Name:  pointer.To("test"),
+					Value: pointer.To("UserValue"),
 				},
 			},
 		},
 		{
 			service: []webapps.NameValuePair{
 				{
-					Name:  utils.String("test"),
-					Value: utils.String("ServiceValue"),
+					Name:  pointer.To("test"),
+					Value: pointer.To("ServiceValue"),
 				},
 				{
-					Name:  utils.String("test2"),
-					Value: utils.String("ServiceValue2"),
+					Name:  pointer.To("test2"),
+					Value: pointer.To("ServiceValue2"),
 				},
 				{
-					Name:  utils.String("test3"),
-					Value: utils.String("ServiceValue3"),
+					Name:  pointer.To("test3"),
+					Value: pointer.To("ServiceValue3"),
 				},
 				{
-					Name:  utils.String("test4"),
-					Value: utils.String("ServiceValue4"),
+					Name:  pointer.To("test4"),
+					Value: pointer.To("ServiceValue4"),
 				},
 			},
 			user: map[string]string{
@@ -61,20 +61,20 @@ func TestMergeUserAppSettings(t *testing.T) {
 			},
 			expected: []webapps.NameValuePair{
 				{
-					Name:  utils.String("test"),
-					Value: utils.String("UserValue"),
+					Name:  pointer.To("test"),
+					Value: pointer.To("UserValue"),
 				},
 				{
-					Name:  utils.String("test2"),
-					Value: utils.String("ServiceValue2"),
+					Name:  pointer.To("test2"),
+					Value: pointer.To("ServiceValue2"),
 				},
 				{
-					Name:  utils.String("test3"),
-					Value: utils.String("ServiceValue3"),
+					Name:  pointer.To("test3"),
+					Value: pointer.To("ServiceValue3"),
 				},
 				{
-					Name:  utils.String("test4"),
-					Value: utils.String("UserValue4"),
+					Name:  pointer.To("test4"),
+					Value: pointer.To("UserValue4"),
 				},
 			},
 		},

--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IpRestriction struct {
@@ -1226,20 +1225,20 @@ func ExpandIpRestrictions(restrictions []IpRestriction) (*[]webapps.IPSecurityRe
 
 		var restriction webapps.IPSecurityRestriction
 		if v.Name != "" {
-			restriction.Name = utils.String(v.Name)
+			restriction.Name = pointer.To(v.Name)
 		}
 
 		if v.IpAddress != "" {
-			restriction.IPAddress = utils.String(v.IpAddress)
+			restriction.IPAddress = pointer.To(v.IpAddress)
 		}
 
 		if v.ServiceTag != "" {
-			restriction.IPAddress = utils.String(v.ServiceTag)
+			restriction.IPAddress = pointer.To(v.ServiceTag)
 			restriction.Tag = pointer.To(webapps.IPFilterTagServiceTag)
 		}
 
 		if v.VnetSubnetId != "" {
-			restriction.VnetSubnetResourceId = utils.String(v.VnetSubnetId)
+			restriction.VnetSubnetResourceId = pointer.To(v.VnetSubnetId)
 		}
 
 		if v.Description != "" {

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LinuxWebAppSlotResource struct{}
@@ -1542,16 +1542,16 @@ func (r LinuxWebAppSlotResource) Exists(ctx context.Context, client *clients.Cli
 	resp, err := client.AppService.WebAppsClient.GetSlot(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Linux %s: %+v", id, err)
 	}
 
 	if response.WasNotFound(resp.HttpResponse) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // Configs

--- a/internal/services/appservice/web_app_active_slot_resource_test.go
+++ b/internal/services/appservice/web_app_active_slot_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebAppActiveSlotResource struct{}
@@ -111,7 +111,7 @@ func (r WebAppActiveSlotResource) Exists(ctx context.Context, client *clients.Cl
 		return nil, fmt.Errorf("missing App Slot Properties for %s", id)
 	}
 
-	return utils.Bool(*app.Model.Properties.SlotSwapStatus.SourceSlotName == slotId.SlotName), nil
+	return pointer.To(*app.Model.Properties.SlotSwapStatus.SourceSlotName == slotId.SlotName), nil
 }
 
 func (r WebAppActiveSlotResource) basicWindows(data acceptance.TestData) string {

--- a/internal/services/appservice/web_app_hybrid_connection_resource_test.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebAppHybridConnectionResource struct{}
@@ -110,12 +110,12 @@ func (r WebAppHybridConnectionResource) Exists(ctx context.Context, clients *cli
 	resp, err := clients.AppService.WebAppsClient.GetHybridConnection(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Windows %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r WebAppHybridConnectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/appservice/windows_function_app_resource_test.go
+++ b/internal/services/appservice/windows_function_app_resource_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WindowsFunctionAppResource struct{}
@@ -1763,14 +1763,14 @@ func (r WindowsFunctionAppResource) Exists(ctx context.Context, client *clients.
 	resp, err := client.AppService.WebAppsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Windows Web App %s: %+v", id, err)
 	}
 	if response.WasNotFound(resp.HttpResponse) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // Configs

--- a/internal/services/appservice/windows_function_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_function_app_slot_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WindowsFunctionAppSlotResource struct{}
@@ -1422,14 +1422,14 @@ func (r WindowsFunctionAppSlotResource) Exists(ctx context.Context, client *clie
 	resp, err := client.AppService.WebAppsClient.GetSlot(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
 	if response.WasNotFound(resp.HttpResponse) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // Configs

--- a/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/extensions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ArcKubernetesClusterExtensionResource struct{}
@@ -99,11 +99,11 @@ func (r ArcKubernetesClusterExtensionResource) Exists(ctx context.Context, clien
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ArcKubernetesClusterExtensionResource) template(data acceptance.TestData, credential string, privateKey string, publicKey string) string {

--- a/internal/services/arckubernetes/arc_kubernetes_cluster_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_cluster_resource_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	arckubernetes "github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2024-01-01/connectedclusters"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ArcKubernetesClusterResource struct{}
@@ -103,11 +103,11 @@ func (r ArcKubernetesClusterResource) Exists(ctx context.Context, clients *clien
 	resp, err := client.ConnectedClusterGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ArcKubernetesClusterResource) template(data acceptance.TestData, credential string) string {

--- a/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource.go
+++ b/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource.go
@@ -18,7 +18,6 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/accounts"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/containers"
 )
@@ -550,7 +549,7 @@ func (r ArcKubernetesFluxConfigurationResource) Create() sdk.ResourceFunc {
 				Properties: &fluxconfiguration.FluxConfigurationProperties{
 					Kustomizations: expandKustomizationDefinitionModel(model.Kustomizations),
 					Scope:          pointer.To(fluxconfiguration.ScopeType(model.Scope)),
-					Suspend:        utils.Bool(!model.ContinuousReconciliationEnabled),
+					Suspend:        pointer.To(!model.ContinuousReconciliationEnabled),
 				},
 			}
 
@@ -660,7 +659,7 @@ func (r ArcKubernetesFluxConfigurationResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("continuous_reconciliation_enabled") {
-				properties.Properties.Suspend = utils.Bool(!model.ContinuousReconciliationEnabled)
+				properties.Properties.Suspend = pointer.To(!model.ContinuousReconciliationEnabled)
 			}
 
 			if properties.Properties.ConfigurationProtectedSettings == nil {
@@ -815,7 +814,7 @@ func expandKustomizationDefinitionModel(inputList []KustomizationDefinitionModel
 		}
 
 		if input.Path != "" {
-			output.Path = utils.String(input.Path)
+			output.Path = pointer.To(input.Path)
 		}
 
 		outputList[input.Name] = output
@@ -864,7 +863,7 @@ func expandBucketDefinitionModel(inputList []BucketDefinitionModel) (*fluxconfig
 
 	input := &inputList[0]
 	output := fluxconfiguration.BucketDefinition{
-		Insecure:              utils.Bool(!input.TlsEnabled),
+		Insecure:              pointer.To(!input.TlsEnabled),
 		SyncIntervalInSeconds: &input.SyncIntervalInSeconds,
 		TimeoutInSeconds:      &input.TimeoutInSeconds,
 	}

--- a/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ArcKubernetesFluxConfigurationResource struct{}
@@ -205,11 +205,11 @@ func (r ArcKubernetesFluxConfigurationResource) Exists(ctx context.Context, clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ArcKubernetesFluxConfigurationResource) template(data acceptance.TestData, credential string, privateKey string, publicKey string) string {

--- a/internal/services/attestation/attestation_provider_resource_test.go
+++ b/internal/services/attestation/attestation_provider_resource_test.go
@@ -19,12 +19,12 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AttestationProviderResource struct {
@@ -169,7 +169,7 @@ func (r AttestationProviderResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func testGenerateTestCertificate(organization string) (string, error) {

--- a/internal/services/authorization/marketplace_role_assignment_resource_test.go
+++ b/internal/services/authorization/marketplace_role_assignment_resource_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RoleAssignmentMarketplaceResource struct{}
@@ -188,13 +187,13 @@ func (r RoleAssignmentMarketplaceResource) Exists(ctx context.Context, client *c
 	resp, err := client.Authorization.ScopedRoleAssignmentsClient.GetById(ctx, commonids.NewScopeID(id.ID()), options)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (RoleAssignmentMarketplaceResource) emptyNameConfig(roleName string) string {

--- a/internal/services/authorization/pim_active_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_active_role_assignment_resource_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PimActiveRoleAssignmentResource struct{}
@@ -144,12 +143,12 @@ func (r PimActiveRoleAssignmentResource) Exists(ctx context.Context, client *cli
 				props.Scope != nil && strings.EqualFold(*props.Scope, scopeId.ID()) &&
 				props.PrincipalId != nil && strings.EqualFold(*props.PrincipalId, id.PrincipalId) &&
 				props.MemberType != nil && *props.MemberType == roleassignmentschedules.MemberTypeDirect {
-				return utils.Bool(true), nil
+				return pointer.To(true), nil
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (PimActiveRoleAssignmentResource) template(data acceptance.TestData) string {

--- a/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PimEligibleRoleAssignmentResource struct{}
@@ -160,12 +159,12 @@ func (r PimEligibleRoleAssignmentResource) Exists(ctx context.Context, client *c
 				props.Scope != nil && strings.EqualFold(*props.Scope, scopeId.ID()) &&
 				props.PrincipalId != nil && strings.EqualFold(*props.PrincipalId, id.PrincipalId) &&
 				props.MemberType != nil && *props.MemberType == roleeligibilityschedules.MemberTypeDirect {
-				return utils.Bool(true), nil
+				return pointer.To(true), nil
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (PimEligibleRoleAssignmentResource) template(data acceptance.TestData) string {

--- a/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ArcMachineConfigurationAssignmentResource struct{}
@@ -46,7 +45,7 @@ func (r ArcMachineConfigurationAssignmentResource) Exists(ctx context.Context, c
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/automanage/automanage_configuration_resource_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AutoManageConfigurationProfileResource struct{}
@@ -277,7 +276,7 @@ func (r AutoManageConfigurationProfileResource) Exists(ctx context.Context, clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineConfigurationAssignmentResource struct{}
@@ -59,7 +58,7 @@ func (r VirtualMachineConfigurationAssignmentResource) Exists(ctx context.Contex
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/automationaccount"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AutomationAccountResource struct{}
@@ -239,7 +239,7 @@ func (t AutomationAccountResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("retrieving Automation Account %q (resource group: %q): %+v", id.AutomationAccountName, id.ResourceGroupName, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (AutomationAccountResource) basic(data acceptance.TestData) string {

--- a/internal/services/automation/automation_connection_certificate_resource.go
+++ b/internal/services/automation/automation_connection_certificate_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/connection"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationConnectionCertificate() *pluginsdk.Resource {
@@ -107,9 +107,9 @@ func resourceAutomationConnectionCertificateCreateUpdate(d *pluginsdk.ResourceDa
 	parameters := connection.ConnectionCreateOrUpdateParameters{
 		Name: id.ConnectionName,
 		Properties: connection.ConnectionCreateOrUpdateProperties{
-			Description: utils.String(d.Get("description").(string)),
+			Description: pointer.To(d.Get("description").(string)),
 			ConnectionType: connection.ConnectionTypeAssociationProperty{
-				Name: utils.String("Azure"),
+				Name: pointer.To("Azure"),
 			},
 			FieldDefinitionValues: &fieldDefinitionValues,
 		},

--- a/internal/services/automation/automation_connection_classic_certificate_resource.go
+++ b/internal/services/automation/automation_connection_classic_certificate_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/connection"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationConnectionClassicCertificate() *pluginsdk.Resource {
@@ -114,9 +114,9 @@ func resourceAutomationConnectionClassicCertificateCreateUpdate(d *pluginsdk.Res
 	parameters := connection.ConnectionCreateOrUpdateParameters{
 		Name: id.ConnectionName,
 		Properties: connection.ConnectionCreateOrUpdateProperties{
-			Description: utils.String(d.Get("description").(string)),
+			Description: pointer.To(d.Get("description").(string)),
 			ConnectionType: connection.ConnectionTypeAssociationProperty{
-				Name: utils.String("AzureClassicCertificate"),
+				Name: pointer.To("AzureClassicCertificate"),
 			},
 			FieldDefinitionValues: &fieldDefinitionValues,
 		},

--- a/internal/services/automation/automation_connection_resource.go
+++ b/internal/services/automation/automation_connection_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/connection"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationConnection() *pluginsdk.Resource {
@@ -129,9 +129,9 @@ func resourceAutomationConnectionCreateUpdate(d *pluginsdk.ResourceData, meta in
 	parameters := connection.ConnectionCreateOrUpdateParameters{
 		Name: id.ConnectionName,
 		Properties: connection.ConnectionCreateOrUpdateProperties{
-			Description: utils.String(d.Get("description").(string)),
+			Description: pointer.To(d.Get("description").(string)),
 			ConnectionType: connection.ConnectionTypeAssociationProperty{
-				Name: utils.String(connectionTypeName),
+				Name: pointer.To(connectionTypeName),
 			},
 			FieldDefinitionValues: &values,
 		},

--- a/internal/services/automation/automation_connection_service_principal_resource.go
+++ b/internal/services/automation/automation_connection_service_principal_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/connection"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationConnectionServicePrincipal() *pluginsdk.Resource {
@@ -121,9 +121,9 @@ func resourceAutomationConnectionServicePrincipalCreateUpdate(d *pluginsdk.Resou
 	parameters := connection.ConnectionCreateOrUpdateParameters{
 		Name: id.ConnectionName,
 		Properties: connection.ConnectionCreateOrUpdateProperties{
-			Description: utils.String(d.Get("description").(string)),
+			Description: pointer.To(d.Get("description").(string)),
 			ConnectionType: connection.ConnectionTypeAssociationProperty{
-				Name: utils.String("AzureServicePrincipal"),
+				Name: pointer.To("AzureServicePrincipal"),
 			},
 			FieldDefinitionValues: &fieldDefinitionValues,
 		},

--- a/internal/services/automation/automation_dsc_configuration_resource.go
+++ b/internal/services/automation/automation_dsc_configuration_resource.go
@@ -13,16 +13,15 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/dscconfiguration"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationDscConfiguration() *pluginsdk.Resource {
@@ -117,20 +116,20 @@ func resourceAutomationDscConfigurationCreateUpdate(d *pluginsdk.ResourceData, m
 	}
 
 	contentEmbedded := d.Get("content_embedded").(string)
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	logVerbose := d.Get("log_verbose").(bool)
 	description := d.Get("description").(string)
 
 	parameters := dscconfiguration.DscConfigurationCreateOrUpdateParameters{
 		Properties: dscconfiguration.DscConfigurationCreateOrUpdateProperties{
-			LogVerbose:  utils.Bool(logVerbose),
-			Description: utils.String(description),
+			LogVerbose:  pointer.To(logVerbose),
+			Description: pointer.To(description),
 			Source: dscconfiguration.ContentSource{
 				Type:  pointer.To(dscconfiguration.ContentSourceTypeEmbeddedContent),
-				Value: utils.String(contentEmbedded),
+				Value: pointer.To(contentEmbedded),
 			},
 		},
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Tags:     pointer.To(expandStringInterfaceMap(d.Get("tags").(map[string]interface{}))),
 	}
 
@@ -168,7 +167,7 @@ func resourceAutomationDscConfigurationRead(d *pluginsdk.ResourceData, meta inte
 	d.Set("automation_account_name", id.AutomationAccountName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		if props := model.Properties; props != nil {
 			d.Set("log_verbose", props.LogVerbose)

--- a/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
+++ b/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/dscnodeconfiguration"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAutomationDscNodeConfiguration() *pluginsdk.Resource {
@@ -107,13 +107,13 @@ func resourceAutomationDscNodeConfigurationCreateUpdate(d *pluginsdk.ResourceDat
 		Properties: &dscnodeconfiguration.DscNodeConfigurationCreateOrUpdateParametersProperties{
 			Source: dscnodeconfiguration.ContentSource{
 				Type:  &contentSourceType,
-				Value: utils.String(content),
+				Value: pointer.To(content),
 			},
 			Configuration: dscnodeconfiguration.DscConfigurationAssociationProperty{
-				Name: utils.String(configurationName),
+				Name: pointer.To(configurationName),
 			},
 		},
-		Name: utils.String(id.NodeConfigurationName),
+		Name: pointer.To(id.NodeConfigurationName),
 	}
 
 	err := client.CreateOrUpdateThenPoll(ctx, id, parameters)

--- a/internal/services/automation/automation_hybrid_runbook_worker_group_resource.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_group_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HybridRunbookWorkerGroupModel struct {
@@ -92,7 +91,7 @@ func (m HybridRunbookWorkerGroupResource) Create() sdk.ResourceFunc {
 			if model.CredentialName != "" {
 				req.Properties = &hybridrunbookworkergroup.HybridRunbookWorkerGroupCreateOrUpdateProperties{}
 				req.Properties.Credential = &hybridrunbookworkergroup.RunAsCredentialAssociationProperty{
-					Name: utils.String(model.CredentialName),
+					Name: pointer.To(model.CredentialName),
 				}
 			}
 			// return 201 cause err in autorest sdk
@@ -163,7 +162,7 @@ func (m HybridRunbookWorkerGroupResource) Update() sdk.ResourceFunc {
 			if meta.ResourceData.HasChange("credential_name") {
 				upd.Properties = &hybridrunbookworkergroup.HybridRunbookWorkerGroupCreateOrUpdateProperties{}
 				upd.Properties.Credential = &hybridrunbookworkergroup.RunAsCredentialAssociationProperty{
-					Name: utils.String(model.CredentialName),
+					Name: pointer.To(model.CredentialName),
 				}
 			}
 			if _, err = client.Update(ctx, *id, upd); err != nil {

--- a/internal/services/automation/automation_hybrid_runbook_worker_group_resource_test.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/hybridrunbookworkergroup"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HybridRunbookWorkerGroupResource struct{}
@@ -28,7 +28,7 @@ func (a HybridRunbookWorkerGroupResource) Exists(ctx context.Context, client *cl
 	if err != nil {
 		return nil, fmt.Errorf("retrieving HybridRunbookWorkerGroup %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (a HybridRunbookWorkerGroupResource) template(data acceptance.TestData) string {

--- a/internal/services/automation/automation_hybrid_runbook_worker_resource.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HybridRunbookWorkerModel struct {
@@ -133,7 +132,7 @@ func (m HybridRunbookWorkerResource) Create() sdk.ResourceFunc {
 				Properties: &hybridrunbookworker.HybridRunbookWorkerCreateOrUpdateParameters{},
 			}
 			if model.VmResourceId != "" {
-				req.Properties.VMResourceId = utils.String(model.VmResourceId)
+				req.Properties.VMResourceId = pointer.To(model.VmResourceId)
 			}
 
 			future, err := client.Create(ctx, id, req)

--- a/internal/services/automation/automation_hybrid_runbook_worker_resource_test.go
+++ b/internal/services/automation/automation_hybrid_runbook_worker_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/hybridrunbookworker"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HybridRunbookWorkerResource struct{}
@@ -29,7 +29,7 @@ func (a HybridRunbookWorkerResource) Exists(ctx context.Context, client *clients
 	if err != nil {
 		return nil, fmt.Errorf("retrieving HybridRunbookWorker %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (a HybridRunbookWorkerResource) template(data acceptance.TestData) string {

--- a/internal/services/automation/automation_python3_package_resource_test.go
+++ b/internal/services/automation/automation_python3_package_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/python3package"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type Python3PackageResource struct{}
@@ -28,7 +28,7 @@ func (a Python3PackageResource) Exists(ctx context.Context, client *clients.Clie
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Python3Package %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func TestAccPython3Package_basic(t *testing.T) {

--- a/internal/services/automation/automation_runbook_resource.go
+++ b/internal/services/automation/automation_runbook_resource.go
@@ -13,12 +13,12 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/jobschedule"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/runbook"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/runbookdraft"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/helper"
@@ -308,7 +308,7 @@ func resourceAutomationRunbookCreateUpdate(d *pluginsdk.ResourceData, meta inter
 
 	// for existing runbook, if only job_schedule field updated, then skip update runbook
 	if d.IsNewResource() || d.HasChangeExcept("job_schedule") {
-		location := azure.NormalizeLocation(d.Get("location").(string))
+		location := location.Normalize(d.Get("location").(string))
 		t := d.Get("tags").(map[string]interface{})
 
 		parameters := runbook.RunbookCreateOrUpdateParameters{
@@ -399,7 +399,7 @@ func resourceAutomationRunbookRead(d *pluginsdk.ResourceData, meta interface{}) 
 	d.Set("name", id.RunbookName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 	model := resp.Model
-	d.Set("location", azure.NormalizeLocation(model.Location))
+	d.Set("location", location.Normalize(model.Location))
 
 	d.Set("automation_account_name", id.AutomationAccountName)
 	if props := model.Properties; props != nil {

--- a/internal/services/automation/automation_runbook_resource_test.go
+++ b/internal/services/automation/automation_runbook_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/runbook"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AutomationRunbookResource struct{}
@@ -158,7 +158,7 @@ func (t AutomationRunbookResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("retrieving Automation Runbook '%s' (resource group: '%s') does not exist", id.RunbookName, id.ResourceGroupName)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (AutomationRunbookResource) PS72(data acceptance.TestData) string {

--- a/internal/services/automation/automation_source_control_resource.go
+++ b/internal/services/automation/automation_source_control_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type Security struct {
@@ -182,12 +181,12 @@ func (m SourceControlResource) Create() sdk.ResourceFunc {
 
 			var param sourcecontrol.SourceControlCreateOrUpdateParameters
 			param.Properties = sourcecontrol.SourceControlCreateOrUpdateProperties{
-				AutoSync:       utils.Bool(model.AutoSync),
-				Branch:         utils.String(model.Branch),
-				Description:    utils.String(model.Description),
-				FolderPath:     utils.String(model.FolderPath),
-				PublishRunbook: utils.Bool(model.PublishRunbook),
-				RepoURL:        utils.String(model.RepoURL),
+				AutoSync:       pointer.To(model.AutoSync),
+				Branch:         pointer.To(model.Branch),
+				Description:    pointer.To(model.Description),
+				FolderPath:     pointer.To(model.FolderPath),
+				PublishRunbook: pointer.To(model.PublishRunbook),
+				RepoURL:        pointer.To(model.RepoURL),
 				SourceType:     &sourceType,
 			}
 
@@ -196,9 +195,9 @@ func (m SourceControlResource) Create() sdk.ResourceFunc {
 				token := model.SecurityToken[0]
 				tokenType := sourcecontrol.TokenType(token.TokenType)
 				param.Properties.SecurityToken.TokenType = &tokenType
-				param.Properties.SecurityToken.AccessToken = utils.String(token.Token)
+				param.Properties.SecurityToken.AccessToken = pointer.To(token.Token)
 				if token.RefreshToken != "" {
-					param.Properties.SecurityToken.RefreshToken = utils.String(token.RefreshToken)
+					param.Properties.SecurityToken.RefreshToken = pointer.To(token.RefreshToken)
 				}
 			}
 
@@ -279,29 +278,29 @@ func (m SourceControlResource) Update() sdk.ResourceFunc {
 			var upd sourcecontrol.SourceControlUpdateParameters
 			prop := &sourcecontrol.SourceControlUpdateProperties{}
 			if meta.ResourceData.HasChange("branch") {
-				prop.Branch = utils.String(model.Branch)
+				prop.Branch = pointer.To(model.Branch)
 			}
 			if meta.ResourceData.HasChange("folder_path") {
-				prop.FolderPath = utils.String(model.FolderPath)
+				prop.FolderPath = pointer.To(model.FolderPath)
 			}
 			if meta.ResourceData.HasChange("automatic_sync") {
-				prop.AutoSync = utils.Bool(model.AutoSync)
+				prop.AutoSync = pointer.To(model.AutoSync)
 			}
 			if meta.ResourceData.HasChange("folder_path") {
-				prop.FolderPath = utils.String(model.FolderPath)
+				prop.FolderPath = pointer.To(model.FolderPath)
 			}
 			if meta.ResourceData.HasChange("publish_runbook_enabled") {
-				prop.PublishRunbook = utils.Bool(model.PublishRunbook)
+				prop.PublishRunbook = pointer.To(model.PublishRunbook)
 			}
 			if meta.ResourceData.HasChange("description") {
-				prop.Description = utils.String(model.Description)
+				prop.Description = pointer.To(model.Description)
 			}
 
 			tokenType := sourcecontrol.TokenType(model.SecurityToken[0].TokenType)
 			if meta.ResourceData.HasChange("security") {
 				prop.SecurityToken = &sourcecontrol.SourceControlSecurityTokenProperties{
-					AccessToken:  utils.String(model.SecurityToken[0].TokenType),
-					RefreshToken: utils.String(model.SecurityToken[0].RefreshToken),
+					AccessToken:  pointer.To(model.SecurityToken[0].TokenType),
+					RefreshToken: pointer.To(model.SecurityToken[0].RefreshToken),
 					TokenType:    &tokenType,
 				}
 			}

--- a/internal/services/automation/automation_variable.go
+++ b/internal/services/automation/automation_variable.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/variable"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func ParseAzureAutomationVariableValue(resource string, input *string) (interface{}, error) {
@@ -179,13 +179,13 @@ func resourceAutomationVariableCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	parameters := variable.VariableCreateOrUpdateParameters{
 		Name: id.VariableName,
 		Properties: variable.VariableCreateOrUpdateProperties{
-			Description: utils.String(description),
-			IsEncrypted: utils.Bool(encrypted),
+			Description: pointer.To(description),
+			IsEncrypted: pointer.To(encrypted),
 		},
 	}
 
 	if varTypeLower != "null" {
-		parameters.Properties.Value = utils.String(value)
+		parameters.Properties.Value = pointer.To(value)
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {

--- a/internal/services/automation/automation_watcher_resource.go
+++ b/internal/services/automation/automation_watcher_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WatcherModel struct {
@@ -143,14 +142,14 @@ func (m WatcherResource) Create() sdk.ResourceFunc {
 
 			param := watcher.Watcher{
 				Properties: &watcher.WatcherProperties{
-					Description:                 utils.String(model.Description),
-					ExecutionFrequencyInSeconds: utils.Int64(model.ExecutionFrequencyInSeconds),
-					ScriptName:                  utils.String(model.ScriptName),
+					Description:                 pointer.To(model.Description),
+					ExecutionFrequencyInSeconds: pointer.To(model.ExecutionFrequencyInSeconds),
+					ScriptName:                  pointer.To(model.ScriptName),
 					ScriptParameters:            &scriptParameters,
-					ScriptRunOn:                 utils.String(model.ScriptRunOn),
+					ScriptRunOn:                 pointer.To(model.ScriptRunOn),
 				},
-				Etag:     utils.String(model.Etag),
-				Location: utils.String(model.Location),
+				Etag:     pointer.To(model.Etag),
+				Location: pointer.To(model.Location),
 				Tags:     &tags,
 			}
 
@@ -231,7 +230,7 @@ func (m WatcherResource) Update() sdk.ResourceFunc {
 			var upd watcher.WatcherUpdateParameters
 			upd.Properties = &watcher.WatcherUpdateProperties{}
 			if meta.ResourceData.HasChange("execution_frequency_in_seconds") {
-				upd.Properties.ExecutionFrequencyInSeconds = utils.Int64(model.ExecutionFrequencyInSeconds)
+				upd.Properties.ExecutionFrequencyInSeconds = pointer.To(model.ExecutionFrequencyInSeconds)
 			}
 			if _, err = client.Update(ctx, *id, upd); err != nil {
 				return fmt.Errorf("updating %s: %v", *id, err)

--- a/internal/services/automation/automation_webhook_resource.go
+++ b/internal/services/automation/automation_webhook_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2015-10-31/webhook"
@@ -136,13 +137,13 @@ func resourceAutomationWebhookCreateUpdate(d *pluginsdk.ResourceData, meta inter
 	parameters := webhook.WebhookCreateOrUpdateParameters{
 		Name: id.WebHookName,
 		Properties: webhook.WebhookCreateOrUpdateProperties{
-			IsEnabled:  utils.Bool(enabled),
+			IsEnabled:  pointer.To(enabled),
 			ExpiryTime: &expiryTime,
 			Parameters: &webhookParameters,
 			Runbook: &webhook.RunbookAssociationProperty{
-				Name: utils.String(runbookName),
+				Name: pointer.To(runbookName),
 			},
-			RunOn: utils.String(runOn),
+			RunOn: pointer.To(runOn),
 		},
 	}
 
@@ -165,7 +166,7 @@ func resourceAutomationWebhookCreateUpdate(d *pluginsdk.ResourceData, meta inter
 		}
 	} else {
 		if d.Get("uri") != nil {
-			parameters.Properties.Uri = utils.String(d.Get("uri").(string))
+			parameters.Properties.Uri = pointer.To(d.Get("uri").(string))
 		}
 	}
 

--- a/internal/services/automation/helper/automation_job_schedule.go
+++ b/internal/services/automation/helper/automation_job_schedule.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2024-10-23/jobschedule"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func ExpandAutomationJobSchedule(input []interface{}, runBookName string) (*map[string]jobschedule.JobScheduleCreateParameters, error) {
@@ -31,10 +30,10 @@ func ExpandAutomationJobSchedule(input []interface{}, runBookName string) (*map[
 		jobScheduleCreateParameters := jobschedule.JobScheduleCreateParameters{
 			Properties: jobschedule.JobScheduleCreateProperties{
 				Schedule: jobschedule.ScheduleAssociationProperty{
-					Name: utils.String(js["schedule_name"].(string)),
+					Name: pointer.To(js["schedule_name"].(string)),
 				},
 				Runbook: jobschedule.RunbookAssociationProperty{
-					Name: utils.String(runBookName),
+					Name: pointer.To(runBookName),
 				},
 			},
 		}

--- a/internal/services/azurestackhci/stack_hci_cluster_resource.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmStackHCICluster() *pluginsdk.Resource {
@@ -122,7 +122,7 @@ func resourceArmStackHCIClusterCreate(d *pluginsdk.ResourceData, meta interface{
 	cluster := clusters.Cluster{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &clusters.ClusterProperties{
-			AadClientId: utils.String(d.Get("client_id").(string)),
+			AadClientId: pointer.To(d.Get("client_id").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -132,10 +132,10 @@ func resourceArmStackHCIClusterCreate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if v, ok := d.GetOk("tenant_id"); ok {
-		cluster.Properties.AadTenantId = utils.String(v.(string))
+		cluster.Properties.AadTenantId = pointer.To(v.(string))
 	} else {
 		tenantId := meta.(*clients.Client).Account.TenantId
-		cluster.Properties.AadTenantId = utils.String(tenantId)
+		cluster.Properties.AadTenantId = pointer.To(tenantId)
 	}
 
 	if _, err := client.Create(ctx, id, cluster); err != nil {
@@ -164,7 +164,7 @@ func resourceArmStackHCIClusterCreate(d *pluginsdk.ResourceData, meta interface{
 		if response.WasNotFound(assignmentsResp.HttpResponse) {
 			properties := configurationprofilehciassignments.ConfigurationProfileAssignment{
 				Properties: &configurationprofilehciassignments.ConfigurationProfileAssignmentProperties{
-					ConfigurationProfile: utils.String(configurationProfileId.ID()),
+					ConfigurationProfile: pointer.To(configurationProfileId.ID()),
 				},
 			}
 
@@ -280,7 +280,7 @@ func resourceArmStackHCIClusterUpdate(d *pluginsdk.ResourceData, meta interface{
 
 			properties := configurationprofilehciassignments.ConfigurationProfileAssignment{
 				Properties: &configurationprofilehciassignments.ConfigurationProfileAssignmentProperties{
-					ConfigurationProfile: utils.String(configurationProfileId.ID()),
+					ConfigurationProfile: pointer.To(configurationProfileId.ID()),
 				},
 			}
 

--- a/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2024-01-01/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StackHCIClusterResource struct{}
@@ -187,13 +187,13 @@ func (r StackHCIClusterResource) Exists(ctx context.Context, client *clients.Cli
 	resp, err := clusterClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StackHCIClusterResource) basicWithoutClientId(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
