### PR TITLE
services `B*` - deprecated function clean up

### DIFF
--- a/internal/services/batch/batch_account_data_source_test.go
+++ b/internal/services/batch/batch_account_data_source_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -23,7 +23,7 @@ func TestAccBatchAccountDataSource_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("pool_allocation_mode").HasValue("BatchService"),
 			),
 		},
@@ -38,7 +38,7 @@ func TestAccBatchAccountDataSource_complete(t *testing.T) {
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("pool_allocation_mode").HasValue("BatchService"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.env").HasValue("test"),
@@ -58,7 +58,7 @@ func TestAccBatchAccountDataSource_userSubscription(t *testing.T) {
 		{
 			Config: r.userSubscription(data, tenantID, subscriptionID),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("pool_allocation_mode").HasValue("UserSubscription"),
 				check.That(data.ResourceName).Key("key_vault_reference.#").HasValue("1"),
 			),
@@ -76,7 +76,7 @@ func TestAccBatchAccountDataSource_cmkVersionedKey(t *testing.T) {
 		{
 			Config: r.cmkVersionedKeyData(data, tenantID),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsSet(),
 			),
 		},
@@ -93,7 +93,7 @@ func TestAccBatchAccountDataSource_cmkVersionlessKey(t *testing.T) {
 		{
 			Config: r.cmkVersionlessKeyData(data, tenantID),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsSet(),
 			),
 		},

--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccount"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -24,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceBatchAccount() *pluginsdk.Resource {
@@ -197,7 +197,7 @@ func resourceBatchAccountCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	log.Printf("[INFO] preparing arguments for Azure Batch account creation.")
 
 	id := batchaccount.NewBatchAccountID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	storageAccountId := d.Get("storage_account_id").(string)
 
 	if d.IsNewResource() {
@@ -284,7 +284,7 @@ func resourceBatchAccountCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	nodeIdentity := d.Get("storage_account_node_identity").(string)
 	if nodeIdentity != "" {
 		parameters.Properties.AutoStorage.NodeIdentityReference = &batchaccount.ComputeNodeIdentityReference{
-			ResourceId: utils.String(nodeIdentity),
+			ResourceId: pointer.To(nodeIdentity),
 		}
 	}
 
@@ -321,8 +321,8 @@ func resourceBatchAccountRead(d *pluginsdk.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		if location := model.Location; location != nil {
-			d.Set("location", azure.NormalizeLocation(*location))
+		if loc := model.Location; loc != nil {
+			d.Set("location", location.Normalize(*loc))
 		}
 
 		identity, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)
@@ -463,7 +463,7 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	nodeIdentity := d.Get("storage_account_node_identity").(string)
 	if nodeIdentity != "" {
 		parameters.Properties.AutoStorage.NodeIdentityReference = &batchaccount.ComputeNodeIdentityReference{
-			ResourceId: utils.String(nodeIdentity),
+			ResourceId: pointer.To(nodeIdentity),
 		}
 	}
 

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccount"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BatchAccountResource struct{}
@@ -341,7 +341,7 @@ func (t BatchAccountResource) Exists(ctx context.Context, clients *clients.Clien
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BatchAccountResource) basic(data acceptance.TestData) string {

--- a/internal/services/batch/batch_application_resource.go
+++ b/internal/services/batch/batch_application_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/application"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceBatchApplication() *pluginsdk.Resource {
@@ -100,9 +100,9 @@ func resourceBatchApplicationCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	parameters := application.Application{
 		Properties: &application.ApplicationProperties{
-			AllowUpdates:   utils.Bool(allowUpdates),
-			DefaultVersion: utils.String(defaultVersion),
-			DisplayName:    utils.String(displayName),
+			AllowUpdates:   pointer.To(allowUpdates),
+			DefaultVersion: pointer.To(defaultVersion),
+			DisplayName:    pointer.To(displayName),
 		},
 	}
 
@@ -166,9 +166,9 @@ func resourceBatchApplicationUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	parameters := application.Application{
 		Properties: &application.ApplicationProperties{
-			AllowUpdates:   utils.Bool(allowUpdates),
-			DefaultVersion: utils.String(defaultVersion),
-			DisplayName:    utils.String(displayName),
+			AllowUpdates:   pointer.To(allowUpdates),
+			DefaultVersion: pointer.To(defaultVersion),
+			DisplayName:    pointer.To(displayName),
 		},
 	}
 

--- a/internal/services/batch/batch_application_resource_test.go
+++ b/internal/services/batch/batch_application_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/application"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BatchApplicationResource struct{}
@@ -81,7 +81,7 @@ func (t BatchApplicationResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("retrieving %s", *id)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BatchApplicationResource) template(data acceptance.TestData, displayName string) string {

--- a/internal/services/batch/batch_certificate_resource_test.go
+++ b/internal/services/batch/batch_certificate_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/certificate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BatchCertificateResource struct{}
@@ -96,7 +96,7 @@ func (t BatchCertificateResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("retrieving %s", *id)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BatchCertificateResource) pfxWithPassword(data acceptance.TestData) string {

--- a/internal/services/batch/batch_job_resource.go
+++ b/internal/services/batch/batch_job_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccount"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/pool"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -126,9 +127,9 @@ func (r BatchJobResource) Create() sdk.ResourceFunc {
 			params := batchDataplane.JobAddParameter{
 				ID:          &model.Name,
 				DisplayName: &model.DisplayName,
-				Priority:    utils.Int32(int32(model.Priority)),
+				Priority:    pointer.To(int32(model.Priority)),
 				Constraints: &batchDataplane.JobConstraints{
-					MaxTaskRetryCount: utils.Int32(int32(model.TaskRetryMaximum)),
+					MaxTaskRetryCount: pointer.To(int32(model.TaskRetryMaximum)),
 				},
 				CommonEnvironmentSettings: r.expandEnvironmentSettings(model.CommonEnvironmentProperties),
 				PoolInfo: &batchDataplane.PoolInformation{
@@ -207,14 +208,14 @@ func (r BatchJobResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("priority") {
-				patch.Priority = utils.Int32(int32(model.Priority))
+				patch.Priority = pointer.To(int32(model.Priority))
 			}
 
 			if metadata.ResourceData.HasChange("task_retry_maximum") {
 				if patch.Constraints == nil {
 					patch.Constraints = new(batchDataplane.JobConstraints)
 				}
-				patch.Constraints.MaxTaskRetryCount = utils.Int32(int32(model.TaskRetryMaximum))
+				patch.Constraints.MaxTaskRetryCount = pointer.To(int32(model.TaskRetryMaximum))
 			}
 
 			id, err := parse.JobID(metadata.ResourceData.Id())
@@ -260,7 +261,7 @@ func (r BatchJobResource) addJob(ctx context.Context, client *batchDataplane.Job
 	deadline, _ := ctx.Deadline()
 	now := time.Now()
 	timeout := deadline.Sub(now)
-	_, err := client.Add(ctx, job, utils.Int32(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now})
+	_, err := client.Add(ctx, job, pointer.To(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now})
 	if err != nil {
 		return fmt.Errorf("creating %s: %v", id, err)
 	}
@@ -271,14 +272,14 @@ func (r BatchJobResource) getJob(ctx context.Context, client *batchDataplane.Job
 	deadline, _ := ctx.Deadline()
 	now := time.Now()
 	timeout := deadline.Sub(now)
-	return client.Get(ctx, id.Name, "", "", utils.Int32(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now}, "", "", nil, nil)
+	return client.Get(ctx, id.Name, "", "", pointer.To(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now}, "", "", nil, nil)
 }
 
 func (r BatchJobResource) patchJob(ctx context.Context, client *batchDataplane.JobClient, id parse.JobId, job batchDataplane.JobPatchParameter) error {
 	deadline, _ := ctx.Deadline()
 	now := time.Now()
 	timeout := deadline.Sub(now)
-	_, err := client.Patch(ctx, id.Name, job, utils.Int32(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now}, "", "", nil, nil)
+	_, err := client.Patch(ctx, id.Name, job, pointer.To(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now}, "", "", nil, nil)
 	return err
 }
 
@@ -286,7 +287,7 @@ func (r BatchJobResource) deleteJob(ctx context.Context, client *batchDataplane.
 	deadline, _ := ctx.Deadline()
 	now := time.Now()
 	timeout := deadline.Sub(now)
-	_, err := client.Delete(ctx, id.Name, utils.Int32(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now}, "", "", nil, nil)
+	_, err := client.Delete(ctx, id.Name, pointer.To(int32(timeout.Seconds())), nil, nil, &date.TimeRFC1123{Time: now}, "", "", nil, nil)
 	return err
 }
 
@@ -297,8 +298,8 @@ func (r BatchJobResource) expandEnvironmentSettings(input map[string]string) *[]
 	m := make([]batchDataplane.EnvironmentSetting, 0, len(input))
 	for k, v := range input {
 		m = append(m, batchDataplane.EnvironmentSetting{
-			Name:  utils.String(k),
-			Value: utils.String(v),
+			Name:  pointer.To(k),
+			Value: pointer.To(v),
 		})
 	}
 	return &m

--- a/internal/services/batch/batch_job_resource_test.go
+++ b/internal/services/batch/batch_job_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccount"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -106,12 +107,12 @@ func (r BatchJobResource) Exists(ctx context.Context, clients *clients.Client, s
 
 	if resp, err := client.Get(ctx, id.Name, "", "", nil, nil, nil, nil, "", "", nil, nil); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r BatchJobResource) basic(data acceptance.TestData) string {

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -706,7 +706,7 @@ func ExpandBatchPoolStartTask(list []interface{}) (*pool.StartTask, error) {
 			resourceId := v.(string)
 			if resourceId != "" {
 				identityReference := pool.ComputeNodeIdentityReference{
-					ResourceId: utils.String(resourceId),
+					ResourceId: pointer.To(resourceId),
 				}
 				resourceFile.IdentityReference = &identityReference
 			}
@@ -734,7 +734,7 @@ func ExpandBatchPoolStartTask(list []interface{}) (*pool.StartTask, error) {
 			settingMap := containerSettingsList[0].(map[string]interface{})
 			containerSettings.ImageName = settingMap["image_name"].(string)
 			if containerRunOptions, ok := settingMap["run_options"]; ok {
-				containerSettings.ContainerRunOptions = utils.String(containerRunOptions.(string))
+				containerSettings.ContainerRunOptions = pointer.To(containerRunOptions.(string))
 			}
 			if registries, ok := settingMap["registry"].([]interface{}); ok && len(registries) > 0 && registries[0] != nil {
 				containerRegMap := registries[0].(map[string]interface{})
@@ -797,7 +797,7 @@ func expandBatchPoolVirtualMachineConfig(d *pluginsdk.ResourceData) (*pool.Virtu
 	}
 
 	if licenseType, ok := d.GetOk("license_type"); ok {
-		result.LicenseType = utils.String(licenseType.(string))
+		result.LicenseType = pointer.To(licenseType.(string))
 	}
 
 	if v, ok := d.GetOk("node_placement"); ok {
@@ -877,7 +877,7 @@ func expandBatchPoolWindowsConfiguration(list []interface{}) *pool.WindowsConfig
 
 	item := list[0].(map[string]interface{})["enable_automatic_updates"].(bool)
 	return &pool.WindowsConfiguration{
-		EnableAutomaticUpdates: utils.Bool(item),
+		EnableAutomaticUpdates: pointer.To(item),
 	}
 }
 
@@ -912,15 +912,15 @@ func expandBatchPoolExtension(ref map[string]interface{}) (*pool.VmExtension, er
 	}
 
 	if autoUpgradeMinorVersion, ok := ref["auto_upgrade_minor_version"]; ok {
-		result.AutoUpgradeMinorVersion = utils.Bool(autoUpgradeMinorVersion.(bool))
+		result.AutoUpgradeMinorVersion = pointer.To(autoUpgradeMinorVersion.(bool))
 	}
 
 	if autoUpgradeEnabled, ok := ref["automatic_upgrade_enabled"]; ok {
-		result.EnableAutomaticUpgrade = utils.Bool(autoUpgradeEnabled.(bool))
+		result.EnableAutomaticUpgrade = pointer.To(autoUpgradeEnabled.(bool))
 	}
 
 	if typeHandlerVersion, ok := ref["type_handler_version"]; ok {
-		result.TypeHandlerVersion = utils.String(typeHandlerVersion.(string))
+		result.TypeHandlerVersion = pointer.To(typeHandlerVersion.(string))
 	}
 
 	if settings, ok := ref["settings_json"]; ok {
@@ -1084,15 +1084,15 @@ func expandBatchPoolAzureBlobFileSystemConfiguration(list []interface{}) (*pool.
 	}
 
 	if accountKey, ok := configMap["account_key"]; ok && accountKey != "" {
-		result.AccountKey = utils.String(accountKey.(string))
+		result.AccountKey = pointer.To(accountKey.(string))
 	} else if sasKey, ok := configMap["sas_key"]; ok && sasKey != "" {
-		result.SasKey = utils.String(sasKey.(string))
+		result.SasKey = pointer.To(sasKey.(string))
 	} else if computedIDRef, err := expandBatchPoolIdentityReference(configMap); err == nil {
 		result.IdentityReference = computedIDRef
 	}
 
 	if blobfuseOptions, ok := configMap["blobfuse_options"]; ok {
-		result.BlobfuseOptions = utils.String(blobfuseOptions.(string))
+		result.BlobfuseOptions = pointer.To(blobfuseOptions.(string))
 	}
 	return &result, nil
 }
@@ -1111,7 +1111,7 @@ func expandBatchPoolAzureFileShareConfiguration(list []interface{}) (*pool.Azure
 	}
 
 	if mountOptions, ok := configMap["mount_options"]; ok {
-		result.MountOptions = utils.String(mountOptions.(string))
+		result.MountOptions = pointer.To(mountOptions.(string))
 	}
 
 	return &result, nil
@@ -1131,7 +1131,7 @@ func expandBatchPoolCIFSMountConfiguration(list []interface{}) (*pool.CIFSMountC
 	}
 
 	if mountOptions, ok := configMap["mount_options"]; ok {
-		result.MountOptions = utils.String(mountOptions.(string))
+		result.MountOptions = pointer.To(mountOptions.(string))
 	}
 
 	return &result, nil
@@ -1149,7 +1149,7 @@ func expandBatchPoolNFSMountConfiguration(list []interface{}) (*pool.NFSMountCon
 	}
 
 	if mountOptions, ok := configMap["mount_options"]; ok {
-		result.MountOptions = utils.String(mountOptions.(string))
+		result.MountOptions = pointer.To(mountOptions.(string))
 	}
 	return &result, nil
 }
@@ -1157,7 +1157,7 @@ func expandBatchPoolNFSMountConfiguration(list []interface{}) (*pool.NFSMountCon
 func expandBatchPoolIdentityReference(ref map[string]interface{}) (*pool.ComputeNodeIdentityReference, error) {
 	var result pool.ComputeNodeIdentityReference
 	if iid, ok := ref["identity_id"]; ok && iid != "" {
-		result.ResourceId = utils.String(iid.(string))
+		result.ResourceId = pointer.To(iid.(string))
 		return &result, nil
 	}
 	return nil, fmt.Errorf("identity_id is empty")
@@ -1177,7 +1177,7 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*pool.NetworkConfi
 	}
 
 	if v, ok := networkConfigValue["accelerated_networking_enabled"]; ok {
-		networkConfiguration.EnableAcceleratedNetworking = pointer.FromBool(v.(bool))
+		networkConfiguration.EnableAcceleratedNetworking = pointer.To(v.(bool))
 	}
 
 	if v, ok := networkConfigValue["subnet_id"]; ok {
@@ -1416,12 +1416,12 @@ func expandBatchPoolUserAccount(ref map[string]interface{}) pool.UserAccount {
 			var linuxUserConfig pool.LinuxUserConfiguration
 			if uid, ok := linuxUserConfigMap["uid"]; ok {
 				linuxUserConfig = pool.LinuxUserConfiguration{
-					Uid: utils.Int64(int64(uid.(int))),
-					Gid: utils.Int64(int64(linuxUserConfigMap["gid"].(int))),
+					Uid: pointer.To(int64(uid.(int))),
+					Gid: pointer.To(int64(linuxUserConfigMap["gid"].(int))),
 				}
 			}
 			if sshPrivateKey, ok := linuxUserConfigMap["ssh_private_key"]; ok {
-				linuxUserConfig.SshPrivateKey = utils.String(sshPrivateKey.(string))
+				linuxUserConfig.SshPrivateKey = pointer.To(sshPrivateKey.(string))
 			}
 			result.LinuxUserConfiguration = &linuxUserConfig
 		}

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceBatchPool() *pluginsdk.Resource {
@@ -888,10 +887,10 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	parameters := pool.Pool{
 		Properties: &pool.PoolProperties{
-			VMSize:                 utils.String(d.Get("vm_size").(string)),
-			DisplayName:            utils.String(d.Get("display_name").(string)),
+			VMSize:                 pointer.To(d.Get("vm_size").(string)),
+			DisplayName:            pointer.To(d.Get("display_name").(string)),
 			InterNodeCommunication: pointer.To(pool.InterNodeCommunicationState(d.Get("inter_node_communication").(string))),
-			TaskSlotsPerNode:       utils.Int64(int64(d.Get("max_tasks_per_node").(int))),
+			TaskSlotsPerNode:       pointer.To(int64(d.Get("max_tasks_per_node").(int))),
 		},
 	}
 
@@ -1403,8 +1402,8 @@ func expandBatchPoolScaleSettings(d *pluginsdk.ResourceData) (*pool.ScaleSetting
 		scaleSettings.FixedScale = &pool.FixedScaleSettings{
 			NodeDeallocationOption: &nodeDeallocationOption,
 			ResizeTimeout:          &resizeTimeout,
-			TargetDedicatedNodes:   utils.Int64(int64(targetDedicatedNodes)),
-			TargetLowPriorityNodes: utils.Int64(int64(targetLowPriorityNodes)),
+			TargetDedicatedNodes:   pointer.To(int64(targetDedicatedNodes)),
+			TargetLowPriorityNodes: pointer.To(int64(targetLowPriorityNodes)),
 		}
 	}
 

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/pool"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BatchPoolResource struct{}
@@ -827,7 +827,7 @@ func (t BatchPoolResource) Exists(ctx context.Context, clients *clients.Client, 
 		return nil, fmt.Errorf("retrieving %s", *id)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BatchPoolResource) fixedScale_complete(data acceptance.TestData) string {

--- a/internal/services/blueprints/blueprint_assignment_resource.go
+++ b/internal/services/blueprints/blueprint_assignment_resource.go
@@ -259,7 +259,7 @@ func resourceBlueprintAssignmentRead(d *pluginsdk.ResourceData, meta interface{}
 	if model := resp.Model; model != nil {
 		p := model.Properties
 
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 		d.Set("target_subscription_id", pointer.From(p.Scope))
 		d.Set("version_id", pointer.From(p.BlueprintId))
 		d.Set("display_name", pointer.From(p.DisplayName))

--- a/internal/services/bot/bot_channel_alexa_resource.go
+++ b/internal/services/bot/bot_channel_alexa_resource.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -87,12 +87,12 @@ func resourceBotChannelAlexaCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	channel := botservice.BotChannel{
 		Properties: botservice.AlexaChannel{
 			Properties: &botservice.AlexaChannelProperties{
-				AlexaSkillID: utils.String(d.Get("skill_id").(string)),
-				IsEnabled:    utils.Bool(true),
+				AlexaSkillID: pointer.To(d.Get("skill_id").(string)),
+				IsEnabled:    pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameAlexaChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -170,12 +170,12 @@ func resourceBotChannelAlexaUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	channel := botservice.BotChannel{
 		Properties: botservice.AlexaChannel{
 			Properties: &botservice.AlexaChannelProperties{
-				AlexaSkillID: utils.String(d.Get("skill_id").(string)),
-				IsEnabled:    utils.Bool(true),
+				AlexaSkillID: pointer.To(d.Get("skill_id").(string)),
+				IsEnabled:    pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameAlexaChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 

--- a/internal/services/bot/bot_channel_alexa_resource_test.go
+++ b/internal/services/bot/bot_channel_alexa_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -83,7 +83,7 @@ func (t BotChannelAlexaResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelAlexaResource) basic(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_direct_line_speech_resource.go
+++ b/internal/services/bot/bot_channel_direct_line_speech_resource.go
@@ -8,12 +8,12 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -108,30 +108,30 @@ func resourceBotChannelDirectLineSpeechCreate(d *pluginsdk.ResourceData, meta in
 	channel := botservice.BotChannel{
 		Properties: botservice.DirectLineSpeechChannel{
 			Properties: &botservice.DirectLineSpeechChannelProperties{
-				CognitiveServiceRegion:          utils.String(d.Get("cognitive_service_location").(string)),
-				CognitiveServiceSubscriptionKey: utils.String(d.Get("cognitive_service_access_key").(string)),
-				IsDefaultBotForCogSvcAccount:    utils.Bool(false),
-				IsEnabled:                       utils.Bool(true),
+				CognitiveServiceRegion:          pointer.To(d.Get("cognitive_service_location").(string)),
+				CognitiveServiceSubscriptionKey: pointer.To(d.Get("cognitive_service_access_key").(string)),
+				IsDefaultBotForCogSvcAccount:    pointer.To(false),
+				IsEnabled:                       pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameDirectLineSpeechChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
 	if v, ok := d.GetOk("cognitive_account_id"); ok {
 		channel, _ := channel.Properties.AsDirectLineSpeechChannel()
-		channel.Properties.CognitiveServiceResourceID = utils.String(v.(string))
+		channel.Properties.CognitiveServiceResourceID = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("custom_speech_model_id"); ok {
 		channel, _ := channel.Properties.AsDirectLineSpeechChannel()
-		channel.Properties.CustomSpeechModelID = utils.String(v.(string))
+		channel.Properties.CustomSpeechModelID = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("custom_voice_deployment_id"); ok {
 		channel, _ := channel.Properties.AsDirectLineSpeechChannel()
-		channel.Properties.CustomVoiceDeploymentID = utils.String(v.(string))
+		channel.Properties.CustomVoiceDeploymentID = pointer.To(v.(string))
 	}
 
 	if _, err := client.Create(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameDirectLineSpeechChannel, channel); err != nil {
@@ -193,30 +193,30 @@ func resourceBotChannelDirectLineSpeechUpdate(d *pluginsdk.ResourceData, meta in
 	channel := botservice.BotChannel{
 		Properties: botservice.DirectLineSpeechChannel{
 			Properties: &botservice.DirectLineSpeechChannelProperties{
-				CognitiveServiceRegion:          utils.String(d.Get("cognitive_service_location").(string)),
-				CognitiveServiceSubscriptionKey: utils.String(d.Get("cognitive_service_access_key").(string)),
-				IsDefaultBotForCogSvcAccount:    utils.Bool(false),
-				IsEnabled:                       utils.Bool(true),
+				CognitiveServiceRegion:          pointer.To(d.Get("cognitive_service_location").(string)),
+				CognitiveServiceSubscriptionKey: pointer.To(d.Get("cognitive_service_access_key").(string)),
+				IsDefaultBotForCogSvcAccount:    pointer.To(false),
+				IsEnabled:                       pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameDirectLineSpeechChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
 	if d.HasChange("cognitive_account_id") {
 		channel, _ := channel.Properties.AsDirectLineSpeechChannel()
-		channel.Properties.CognitiveServiceResourceID = utils.String(d.Get("cognitive_account_id").(string))
+		channel.Properties.CognitiveServiceResourceID = pointer.To(d.Get("cognitive_account_id").(string))
 	}
 
 	if v, ok := d.GetOk("custom_speech_model_id"); ok {
 		channel, _ := channel.Properties.AsDirectLineSpeechChannel()
-		channel.Properties.CustomSpeechModelID = utils.String(v.(string))
+		channel.Properties.CustomSpeechModelID = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("custom_voice_deployment_id"); ok {
 		channel, _ := channel.Properties.AsDirectLineSpeechChannel()
-		channel.Properties.CustomVoiceDeploymentID = utils.String(v.(string))
+		channel.Properties.CustomVoiceDeploymentID = pointer.To(v.(string))
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameDirectLineSpeechChannel, channel); err != nil {

--- a/internal/services/bot/bot_channel_direct_line_speech_resource_test.go
+++ b/internal/services/bot/bot_channel_direct_line_speech_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -118,7 +118,7 @@ func (r BotChannelDirectLineSpeechResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelDirectLineSpeechResource) cognitiveAccount(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_directline_resource.go
+++ b/internal/services/bot/bot_channel_directline_resource.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -170,7 +170,7 @@ func resourceBotChannelDirectlineCreate(d *pluginsdk.ResourceData, meta interfac
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameDirectLineChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -245,7 +245,7 @@ func resourceBotChannelDirectlineUpdate(d *pluginsdk.ResourceData, meta interfac
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameDirectLineChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -292,9 +292,9 @@ func expandDirectlineSites(input []interface{}) *[]botservice.DirectLineSite {
 
 		site := element.(map[string]interface{})
 		expanded := botservice.DirectLineSite{
-			IsBlockUserUploadEnabled:    utils.Bool(!site["user_upload_enabled"].(bool)),
-			IsEndpointParametersEnabled: utils.Bool(site["endpoint_parameters_enabled"].(bool)),
-			IsNoStorageEnabled:          utils.Bool(!site["storage_enabled"].(bool)),
+			IsBlockUserUploadEnabled:    pointer.To(!site["user_upload_enabled"].(bool)),
+			IsEndpointParametersEnabled: pointer.To(site["endpoint_parameters_enabled"].(bool)),
+			IsNoStorageEnabled:          pointer.To(!site["storage_enabled"].(bool)),
 		}
 
 		if v, ok := site["name"].(string); ok {

--- a/internal/services/bot/bot_channel_directline_resource_test.go
+++ b/internal/services/bot/bot_channel_directline_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -89,7 +89,7 @@ func (t BotChannelDirectlineResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelDirectlineResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_email_resource.go
+++ b/internal/services/bot/bot_channel_email_resource.go
@@ -14,14 +14,12 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/botservice/2022-09-15/channel"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceBotChannelEmail() *pluginsdk.Resource {
@@ -106,20 +104,20 @@ func resourceBotChannelEmailCreate(d *pluginsdk.ResourceData, meta interface{}) 
 				IsEnabled:    true,
 			},
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     pointer.To(channel.KindBot),
 	}
 
 	if v, ok := d.GetOk("email_password"); ok {
 		channelProps := parameters.Properties.(channel.EmailChannel)
 		channelProps.Properties.AuthMethod = pointer.To(channel.EmailChannelAuthMethodZero)
-		channelProps.Properties.Password = utils.String(v.(string))
+		channelProps.Properties.Password = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("magic_code"); ok {
 		channelProps := parameters.Properties.(channel.EmailChannel)
 		channelProps.Properties.AuthMethod = pointer.To(channel.EmailChannelAuthMethodOne)
-		channelProps.Properties.MagicCode = utils.String(v.(string))
+		channelProps.Properties.MagicCode = pointer.To(v.(string))
 	}
 
 	if _, err := client.Create(ctx, resourceId, parameters); err != nil {
@@ -186,20 +184,20 @@ func resourceBotChannelEmailUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 				IsEnabled:    true,
 			},
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     pointer.To(channel.KindBot),
 	}
 
 	if v, ok := d.GetOk("email_password"); ok {
 		channelProps := parameters.Properties.(channel.EmailChannel)
 		channelProps.Properties.AuthMethod = pointer.To(channel.EmailChannelAuthMethodZero)
-		channelProps.Properties.Password = utils.String(v.(string))
+		channelProps.Properties.Password = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("magic_code"); ok {
 		channelProps := parameters.Properties.(channel.EmailChannel)
 		channelProps.Properties.AuthMethod = pointer.To(channel.EmailChannelAuthMethodOne)
-		channelProps.Properties.MagicCode = utils.String(v.(string))
+		channelProps.Properties.MagicCode = pointer.To(v.(string))
 	}
 
 	if _, err := client.Update(ctx, *id, parameters); err != nil {

--- a/internal/services/bot/bot_channel_email_resource_test.go
+++ b/internal/services/bot/bot_channel_email_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -93,7 +93,7 @@ func (t BotChannelEmailResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelEmailResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_facebook_resource.go
+++ b/internal/services/bot/bot_channel_facebook_resource.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -113,14 +113,14 @@ func resourceBotChannelFacebookCreate(d *pluginsdk.ResourceData, meta interface{
 	channel := botservice.BotChannel{
 		Properties: botservice.FacebookChannel{
 			Properties: &botservice.FacebookChannelProperties{
-				AppID:     utils.String(d.Get("facebook_application_id").(string)),
-				AppSecret: utils.String(d.Get("facebook_application_secret").(string)),
+				AppID:     pointer.To(d.Get("facebook_application_id").(string)),
+				AppSecret: pointer.To(d.Get("facebook_application_secret").(string)),
 				Pages:     expandFacebookPage(d.Get("page").(*pluginsdk.Set).List()),
-				IsEnabled: utils.Bool(true),
+				IsEnabled: pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameFacebookChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -191,14 +191,14 @@ func resourceBotChannelFacebookUpdate(d *pluginsdk.ResourceData, meta interface{
 	channel := botservice.BotChannel{
 		Properties: botservice.FacebookChannel{
 			Properties: &botservice.FacebookChannelProperties{
-				AppID:     utils.String(d.Get("facebook_application_id").(string)),
-				AppSecret: utils.String(d.Get("facebook_application_secret").(string)),
+				AppID:     pointer.To(d.Get("facebook_application_id").(string)),
+				AppSecret: pointer.To(d.Get("facebook_application_secret").(string)),
 				Pages:     expandFacebookPage(d.Get("page").(*pluginsdk.Set).List()),
-				IsEnabled: utils.Bool(true),
+				IsEnabled: pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameFacebookChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -236,8 +236,8 @@ func expandFacebookPage(input []interface{}) *[]botservice.FacebookPage {
 		v := item.(map[string]interface{})
 
 		result := botservice.FacebookPage{
-			AccessToken: utils.String(v["access_token"].(string)),
-			ID:          utils.String(v["id"].(string)),
+			AccessToken: pointer.To(v["access_token"].(string)),
+			ID:          pointer.To(v["id"].(string)),
 		}
 
 		results = append(results, result)

--- a/internal/services/bot/bot_channel_facebook_resource_test.go
+++ b/internal/services/bot/bot_channel_facebook_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -89,7 +89,7 @@ func (t BotChannelFacebookResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelFacebookResource) basic(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_line_resource.go
+++ b/internal/services/bot/bot_channel_line_resource.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -105,7 +105,7 @@ func resourceBotChannelLineCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameLineChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -177,7 +177,7 @@ func resourceBotChannelLineUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameLineChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -215,8 +215,8 @@ func expandLineChannel(input []interface{}) *[]botservice.LineRegistration {
 		v := item.(map[string]interface{})
 
 		results = append(results, botservice.LineRegistration{
-			ChannelSecret:      utils.String(v["secret"].(string)),
-			ChannelAccessToken: utils.String(v["access_token"].(string)),
+			ChannelSecret:      pointer.To(v["secret"].(string)),
+			ChannelAccessToken: pointer.To(v["access_token"].(string)),
 		})
 	}
 

--- a/internal/services/bot/bot_channel_line_resource_test.go
+++ b/internal/services/bot/bot_channel_line_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -106,7 +106,7 @@ func (t BotChannelLineResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelLineResource) basic(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_ms_teams_resource.go
+++ b/internal/services/bot/bot_channel_ms_teams_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -131,7 +130,7 @@ func resourceBotChannelMsTeamsCreate(d *pluginsdk.ResourceData, meta interface{}
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameMsTeamsChannel,
 		},
-		Location: pointer.To(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -217,7 +216,7 @@ func resourceBotChannelMsTeamsUpdate(d *pluginsdk.ResourceData, meta interface{}
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameMsTeamsChannel,
 		},
-		Location: pointer.To(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 

--- a/internal/services/bot/bot_channel_slack_resource.go
+++ b/internal/services/bot/bot_channel_slack_resource.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -111,22 +111,22 @@ func resourceBotChannelSlackCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	channel := botservice.BotChannel{
 		Properties: botservice.SlackChannel{
 			Properties: &botservice.SlackChannelProperties{
-				ClientID:                utils.String(d.Get("client_id").(string)),
-				ClientSecret:            utils.String(d.Get("client_secret").(string)),
-				VerificationToken:       utils.String(d.Get("verification_token").(string)),
-				LandingPageURL:          utils.String(d.Get("landing_page_url").(string)),
-				IsEnabled:               utils.Bool(true),
-				RegisterBeforeOAuthFlow: utils.Bool(true),
+				ClientID:                pointer.To(d.Get("client_id").(string)),
+				ClientSecret:            pointer.To(d.Get("client_secret").(string)),
+				VerificationToken:       pointer.To(d.Get("verification_token").(string)),
+				LandingPageURL:          pointer.To(d.Get("landing_page_url").(string)),
+				IsEnabled:               pointer.To(true),
+				RegisterBeforeOAuthFlow: pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameSlackChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
 	if v, ok := d.GetOk("signing_secret"); ok {
 		channel, _ := channel.Properties.AsSlackChannel()
-		channel.Properties.SigningSecret = utils.String(v.(string))
+		channel.Properties.SigningSecret = pointer.To(v.(string))
 	}
 
 	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.BotServiceName, botservice.ChannelNameSlackChannel, channel); err != nil {
@@ -187,22 +187,22 @@ func resourceBotChannelSlackUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	channel := botservice.BotChannel{
 		Properties: botservice.SlackChannel{
 			Properties: &botservice.SlackChannelProperties{
-				ClientID:                utils.String(d.Get("client_id").(string)),
-				ClientSecret:            utils.String(d.Get("client_secret").(string)),
-				VerificationToken:       utils.String(d.Get("verification_token").(string)),
-				LandingPageURL:          utils.String(d.Get("landing_page_url").(string)),
-				IsEnabled:               utils.Bool(true),
-				RegisterBeforeOAuthFlow: utils.Bool(true),
+				ClientID:                pointer.To(d.Get("client_id").(string)),
+				ClientSecret:            pointer.To(d.Get("client_secret").(string)),
+				VerificationToken:       pointer.To(d.Get("verification_token").(string)),
+				LandingPageURL:          pointer.To(d.Get("landing_page_url").(string)),
+				IsEnabled:               pointer.To(true),
+				RegisterBeforeOAuthFlow: pointer.To(true),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameSlackChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
 	if v, ok := d.GetOk("signing_secret"); ok {
 		channel, _ := channel.Properties.AsSlackChannel()
-		channel.Properties.SigningSecret = utils.String(v.(string))
+		channel.Properties.SigningSecret = pointer.To(v.(string))
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.BotServiceName, botservice.ChannelNameSlackChannel, channel); err != nil {

--- a/internal/services/bot/bot_channel_slack_resource_test.go
+++ b/internal/services/bot/bot_channel_slack_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -92,7 +92,7 @@ func (t BotChannelSlackResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelSlackResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_sms_resource.go
+++ b/internal/services/bot/bot_channel_sms_resource.go
@@ -8,10 +8,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -98,15 +98,15 @@ func resourceBotChannelSMSCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	channel := botservice.BotChannel{
 		Properties: botservice.SmsChannel{
 			Properties: &botservice.SmsChannelProperties{
-				AccountSID:  utils.String(d.Get("sms_channel_account_security_id").(string)),
-				AuthToken:   utils.String(d.Get("sms_channel_auth_token").(string)),
-				IsValidated: utils.Bool(true),
-				IsEnabled:   utils.Bool(true),
-				Phone:       utils.String(d.Get("phone_number").(string)),
+				AccountSID:  pointer.To(d.Get("sms_channel_account_security_id").(string)),
+				AuthToken:   pointer.To(d.Get("sms_channel_auth_token").(string)),
+				IsValidated: pointer.To(true),
+				IsEnabled:   pointer.To(true),
+				Phone:       pointer.To(d.Get("phone_number").(string)),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameSmsChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -174,15 +174,15 @@ func resourceBotChannelSMSUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	channel := botservice.BotChannel{
 		Properties: botservice.SmsChannel{
 			Properties: &botservice.SmsChannelProperties{
-				AccountSID:  utils.String(d.Get("sms_channel_account_security_id").(string)),
-				AuthToken:   utils.String(d.Get("sms_channel_auth_token").(string)),
-				IsValidated: utils.Bool(true),
-				IsEnabled:   utils.Bool(true),
-				Phone:       utils.String(d.Get("phone_number").(string)),
+				AccountSID:  pointer.To(d.Get("sms_channel_account_security_id").(string)),
+				AuthToken:   pointer.To(d.Get("sms_channel_auth_token").(string)),
+				IsValidated: pointer.To(true),
+				IsEnabled:   pointer.To(true),
+				Phone:       pointer.To(d.Get("phone_number").(string)),
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameSmsChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 

--- a/internal/services/bot/bot_channel_sms_resource_test.go
+++ b/internal/services/bot/bot_channel_sms_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -65,7 +65,7 @@ func (t BotChannelSMSResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelSMSResource) basic(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channel_web_chat_resource.go
+++ b/internal/services/bot/bot_channel_web_chat_resource.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
@@ -126,7 +126,7 @@ func resourceBotChannelWebChatCreate(d *pluginsdk.ResourceData, meta interface{}
 			Properties:  &botservice.WebChatChannelProperties{},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameWebChatChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -202,7 +202,7 @@ func resourceBotChannelWebChatUpdate(d *pluginsdk.ResourceData, meta interface{}
 			Properties:  &botservice.WebChatChannelProperties{},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameWebChatChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Kind:     botservice.KindBot,
 	}
 
@@ -243,14 +243,14 @@ func resourceBotChannelWebChatDelete(d *pluginsdk.ResourceData, meta interface{}
 			Properties: &botservice.WebChatChannelProperties{
 				Sites: &[]botservice.WebChatSite{
 					{
-						SiteName:  utils.String("Default Site"),
-						IsEnabled: utils.Bool(true),
+						SiteName:  pointer.To("Default Site"),
+						IsEnabled: pointer.To(true),
 					},
 				},
 			},
 			ChannelName: botservice.ChannelNameBasicChannelChannelNameWebChatChannel,
 		},
-		Location: utils.String(azure.NormalizeLocation(*existing.Location)),
+		Location: pointer.To(location.Normalize(*existing.Location)),
 		Kind:     botservice.KindBot,
 	}
 
@@ -269,14 +269,14 @@ func expandSites(input []interface{}) *[]botservice.WebChatSite {
 	for _, item := range input {
 		site := item.(map[string]interface{})
 		result := botservice.WebChatSite{
-			IsEnabled:                   utils.Bool(true),
-			IsBlockUserUploadEnabled:    utils.Bool(!site["user_upload_enabled"].(bool)),
-			IsEndpointParametersEnabled: utils.Bool(site["endpoint_parameters_enabled"].(bool)),
-			IsNoStorageEnabled:          utils.Bool(!site["storage_enabled"].(bool)),
+			IsEnabled:                   pointer.To(true),
+			IsBlockUserUploadEnabled:    pointer.To(!site["user_upload_enabled"].(bool)),
+			IsEndpointParametersEnabled: pointer.To(site["endpoint_parameters_enabled"].(bool)),
+			IsNoStorageEnabled:          pointer.To(!site["storage_enabled"].(bool)),
 		}
 
 		if siteName := site["name"].(string); siteName != "" {
-			result.SiteName = utils.String(siteName)
+			result.SiteName = pointer.To(siteName)
 		}
 
 		results = append(results, result)

--- a/internal/services/bot/bot_channel_web_chat_resource_test.go
+++ b/internal/services/bot/bot_channel_web_chat_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/botservice/2021-05-01-preview/botservice"
 )
 
@@ -104,7 +104,7 @@ func (r BotChannelWebChatResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelWebChatResource) basic(data acceptance.TestData) string {

--- a/internal/services/bot/bot_channels_registration_resource.go
+++ b/internal/services/bot/bot_channels_registration_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -189,19 +190,19 @@ func resourceBotChannelsRegistrationCreate(d *pluginsdk.ResourceData, meta inter
 
 	bot := botservice.Bot{
 		Properties: &botservice.BotProperties{
-			DisplayName:                       utils.String(displayName),
-			Endpoint:                          utils.String(d.Get("endpoint").(string)),
-			MsaAppID:                          utils.String(d.Get("microsoft_app_id").(string)),
-			CmekKeyVaultURL:                   utils.String(d.Get("cmk_key_vault_url").(string)),
-			Description:                       utils.String(d.Get("description").(string)),
-			DeveloperAppInsightKey:            utils.String(d.Get("developer_app_insights_key").(string)),
-			DeveloperAppInsightsAPIKey:        utils.String(d.Get("developer_app_insights_api_key").(string)),
-			DeveloperAppInsightsApplicationID: utils.String(d.Get("developer_app_insights_application_id").(string)),
-			IconURL:                           utils.String(d.Get("icon_url").(string)),
-			IsCmekEnabled:                     utils.Bool(false),
-			IsStreamingSupported:              utils.Bool(d.Get("streaming_endpoint_enabled").(bool)),
+			DisplayName:                       pointer.To(displayName),
+			Endpoint:                          pointer.To(d.Get("endpoint").(string)),
+			MsaAppID:                          pointer.To(d.Get("microsoft_app_id").(string)),
+			CmekKeyVaultURL:                   pointer.To(d.Get("cmk_key_vault_url").(string)),
+			Description:                       pointer.To(d.Get("description").(string)),
+			DeveloperAppInsightKey:            pointer.To(d.Get("developer_app_insights_key").(string)),
+			DeveloperAppInsightsAPIKey:        pointer.To(d.Get("developer_app_insights_api_key").(string)),
+			DeveloperAppInsightsApplicationID: pointer.To(d.Get("developer_app_insights_application_id").(string)),
+			IconURL:                           pointer.To(d.Get("icon_url").(string)),
+			IsCmekEnabled:                     pointer.To(false),
+			IsStreamingSupported:              pointer.To(d.Get("streaming_endpoint_enabled").(bool)),
 		},
-		Location: utils.String(d.Get("location").(string)),
+		Location: pointer.To(d.Get("location").(string)),
 		Sku: &botservice.Sku{
 			Name: botservice.SkuName(d.Get("sku").(string)),
 		},
@@ -210,7 +211,7 @@ func resourceBotChannelsRegistrationCreate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	if _, ok := d.GetOk("cmk_key_vault_url"); ok {
-		bot.Properties.IsCmekEnabled = utils.Bool(true)
+		bot.Properties.IsCmekEnabled = pointer.To(true)
 	}
 
 	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.Name, bot); err != nil {
@@ -295,19 +296,19 @@ func resourceBotChannelsRegistrationUpdate(d *pluginsdk.ResourceData, meta inter
 
 	bot := botservice.Bot{
 		Properties: &botservice.BotProperties{
-			DisplayName:                       utils.String(displayName),
-			Endpoint:                          utils.String(d.Get("endpoint").(string)),
-			MsaAppID:                          utils.String(d.Get("microsoft_app_id").(string)),
-			CmekKeyVaultURL:                   utils.String(d.Get("cmk_key_vault_url").(string)),
-			Description:                       utils.String(d.Get("description").(string)),
-			DeveloperAppInsightKey:            utils.String(d.Get("developer_app_insights_key").(string)),
-			DeveloperAppInsightsAPIKey:        utils.String(d.Get("developer_app_insights_api_key").(string)),
-			DeveloperAppInsightsApplicationID: utils.String(d.Get("developer_app_insights_application_id").(string)),
-			IconURL:                           utils.String(d.Get("icon_url").(string)),
-			IsCmekEnabled:                     utils.Bool(false),
-			IsStreamingSupported:              utils.Bool(d.Get("streaming_endpoint_enabled").(bool)),
+			DisplayName:                       pointer.To(displayName),
+			Endpoint:                          pointer.To(d.Get("endpoint").(string)),
+			MsaAppID:                          pointer.To(d.Get("microsoft_app_id").(string)),
+			CmekKeyVaultURL:                   pointer.To(d.Get("cmk_key_vault_url").(string)),
+			Description:                       pointer.To(d.Get("description").(string)),
+			DeveloperAppInsightKey:            pointer.To(d.Get("developer_app_insights_key").(string)),
+			DeveloperAppInsightsAPIKey:        pointer.To(d.Get("developer_app_insights_api_key").(string)),
+			DeveloperAppInsightsApplicationID: pointer.To(d.Get("developer_app_insights_application_id").(string)),
+			IconURL:                           pointer.To(d.Get("icon_url").(string)),
+			IsCmekEnabled:                     pointer.To(false),
+			IsStreamingSupported:              pointer.To(d.Get("streaming_endpoint_enabled").(bool)),
 		},
-		Location: utils.String(d.Get("location").(string)),
+		Location: pointer.To(d.Get("location").(string)),
 		Sku: &botservice.Sku{
 			Name: botservice.SkuName(d.Get("sku").(string)),
 		},
@@ -316,7 +317,7 @@ func resourceBotChannelsRegistrationUpdate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	if _, ok := d.GetOk("cmk_key_vault_url"); ok {
-		bot.Properties.IsCmekEnabled = utils.Bool(true)
+		bot.Properties.IsCmekEnabled = pointer.To(true)
 	}
 
 	// d.GetOk cannot identify whether user sets the property that is bool type and `public_network_access_enabled` is set as `false`. So it has to identify it using `d.GetRawConfig()`

--- a/internal/services/bot/bot_channels_registration_resource_test.go
+++ b/internal/services/bot/bot_channels_registration_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BotChannelsRegistrationResource struct{}
@@ -124,7 +124,7 @@ func (t BotChannelsRegistrationResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotChannelsRegistrationResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/bot/bot_connection_resource.go
+++ b/internal/services/bot/bot_connection_resource.go
@@ -220,13 +220,13 @@ func resourceArmBotConnectionUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	connection := botservice.ConnectionSetting{
 		Properties: &botservice.ConnectionSettingProperties{
-			ServiceProviderDisplayName: utils.String(d.Get("service_provider_name").(string)),
-			ClientID:                   utils.String(d.Get("client_id").(string)),
-			ClientSecret:               utils.String(d.Get("client_secret").(string)),
-			Scopes:                     utils.String(d.Get("scopes").(string)),
+			ServiceProviderDisplayName: pointer.To(d.Get("service_provider_name").(string)),
+			ClientID:                   pointer.To(d.Get("client_id").(string)),
+			ClientSecret:               pointer.To(d.Get("client_secret").(string)),
+			Scopes:                     pointer.To(d.Get("scopes").(string)),
 		},
 		Kind:     botservice.KindBot,
-		Location: utils.String(d.Get("location").(string)),
+		Location: pointer.To(d.Get("location").(string)),
 	}
 
 	if v, ok := d.GetOk("parameters"); ok {
@@ -265,8 +265,8 @@ func expandBotConnectionParameters(input map[string]interface{}) *[]botservice.C
 
 	for k, v := range input {
 		output = append(output, botservice.ConnectionSettingParameter{
-			Key:   utils.String(k),
-			Value: utils.String(v.(string)),
+			Key:   pointer.To(k),
+			Value: pointer.To(v.(string)),
 		})
 	}
 	return &output

--- a/internal/services/bot/bot_connection_resource_test.go
+++ b/internal/services/bot/bot_connection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BotConnectionResource struct{}
@@ -66,7 +66,7 @@ func (t BotConnectionResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r BotConnectionResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/bot/bot_service_azure_bot_resource_test.go
+++ b/internal/services/bot/bot_service_azure_bot_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BotServiceAzureBotResource struct{}
@@ -148,7 +148,7 @@ func (t BotServiceAzureBotResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotServiceAzureBotResource) basic(data acceptance.TestData) string {

--- a/internal/services/bot/bot_service_resource_base.go
+++ b/internal/services/bot/bot_service_resource_base.go
@@ -196,7 +196,7 @@ func (br botBaseResource) createFunc(resourceName, botKind string) sdk.ResourceF
 			}
 
 			props := botservice.Bot{
-				Location: utils.String(metadata.ResourceData.Get("location").(string)),
+				Location: pointer.To(metadata.ResourceData.Get("location").(string)),
 				Sku: &botservice.Sku{
 					Name: botservice.SkuName(metadata.ResourceData.Get("sku").(string)),
 				},
@@ -209,7 +209,7 @@ func (br botBaseResource) createFunc(resourceName, botKind string) sdk.ResourceF
 					DeveloperAppInsightsAPIKey:        pointer.To(metadata.ResourceData.Get("developer_app_insights_api_key").(string)),
 					DeveloperAppInsightsApplicationID: pointer.To(metadata.ResourceData.Get("developer_app_insights_application_id").(string)),
 					DisableLocalAuth:                  pointer.To(!metadata.ResourceData.Get("local_authentication_enabled").(bool)),
-					IsCmekEnabled:                     utils.Bool(false),
+					IsCmekEnabled:                     pointer.To(false),
 					CmekKeyVaultURL:                   pointer.To(metadata.ResourceData.Get("cmk_key_vault_key_url").(string)),
 					LuisAppIds:                        utils.ExpandStringSlice(metadata.ResourceData.Get("luis_app_ids").([]interface{})),
 					LuisKey:                           pointer.To(metadata.ResourceData.Get("luis_key").(string)),
@@ -221,7 +221,7 @@ func (br botBaseResource) createFunc(resourceName, botKind string) sdk.ResourceF
 			}
 
 			if _, ok := metadata.ResourceData.GetOk("cmk_key_vault_key_url"); ok {
-				props.Properties.IsCmekEnabled = utils.Bool(true)
+				props.Properties.IsCmekEnabled = pointer.To(true)
 			}
 
 			if v, ok := metadata.ResourceData.GetOk("microsoft_app_type"); ok {
@@ -262,27 +262,27 @@ func (br botBaseResource) updateFunc() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("display_name") {
-				existing.Properties.DisplayName = utils.String(metadata.ResourceData.Get("display_name").(string))
+				existing.Properties.DisplayName = pointer.To(metadata.ResourceData.Get("display_name").(string))
 			}
 
 			if metadata.ResourceData.HasChange("endpoint") {
-				existing.Properties.Endpoint = utils.String(metadata.ResourceData.Get("endpoint").(string))
+				existing.Properties.Endpoint = pointer.To(metadata.ResourceData.Get("endpoint").(string))
 			}
 
 			if metadata.ResourceData.HasChange("developer_app_insights_key") {
-				existing.Properties.DeveloperAppInsightKey = utils.String(metadata.ResourceData.Get("developer_app_insights_key").(string))
+				existing.Properties.DeveloperAppInsightKey = pointer.To(metadata.ResourceData.Get("developer_app_insights_key").(string))
 			}
 
 			if metadata.ResourceData.HasChange("developer_app_insights_api_key") {
-				existing.Properties.DeveloperAppInsightsAPIKey = utils.String(metadata.ResourceData.Get("developer_app_insights_api_key").(string))
+				existing.Properties.DeveloperAppInsightsAPIKey = pointer.To(metadata.ResourceData.Get("developer_app_insights_api_key").(string))
 			}
 
 			if metadata.ResourceData.HasChange("developer_app_insights_application_id") {
-				existing.Properties.DeveloperAppInsightsApplicationID = utils.String(metadata.ResourceData.Get("developer_app_insights_application_id").(string))
+				existing.Properties.DeveloperAppInsightsApplicationID = pointer.To(metadata.ResourceData.Get("developer_app_insights_application_id").(string))
 			}
 
 			if metadata.ResourceData.HasChange("local_authentication_enabled") {
-				existing.Properties.DisableLocalAuth = utils.Bool(!metadata.ResourceData.Get("local_authentication_enabled").(bool))
+				existing.Properties.DisableLocalAuth = pointer.To(!metadata.ResourceData.Get("local_authentication_enabled").(bool))
 			}
 
 			if metadata.ResourceData.HasChange("luis_app_ids") {
@@ -290,7 +290,7 @@ func (br botBaseResource) updateFunc() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("luis_key") {
-				existing.Properties.LuisKey = utils.String(metadata.ResourceData.Get("luis_key").(string))
+				existing.Properties.LuisKey = pointer.To(metadata.ResourceData.Get("luis_key").(string))
 			}
 
 			if metadata.ResourceData.HasChange("public_network_access_enabled") {
@@ -302,11 +302,11 @@ func (br botBaseResource) updateFunc() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("streaming_endpoint_enabled") {
-				existing.Properties.IsStreamingSupported = utils.Bool(metadata.ResourceData.Get("streaming_endpoint_enabled").(bool))
+				existing.Properties.IsStreamingSupported = pointer.To(metadata.ResourceData.Get("streaming_endpoint_enabled").(bool))
 			}
 
 			if metadata.ResourceData.HasChange("icon_url") {
-				existing.Properties.IconURL = utils.String(metadata.ResourceData.Get("icon_url").(string))
+				existing.Properties.IconURL = pointer.To(metadata.ResourceData.Get("icon_url").(string))
 			}
 
 			if metadata.ResourceData.HasChange("tags") {

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BotWebAppResource struct{}
@@ -88,7 +88,7 @@ func (t BotWebAppResource) Exists(ctx context.Context, clients *clients.Client, 
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (BotWebAppResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/bot/healthbot_resource_test.go
+++ b/internal/services/bot/healthbot_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/healthbot/2022-08-08/healthbots"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HealthbotResource struct{}
@@ -99,7 +99,7 @@ func (r HealthbotResource) Exists(ctx context.Context, client *clients.Client, s
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HealthbotResource) template(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
