### PR TITLE
services `C*` - deprecated function clean up

### DIFF
--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -196,7 +196,7 @@ func resourceArmCdnEndpointCustomDomainCreate(d *pluginsdk.ResourceData, meta in
 
 	props := cdn.CustomDomainParameters{
 		CustomDomainPropertiesParameters: &cdn.CustomDomainPropertiesParameters{
-			HostName: utils.String(d.Get("host_name").(string)),
+			HostName: pointer.To(d.Get("host_name").(string)),
 		},
 	}
 
@@ -447,7 +447,7 @@ func expandArmCdnEndpointCustomDomainCdnManagedHttpsSettings(input []interface{}
 	raw := input[0].(map[string]interface{})
 	output := &cdn.ManagedHTTPSParameters{
 		CertificateSourceParameters: &cdn.CertificateSourceParameters{
-			OdataType:       utils.String("#Microsoft.Azure.Cdn.Models.CdnCertificateSourceParameters"),
+			OdataType:       pointer.To("#Microsoft.Azure.Cdn.Models.CdnCertificateSourceParameters"),
 			CertificateType: cdn.CertificateType(raw["certificate_type"].(string)),
 		},
 		CertificateSource: cdn.CertificateSourceCdn,
@@ -493,14 +493,14 @@ func expandArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Contex
 
 	output := &cdn.UserManagedHTTPSParameters{
 		CertificateSourceParameters: &cdn.KeyVaultCertificateSourceParameters{
-			OdataType:         utils.String("#Microsoft.Azure.Cdn.Models.KeyVaultCertificateSourceParameters"),
+			OdataType:         pointer.To("#Microsoft.Azure.Cdn.Models.KeyVaultCertificateSourceParameters"),
 			SubscriptionID:    pointer.To(keyVaultId.SubscriptionId),
 			ResourceGroupName: pointer.To(keyVaultId.ResourceGroupName),
 			VaultName:         pointer.To(keyVaultId.VaultName),
 			SecretName:        pointer.To(keyVaultSecretId.Name),
 			SecretVersion:     SecretVersion,
-			UpdateRule:        utils.String("NoAction"),
-			DeleteRule:        utils.String("NoAction"),
+			UpdateRule:        pointer.To("NoAction"),
+			DeleteRule:        pointer.To("NoAction"),
 		},
 		CertificateSource: cdn.CertificateSourceAzureKeyVault,
 		ProtocolType:      cdn.ProtocolTypeServerNameIndication,

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -220,11 +221,11 @@ func (r CdnEndpointCustomDomainResource) Exists(ctx context.Context, client *cli
 	resp, err := client.Cdn.CustomDomainsClient.Get(ctx, id.ResourceGroup, id.ProfileName, id.EndpointName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnEndpointCustomDomainResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -242,7 +243,7 @@ func (r CdnEndpointCustomDomainResource) Destroy(ctx context.Context, client *cl
 		return nil, fmt.Errorf("waiting for deletion of %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnEndpointCustomDomainResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/migration"
@@ -240,7 +240,7 @@ func resourceCdnEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return tf.ImportAsExistsError("azurerm_cdn_endpoint", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
@@ -260,7 +260,7 @@ func resourceCdnEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("origin_host_header"); ok {
-		endpoint.OriginHostHeader = utils.String(v.(string))
+		endpoint.OriginHostHeader = pointer.To(v.(string))
 	}
 
 	if _, ok := d.GetOk("content_types_to_compress"); ok {
@@ -274,7 +274,7 @@ func resourceCdnEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("is_compression_enabled"); ok {
-		endpoint.IsCompressionEnabled = utils.Bool(v.(bool))
+		endpoint.IsCompressionEnabled = pointer.To(v.(bool))
 	}
 
 	if optimizationType != "" {
@@ -282,11 +282,11 @@ func resourceCdnEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if originPath != "" {
-		endpoint.OriginPath = utils.String(originPath)
+		endpoint.OriginPath = pointer.To(originPath)
 	}
 
 	if probePath != "" {
-		endpoint.ProbePath = utils.String(probePath)
+		endpoint.ProbePath = pointer.To(probePath)
 	}
 
 	origins := expandAzureRmCdnEndpointOrigins(d)
@@ -342,7 +342,7 @@ func resourceCdnEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
@@ -395,7 +395,7 @@ func resourceCdnEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if v, ok := d.GetOk("origin_host_header"); ok {
-			endpoint.OriginHostHeader = utils.String(v.(string))
+			endpoint.OriginHostHeader = pointer.To(v.(string))
 		}
 
 		if _, ok := d.GetOk("content_types_to_compress"); ok {
@@ -409,7 +409,7 @@ func resourceCdnEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if v, ok := d.GetOk("is_compression_enabled"); ok {
-			endpoint.IsCompressionEnabled = utils.Bool(v.(bool))
+			endpoint.IsCompressionEnabled = pointer.To(v.(bool))
 		}
 
 		if optimizationType != "" {
@@ -417,11 +417,11 @@ func resourceCdnEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if originPath != "" {
-			endpoint.OriginPath = utils.String(originPath)
+			endpoint.OriginPath = pointer.To(originPath)
 		}
 
 		if probePath != "" {
-			endpoint.ProbePath = utils.String(probePath)
+			endpoint.ProbePath = pointer.To(probePath)
 		}
 
 		origins := expandAzureRmCdnEndpointOrigins(d)
@@ -578,7 +578,7 @@ func expandCdnEndpointGeoFilters(d *pluginsdk.ResourceData) *[]cdn.GeoFilter {
 
 		filter := cdn.GeoFilter{
 			Action:       cdn.GeoFilterActions(action),
-			RelativePath: utils.String(relativePath),
+			RelativePath: pointer.To(relativePath),
 			CountryCodes: &countryCodes,
 		}
 		filters = append(filters, filter)
@@ -650,20 +650,20 @@ func expandAzureRmCdnEndpointOrigins(d *pluginsdk.ResourceData) []cdn.DeepCreate
 		hostName := data["host_name"].(string)
 
 		origin := cdn.DeepCreatedOrigin{
-			Name: utils.String(name),
+			Name: pointer.To(name),
 			DeepCreatedOriginProperties: &cdn.DeepCreatedOriginProperties{
-				HostName: utils.String(hostName),
+				HostName: pointer.To(hostName),
 			},
 		}
 
 		if v, ok := data["https_port"]; ok {
 			port := v.(int)
-			origin.HTTPSPort = utils.Int32(int32(port))
+			origin.HTTPSPort = pointer.To(int32(port))
 		}
 
 		if v, ok := data["http_port"]; ok {
 			port := v.(int)
-			origin.HTTPPort = utils.Int32(int32(port))
+			origin.HTTPPort = pointer.To(int32(port))
 		}
 
 		origins = append(origins, origin)
@@ -712,7 +712,7 @@ func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []interface
 func expandArmCdnEndpointDeliveryPolicy(globalRulesRaw []interface{}, deliveryRulesRaw []interface{}) (*cdn.EndpointPropertiesUpdateParametersDeliveryPolicy, error) {
 	deliveryRules := make([]cdn.DeliveryRule, 0)
 	deliveryPolicy := cdn.EndpointPropertiesUpdateParametersDeliveryPolicy{
-		Description: utils.String(""),
+		Description: pointer.To(""),
 		Rules:       &deliveryRules,
 	}
 

--- a/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -377,11 +378,11 @@ func (r CdnEndpointResource) Exists(ctx context.Context, client *clients.Client,
 	resp, err := client.Cdn.EndpointsClient.Get(ctx, id.ResourceGroup, id.ProfileName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving CDN Endpoint %q (Resource Group %q / Profile Name %q): %+v", id.Name, id.ResourceGroup, id.ProfileName, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnEndpointResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -399,7 +400,7 @@ func (r CdnEndpointResource) Destroy(ctx context.Context, client *clients.Client
 		return nil, fmt.Errorf("waiting for deletion of CDN Endpoint %q (Resource Group %q / Profile %q): %+v", id.Name, id.ResourceGroup, id.ProfileName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -84,12 +85,12 @@ func (r CdnFrontDoorCustomDomainAssociationResource) Exists(ctx context.Context,
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AssociationName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorCustomDomainAssociationResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/profiles"
 	dnsValidate "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -163,7 +164,7 @@ func resourceCdnFrontDoorCustomDomainCreate(d *pluginsdk.ResourceData, meta inte
 
 	props := cdn.AFDDomain{
 		AFDDomainProperties: &cdn.AFDDomainProperties{
-			HostName: utils.String(d.Get("host_name").(string)),
+			HostName: pointer.To(d.Get("host_name").(string)),
 		},
 	}
 

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -99,12 +100,12 @@ func (r CdnFrontDoorCustomDomainResource) Exists(ctx context.Context, clients *c
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.CustomDomainName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorCustomDomainResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_endpoint_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_endpoint_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -94,8 +95,8 @@ func resourceCdnFrontDoorEndpointCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	props := cdn.AFDEndpoint{
-		Name:     utils.String(d.Get("name").(string)),
-		Location: utils.String(location.Normalize("global")),
+		Name:     pointer.To(d.Get("name").(string)),
+		Location: pointer.To(location.Normalize("global")),
 		AFDEndpointProperties: &cdn.AFDEndpointProperties{
 			EnabledState: expandEnabledBool(d.Get("enabled").(bool)),
 		},

--- a/internal/services/cdn/cdn_frontdoor_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_endpoint_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -91,11 +92,11 @@ func (r CdnFrontDoorEndpointResource) Exists(ctx context.Context, clients *clien
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -704,8 +704,8 @@ func resourceCdnFrontDoorFirewallPolicyCreate(d *pluginsdk.ResourceData, meta in
 			captchaExpirationInMinutes = v.(int)
 		}
 
-		payload.Properties.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.FromInt64(int64(jsChallengeExpirationInMinutes))
-		payload.Properties.PolicySettings.CaptchaExpirationInMinutes = pointer.FromInt64(int64(captchaExpirationInMinutes))
+		payload.Properties.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.To(int64(jsChallengeExpirationInMinutes))
+		payload.Properties.PolicySettings.CaptchaExpirationInMinutes = pointer.To(int64(captchaExpirationInMinutes))
 	}
 
 	if managedRules != nil {
@@ -796,8 +796,8 @@ func resourceCdnFrontDoorFirewallPolicyUpdate(d *pluginsdk.ResourceData, meta in
 				captchaExpirationInMinutes = v.(int)
 			}
 
-			props.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.FromInt64(int64(jsChallengeExpirationInMinutes))
-			props.PolicySettings.CaptchaExpirationInMinutes = pointer.FromInt64(int64(captchaExpirationInMinutes))
+			props.PolicySettings.JavascriptChallengeExpirationInMinutes = pointer.To(int64(jsChallengeExpirationInMinutes))
+			props.PolicySettings.CaptchaExpirationInMinutes = pointer.To(int64(captchaExpirationInMinutes))
 		}
 
 		if redirectUrl := d.Get("redirect_url").(string); redirectUrl != "" {

--- a/internal/services/cdn/cdn_frontdoor_helpers.go
+++ b/internal/services/cdn/cdn_frontdoor_helpers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	dnsValidate "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
 	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -57,7 +58,7 @@ func expandResourceReference(input string) *cdn.ResourceReference {
 	}
 
 	return &cdn.ResourceReference{
-		ID: utils.String(input),
+		ID: pointer.To(input),
 	}
 }
 
@@ -221,7 +222,7 @@ func expandCustomDomainActivatedResourceArray(input []interface{}) *[]cdn.Activa
 	for _, customDomain := range input {
 		if id, err := parse.FrontDoorCustomDomainID(customDomain.(string)); err == nil {
 			results = append(results, cdn.ActivatedResourceReference{
-				ID: utils.String(id.ID()),
+				ID: pointer.To(id.ID()),
 			})
 		}
 	}

--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/azuresdkhacks"
@@ -170,7 +171,7 @@ func resourceCdnFrontDoorOriginGroupCreate(d *pluginsdk.ResourceData, meta inter
 			HealthProbeSettings:   expandCdnFrontDoorOriginGroupHealthProbeParameters(d.Get("health_probe").([]interface{})),
 			LoadBalancingSettings: expandCdnFrontDoorOriginGroupLoadBalancingSettingsParameters(d.Get("load_balancing").([]interface{})),
 			SessionAffinityState:  expandEnabledBool(d.Get("session_affinity_enabled").(bool)),
-			TrafficRestorationTimeToHealedOrNewEndpointsInMinutes: utils.Int32(int32(d.Get("restore_traffic_time_to_healed_or_new_endpoint_in_minutes").(int))),
+			TrafficRestorationTimeToHealedOrNewEndpointsInMinutes: pointer.To(int32(d.Get("restore_traffic_time_to_healed_or_new_endpoint_in_minutes").(int))),
 		},
 	}
 
@@ -259,7 +260,7 @@ func resourceCdnFrontDoorOriginGroupUpdate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	if d.HasChange("restore_traffic_time_to_healed_or_new_endpoint_in_minutes") {
-		params.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = utils.Int32(int32(d.Get("restore_traffic_time_to_healed_or_new_endpoint_in_minutes").(int)))
+		params.TrafficRestorationTimeToHealedOrNewEndpointsInMinutes = pointer.To(int32(d.Get("restore_traffic_time_to_healed_or_new_endpoint_in_minutes").(int)))
 	}
 
 	if d.HasChange("session_affinity_enabled") {
@@ -313,8 +314,8 @@ func expandCdnFrontDoorOriginGroupHealthProbeParameters(input []interface{}) *cd
 	probeProtocolValue := cdn.ProbeProtocol(v["protocol"].(string))
 	probeRequestTypeValue := cdn.HealthProbeRequestType(v["request_type"].(string))
 	return &cdn.HealthProbeParameters{
-		ProbeIntervalInSeconds: utils.Int32(int32(v["interval_in_seconds"].(int))),
-		ProbePath:              utils.String(v["path"].(string)),
+		ProbeIntervalInSeconds: pointer.To(int32(v["interval_in_seconds"].(int))),
+		ProbePath:              pointer.To(v["path"].(string)),
 		ProbeProtocol:          probeProtocolValue,
 		ProbeRequestType:       probeRequestTypeValue,
 	}
@@ -328,9 +329,9 @@ func expandCdnFrontDoorOriginGroupLoadBalancingSettingsParameters(input []interf
 	v := input[0].(map[string]interface{})
 
 	return &cdn.LoadBalancingSettingsParameters{
-		AdditionalLatencyInMilliseconds: utils.Int32(int32(v["additional_latency_in_milliseconds"].(int))),
-		SampleSize:                      utils.Int32(int32(v["sample_size"].(int))),
-		SuccessfulSamplesRequired:       utils.Int32(int32(v["successful_samples_required"].(int))),
+		AdditionalLatencyInMilliseconds: pointer.To(int32(v["additional_latency_in_milliseconds"].(int))),
+		SampleSize:                      pointer.To(int32(v["sample_size"].(int))),
+		SuccessfulSamplesRequired:       pointer.To(int32(v["successful_samples_required"].(int))),
 	}
 }
 

--- a/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_group_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -146,11 +147,11 @@ func (r CdnFrontDoorOriginGroupResource) Exists(ctx context.Context, clients *cl
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.OriginGroupName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorOriginGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_origin_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource.go
@@ -217,16 +217,16 @@ func resourceCdnFrontDoorOriginCreate(d *pluginsdk.ResourceData, meta interface{
 	enableCertNameCheck := d.Get("certificate_name_check_enabled").(bool)
 	props := &cdn.AFDOriginProperties{
 		EnabledState:                expandEnabledBool(enabled),
-		EnforceCertificateNameCheck: utils.Bool(enableCertNameCheck),
-		HostName:                    utils.String(d.Get("host_name").(string)),
-		HTTPPort:                    utils.Int32(int32(d.Get("http_port").(int))),
-		HTTPSPort:                   utils.Int32(int32(d.Get("https_port").(int))),
-		Priority:                    utils.Int32(int32(d.Get("priority").(int))),
-		Weight:                      utils.Int32(int32(d.Get("weight").(int))),
+		EnforceCertificateNameCheck: pointer.To(enableCertNameCheck),
+		HostName:                    pointer.To(d.Get("host_name").(string)),
+		HTTPPort:                    pointer.To(int32(d.Get("http_port").(int))),
+		HTTPSPort:                   pointer.To(int32(d.Get("https_port").(int))),
+		Priority:                    pointer.To(int32(d.Get("priority").(int))),
+		Weight:                      pointer.To(int32(d.Get("weight").(int))),
 	}
 
 	if originHostHeader := d.Get("origin_host_header").(string); originHostHeader != "" {
-		props.OriginHostHeader = utils.String(originHostHeader)
+		props.OriginHostHeader = pointer.To(originHostHeader)
 	}
 
 	expanded, err := expandPrivateLinkSettings(d.Get("private_link").([]interface{}), profiles.SkuName(skuName), enableCertNameCheck)
@@ -307,7 +307,7 @@ func resourceCdnFrontDoorOriginUpdate(d *pluginsdk.ResourceData, meta interface{
 	params := &azuresdkhacks.AFDOriginUpdatePropertiesParameters{}
 
 	if d.HasChange("certificate_name_check_enabled") {
-		params.EnforceCertificateNameCheck = utils.Bool(d.Get("certificate_name_check_enabled").(bool))
+		params.EnforceCertificateNameCheck = pointer.To(d.Get("certificate_name_check_enabled").(bool))
 	}
 
 	if d.HasChange("enabled") {
@@ -315,22 +315,22 @@ func resourceCdnFrontDoorOriginUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("host_name") {
-		params.HostName = utils.String(d.Get("host_name").(string))
+		params.HostName = pointer.To(d.Get("host_name").(string))
 	}
 
 	if d.HasChange("http_port") {
-		params.HTTPPort = utils.Int32(int32(d.Get("http_port").(int)))
+		params.HTTPPort = pointer.To(int32(d.Get("http_port").(int)))
 	}
 
 	if d.HasChange("https_port") {
-		params.HTTPSPort = utils.Int32(int32(d.Get("https_port").(int)))
+		params.HTTPSPort = pointer.To(int32(d.Get("https_port").(int)))
 	}
 
 	// The API requires that an explicit null be passed as the 'origin_host_header' value to remove the origin host header, see issue #20617
 	// Since null is a valid value, we now have to always pass the value during update else we will inadvertently clear the value, see issue #20866
 	params.OriginHostHeader = nil
 	if d.Get("origin_host_header").(string) != "" {
-		params.OriginHostHeader = utils.String(d.Get("origin_host_header").(string))
+		params.OriginHostHeader = pointer.To(d.Get("origin_host_header").(string))
 	}
 
 	if d.HasChange("private_link") {
@@ -367,11 +367,11 @@ func resourceCdnFrontDoorOriginUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("priority") {
-		params.Priority = utils.Int32(int32(d.Get("priority").(int)))
+		params.Priority = pointer.To(int32(d.Get("priority").(int)))
 	}
 
 	if d.HasChange("weight") {
-		params.Weight = utils.Int32(int32(d.Get("weight").(int)))
+		params.Weight = pointer.To(int32(d.Get("weight").(int)))
 	}
 
 	payload := &azuresdkhacks.AFDOriginUpdateParameters{
@@ -464,11 +464,11 @@ func expandPrivateLinkSettings(input []interface{}, skuName profiles.SkuName, en
 
 	return &cdn.SharedPrivateLinkResourceProperties{
 		PrivateLink: &cdn.ResourceReference{
-			ID: utils.String(resourceId),
+			ID: pointer.To(resourceId),
 		},
-		GroupID:             utils.String(groupId),
-		PrivateLinkLocation: utils.String(location),
-		RequestMessage:      utils.String(requestMessage),
+		GroupID:             pointer.To(groupId),
+		PrivateLinkLocation: pointer.To(location),
+		RequestMessage:      pointer.To(requestMessage),
 	}, nil
 }
 

--- a/internal/services/cdn/cdn_frontdoor_origin_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_origin_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -244,12 +245,12 @@ func (r CdnFrontDoorOriginResource) Exists(ctx context.Context, clients *clients
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.OriginGroupName, id.OriginName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 //nolint:unused

--- a/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_profile_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CdnFrontDoorProfileResource struct{}
@@ -278,11 +277,11 @@ func (r CdnFrontDoorProfileResource) Exists(ctx context.Context, clients *client
 	resp, err := client.Get(ctx, pointer.From(id))
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorProfileResource) template(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -290,7 +291,7 @@ func resourceCdnFrontDoorRouteCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if originPath := d.Get("cdn_frontdoor_origin_path").(string); originPath != "" {
-		props.OriginPath = utils.String(originPath)
+		props.OriginPath = pointer.To(originPath)
 	}
 
 	future, err := client.Create(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.RouteName, props)
@@ -495,7 +496,7 @@ func resourceCdnFrontDoorRouteUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		originPath := d.Get("cdn_frontdoor_origin_path").(string)
 		if originPath != "" {
-			updateProps.OriginPath = utils.String(originPath)
+			updateProps.OriginPath = pointer.To(originPath)
 		}
 	}
 
@@ -582,7 +583,7 @@ func expandRuleSetReferenceArray(input []interface{}) *[]cdn.ResourceReference {
 
 	for _, item := range input {
 		results = append(results, cdn.ResourceReference{
-			ID: utils.String(item.(string)),
+			ID: pointer.To(item.(string)),
 		})
 	}
 
@@ -604,7 +605,7 @@ func expandCdnFrontdoorRouteCacheConfiguration(input []interface{}) *cdn.AfdRout
 
 	cacheConfiguration := &cdn.AfdRouteCacheConfiguration{
 		CompressionSettings: &cdn.CompressionSettings{
-			IsCompressionEnabled: utils.Bool(compressionEnabled),
+			IsCompressionEnabled: pointer.To(compressionEnabled),
 		},
 		QueryParameters:            expandStringSliceToCsvFormat(v["query_strings"].([]interface{})),
 		QueryStringCachingBehavior: queryStringCachingBehaviorValue,

--- a/internal/services/cdn/cdn_frontdoor_route_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -119,12 +120,12 @@ func (r CdnFrontDoorRouteResource) Exists(ctx context.Context, clients *clients.
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.RouteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorRouteResource) template(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-09-01/rules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CdnFrontDoorRuleResource struct{}
@@ -476,7 +476,7 @@ func (r CdnFrontDoorRuleResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorRuleResource) template(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_set_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/rulesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CdnFrontDoorRuleSetResource struct{}
@@ -73,7 +73,7 @@ func (r CdnFrontDoorRuleSetResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontDoorRuleSetResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_secret_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_secret_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -80,11 +81,11 @@ func (r CdnFrontdoorSecretResource) Exists(ctx context.Context, clients *clients
 	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.SecretName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnFrontdoorSecretResource) preCheck(t *testing.T) {

--- a/internal/services/cdn/cdn_profile_resource.go
+++ b/internal/services/cdn/cdn_profile_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/migration"
@@ -127,7 +126,7 @@ func resourceCdnProfileCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	sku := d.Get("sku").(string)
 	t := d.Get("tags").(map[string]interface{})
 

--- a/internal/services/cdn/cdn_profile_resource_test.go
+++ b/internal/services/cdn/cdn_profile_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -142,11 +143,11 @@ func (r CdnProfileResource) Exists(ctx context.Context, client *clients.Client, 
 	resp, err := client.Cdn.ProfilesClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Cdn Profile %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CdnProfileResource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/deliveryruleactions/cache_expiration.go
+++ b/internal/services/cdn/deliveryruleactions/cache_expiration.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func CacheExpiration() *pluginsdk.Resource {
@@ -44,9 +44,9 @@ func ExpandArmCdnEndpointActionCacheExpiration(input []interface{}) (*[]cdn.Basi
 		cacheExpirationAction := cdn.DeliveryRuleCacheExpirationAction{
 			Name: cdn.NameBasicDeliveryRuleActionNameCacheExpiration,
 			Parameters: &cdn.CacheExpirationActionParameters{
-				OdataType:     utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleCacheExpirationActionParameters"),
+				OdataType:     pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleCacheExpirationActionParameters"),
 				CacheBehavior: cdn.CacheBehavior(item["behavior"].(string)),
-				CacheType:     utils.String("All"),
+				CacheType:     pointer.To("All"),
 			},
 		}
 
@@ -55,7 +55,7 @@ func ExpandArmCdnEndpointActionCacheExpiration(input []interface{}) (*[]cdn.Basi
 				return nil, errors.New("cache expiration duration must not be set when using behavior `BypassCache`")
 			}
 
-			cacheExpirationAction.Parameters.CacheDuration = utils.String(duration)
+			cacheExpirationAction.Parameters.CacheDuration = pointer.To(duration)
 		}
 
 		output = append(output, cacheExpirationAction)

--- a/internal/services/cdn/deliveryruleactions/cache_key_query_string.go
+++ b/internal/services/cdn/deliveryruleactions/cache_key_query_string.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func CacheKeyQueryString() *pluginsdk.Resource {
@@ -43,7 +43,7 @@ func ExpandArmCdnEndpointActionCacheKeyQueryString(input []interface{}) (*[]cdn.
 		cacheKeyQueryStringAction := cdn.DeliveryRuleCacheKeyQueryStringAction{
 			Name: cdn.NameBasicDeliveryRuleActionNameCacheKeyQueryString,
 			Parameters: &cdn.CacheKeyQueryStringActionParameters{
-				OdataType:           utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"),
+				OdataType:           pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"),
 				QueryStringBehavior: cdn.QueryStringBehavior(item["behavior"].(string)),
 			},
 		}
@@ -53,7 +53,7 @@ func ExpandArmCdnEndpointActionCacheKeyQueryString(input []interface{}) (*[]cdn.
 				return nil, errors.New("parameters can not be empty if the behaviour is either Include or Exclude")
 			}
 		} else {
-			cacheKeyQueryStringAction.Parameters.QueryParameters = utils.String(parameters)
+			cacheKeyQueryStringAction.Parameters.QueryParameters = pointer.To(parameters)
 		}
 
 		output = append(output, cacheKeyQueryStringAction)

--- a/internal/services/cdn/deliveryruleactions/modify_request_header.go
+++ b/internal/services/cdn/deliveryruleactions/modify_request_header.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func ModifyRequestHeader() *pluginsdk.Resource {
@@ -47,14 +47,14 @@ func ExpandArmCdnEndpointActionModifyRequestHeader(input []interface{}) (*[]cdn.
 		requestHeaderAction := cdn.DeliveryRuleRequestHeaderAction{
 			Name: cdn.NameBasicDeliveryRuleActionNameModifyRequestHeader,
 			Parameters: &cdn.HeaderActionParameters{
-				OdataType:    utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters"),
+				OdataType:    pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters"),
 				HeaderAction: cdn.HeaderAction(item["action"].(string)),
-				HeaderName:   utils.String(item["name"].(string)),
+				HeaderName:   pointer.To(item["name"].(string)),
 			},
 		}
 
 		if value := item["value"].(string); value != "" {
-			requestHeaderAction.Parameters.Value = utils.String(value)
+			requestHeaderAction.Parameters.Value = pointer.To(value)
 		}
 
 		output = append(output, requestHeaderAction)

--- a/internal/services/cdn/deliveryruleactions/modify_response_header.go
+++ b/internal/services/cdn/deliveryruleactions/modify_response_header.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func ModifyResponseHeader() *pluginsdk.Resource {
@@ -47,14 +47,14 @@ func ExpandArmCdnEndpointActionModifyResponseHeader(input []interface{}) (*[]cdn
 		requestHeaderAction := cdn.DeliveryRuleResponseHeaderAction{
 			Name: cdn.NameBasicDeliveryRuleActionNameModifyResponseHeader,
 			Parameters: &cdn.HeaderActionParameters{
-				OdataType:    utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters"),
+				OdataType:    pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters"),
 				HeaderAction: cdn.HeaderAction(item["action"].(string)),
-				HeaderName:   utils.String(item["name"].(string)),
+				HeaderName:   pointer.To(item["name"].(string)),
 			},
 		}
 
 		if value := item["value"].(string); value != "" {
-			requestHeaderAction.Parameters.Value = utils.String(value)
+			requestHeaderAction.Parameters.Value = pointer.To(value)
 		}
 
 		output = append(output, requestHeaderAction)

--- a/internal/services/cdn/deliveryruleactions/url_redirect.go
+++ b/internal/services/cdn/deliveryruleactions/url_redirect.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func URLRedirect() *pluginsdk.Resource {
@@ -71,7 +71,7 @@ func ExpandArmCdnEndpointActionUrlRedirect(input []interface{}) (*[]cdn.BasicDel
 		item := v.(map[string]interface{})
 
 		params := cdn.URLRedirectActionParameters{
-			OdataType:    utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlRedirectActionParameters"),
+			OdataType:    pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlRedirectActionParameters"),
 			RedirectType: cdn.RedirectType(item["redirect_type"].(string)),
 		}
 
@@ -80,19 +80,19 @@ func ExpandArmCdnEndpointActionUrlRedirect(input []interface{}) (*[]cdn.BasicDel
 		}
 
 		if hostname := item["hostname"]; hostname.(string) != "" {
-			params.CustomHostname = utils.String(hostname.(string))
+			params.CustomHostname = pointer.To(hostname.(string))
 		}
 
 		if path := item["path"]; path.(string) != "" {
-			params.CustomPath = utils.String(path.(string))
+			params.CustomPath = pointer.To(path.(string))
 		}
 
 		if queryString := item["query_string"]; queryString.(string) != "" {
-			params.CustomQueryString = utils.String(queryString.(string))
+			params.CustomQueryString = pointer.To(queryString.(string))
 		}
 
 		if fragment := item["fragment"]; fragment.(string) != "" {
-			params.CustomFragment = utils.String(fragment.(string))
+			params.CustomFragment = pointer.To(fragment.(string))
 		}
 
 		output = append(output, cdn.URLRedirectAction{

--- a/internal/services/cdn/deliveryruleactions/url_rewrite.go
+++ b/internal/services/cdn/deliveryruleactions/url_rewrite.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func URLRewrite() *pluginsdk.Resource {
@@ -45,10 +45,10 @@ func ExpandArmCdnEndpointActionURLRewrite(input []interface{}) (*[]cdn.BasicDeli
 		output = append(output, cdn.URLRewriteAction{
 			Name: cdn.NameBasicDeliveryRuleActionNameURLRewrite,
 			Parameters: &cdn.URLRewriteActionParameters{
-				OdataType:             utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlRewriteActionParameters"),
-				SourcePattern:         utils.String(item["source_pattern"].(string)),
-				Destination:           utils.String(item["destination"].(string)),
-				PreserveUnmatchedPath: utils.Bool(item["preserve_unmatched_path"].(bool)),
+				OdataType:             pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlRewriteActionParameters"),
+				SourcePattern:         pointer.To(item["source_pattern"].(string)),
+				Destination:           pointer.To(item["destination"].(string)),
+				PreserveUnmatchedPath: pointer.To(item["preserve_unmatched_path"].(bool)),
 			},
 		})
 	}

--- a/internal/services/cdn/deliveryruleconditions/cookies.go
+++ b/internal/services/cdn/deliveryruleconditions/cookies.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -75,10 +76,10 @@ func ExpandArmCdnEndpointConditionCookies(input []interface{}) []cdn.BasicDelive
 		cookiesCondition := cdn.DeliveryRuleCookiesCondition{
 			Name: cdn.NameCookies,
 			Parameters: &cdn.CookiesMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleCookiesConditionParameters"),
-				Selector:        utils.String(item["selector"].(string)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleCookiesConditionParameters"),
+				Selector:        pointer.To(item["selector"].(string)),
 				Operator:        cdn.CookiesOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/device.go
+++ b/internal/services/cdn/deliveryruleconditions/device.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -54,9 +55,9 @@ func ExpandArmCdnEndpointConditionDevice(input []interface{}) []cdn.BasicDeliver
 		output = append(output, cdn.DeliveryRuleIsDeviceCondition{
 			Name: cdn.NameHTTPVersion,
 			Parameters: &cdn.IsDeviceMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleIsDeviceConditionParameters"),
-				Operator:        utils.String(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleIsDeviceConditionParameters"),
+				Operator:        pointer.To(item["operator"].(string)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		})

--- a/internal/services/cdn/deliveryruleconditions/http_version.go
+++ b/internal/services/cdn/deliveryruleconditions/http_version.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -56,9 +57,9 @@ func ExpandArmCdnEndpointConditionHTTPVersion(input []interface{}) []cdn.BasicDe
 		output = append(output, cdn.DeliveryRuleHTTPVersionCondition{
 			Name: cdn.NameHTTPVersion,
 			Parameters: &cdn.HTTPVersionMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleHttpVersionConditionParameters"),
-				Operator:        utils.String(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleHttpVersionConditionParameters"),
+				Operator:        pointer.To(item["operator"].(string)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		})

--- a/internal/services/cdn/deliveryruleconditions/post_arg.go
+++ b/internal/services/cdn/deliveryruleconditions/post_arg.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -77,10 +78,10 @@ func ExpandArmCdnEndpointConditionPostArg(input []interface{}) []cdn.BasicDelive
 		condition := cdn.DeliveryRulePostArgsCondition{
 			Name: cdn.NameCookies,
 			Parameters: &cdn.PostArgsMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRulePostArgsConditionParameters"),
-				Selector:        utils.String(item["selector"].(string)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRulePostArgsConditionParameters"),
+				Selector:        pointer.To(item["selector"].(string)),
 				Operator:        cdn.PostArgsOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/query_string.go
+++ b/internal/services/cdn/deliveryruleconditions/query_string.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -71,9 +72,9 @@ func ExpandArmCdnEndpointConditionQueryString(input []interface{}) []cdn.BasicDe
 		queryStringCondition := cdn.DeliveryRuleQueryStringCondition{
 			Name: cdn.NameQueryString,
 			Parameters: &cdn.QueryStringMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleQueryStringConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleQueryStringConditionParameters"),
 				Operator:        cdn.QueryStringOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/remote_address.go
+++ b/internal/services/cdn/deliveryruleconditions/remote_address.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -53,9 +54,9 @@ func ExpandArmCdnEndpointConditionRemoteAddress(input []interface{}) []cdn.Basic
 		output = append(output, cdn.DeliveryRuleRemoteAddressCondition{
 			Name: cdn.NameRemoteAddress,
 			Parameters: &cdn.RemoteAddressMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleRemoteAddressConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleRemoteAddressConditionParameters"),
 				Operator:        cdn.RemoteAddressOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		})

--- a/internal/services/cdn/deliveryruleconditions/request_body.go
+++ b/internal/services/cdn/deliveryruleconditions/request_body.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -71,9 +72,9 @@ func ExpandArmCdnEndpointConditionRequestBody(input []interface{}) []cdn.BasicDe
 		queryStringCondition := cdn.DeliveryRuleRequestBodyCondition{
 			Name: cdn.NameRequestBody,
 			Parameters: &cdn.RequestBodyMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestBodyConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestBodyConditionParameters"),
 				Operator:        cdn.RequestBodyOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/request_header.go
+++ b/internal/services/cdn/deliveryruleconditions/request_header.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -76,10 +77,10 @@ func ExpandArmCdnEndpointConditionRequestHeader(input []interface{}) []cdn.Basic
 		requestHeaderCondition := cdn.DeliveryRuleRequestHeaderCondition{
 			Name: cdn.NameRequestHeader,
 			Parameters: &cdn.RequestHeaderMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestHeaderConditionParameters"),
-				Selector:        utils.String(item["selector"].(string)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestHeaderConditionParameters"),
+				Selector:        pointer.To(item["selector"].(string)),
 				Operator:        cdn.RequestHeaderOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/request_method.go
+++ b/internal/services/cdn/deliveryruleconditions/request_method.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -58,9 +59,9 @@ func ExpandArmCdnEndpointConditionRequestMethod(input []interface{}) []cdn.Basic
 		output = append(output, cdn.DeliveryRuleRequestMethodCondition{
 			Name: cdn.NameRequestMethod,
 			Parameters: &cdn.RequestMethodMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestMethodConditionParameters"),
-				Operator:        utils.String(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestMethodConditionParameters"),
+				Operator:        pointer.To(item["operator"].(string)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		})

--- a/internal/services/cdn/deliveryruleconditions/request_scheme.go
+++ b/internal/services/cdn/deliveryruleconditions/request_scheme.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -55,14 +56,14 @@ func ExpandArmCdnEndpointConditionRequestScheme(input []interface{}) []cdn.Basic
 		requestSchemeCondition := cdn.DeliveryRuleRequestSchemeCondition{
 			Name: cdn.NameRequestScheme,
 			Parameters: &cdn.RequestSchemeMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestSchemeConditionParameters"),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestSchemeConditionParameters"),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}
 
 		if operator := item["operator"]; operator.(string) != "" {
-			requestSchemeCondition.Parameters.Operator = utils.String(operator.(string))
+			requestSchemeCondition.Parameters.Operator = pointer.To(operator.(string))
 		}
 
 		output = append(output, requestSchemeCondition)

--- a/internal/services/cdn/deliveryruleconditions/request_uri.go
+++ b/internal/services/cdn/deliveryruleconditions/request_uri.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -70,9 +71,9 @@ func ExpandArmCdnEndpointConditionRequestURI(input []interface{}) []cdn.BasicDel
 		requestURICondition := cdn.DeliveryRuleRequestURICondition{
 			Name: cdn.NameRequestURI,
 			Parameters: &cdn.RequestURIMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestUriConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleRequestUriConditionParameters"),
 				Operator:        cdn.RequestURIOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/url_file_extension.go
+++ b/internal/services/cdn/deliveryruleconditions/url_file_extension.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -71,9 +72,9 @@ func ExpandArmCdnEndpointConditionURLFileExtension(input []interface{}) []cdn.Ba
 		requestURICondition := cdn.DeliveryRuleURLFileExtensionCondition{
 			Name: cdn.NameURLFileExtension,
 			Parameters: &cdn.URLFileExtensionMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlFileExtensionMatchConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlFileExtensionMatchConditionParameters"),
 				Operator:        cdn.URLFileExtensionOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/url_file_name.go
+++ b/internal/services/cdn/deliveryruleconditions/url_file_name.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -71,9 +72,9 @@ func ExpandArmCdnEndpointConditionURLFileName(input []interface{}) []cdn.BasicDe
 		requestURICondition := cdn.DeliveryRuleURLFileNameCondition{
 			Name: cdn.NameURLFileName,
 			Parameters: &cdn.URLFileNameMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlFilenameConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlFilenameConditionParameters"),
 				Operator:        cdn.URLFileNameOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/deliveryruleconditions/url_path.go
+++ b/internal/services/cdn/deliveryruleconditions/url_path.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -73,9 +74,9 @@ func ExpandArmCdnEndpointConditionURLPath(input []interface{}) []cdn.BasicDelive
 		requestURICondition := cdn.DeliveryRuleURLPathCondition{
 			Name: cdn.NameURLPath,
 			Parameters: &cdn.URLPathMatchConditionParameters{
-				OdataType:       utils.String("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlPathMatchConditionParameters"),
+				OdataType:       pointer.To("Microsoft.Azure.Cdn.Models.DeliveryRuleUrlPathMatchConditionParameters"),
 				Operator:        cdn.URLPathOperator(item["operator"].(string)),
-				NegateCondition: utils.Bool(item["negate_condition"].(bool)),
+				NegateCondition: pointer.To(item["negate_condition"].(bool)),
 				MatchValues:     utils.ExpandStringSlice(item["match_values"].(*pluginsdk.Set).List()),
 			},
 		}

--- a/internal/services/cdn/endpoint_delivery_rule.go
+++ b/internal/services/cdn/endpoint_delivery_rule.go
@@ -5,12 +5,12 @@ package cdn
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/deliveryruleactions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/deliveryruleconditions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func endpointDeliveryRule() *pluginsdk.Schema {
@@ -164,8 +164,8 @@ func endpointDeliveryRule() *pluginsdk.Schema {
 
 func expandArmCdnEndpointDeliveryRule(rule map[string]interface{}) (*cdn.DeliveryRule, error) {
 	deliveryRule := cdn.DeliveryRule{
-		Name:  utils.String(rule["name"].(string)),
-		Order: utils.Int32(int32(rule["order"].(int))),
+		Name:  pointer.To(rule["name"].(string)),
+		Order: pointer.To(int32(rule["order"].(int))),
 	}
 
 	deliveryRule.Conditions = expandDeliveryRuleConditions(rule)

--- a/internal/services/cdn/endpoint_global_delivery_rule.go
+++ b/internal/services/cdn/endpoint_global_delivery_rule.go
@@ -5,9 +5,9 @@ package cdn
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/deliveryruleactions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func endpointGlobalDeliveryRule() *pluginsdk.Schema {
@@ -112,8 +112,8 @@ func endpointGlobalDeliveryRule() *pluginsdk.Schema {
 
 func expandArmCdnEndpointGlobalDeliveryRule(rule map[string]interface{}) (*cdn.DeliveryRule, error) {
 	deliveryRule := cdn.DeliveryRule{
-		Name:  utils.String("Global"),
-		Order: utils.Int32(0),
+		Name:  pointer.To("Global"),
+		Order: pointer.To(int32(0)),
 	}
 
 	actions, err := expandDeliveryRuleActions(rule)

--- a/internal/services/cdn/frontdoorruleactions/cdn_frontdoor_rule_actions.go
+++ b/internal/services/cdn/frontdoorruleactions/cdn_frontdoor_rule_actions.go
@@ -286,7 +286,7 @@ func ExpandCdnFrontDoorRouteConfigurationOverrideAction(input []interface{}) (*[
 			}
 
 			if cacheDuration != "" {
-				cacheConfiguration.CacheDuration = utils.String(cacheDuration)
+				cacheConfiguration.CacheDuration = pointer.To(cacheDuration)
 			}
 
 			if queryParameters := cacheConfiguration.QueryParameters; queryParameters == nil {

--- a/internal/services/cdn/frontdoorsecretparams/cdn_frontdoor_secret_params.go
+++ b/internal/services/cdn/frontdoorsecretparams/cdn_frontdoor_secret_params.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CdnFrontDoorSecretParameters struct {
@@ -87,13 +87,13 @@ func ExpandCdnFrontDoorCustomerCertificateParameters(ctx context.Context, input 
 	customerCertificate := &cdn.CustomerCertificateParameters{
 		Type: m.CustomerCertificate.TypeName,
 		SecretSource: &cdn.ResourceReference{
-			ID: utils.String(secretSource.ID()),
+			ID: pointer.To(secretSource.ID()),
 		},
-		UseLatestVersion: utils.Bool(useLatest),
+		UseLatestVersion: pointer.To(useLatest),
 	}
 
 	if !useLatest {
-		customerCertificate.SecretVersion = utils.String(certificateId.Version)
+		customerCertificate.SecretVersion = pointer.To(certificateId.Version)
 	}
 
 	return customerCertificate, nil

--- a/internal/services/cdn/migration/cdn_endpoint_test.go
+++ b/internal/services/cdn/migration/cdn_endpoint_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestCdnEndpointV1ToV2(t *testing.T) {
@@ -28,14 +28,14 @@ func TestCdnEndpointV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/cdn/migration/cdn_profile_test.go
+++ b/internal/services/cdn/migration/cdn_profile_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestCdnProfileV1ToV2(t *testing.T) {
@@ -28,14 +28,14 @@ func TestCdnProfileV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Cdn/profiles/profile1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/chaosstudio/chaos_studio_capability_resource_test.go
+++ b/internal/services/chaosstudio/chaos_studio_capability_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ChaosStudioCapabilityTestResource struct{}
@@ -74,7 +74,7 @@ func (r ChaosStudioCapabilityTestResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ChaosStudioCapabilityTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/chaosstudio/chaos_studio_experiment_resource_test.go
+++ b/internal/services/chaosstudio/chaos_studio_experiment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/experiments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ChaosStudioExperimentTestResource struct{}
@@ -147,7 +147,7 @@ func (r ChaosStudioExperimentTestResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ChaosStudioExperimentTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/chaosstudio/chaos_studio_target_resource_gen_test.go
+++ b/internal/services/chaosstudio/chaos_studio_target_resource_gen_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ChaosStudioTargetTestResource struct{}
@@ -59,7 +59,7 @@ func (r ChaosStudioTargetTestResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ChaosStudioTargetTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/cognitive/cognitive_account_customer_managed_key_resource.go
+++ b/internal/services/cognitive/cognitive_account_customer_managed_key_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceCognitiveAccountCustomerManagedKey() *pluginsdk.Resource {
@@ -101,9 +100,9 @@ func resourceCognitiveAccountCustomerManagedKeyCreateUpdate(d *pluginsdk.Resourc
 		return err
 	}
 	props.Properties.Encryption.KeyVaultProperties = &cognitiveservicesaccounts.KeyVaultProperties{
-		KeyName:     utils.String(keyId.Name),
-		KeyVersion:  utils.String(keyId.Version),
-		KeyVaultUri: utils.String(keyId.KeyVaultBaseUrl),
+		KeyName:     pointer.To(keyId.Name),
+		KeyVersion:  pointer.To(keyId.Version),
+		KeyVaultUri: pointer.To(keyId.KeyVaultBaseUrl),
 	}
 
 	if identityClientId := d.Get("identity_client_id").(string); identityClientId != "" {

--- a/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CognitiveAccountCustomerManagedKeyResource struct{}
@@ -104,14 +104,14 @@ func (r CognitiveAccountCustomerManagedKeyResource) Exists(ctx context.Context, 
 	}
 
 	if resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.Encryption == nil || resp.Model.Properties.Encryption.KeySource == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	if *resp.Model.Properties.Encryption.KeySource == cognitiveservicesaccounts.KeySourceMicrosoftPointCognitiveServices {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CognitiveAccountCustomerManagedKeyResource) basic(data acceptance.TestData) string {

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
 	search "github.com/hashicorp/go-azure-sdk/resource-manager/search/2025-05-01/services"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	commonValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -468,7 +467,7 @@ func resourceCognitiveAccountCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	props := cognitiveservicesaccounts.Account{
 		Kind:     pointer.To(kind),
-		Location: pointer.To(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Sku:      &sku,
 		Properties: &cognitiveservicesaccounts.AccountProperties{
 			ApiProperties:                 apiProps,

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CognitiveAccountResource struct{}
@@ -579,7 +579,7 @@ func (t CognitiveAccountResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (CognitiveAccountResource) basic(data acceptance.TestData) string {

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type cognitiveDeploymentModel struct {
@@ -406,13 +405,13 @@ func expandDeploymentSkuModel(inputList []DeploymentSkuModel) *deployments.Sku {
 		Name: input.Name,
 	}
 	if input.Capacity != 0 {
-		s.Capacity = utils.Int64(input.Capacity)
+		s.Capacity = pointer.To(input.Capacity)
 	}
 	if input.Family != "" {
-		s.Family = utils.String(input.Family)
+		s.Family = pointer.To(input.Family)
 	}
 	if input.Size != "" {
-		s.Size = utils.String(input.Size)
+		s.Size = pointer.To(input.Size)
 	}
 	if input.Tier != "" {
 		tier := deployments.SkuTier(input.Tier)

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/deployments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CognitiveDeploymentTestResource struct{}
@@ -124,11 +124,11 @@ func (r CognitiveDeploymentTestResource) Exists(ctx context.Context, clients *cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CognitiveDeploymentTestResource) template(data acceptance.TestData) string {

--- a/internal/services/communication/communication_service_resource_test.go
+++ b/internal/services/communication/communication_service_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CommunicationServiceTestResource struct{}
@@ -101,13 +101,13 @@ func (r CommunicationServiceTestResource) Exists(ctx context.Context, client *cl
 	resp, err := clusterClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving Communication Service %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CommunicationServiceTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/communication/email_communication_service_domain_resource_test.go
+++ b/internal/services/communication/email_communication_service_domain_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/domains"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EmailServiceDomainTestResource struct{}
@@ -81,13 +81,13 @@ func (r EmailServiceDomainTestResource) Exists(ctx context.Context, client *clie
 	resp, err := domainClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving Email Domain Communication Service %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r EmailServiceDomainTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/communication/email_communication_service_resource_test.go
+++ b/internal/services/communication/email_communication_service_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EmailServiceTestResource struct{}
@@ -81,13 +81,13 @@ func (r EmailServiceTestResource) Exists(ctx context.Context, client *clients.Cl
 	resp, err := clusterClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving Email Communication Service %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r EmailServiceTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/availability_set_resource.go
+++ b/internal/services/compute/availability_set_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -23,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name availability_set -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
@@ -130,15 +130,15 @@ func resourceAvailabilitySetCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	payload := availabilitysets.AvailabilitySet{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &availabilitysets.AvailabilitySetProperties{
-			PlatformFaultDomainCount:  utils.Int64(int64(faultDomainCount)),
-			PlatformUpdateDomainCount: utils.Int64(int64(updateDomainCount)),
+			PlatformFaultDomainCount:  pointer.To(int64(faultDomainCount)),
+			PlatformUpdateDomainCount: pointer.To(int64(updateDomainCount)),
 		},
 		Tags: tags.Expand(t),
 	}
 
 	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
 		payload.Properties.ProximityPlacementGroup = &availabilitysets.SubResource{
-			Id: utils.String(v.(string)),
+			Id: pointer.To(v.(string)),
 		}
 	}
 

--- a/internal/services/compute/availability_set_resource_test.go
+++ b/internal/services/compute/availability_set_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AvailabilitySetResource struct{}
@@ -154,7 +154,7 @@ func (AvailabilitySetResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (AvailabilitySetResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -170,7 +170,7 @@ func (AvailabilitySetResource) Destroy(ctx context.Context, client *clients.Clie
 		}
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (AvailabilitySetResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/capacity_reservation_group_resource_test.go
+++ b/internal/services/compute/capacity_reservation_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CapacityReservationGroupResource struct{}
@@ -91,12 +91,12 @@ func (r CapacityReservationGroupResource) Exists(ctx context.Context, client *cl
 	resp, err := client.Compute.CapacityReservationGroupsClient.Get(ctx, *id, capacityreservationgroups.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CapacityReservationGroupResource) template(data acceptance.TestData) string {

--- a/internal/services/compute/capacity_reservation_resource.go
+++ b/internal/services/compute/capacity_reservation_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name capacity_reservation -service-package-name compute -properties "name" -compare-values "subscription_id:capacity_reservation_group_id,resource_group_name:capacity_reservation_group_id,capacity_reservation_group_name:capacity_reservation_group_id"
@@ -230,8 +229,8 @@ func resourceCapacityReservationDelete(d *pluginsdk.ResourceData, meta interface
 func expandCapacityReservationSku(input []interface{}) capacityreservations.Sku {
 	v := input[0].(map[string]interface{})
 	return capacityreservations.Sku{
-		Name:     utils.String(v["name"].(string)),
-		Capacity: utils.Int64(int64(v["capacity"].(int))),
+		Name:     pointer.To(v["name"].(string)),
+		Capacity: pointer.To(int64(v["capacity"].(int))),
 	}
 }
 

--- a/internal/services/compute/capacity_reservation_resource_test.go
+++ b/internal/services/compute/capacity_reservation_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CapacityReservationResource struct{}
@@ -111,11 +111,11 @@ func (r CapacityReservationResource) Exists(ctx context.Context, client *clients
 	resp, err := client.Compute.CapacityReservationsClient.Get(ctx, *id, capacityreservations.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CapacityReservationResource) template(data acceptance.TestData) string {

--- a/internal/services/compute/dedicated_host_group_resource.go
+++ b/internal/services/compute/dedicated_host_group_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host_group -service-package-name compute -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
@@ -115,7 +115,7 @@ func resourceDedicatedHostGroupCreate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if v, ok := d.GetOk("automatic_placement_enabled"); ok {
-		payload.Properties.SupportAutomaticPlacement = utils.Bool(v.(bool))
+		payload.Properties.SupportAutomaticPlacement = pointer.To(v.(bool))
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id, payload); err != nil {

--- a/internal/services/compute/dedicated_host_group_resource_test.go
+++ b/internal/services/compute/dedicated_host_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedhostgroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DedicatedHostGroupResource struct{}
@@ -92,7 +92,7 @@ func (r DedicatedHostGroupResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("retrieving Compute Dedicated Host Group %q", id)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (DedicatedHostGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/dedicated_host_resource.go
+++ b/internal/services/compute/dedicated_host_resource.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host -service-package-name compute -properties "name" -compare-values "subscription_id:dedicated_host_group_id,resource_group_name:dedicated_host_group_id,host_group_name:dedicated_host_group_id"
@@ -174,12 +173,12 @@ func resourceDedicatedHostCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	payload := dedicatedhosts.DedicatedHost{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &dedicatedhosts.DedicatedHostProperties{
-			AutoReplaceOnFailure: utils.Bool(d.Get("auto_replace_on_failure").(bool)),
+			AutoReplaceOnFailure: pointer.To(d.Get("auto_replace_on_failure").(bool)),
 			LicenseType:          &licenseType,
-			PlatformFaultDomain:  utils.Int64(int64(d.Get("platform_fault_domain").(int))),
+			PlatformFaultDomain:  pointer.To(int64(d.Get("platform_fault_domain").(int))),
 		},
 		Sku: dedicatedhosts.Sku{
-			Name: utils.String(d.Get("sku_name").(string)),
+			Name: pointer.To(d.Get("sku_name").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -253,7 +252,7 @@ func resourceDedicatedHostUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	if d.HasChanges("auto_replace_on_failure", "license_type") {
 		payload.Properties = &dedicatedhosts.DedicatedHostProperties{}
 		if d.HasChange("auto_replace_on_failure") {
-			payload.Properties.AutoReplaceOnFailure = utils.Bool(d.Get("auto_replace_on_failure").(bool))
+			payload.Properties.AutoReplaceOnFailure = pointer.To(d.Get("auto_replace_on_failure").(bool))
 		}
 		if d.HasChange("license_type") {
 			licenseType := dedicatedhosts.DedicatedHostLicenseTypes(d.Get("license_type").(string))

--- a/internal/services/compute/dedicated_host_resource_test.go
+++ b/internal/services/compute/dedicated_host_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/dedicatedhosts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DedicatedHostResource struct{}
@@ -180,7 +180,7 @@ func (t DedicatedHostResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving Compute Dedicated Host %q", id.String())
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r DedicatedHostResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/disk_encryption_set_data_source.go
+++ b/internal/services/compute/disk_encryption_set_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceDiskEncryptionSet() *pluginsdk.Resource {
@@ -80,7 +80,7 @@ func dataSourceDiskEncryptionSetRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("name", id.DiskEncryptionSetName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	d.Set("location", location.NormalizeNilable(utils.String(model.Location)))
+	d.Set("location", location.NormalizeNilable(pointer.To(model.Location)))
 
 	if props := model.Properties; props != nil {
 		d.Set("auto_key_rotation_enabled", props.RotationToLatestKeyVersionEnabled)

--- a/internal/services/compute/disk_encryption_set_resource.go
+++ b/internal/services/compute/disk_encryption_set_resource.go
@@ -31,7 +31,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
@@ -172,7 +171,7 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 			}
 
 			activeKey.SourceVault = &diskencryptionsets.SourceVault{
-				Id: utils.String(keyVaultDetails.keyVaultId),
+				Id: pointer.To(keyVaultDetails.keyVaultId),
 			}
 		}
 
@@ -213,7 +212,7 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &diskencryptionsets.EncryptionSetProperties{
 			ActiveKey:                         activeKey,
-			RotationToLatestKeyVersionEnabled: utils.Bool(rotationToLatestKeyVersionEnabled),
+			RotationToLatestKeyVersionEnabled: pointer.To(rotationToLatestKeyVersionEnabled),
 			EncryptionType:                    &encryptionType,
 		},
 		Identity: expandedIdentity,
@@ -221,7 +220,7 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("federated_client_id"); ok {
-		params.Properties.FederatedClientId = utils.String(v.(string))
+		params.Properties.FederatedClientId = pointer.To(v.(string))
 	}
 
 	err = client.CreateOrUpdateThenPoll(ctx, id, params)
@@ -442,7 +441,7 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 			}
 
 			update.Properties.ActiveKey.SourceVault = &diskencryptionsets.SourceVault{
-				Id: utils.String(keyVaultDetails.keyVaultId),
+				Id: pointer.To(keyVaultDetails.keyVaultId),
 			}
 		}
 	} else if managedHsmKeyId, ok := d.GetOk("managed_hsm_key_id"); ok && d.HasChange("managed_hsm_key_id") {
@@ -458,7 +457,7 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 			update.Properties = &diskencryptionsets.DiskEncryptionSetUpdateProperties{}
 		}
 
-		update.Properties.RotationToLatestKeyVersionEnabled = utils.Bool(rotationToLatestKeyVersionEnabled)
+		update.Properties.RotationToLatestKeyVersionEnabled = pointer.To(rotationToLatestKeyVersionEnabled)
 	}
 
 	if d.HasChange("federated_client_id") {
@@ -468,9 +467,9 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		v, ok := d.GetOk("federated_client_id")
 		if ok {
-			update.Properties.FederatedClientId = utils.String(v.(string))
+			update.Properties.FederatedClientId = pointer.To(v.(string))
 		} else {
-			update.Properties.FederatedClientId = utils.String("None") // this is the only way to remove the federated client id
+			update.Properties.FederatedClientId = pointer.To("None") // this is the only way to remove the federated client id
 		}
 	}
 

--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DiskEncryptionSetResource struct{}
@@ -272,7 +272,7 @@ func (DiskEncryptionSetResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving Compute Disk Encryption Set %q: `model` was nil", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }
 
 func (DiskEncryptionSetResource) dependencies(data acceptance.TestData, purgeProtectionEnabled bool) string {

--- a/internal/services/compute/encryption_settings.go
+++ b/internal/services/compute/encryption_settings.go
@@ -4,10 +4,10 @@
 package compute
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func encryptionSettingsSchema() *pluginsdk.Schema {
@@ -77,7 +77,7 @@ func expandSnapshotDiskEncryptionSettings(settingsList []interface{}) *snapshots
 		diskEncryptionKey = &snapshots.KeyVaultAndSecretReference{
 			SecretURL: secretURL,
 			SourceVault: snapshots.SourceVault{
-				Id: utils.String(sourceVaultId),
+				Id: pointer.To(sourceVaultId),
 			},
 		}
 	}
@@ -91,7 +91,7 @@ func expandSnapshotDiskEncryptionSettings(settingsList []interface{}) *snapshots
 		keyEncryptionKey = &snapshots.KeyVaultAndKeyReference{
 			KeyURL: secretURL,
 			SourceVault: snapshots.SourceVault{
-				Id: utils.String(sourceVaultId),
+				Id: pointer.To(sourceVaultId),
 			},
 		}
 	}
@@ -183,7 +183,7 @@ func expandManagedDiskEncryptionSettings(settingsList []interface{}) *disks.Encr
 		diskEncryptionKey = &disks.KeyVaultAndSecretReference{
 			SecretURL: secretURL,
 			SourceVault: disks.SourceVault{
-				Id: utils.String(sourceVaultId),
+				Id: pointer.To(sourceVaultId),
 			},
 		}
 	}
@@ -197,7 +197,7 @@ func expandManagedDiskEncryptionSettings(settingsList []interface{}) *disks.Encr
 		keyEncryptionKey = &disks.KeyVaultAndKeyReference{
 			KeyURL: secretURL,
 			SourceVault: disks.SourceVault{
-				Id: utils.String(sourceVaultId),
+				Id: pointer.To(sourceVaultId),
 			},
 		}
 	}

--- a/internal/services/compute/gallery_application_resource.go
+++ b/internal/services/compute/gallery_application_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application -properties "name" -service-package-name compute -compare-values "subscription_id:gallery_id,resource_group_name:gallery_id,gallery_name:gallery_id"
@@ -159,7 +158,7 @@ func (r GalleryApplicationResource) Create() sdk.ResourceFunc {
 			}
 
 			if state.Description != "" {
-				payload.Properties.Description = utils.String(state.Description)
+				payload.Properties.Description = pointer.To(state.Description)
 			}
 
 			if state.EndOfLifeDate != "" {
@@ -168,15 +167,15 @@ func (r GalleryApplicationResource) Create() sdk.ResourceFunc {
 			}
 
 			if state.Eula != "" {
-				payload.Properties.Eula = utils.String(state.Eula)
+				payload.Properties.Eula = pointer.To(state.Eula)
 			}
 
 			if state.PrivacyStatementURI != "" {
-				payload.Properties.PrivacyStatementUri = utils.String(state.PrivacyStatementURI)
+				payload.Properties.PrivacyStatementUri = pointer.To(state.PrivacyStatementURI)
 			}
 
 			if state.ReleaseNoteURI != "" {
-				payload.Properties.ReleaseNoteUri = utils.String(state.ReleaseNoteURI)
+				payload.Properties.ReleaseNoteUri = pointer.To(state.ReleaseNoteURI)
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
@@ -291,7 +290,7 @@ func (r GalleryApplicationResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("description") {
-					payload.Properties.Description = utils.String(state.Description)
+					payload.Properties.Description = pointer.To(state.Description)
 				}
 
 				if metadata.ResourceData.HasChange("end_of_life_date") {
@@ -300,15 +299,15 @@ func (r GalleryApplicationResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("eula") {
-					payload.Properties.Eula = utils.String(state.Eula)
+					payload.Properties.Eula = pointer.To(state.Eula)
 				}
 
 				if metadata.ResourceData.HasChange("privacy_statement_uri") {
-					payload.Properties.PrivacyStatementUri = utils.String(state.PrivacyStatementURI)
+					payload.Properties.PrivacyStatementUri = pointer.To(state.PrivacyStatementURI)
 				}
 
 				if metadata.ResourceData.HasChange("release_note_uri") {
-					payload.Properties.ReleaseNoteUri = utils.String(state.ReleaseNoteURI)
+					payload.Properties.ReleaseNoteUri = pointer.To(state.ReleaseNoteURI)
 				}
 			}
 

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name gallery_application_version -properties "name" -service-package-name compute -compare-values "subscription_id:gallery_application_id,resource_group_name:gallery_application_id,gallery_name:gallery_application_id,application_name:gallery_application_id"
@@ -254,8 +253,8 @@ func (r GalleryApplicationVersionResource) Create() sdk.ResourceFunc {
 				Location: location.Normalize(state.Location),
 				Properties: &galleryapplicationversions.GalleryApplicationVersionProperties{
 					PublishingProfile: galleryapplicationversions.GalleryApplicationVersionPublishingProfile{
-						EnableHealthCheck: utils.Bool(state.EnableHealthCheck),
-						ExcludeFromLatest: utils.Bool(state.ExcludeFromLatest),
+						EnableHealthCheck: pointer.To(state.EnableHealthCheck),
+						ExcludeFromLatest: pointer.To(state.ExcludeFromLatest),
 						ManageActions:     expandGalleryApplicationVersionManageAction(state.ManageAction),
 						Source:            expandGalleryApplicationVersionSource(state.Source),
 						TargetRegions:     expandGalleryApplicationVersionTargetRegion(state.TargetRegion),
@@ -394,7 +393,7 @@ func (r GalleryApplicationVersionResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("enable_health_check") {
-					payload.Properties.PublishingProfile.EnableHealthCheck = utils.Bool(state.EnableHealthCheck)
+					payload.Properties.PublishingProfile.EnableHealthCheck = pointer.To(state.EnableHealthCheck)
 				}
 
 				if metadata.ResourceData.HasChange("end_of_life_date") {
@@ -403,7 +402,7 @@ func (r GalleryApplicationVersionResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("exclude_from_latest") {
-					payload.Properties.PublishingProfile.ExcludeFromLatest = utils.Bool(state.ExcludeFromLatest)
+					payload.Properties.PublishingProfile.ExcludeFromLatest = pointer.To(state.ExcludeFromLatest)
 				}
 
 				if metadata.ResourceData.HasChange("manage_actions") {
@@ -504,7 +503,7 @@ func expandGalleryApplicationVersionManageAction(input []ManageAction) *gallerya
 	return &galleryapplicationversions.UserArtifactManage{
 		Install: v.Install,
 		Remove:  v.Remove,
-		Update:  utils.String(v.Update),
+		Update:  pointer.To(v.Update),
 	}
 }
 
@@ -534,7 +533,7 @@ func expandGalleryApplicationVersionSource(input []Source) galleryapplicationver
 	v := input[0]
 	return galleryapplicationversions.UserArtifactSource{
 		MediaLink:                v.MediaLink,
-		DefaultConfigurationLink: utils.String(v.DefaultConfigurationLink),
+		DefaultConfigurationLink: pointer.To(v.DefaultConfigurationLink),
 	}
 }
 

--- a/internal/services/compute/image_resource.go
+++ b/internal/services/compute/image_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceImage() *pluginsdk.Resource {
@@ -255,7 +254,7 @@ func resourceImageCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	storageProfile := images.ImageStorageProfile{
 		OsDisk:        expandImageOSDisk(d.Get("os_disk").([]interface{})),
 		DataDisks:     expandImageDataDisks(d.Get("data_disk").([]interface{})),
-		ZoneResilient: utils.Bool(d.Get("zone_resilient").(bool)),
+		ZoneResilient: pointer.To(d.Get("zone_resilient").(bool)),
 	}
 
 	// either source VM or storage profile can be specified, but not both

--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/ssh"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ImageResource struct{}
@@ -202,7 +201,7 @@ func (ImageResource) Exists(ctx context.Context, clients *clients.Client, state 
 		return nil, fmt.Errorf("retrieving Compute Image %q", id)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ImageResource) generalizeVirtualMachine(data acceptance.TestData) func(context.Context, *clients.Client, *pluginsdk.InstanceState) error {

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLinuxVirtualMachine() *pluginsdk.Resource {
@@ -837,7 +836,7 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 		}
 
 		params.Properties.BillingProfile = &virtualmachines.BillingProfile{
-			MaxPrice: utils.Float(v),
+			MaxPrice: pointer.To(v),
 		}
 	}
 
@@ -1324,7 +1323,7 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 
 		maxBidPrice := d.Get("max_bid_price").(float64)
 		update.Properties.BillingProfile = &virtualmachines.BillingProfile{
-			MaxPrice: utils.Float(maxBidPrice),
+			MaxPrice: pointer.To(maxBidPrice),
 		}
 	}
 
@@ -1696,7 +1695,7 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 
 		update := disks.DiskUpdate{
 			Properties: &disks.DiskUpdateProperties{
-				DiskSizeGB: utils.Int64(int64(newSize)),
+				DiskSizeGB: pointer.To(int64(newSize)),
 			},
 		}
 

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -341,7 +340,7 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	createOption := disks.DiskCreateOption(d.Get("create_option").(string))
 	storageAccountType := d.Get("storage_account_type").(string)
 	osType := disks.OperatingSystemTypes(d.Get("os_type").(string))

--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagedDiskResource struct{}
@@ -921,7 +920,7 @@ func (ManagedDiskResource) Exists(ctx context.Context, clients *clients.Client, 
 		return nil, fmt.Errorf("retrieving Compute Managed Disk %q", id.String())
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ManagedDiskResource) empty(data acceptance.TestData) string {

--- a/internal/services/compute/managed_disk_sas_token_resource_test.go
+++ b/internal/services/compute/managed_disk_sas_token_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagedDiskSASTokenResource struct{}
@@ -47,7 +47,7 @@ func (t ManagedDiskSASTokenResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("Disk SAS token %s (resource group %s): %s", id.DiskName, id.ResourceGroupName, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagedDiskSASTokenResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/marketplace_agreement_resource.go
+++ b/internal/services/compute/marketplace_agreement_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMarketplaceAgreement() *pluginsdk.Resource {
@@ -113,7 +113,7 @@ func resourceMarketplaceAgreementCreate(d *pluginsdk.ResourceData, meta interfac
 		return fmt.Errorf("retrieving %s: AgreementProperties was nil", id)
 	}
 
-	terms.Properties.Accepted = utils.Bool(true)
+	terms.Properties.Accepted = pointer.To(true)
 
 	log.Printf("[DEBUG] Accepting the Marketplace Terms for %s", id)
 	if _, err := client.MarketplaceAgreementsCreate(ctx, agreementId, *terms); err != nil {

--- a/internal/services/compute/marketplace_agreement_resource_test.go
+++ b/internal/services/compute/marketplace_agreement_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MarketplaceAgreementResource struct{}
@@ -89,12 +88,12 @@ func (t MarketplaceAgreementResource) Exists(ctx context.Context, clients *clien
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			if accept := props.Accepted; accept != nil && *accept {
-				return utils.Bool(true), nil
+				return pointer.To(true), nil
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (MarketplaceAgreementResource) basic(offer string) string {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 const (
@@ -1531,7 +1530,7 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 	// /{nicResourceID}/|providers|Microsoft.Compute|virtualMachineScaleSets|acctestvmss-190923101253410278|virtualMachines|0|networkInterfaces|example/ipConfigurations/internal and cannot be deleted.
 	// In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet.
 	if resp.Model != nil && resp.Model.Sku != nil {
-		resp.Model.Sku.Capacity = utils.Int64(int64(0))
+		resp.Model.Sku.Capacity = pointer.To(int64(0))
 
 		log.Printf("[DEBUG] Scaling instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 		update := virtualmachinescalesets.VirtualMachineScaleSetUpdate{
@@ -1605,7 +1604,7 @@ func expandOrchestratedVirtualMachineScaleSetSku(input string, capacity int) (*v
 
 	sku := &virtualmachinescalesets.Sku{
 		Name:     pointer.To(input),
-		Capacity: utils.Int64(int64(capacity)),
+		Capacity: pointer.To(int64(capacity)),
 	}
 
 	if input != SkuNameMix {

--- a/internal/services/compute/proximity_placement_group_resource_test.go
+++ b/internal/services/compute/proximity_placement_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ProximityPlacementGroupResource struct{}
@@ -151,7 +151,7 @@ func (t ProximityPlacementGroupResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ProximityPlacementGroupResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -164,7 +164,7 @@ func (ProximityPlacementGroupResource) Destroy(ctx context.Context, client *clie
 		return nil, fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (ProximityPlacementGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/restore_point_collection_resource_test.go
+++ b/internal/services/compute/restore_point_collection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/restorepointcollections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RestorePointCollectionResource struct{}
@@ -66,7 +66,7 @@ func (r RestorePointCollectionResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r RestorePointCollectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSharedImageVersion() *pluginsdk.Resource {
@@ -235,7 +234,7 @@ func resourceSharedImageVersionCreate(d *pluginsdk.ResourceData, meta interface{
 				TargetRegions:     targetRegions,
 			},
 			SafetyProfile: &galleryimageversions.GalleryImageVersionSafetyProfile{
-				AllowDeletionOfReplicatedLocations: utils.Bool(d.Get("deletion_of_replicated_locations_enabled").(bool)),
+				AllowDeletionOfReplicatedLocations: pointer.To(d.Get("deletion_of_replicated_locations_enabled").(bool)),
 			},
 			StorageProfile: galleryimageversions.GalleryImageVersionStorageProfile{},
 		},
@@ -253,11 +252,11 @@ func resourceSharedImageVersionCreate(d *pluginsdk.ResourceData, meta interface{
 		_, err := virtualmachines.ParseVirtualMachineID(v.(string))
 		if err == nil {
 			version.Properties.StorageProfile.Source = &galleryimageversions.GalleryArtifactVersionFullSource{
-				VirtualMachineId: utils.String(v.(string)),
+				VirtualMachineId: pointer.To(v.(string)),
 			}
 		} else {
 			version.Properties.StorageProfile.Source = &galleryimageversions.GalleryArtifactVersionFullSource{
-				Id: utils.String(v.(string)),
+				Id: pointer.To(v.(string)),
 			}
 		}
 	}

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -12,10 +12,10 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/migration"
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSnapshot() *pluginsdk.Resource {
@@ -152,7 +151,7 @@ func resourceSnapshotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	defer cancel()
 
 	id := snapshots.NewSnapshotID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	createOption := d.Get("create_option").(string)
 	t := d.Get("tags").(map[string]interface{})
 
@@ -175,21 +174,21 @@ func resourceSnapshotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			CreationData: snapshots.CreationData{
 				CreateOption: snapshots.DiskCreateOption(createOption),
 			},
-			Incremental: utils.Bool(d.Get("incremental_enabled").(bool)),
+			Incremental: pointer.To(d.Get("incremental_enabled").(bool)),
 		},
 		Tags: tags.Expand(t),
 	}
 
 	if v, ok := d.GetOk("source_uri"); ok {
-		properties.Properties.CreationData.SourceUri = utils.String(v.(string))
+		properties.Properties.CreationData.SourceUri = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("source_resource_id"); ok {
-		properties.Properties.CreationData.SourceResourceId = utils.String(v.(string))
+		properties.Properties.CreationData.SourceResourceId = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_account_id"); ok {
-		properties.Properties.CreationData.StorageAccountId = utils.String(v.(string))
+		properties.Properties.CreationData.StorageAccountId = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("network_access_policy"); ok {
@@ -197,7 +196,7 @@ func resourceSnapshotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if v, ok := d.GetOk("disk_access_id"); ok {
-		properties.Properties.DiskAccessId = utils.String(v.(string))
+		properties.Properties.DiskAccessId = pointer.To(v.(string))
 	}
 
 	properties.Properties.PublicNetworkAccess = pointer.To(snapshots.PublicNetworkAccessEnabled)
@@ -207,7 +206,7 @@ func resourceSnapshotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	diskSizeGB := d.Get("disk_size_gb").(int)
 	if diskSizeGB > 0 {
-		properties.Properties.DiskSizeGB = utils.Int64(int64(diskSizeGB))
+		properties.Properties.DiskSizeGB = pointer.To(int64(diskSizeGB))
 	}
 
 	properties.Properties.EncryptionSettingsCollection = expandSnapshotDiskEncryptionSettings(d.Get("encryption_settings").([]interface{}))
@@ -246,7 +245,7 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		if props := model.Properties; props != nil {
 			data := props.CreationData

--- a/internal/services/compute/snapshot_resource_test.go
+++ b/internal/services/compute/snapshot_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SnapshotResource struct{}
@@ -219,7 +219,7 @@ func (t SnapshotResource) Exists(ctx context.Context, clients *clients.Client, s
 		return nil, fmt.Errorf("retrieving Compute Shared Image Gallery %q", id)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (SnapshotResource) fromManagedDisk(data acceptance.TestData) string {

--- a/internal/services/compute/ssh_keys_test.go
+++ b/internal/services/compute/ssh_keys_test.go
@@ -6,7 +6,7 @@ package compute
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestParseUsernameFromAuthorizedKeysPath(t *testing.T) {
@@ -40,15 +40,15 @@ func TestParseUsernameFromAuthorizedKeysPath(t *testing.T) {
 		},
 		{
 			Input:    "/home/username/.ssh/authorized_keys",
-			Expected: utils.String("username"),
+			Expected: pointer.To("username"),
 		},
 		{
 			Input:    "/home/abc123/.ssh/authorized_keys",
-			Expected: utils.String("abc123"),
+			Expected: pointer.To("abc123"),
 		},
 		{
 			Input:    "/home/!!&abc-123!/.ssh/authorized_keys",
-			Expected: utils.String("!!&abc-123!"),
+			Expected: pointer.To("!!&abc-123!"),
 		},
 	}
 	for _, v := range testData {

--- a/internal/services/compute/ssh_public_key_resource.go
+++ b/internal/services/compute/ssh_public_key_resource.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSshPublicKey() *pluginsdk.Resource {
@@ -90,7 +90,7 @@ func resourceSshPublicKeyCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	payload := sshpublickeys.SshPublicKeyResource{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &sshpublickeys.SshPublicKeyResourceProperties{
-			PublicKey: utils.String(d.Get("public_key").(string)),
+			PublicKey: pointer.To(d.Get("public_key").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -161,7 +161,7 @@ func resourceSshPublicKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	payload := sshpublickeys.SshPublicKeyUpdateResource{}
 	if d.HasChange("public_key") {
 		payload.Properties = &sshpublickeys.SshPublicKeyResourceProperties{
-			PublicKey: utils.String(d.Get("public_key").(string)),
+			PublicKey: pointer.To(d.Get("public_key").(string)),
 		}
 	}
 	if d.HasChange("tags") {

--- a/internal/services/compute/ssh_public_key_resource_test.go
+++ b/internal/services/compute/ssh_public_key_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/sshpublickeys"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SSHPublicKeyResource struct{}
@@ -56,7 +56,7 @@ func (t SSHPublicKeyResource) Exists(ctx context.Context, clients *clients.Clien
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (SSHPublicKeyResource) template(data acceptance.TestData, sshKey string) string {

--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineDataDiskAttachmentResource struct{}
@@ -298,7 +297,7 @@ func (VirtualMachineDataDiskAttachmentResource) Destroy(ctx context.Context, cli
 		}
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r VirtualMachineDataDiskAttachmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/virtual_machine_restore_point_collection_resource_test.go
+++ b/internal/services/compute/virtual_machine_restore_point_collection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/restorepointcollections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineRestorePointCollectionResource struct{}
@@ -66,7 +66,7 @@ func (r VirtualMachineRestorePointCollectionResource) Exists(ctx context.Context
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualMachineRestorePointCollectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/virtual_machine_restore_point_resource_test.go
+++ b/internal/services/compute/virtual_machine_restore_point_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/restorepoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineRestorePointResource struct{}
@@ -64,7 +64,7 @@ func (r VirtualMachineRestorePointResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualMachineRestorePointResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/virtual_machine_run_command_resource_test.go
+++ b/internal/services/compute/virtual_machine_run_command_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-03-01/virtualmachineruncommands"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineRunCommandTestResource struct{}
@@ -190,7 +190,7 @@ func (r VirtualMachineRunCommandTestResource) Exists(ctx context.Context, client
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualMachineRunCommandTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WindowsVirtualMachineResource struct{}
@@ -27,7 +27,7 @@ func (r WindowsVirtualMachineResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving Windows %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (WindowsVirtualMachineResource) templateBase(data acceptance.TestData) string {

--- a/internal/services/confidentialledger/confidential_ledger_resource.go
+++ b/internal/services/confidentialledger/confidential_ledger_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceConfidentialLedger() *pluginsdk.Resource {
@@ -154,7 +154,7 @@ func resourceConfidentialLedgerCreate(d *pluginsdk.ResourceData, meta interface{
 	ledgerType := confidentialledger.LedgerType(d.Get("ledger_type").(string))
 	location := location.Normalize(d.Get("location").(string))
 	parameters := confidentialledger.ConfidentialLedger{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &confidentialledger.LedgerProperties{
 			AadBasedSecurityPrincipals:  aadBasedUsers,
 			CertBasedSecurityPrincipals: certBasedUsers,
@@ -302,8 +302,8 @@ func expandAADBasedSecurityPrincipal(input []interface{}) *[]confidentialledger.
 
 		result := confidentialledger.AADBasedSecurityPrincipal{
 			LedgerRoleName: &ledgerRoleName,
-			PrincipalId:    utils.String(principalId),
-			TenantId:       utils.String(tenantId),
+			PrincipalId:    pointer.To(principalId),
+			TenantId:       pointer.To(tenantId),
 		}
 
 		output = append(output, result)
@@ -320,7 +320,7 @@ func expandCertBasedSecurityPrincipal(input []interface{}) *[]confidentialledger
 
 		ledgerRoleName := confidentialledger.LedgerRoleName(v["ledger_role_name"].(string))
 		output = append(output, confidentialledger.CertBasedSecurityPrincipal{
-			Cert:           utils.String(v["pem_public_key"].(string)),
+			Cert:           pointer.To(v["pem_public_key"].(string)),
 			LedgerRoleName: &ledgerRoleName,
 		})
 	}

--- a/internal/services/consumption/consumption_budget_base.go
+++ b/internal/services/consumption/consumption_budget_base.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -386,7 +387,7 @@ func createOrUpdateConsumptionBudget(ctx context.Context, client *budgets.Budget
 	// 'Cost' is the only valid Budget type today according to the API spec.
 
 	parameters := budgets.Budget{
-		Name: utils.String(id.BudgetName),
+		Name: pointer.To(id.BudgetName),
 		Properties: &budgets.BudgetProperties{
 			Amount:        metadata.ResourceData.Get("amount").(float64),
 			Category:      budgets.CategoryTypeCost,
@@ -398,7 +399,7 @@ func createOrUpdateConsumptionBudget(ctx context.Context, client *budgets.Budget
 	}
 
 	if v, ok := metadata.ResourceData.GetOk("etag"); ok {
-		parameters.ETag = utils.String(v.(string))
+		parameters.ETag = pointer.To(v.(string))
 	}
 
 	_, err = client.CreateOrUpdate(ctx, id, parameters)
@@ -432,7 +433,7 @@ func expandConsumptionBudgetTimePeriod(i []interface{}) (*budgets.BudgetTimePeri
 				return nil, fmt.Errorf("end_date '%s' was not in the correct format: %+v", endDateInput, err)
 			}
 
-			timePeriod.EndDate = utils.String(input["end_date"].(string))
+			timePeriod.EndDate = pointer.To(input["end_date"].(string))
 		}
 	}
 

--- a/internal/services/consumption/consumption_budget_management_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ConsumptionBudgetManagementGroupResource struct{}
@@ -122,7 +122,7 @@ func (ConsumptionBudgetManagementGroupResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ConsumptionBudgetManagementGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/consumption/consumption_budget_resource_group_resource_test.go
+++ b/internal/services/consumption/consumption_budget_resource_group_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ConsumptionBudgetResourceGroupResource struct{}
@@ -122,7 +122,7 @@ func (ConsumptionBudgetResourceGroupResource) Exists(ctx context.Context, client
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ConsumptionBudgetResourceGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/consumption/consumption_budget_subscription_resource_test.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func consumptionBudgetTestStartDate() time.Time {
@@ -129,7 +129,7 @@ func (ConsumptionBudgetSubscriptionResource) Exists(ctx context.Context, clients
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ConsumptionBudgetSubscriptionResource) basic(data acceptance.TestData) string {

--- a/internal/services/containerapps/container_app_data_source.go
+++ b/internal/services/containerapps/container_app_data_source.go
@@ -178,7 +178,7 @@ func (r ContainerAppDataSource) Read() sdk.ResourceFunc {
 							containerApp.Ingress = helpers.FlattenContainerAppIngress(config.Ingress, id.ContainerAppName)
 							containerApp.Registries = helpers.FlattenContainerAppRegistries(config.Registries)
 							containerApp.Dapr = helpers.FlattenContainerAppDapr(config.Dapr)
-							containerApp.MaxInactiveRevisions = pointer.ToInt64(config.MaxInactiveRevisions)
+							containerApp.MaxInactiveRevisions = pointer.From(config.MaxInactiveRevisions)
 						}
 					}
 					containerApp.LatestRevisionName = pointer.From(props.LatestRevisionName)

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerAppJobResource struct{}
@@ -33,7 +32,7 @@ func (r ContainerAppJobResource) Exists(ctx context.Context, client *clients.Cli
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccContainerAppJob_basic(t *testing.T) {

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -210,7 +210,7 @@ func (r ContainerAppResource) Create() sdk.ResourceFunc {
 						Dapr:                 helpers.ExpandContainerAppDapr(app.Dapr),
 						Secrets:              secrets,
 						Registries:           registries,
-						MaxInactiveRevisions: pointer.FromInt64(app.MaxInactiveRevisions),
+						MaxInactiveRevisions: pointer.To(app.MaxInactiveRevisions),
 					},
 					ManagedEnvironmentId: pointer.To(app.ManagedEnvironmentId),
 					Template:             helpers.ExpandContainerAppTemplate(app.Template, metadata),
@@ -287,7 +287,7 @@ func (r ContainerAppResource) Read() sdk.ResourceFunc {
 						state.Ingress = helpers.FlattenContainerAppIngress(config.Ingress, id.ContainerAppName)
 						state.Registries = helpers.FlattenContainerAppRegistries(config.Registries)
 						state.Dapr = helpers.FlattenContainerAppDapr(config.Dapr)
-						state.MaxInactiveRevisions = pointer.ToInt64(config.MaxInactiveRevisions)
+						state.MaxInactiveRevisions = pointer.From(config.MaxInactiveRevisions)
 					}
 					state.LatestRevisionName = pointer.From(props.LatestRevisionName)
 					state.LatestRevisionFqdn = pointer.From(props.LatestRevisionFqdn)
@@ -385,7 +385,7 @@ func (r ContainerAppResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("max_inactive_revisions") {
-				model.Properties.Configuration.MaxInactiveRevisions = pointer.FromInt64(state.MaxInactiveRevisions)
+				model.Properties.Configuration.MaxInactiveRevisions = pointer.To(state.MaxInactiveRevisions)
 			}
 
 			if metadata.ResourceData.HasChange("dapr") {

--- a/internal/services/containers/container_connected_registry_resource.go
+++ b/internal/services/containers/container_connected_registry_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerConnectedRegistryResource struct{}
@@ -238,8 +237,8 @@ func (r ContainerConnectedRegistryResource) Create() sdk.ResourceFunc {
 					Parent: connectedregistries.ParentProperties{
 						SyncProperties: connectedregistries.SyncProperties{
 							TokenId:    model.SyncTokenId,
-							Schedule:   utils.String(model.SyncSchedule),
-							SyncWindow: utils.String(model.SyncWindow),
+							Schedule:   pointer.To(model.SyncSchedule),
+							SyncWindow: pointer.To(model.SyncWindow),
 							MessageTtl: model.SyncMessageTTL,
 						},
 					},
@@ -254,9 +253,9 @@ func (r ContainerConnectedRegistryResource) Create() sdk.ResourceFunc {
 
 			if model.ParentRegistryId != "" {
 				if pid, err := registries.ParseRegistryID(model.ParentRegistryId); err == nil {
-					params.Properties.Parent.Id = utils.String(pid.ID())
+					params.Properties.Parent.Id = pointer.To(pid.ID())
 				} else if pid, err := connectedregistries.ParseConnectedRegistryID(model.ParentRegistryId); err == nil {
-					params.Properties.Parent.Id = utils.String(pid.ID())
+					params.Properties.Parent.Id = pointer.To(pid.ID())
 				}
 			}
 

--- a/internal/services/containers/container_connected_registry_resource_test.go
+++ b/internal/services/containers/container_connected_registry_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/connectedregistries"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerConnectedRegistryResource struct{}
@@ -149,12 +149,12 @@ func (r ContainerConnectedRegistryResource) Exists(ctx context.Context, clients 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ContainerConnectedRegistryResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -1407,7 +1407,7 @@ func expandSingleContainerVolume(input interface{}) (*[]containerinstance.Volume
 		vm := containerinstance.VolumeMount{
 			Name:      name,
 			MountPath: mountPath,
-			ReadOnly:  pointer.FromBool(readOnly),
+			ReadOnly:  pointer.To(readOnly),
 		}
 
 		volumeMounts = append(volumeMounts, vm)
@@ -1445,7 +1445,7 @@ func expandSingleContainerVolume(input interface{}) (*[]containerinstance.Volume
 			}
 			cv.AzureFile = &containerinstance.AzureFileVolume{
 				ShareName:          shareName,
-				ReadOnly:           pointer.FromBool(readOnly),
+				ReadOnly:           pointer.To(readOnly),
 				StorageAccountName: storageAccountName,
 				StorageAccountKey:  pointer.To(storageAccountKey),
 			}
@@ -1502,23 +1502,23 @@ func expandContainerProbe(input interface{}) *containerinstance.ContainerProbe {
 		probeConfig := p.(map[string]interface{})
 
 		if v := probeConfig["initial_delay_seconds"].(int); v > 0 {
-			probe.InitialDelaySeconds = pointer.FromInt64(int64(v))
+			probe.InitialDelaySeconds = pointer.To(int64(v))
 		}
 
 		if v := probeConfig["period_seconds"].(int); v > 0 {
-			probe.PeriodSeconds = pointer.FromInt64(int64(v))
+			probe.PeriodSeconds = pointer.To(int64(v))
 		}
 
 		if v := probeConfig["failure_threshold"].(int); v > 0 {
-			probe.FailureThreshold = pointer.FromInt64(int64(v))
+			probe.FailureThreshold = pointer.To(int64(v))
 		}
 
 		if v := probeConfig["success_threshold"].(int); v > 0 {
-			probe.SuccessThreshold = pointer.FromInt64(int64(v))
+			probe.SuccessThreshold = pointer.To(int64(v))
 		}
 
 		if v := probeConfig["timeout_seconds"].(int); v > 0 {
-			probe.TimeoutSeconds = pointer.FromInt64(int64(v))
+			probe.TimeoutSeconds = pointer.To(int64(v))
 		}
 
 		commands := probeConfig["exec"].([]interface{})

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2023-05-01/containerinstance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerGroupResource struct{}
@@ -2304,7 +2304,7 @@ func (t ContainerGroupResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("unexpected nil model of %q", id)
 	}
 
-	return utils.Bool(resp.Model.Id != nil), nil
+	return pointer.To(resp.Model.Id != nil), nil
 }
 
 func (ContainerGroupResource) withPrivateEmpty(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_agent_pool_resource.go
+++ b/internal/services/containers/container_registry_agent_pool_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceContainerRegistryAgentPool() *pluginsdk.Resource {
@@ -120,7 +119,7 @@ func resourceContainerRegistryAgentPoolCreate(d *pluginsdk.ResourceData, meta in
 		Properties: &agentpools.AgentPoolProperties{
 			// @favoretti: Only Linux is supported
 			Os:    pointer.To(agentpools.OSLinux),
-			Count: utils.Int64(int64(d.Get("instance_count").(int))),
+			Count: pointer.To(int64(d.Get("instance_count").(int))),
 			Tier:  pointer.To(d.Get("tier").(string)),
 		},
 
@@ -153,7 +152,7 @@ func resourceContainerRegistryAgentPoolUpdate(d *pluginsdk.ResourceData, meta in
 
 	parameters := agentpools.AgentPoolUpdateParameters{
 		Properties: &agentpools.AgentPoolPropertiesUpdateParameters{
-			Count: utils.Int64(int64(d.Get("instance_count").(int))),
+			Count: pointer.To(int64(d.Get("instance_count").(int))),
 		},
 	}
 

--- a/internal/services/containers/container_registry_agent_pool_resource_test.go
+++ b/internal/services/containers/container_registry_agent_pool_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/agentpools"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryAgentPoolResource struct{}
@@ -77,7 +77,7 @@ func (t ContainerRegistryAgentPoolResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ContainerRegistryAgentPoolResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/operation"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/registries"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/replications"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -278,7 +277,7 @@ func resourceContainerRegistry() *pluginsdk.Resource {
 			var geoReplicationLocations []string
 			for _, v := range geoReplications {
 				v := v.(map[string]interface{})
-				geoReplicationLocations = append(geoReplicationLocations, azure.NormalizeLocation(v["location"]))
+				geoReplicationLocations = append(geoReplicationLocations, location.Normalize(v["location"].(string)))
 			}
 			location := location.Normalize(d.Get("location").(string))
 			for _, loc := range geoReplicationLocations {
@@ -1005,7 +1004,7 @@ func expandReplications(p []interface{}) []replications.Replication {
 	}
 	for _, v := range p {
 		value := v.(map[string]interface{})
-		location := azure.NormalizeLocation(value["location"])
+		location := location.Normalize(value["location"].(string))
 		tags := tags.Expand(value["tags"].(map[string]interface{}))
 		zoneRedundancy := replications.ZoneRedundancyDisabled
 		if value["zone_redundancy_enabled"].(bool) {

--- a/internal/services/containers/container_registry_resource_test.go
+++ b/internal/services/containers/container_registry_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/registries"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryResource struct{}
@@ -414,7 +414,7 @@ func (t ContainerRegistryResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ContainerRegistryResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_scope_map_resource_test.go
+++ b/internal/services/containers/container_registry_scope_map_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/scopemaps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryScopeMapResource struct{}
@@ -108,7 +108,7 @@ func (ContainerRegistryScopeMapResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ContainerRegistryScopeMapResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_task_resource_test.go
+++ b/internal/services/containers/container_registry_task_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryTaskResource struct {
@@ -480,12 +480,12 @@ func (r ContainerRegistryTaskResource) Exists(ctx context.Context, clients *clie
 
 	if resp, err := client.Get(ctx, *id); err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ContainerRegistryTaskResource) dockerStepBasic(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_token_password_resource.go
+++ b/internal/services/containers/container_registry_token_password_resource.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryTokenPasswordResource struct{}
@@ -315,7 +314,7 @@ func (r ContainerRegistryTokenPasswordResource) expandContainerRegistryTokenPass
 			password := password[0]
 			ret := &tokens.TokenPassword{
 				Name:  pointer.To(tokens.TokenPasswordName(name)),
-				Value: utils.String(password.Value),
+				Value: pointer.To(password.Value),
 			}
 			if v := password.Expiry; v != "" {
 				t, err := time.Parse(time.RFC3339, v)
@@ -451,7 +450,7 @@ PasswordGenLoop:
 		}
 
 		param := registries.GenerateCredentialsParameters{
-			TokenId: utils.String(id.ID()),
+			TokenId: pointer.To(id.ID()),
 			Expiry:  password.Expiry,
 			Name:    (*registries.TokenPasswordName)(password.Name),
 		}

--- a/internal/services/containers/container_registry_token_password_resource_test.go
+++ b/internal/services/containers/container_registry_token_password_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/tokens"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryTokenPasswordResource struct {
@@ -173,7 +173,7 @@ func (r ContainerRegistryTokenPasswordResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("checking for presence of existing %s: unexpected nil tokenProperties.credentials.passwords", id)
 	}
 	// ACR token with no password returns a empty array for ".password"
-	return utils.Bool(len(*pwds) != 0), nil
+	return pointer.To(len(*pwds) != 0), nil
 }
 
 func (r ContainerRegistryTokenPasswordResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_token_resource.go
+++ b/internal/services/containers/container_registry_token_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/scopemaps"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceContainerRegistryToken() *pluginsdk.Resource {
@@ -106,7 +106,7 @@ func resourceContainerRegistryTokenCreate(d *pluginsdk.ResourceData, meta interf
 
 	parameters := tokens.Token{
 		Properties: &tokens.TokenProperties{
-			ScopeMapId: utils.String(scopeMapID),
+			ScopeMapId: pointer.To(scopeMapID),
 			Status:     &status,
 		},
 	}
@@ -144,7 +144,7 @@ func resourceContainerRegistryTokenUpdate(d *pluginsdk.ResourceData, meta interf
 
 	parameters := tokens.TokenUpdateParameters{
 		Properties: &tokens.TokenUpdateProperties{
-			ScopeMapId: utils.String(scopeMapID),
+			ScopeMapId: pointer.To(scopeMapID),
 			Status:     &status,
 		},
 	}

--- a/internal/services/containers/container_registry_token_resource_test.go
+++ b/internal/services/containers/container_registry_token_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/tokens"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryTokenResource struct{}
@@ -102,7 +102,7 @@ func (t ContainerRegistryTokenResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ContainerRegistryTokenResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/container_registry_webhook_resource_test.go
+++ b/internal/services/containers/container_registry_webhook_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2025-04-01/webhooks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContainerRegistryWebhookResource struct{}
@@ -634,5 +634,5 @@ func (t ContainerRegistryWebhookResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -985,20 +985,20 @@ func flattenKubernetesClusterCredentials(model *managedclusters.CredentialResult
 			if strings.Contains(rawConfig, "apiserver-id:") || strings.Contains(rawConfig, "exec") {
 				kubeConfigAAD, err := kubernetes.ParseKubeConfigAAD(rawConfig)
 				if err != nil {
-					return utils.String(rawConfig), []interface{}{}
+					return pointer.To(rawConfig), []interface{}{}
 				}
 
 				flattenedKubeConfig = flattenKubernetesClusterDataSourceKubeConfigAAD(*kubeConfigAAD)
 			} else {
 				kubeConfig, err := kubernetes.ParseKubeConfig(rawConfig)
 				if err != nil {
-					return utils.String(rawConfig), []interface{}{}
+					return pointer.To(rawConfig), []interface{}{}
 				}
 
 				flattenedKubeConfig = flattenKubernetesClusterDataSourceKubeConfig(*kubeConfig)
 			}
 
-			return utils.String(rawConfig), flattenedKubeConfig
+			return pointer.To(rawConfig), flattenedKubeConfig
 		}
 	}
 

--- a/internal/services/containers/kubernetes_cluster_extension_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_extension_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/extensions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesClusterExtensionResource struct{}
@@ -106,11 +106,11 @@ func (r KubernetesClusterExtensionResource) Exists(ctx context.Context, clients 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KubernetesClusterExtensionResource) template(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1718,7 +1718,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	dnsPrefix := d.Get("dns_prefix").(string)
 	kubernetesVersion := d.Get("kubernetes_version").(string)
 

--- a/internal/services/containers/kubernetes_cluster_trusted_access_role_binding_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_trusted_access_role_binding_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-07-01/trustedaccess"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesClusterTrustedAccessRoleBindingTestResource struct{}
@@ -59,7 +59,7 @@ func (r KubernetesClusterTrustedAccessRoleBindingTestResource) Exists(ctx contex
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KubernetesClusterTrustedAccessRoleBindingTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_fleet_manager_resource_test.go
+++ b/internal/services/containers/kubernetes_fleet_manager_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-04-01/fleets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesFleetManagerTestResource struct{}
@@ -103,7 +103,7 @@ func (r KubernetesFleetManagerTestResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KubernetesFleetManagerTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_fleet_member_resource_gen_test.go
+++ b/internal/services/containers/kubernetes_fleet_member_resource_gen_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-04-01/fleetmembers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesFleetMemberTestResource struct{}
@@ -103,7 +103,7 @@ func (r KubernetesFleetMemberTestResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KubernetesFleetMemberTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_fleet_update_run_resource.go
+++ b/internal/services/containers/kubernetes_fleet_update_run_resource.go
@@ -385,7 +385,7 @@ func expandKubernetesFleetUpdateRunStage(input []KubernetesFleetUpdateRunResourc
 	for _, stage := range input {
 		output = append(output, updateruns.UpdateStage{
 			Name:                    stage.Name,
-			AfterStageWaitInSeconds: pointer.FromInt64(stage.AfterStageWaitInSeconds),
+			AfterStageWaitInSeconds: pointer.To(stage.AfterStageWaitInSeconds),
 			Groups:                  expandKubernetesFleetUpdateRunGroup(stage.Group),
 		})
 	}

--- a/internal/services/containers/kubernetes_fleet_update_strategy_resource.go
+++ b/internal/services/containers/kubernetes_fleet_update_strategy_resource.go
@@ -245,7 +245,7 @@ func expandKubernetesFleetUpdateStrategyStage(input []KubernetesFleetUpdateStrat
 	for _, stage := range input {
 		output = append(output, fleetupdatestrategies.UpdateStage{
 			Name:                    stage.Name,
-			AfterStageWaitInSeconds: pointer.FromInt64(stage.AfterStageWaitInSeconds),
+			AfterStageWaitInSeconds: pointer.To(stage.AfterStageWaitInSeconds),
 			Groups:                  expandKubernetesFleetUpdateStrategyGroup(stage.Group),
 		})
 	}
@@ -267,7 +267,7 @@ func flattenKubernetesFleetUpdateStrategyStage(input []fleetupdatestrategies.Upd
 	for _, stage := range input {
 		output = append(output, KubernetesFleetUpdateStrategyResourceUpdateStageSchema{
 			Name:                    stage.Name,
-			AfterStageWaitInSeconds: pointer.ToInt64(stage.AfterStageWaitInSeconds),
+			AfterStageWaitInSeconds: pointer.From(stage.AfterStageWaitInSeconds),
 			Group:                   flattenKubernetesFleetUpdateStrategyGroup(stage.Groups),
 		})
 	}

--- a/internal/services/containers/kubernetes_fleet_update_strategy_resource_test.go
+++ b/internal/services/containers/kubernetes_fleet_update_strategy_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2024-04-01/fleetupdatestrategies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesFleetUpdateStrategyTestResource struct{}
@@ -103,7 +103,7 @@ func (r KubernetesFleetUpdateStrategyTestResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KubernetesFleetUpdateStrategyTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_flux_configuration_resource.go
+++ b/internal/services/containers/kubernetes_flux_configuration_resource.go
@@ -18,7 +18,6 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/accounts"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/containers"
 )
@@ -643,7 +642,7 @@ func (r KubernetesFluxConfigurationResource) Create() sdk.ResourceFunc {
 				Properties: &fluxconfiguration.FluxConfigurationProperties{
 					Kustomizations: expandKustomizationDefinitionModel(model.Kustomizations),
 					Scope:          pointer.To(fluxconfiguration.ScopeType(model.Scope)),
-					Suspend:        utils.Bool(!model.ContinuousReconciliationEnabled),
+					Suspend:        pointer.To(!model.ContinuousReconciliationEnabled),
 				},
 			}
 
@@ -753,7 +752,7 @@ func (r KubernetesFluxConfigurationResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("continuous_reconciliation_enabled") {
-				properties.Properties.Suspend = utils.Bool(!model.ContinuousReconciliationEnabled)
+				properties.Properties.Suspend = pointer.To(!model.ContinuousReconciliationEnabled)
 			}
 
 			if properties.Properties.ConfigurationProtectedSettings == nil {
@@ -928,7 +927,7 @@ func expandKustomizationDefinitionModel(inputList []KustomizationDefinitionModel
 		}
 
 		if input.Path != "" {
-			output.Path = utils.String(input.Path)
+			output.Path = pointer.To(input.Path)
 		}
 
 		outputList[input.Name] = output
@@ -1016,7 +1015,7 @@ func expandBucketDefinitionModel(inputList []BucketDefinitionModel) (*fluxconfig
 
 	input := &inputList[0]
 	output := fluxconfiguration.BucketDefinition{
-		Insecure:              utils.Bool(!input.TlsEnabled),
+		Insecure:              pointer.To(!input.TlsEnabled),
 		SyncIntervalInSeconds: &input.SyncIntervalInSeconds,
 		TimeoutInSeconds:      &input.TimeoutInSeconds,
 	}

--- a/internal/services/containers/kubernetes_flux_configuration_resource_test.go
+++ b/internal/services/containers/kubernetes_flux_configuration_resource_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2024-11-01/fluxconfiguration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesFluxConfigurationResource struct{}
@@ -304,11 +304,11 @@ func (r KubernetesFluxConfigurationResource) Exists(ctx context.Context, clients
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KubernetesFluxConfigurationResource) template(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_node_pool_snapshot_data_source_test.go
+++ b/internal/services/containers/kubernetes_node_pool_snapshot_data_source_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-07-01/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-07-01/snapshots"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KubernetesNodePoolSnapshotDataSource struct{}
@@ -44,7 +44,7 @@ func TestAccDataSourceKubernetesNodePoolSnapshot_basic(t *testing.T) {
 						Location: data.Locations.Primary,
 						Properties: &snapshots.SnapshotProperties{
 							CreationData: &snapshots.CreationData{
-								SourceResourceId: utils.String(poolId.ID()),
+								SourceResourceId: pointer.To(poolId.ID()),
 							},
 						},
 					}

--- a/internal/services/containers/migration/kubernetes_cluster_node_pool_test.go
+++ b/internal/services/containers/migration/kubernetes_cluster_node_pool_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestKubernetesClusterNodePoolV0ToV1_id(t *testing.T) {
@@ -30,7 +30,7 @@ func TestKubernetesClusterNodePoolV0ToV1_id(t *testing.T) {
 				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
 				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1"),
 		},
 		{
 			name: "new id",
@@ -38,7 +38,7 @@ func TestKubernetesClusterNodePoolV0ToV1_id(t *testing.T) {
 				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
 				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1"),
 		},
 	}
 	for _, test := range testData {
@@ -82,7 +82,7 @@ func TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id(t *testing.T) {
 				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
 				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
 		},
 		{
 			name: "new id",
@@ -90,7 +90,7 @@ func TestKubernetesClusterNodePoolV0ToV1_kubernetes_cluster_id(t *testing.T) {
 				"id":                    "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1/agentPools/pool1",
 				"kubernetes_cluster_id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/containers/migration/kubernetes_cluster_test.go
+++ b/internal/services/containers/migration/kubernetes_cluster_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestKubernetesClusterV0ToV1(t *testing.T) {
@@ -28,14 +28,14 @@ func TestKubernetesClusterV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/cosmos/common/autoscale_settings.go
+++ b/internal/services/cosmos/common/autoscale_settings.go
@@ -7,9 +7,9 @@ import (
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func ExpandCosmosDbAutoscaleSettingsLegacy(d *pluginsdk.ResourceData) *documentdb.AutoscaleSettings {
@@ -23,7 +23,7 @@ func ExpandCosmosDbAutoscaleSettingsLegacy(d *pluginsdk.ResourceData) *documentd
 	autoscaleSettings := documentdb.AutoscaleSettings{}
 
 	if maxThroughput, ok := input["max_throughput"].(int); ok {
-		autoscaleSettings.MaxThroughput = utils.Int32(int32(maxThroughput))
+		autoscaleSettings.MaxThroughput = pointer.To(int32(maxThroughput))
 	}
 
 	return &autoscaleSettings
@@ -40,7 +40,7 @@ func ExpandCosmosDbAutoscaleSettings(d *pluginsdk.ResourceData) *cosmosdb.AutoSc
 	autoscaleSettings := cosmosdb.AutoScaleSettings{}
 
 	if maxThroughput, ok := input["max_throughput"].(int); ok {
-		autoscaleSettings.MaxThroughput = utils.Int64(int64(maxThroughput))
+		autoscaleSettings.MaxThroughput = pointer.To(int64(maxThroughput))
 	}
 
 	return &autoscaleSettings

--- a/internal/services/cosmos/common/conflict_resolution_policy.go
+++ b/internal/services/cosmos/common/conflict_resolution_policy.go
@@ -4,8 +4,8 @@
 package common
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func ExpandCosmosDbConflicResolutionPolicy(inputs []interface{}) *cosmosdb.ConflictResolutionPolicy {
@@ -20,11 +20,11 @@ func ExpandCosmosDbConflicResolutionPolicy(inputs []interface{}) *cosmosdb.Confl
 	}
 
 	if conflictResolutionPath, ok := input["conflict_resolution_path"].(string); ok {
-		conflict.ConflictResolutionPath = utils.String(conflictResolutionPath)
+		conflict.ConflictResolutionPath = pointer.To(conflictResolutionPath)
 	}
 
 	if conflictResolutionProcedure, ok := input["conflict_resolution_procedure"].(string); ok {
-		conflict.ConflictResolutionProcedure = utils.String(conflictResolutionProcedure)
+		conflict.ConflictResolutionProcedure = pointer.To(conflictResolutionProcedure)
 	}
 
 	return conflict

--- a/internal/services/cosmos/common/cors_rule.go
+++ b/internal/services/cosmos/common/cors_rule.go
@@ -96,12 +96,12 @@ func ExpandCosmosCorsRule(input []interface{}) *[]cosmosdb.CorsPolicy {
 		corsRuleAttr := attr.(map[string]interface{})
 		corsRule := cosmosdb.CorsPolicy{}
 		corsRule.AllowedOrigins = strings.Join(*utils.ExpandStringSlice(corsRuleAttr["allowed_origins"].([]interface{})), ",")
-		corsRule.ExposedHeaders = utils.String(strings.Join(*utils.ExpandStringSlice(corsRuleAttr["exposed_headers"].([]interface{})), ","))
-		corsRule.AllowedHeaders = utils.String(strings.Join(*utils.ExpandStringSlice(corsRuleAttr["allowed_headers"].([]interface{})), ","))
-		corsRule.AllowedMethods = utils.String(strings.Join(*utils.ExpandStringSlice(corsRuleAttr["allowed_methods"].([]interface{})), ","))
+		corsRule.ExposedHeaders = pointer.To(strings.Join(*utils.ExpandStringSlice(corsRuleAttr["exposed_headers"].([]interface{})), ","))
+		corsRule.AllowedHeaders = pointer.To(strings.Join(*utils.ExpandStringSlice(corsRuleAttr["allowed_headers"].([]interface{})), ","))
+		corsRule.AllowedMethods = pointer.To(strings.Join(*utils.ExpandStringSlice(corsRuleAttr["allowed_methods"].([]interface{})), ","))
 
 		if corsRuleAttr["max_age_in_seconds"].(int) != 0 {
-			corsRule.MaxAgeInSeconds = utils.Int64(int64(corsRuleAttr["max_age_in_seconds"].(int)))
+			corsRule.MaxAgeInSeconds = pointer.To(int64(corsRuleAttr["max_age_in_seconds"].(int)))
 		}
 
 		corsRules = append(corsRules, corsRule)

--- a/internal/services/cosmos/common/indexing_policy.go
+++ b/internal/services/cosmos/common/indexing_policy.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func expandAzureRmCosmosDBIndexingPolicyIncludedPaths(input []interface{}) *[]cosmosdb.IncludedPath {
@@ -21,7 +21,7 @@ func expandAzureRmCosmosDBIndexingPolicyIncludedPaths(input []interface{}) *[]co
 	for _, v := range input {
 		includedPath := v.(map[string]interface{})
 		path := cosmosdb.IncludedPath{
-			Path: utils.String(includedPath["path"].(string)),
+			Path: pointer.To(includedPath["path"].(string)),
 		}
 
 		includedPaths = append(includedPaths, path)
@@ -39,7 +39,7 @@ func expandAzureRmCosmosDBIndexingPolicyExcludedPaths(input []interface{}) *[]co
 	for _, v := range input {
 		block := v.(map[string]interface{})
 		paths = append(paths, cosmosdb.ExcludedPath{
-			Path: utils.String(block["path"].(string)),
+			Path: pointer.To(block["path"].(string)),
 		})
 	}
 
@@ -57,7 +57,7 @@ func ExpandAzureRmCosmosDBIndexingPolicyCompositeIndexes(input []interface{}) *[
 
 			order := cosmosdb.CompositePathSortOrder(strings.ToLower(data["order"].(string)))
 			index := cosmosdb.CompositePath{
-				Path:  utils.String(data["path"].(string)),
+				Path:  pointer.To(data["path"].(string)),
 				Order: &order,
 			}
 			indexPairs = append(indexPairs, index)
@@ -85,7 +85,7 @@ func ExpandAzureRmCosmosDBIndexingPolicySpatialIndexes(input []interface{}) *[]c
 		indexPair := i.(map[string]interface{})
 		indexes = append(indexes, cosmosdb.SpatialSpec{
 			Types: &spatialTypes,
-			Path:  utils.String(indexPair["path"].(string)),
+			Path:  pointer.To(indexPair["path"].(string)),
 		})
 	}
 

--- a/internal/services/cosmos/common/indexing_policy_test.go
+++ b/internal/services/cosmos/common/indexing_policy_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
@@ -42,10 +41,10 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeConsistent),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 			},
@@ -57,10 +56,10 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeConsistent),
 				ExcludedPaths: &[]cosmosdb.ExcludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 			},
@@ -72,18 +71,18 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeConsistent),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 				ExcludedPaths: &[]cosmosdb.ExcludedPath{
 					{
-						Path: utils.String("/testing/?"),
+						Path: pointer.To("/testing/?"),
 					},
 					{
-						Path: utils.String("/bar/?"),
+						Path: pointer.To("/bar/?"),
 					},
 				},
 			},
@@ -95,21 +94,21 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeConsistent),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 				ExcludedPaths: &[]cosmosdb.ExcludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 					{
-						Path: utils.String("/testing/?"),
+						Path: pointer.To("/testing/?"),
 					},
 					{
-						Path: utils.String("/bar/?"),
+						Path: pointer.To("/bar/?"),
 					},
 				},
 			},
@@ -121,10 +120,10 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeConsistent),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/testing/?"),
+						Path: pointer.To("/testing/?"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 			},
@@ -136,18 +135,18 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeConsistent),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 				ExcludedPaths: &[]cosmosdb.ExcludedPath{
 					{
-						Path: utils.String("/bar/?"),
+						Path: pointer.To("/bar/?"),
 					},
 					{
-						Path: utils.String("/foo/?"),
+						Path: pointer.To("/foo/?"),
 					},
 				},
 			},
@@ -159,7 +158,7 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeNone),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 				},
 			},
@@ -171,7 +170,7 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeNone),
 				ExcludedPaths: &[]cosmosdb.ExcludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 				},
 			},
@@ -183,12 +182,12 @@ func TestValidateAzureRmCosmosDbIndexingPolicy(t *testing.T) {
 				IndexingMode: pointer.To(cosmosdb.IndexingModeNone),
 				IncludedPaths: &[]cosmosdb.IncludedPath{
 					{
-						Path: utils.String("/*"),
+						Path: pointer.To("/*"),
 					},
 				},
 				ExcludedPaths: &[]cosmosdb.ExcludedPath{
 					{
-						Path: utils.String("/testing/?"),
+						Path: pointer.To("/testing/?"),
 					},
 				},
 			},

--- a/internal/services/cosmos/common/ip_rules.go
+++ b/internal/services/cosmos/common/ip_rules.go
@@ -6,8 +6,8 @@ package common
 import (
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // CosmosDBIpRulesToIpRangeFilterDataSource todo Remove for 4.0
@@ -37,7 +37,7 @@ func CosmosDBIpRangeFilterToIpRules(ipRangeFilter []string) *[]cosmosdb.IPAddres
 	ipRules := make([]cosmosdb.IPAddressOrRange, 0)
 	for _, ipRange := range ipRangeFilter {
 		ipRules = append(ipRules, cosmosdb.IPAddressOrRange{
-			IPAddressOrRange: utils.String(ipRange),
+			IPAddressOrRange: pointer.To(ipRange),
 		})
 	}
 
@@ -50,7 +50,7 @@ func CosmosDBIpRangeFilterToIpRulesThreePointOh(ipRangeFilter string) *[]cosmosd
 	if len(ipRangeFilter) > 0 {
 		for _, ipRange := range strings.Split(ipRangeFilter, ",") {
 			ipRules = append(ipRules, cosmosdb.IPAddressOrRange{
-				IPAddressOrRange: utils.String(ipRange),
+				IPAddressOrRange: pointer.To(ipRange),
 			})
 		}
 	}

--- a/internal/services/cosmos/common/throughput.go
+++ b/internal/services/cosmos/common/throughput.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func GetThroughputFromResultLegacy(throughputResponse documentdb.ThroughputSettingsGetResults) *int32 {
@@ -41,11 +41,11 @@ func GetThroughputFromResult(throughputResponse cosmosdb.ThroughputSettingsGetRe
 }
 
 func ConvertThroughputFromResourceDataLegacy(throughput interface{}) *int32 {
-	return utils.Int32(int32(throughput.(int)))
+	return pointer.To(int32(throughput.(int)))
 }
 
 func ConvertThroughputFromResourceData(throughput interface{}) *int64 {
-	return utils.Int64(int64(throughput.(int)))
+	return pointer.To(int64(throughput.(int)))
 }
 
 func ExpandCosmosDBThroughputSettingsUpdateParametersLegacy(d *pluginsdk.ResourceData) *documentdb.ThroughputSettingsUpdateParameters {

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1002,15 +1002,15 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 
 	if existing.Model.Properties.Locations != nil {
 		for _, l := range *existing.Model.Properties.Locations {
-			location := cosmosdb.Location{
+			loc := cosmosdb.Location{
 				Id:               l.Id,
 				LocationName:     l.LocationName,
 				FailoverPriority: l.FailoverPriority,
 				IsZoneRedundant:  l.IsZoneRedundant,
 			}
 
-			cosmosLocations = append(cosmosLocations, location)
-			cosmosLocationsMap[azure.NormalizeLocation(*location.LocationName)] = location
+			cosmosLocations = append(cosmosLocations, loc)
+			cosmosLocationsMap[location.Normalize(*loc.LocationName)] = loc
 		}
 	}
 
@@ -1678,7 +1678,7 @@ func resourceCosmosDbAccountApiCreateOrUpdate(client *cosmosdb.CosmosDBClient, c
 
 				for _, desiredLocation := range account.Properties.Locations {
 					for index, l := range locations {
-						if azure.NormalizeLocation(*desiredLocation.LocationName) == azure.NormalizeLocation(*l.LocationName) {
+						if location.Normalize(*desiredLocation.LocationName) == location.Normalize(*l.LocationName) {
 							break
 						}
 
@@ -1723,7 +1723,7 @@ func expandAzureRmCosmosDBAccountConsistencyPolicy(d *pluginsdk.ResourceData) *c
 		if stalenessPrefix == 0 {
 			stalenessPrefix = 100
 		}
-		policy.MaxStalenessPrefix = pointer.FromInt64(int64(stalenessPrefix))
+		policy.MaxStalenessPrefix = pointer.To(int64(stalenessPrefix))
 	}
 	if maxInterval, ok := input["max_interval_in_seconds"].(int); ok {
 		if maxInterval == 0 {
@@ -1741,9 +1741,9 @@ func expandAzureRmCosmosDBAccountGeoLocations(d *pluginsdk.ResourceData) ([]cosm
 		data := l.(map[string]interface{})
 
 		location := cosmosdb.Location{
-			LocationName:     pointer.To(azure.NormalizeLocation(data["location"].(string))),
+			LocationName:     pointer.To(location.Normalize(data["location"].(string))),
 			FailoverPriority: pointer.To(int64(data["failover_priority"].(int))),
-			IsZoneRedundant:  pointer.FromBool(data["zone_redundant"].(bool)),
+			IsZoneRedundant:  pointer.To(data["zone_redundant"].(bool)),
 		}
 
 		locations = append(locations, location)
@@ -1802,7 +1802,7 @@ func expandAzureRmCosmosDBAccountVirtualNetworkRules(d *pluginsdk.ResourceData) 
 		m := r.(map[string]interface{})
 		s[i] = cosmosdb.VirtualNetworkRule{
 			Id:                               pointer.To(m["id"].(string)),
-			IgnoreMissingVNetServiceEndpoint: pointer.FromBool(m["ignore_missing_vnet_service_endpoint"].(bool)),
+			IgnoreMissingVNetServiceEndpoint: pointer.To(m["ignore_missing_vnet_service_endpoint"].(bool)),
 		}
 	}
 

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -2589,7 +2589,7 @@ func checkAccCosmosDBAccount_basic(data acceptance.TestData, consistency cosmosd
 	return acceptance.ComposeTestCheckFunc(
 		check.That(data.ResourceName).Key("name").Exists(),
 		check.That(data.ResourceName).Key("resource_group_name").Exists(),
-		check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+		check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 		check.That(data.ResourceName).Key("tags.%").HasValue("0"),
 		check.That(data.ResourceName).Key("offer_type").HasValue(string(cosmosdb.DatabaseAccountOfferTypeStandard)),
 		check.That(data.ResourceName).Key("consistency_policy.0.consistency_level").HasValue(string(consistency)),

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/attestation/validate"
@@ -25,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceCassandraCluster() *pluginsdk.Resource {
@@ -170,14 +168,14 @@ func resourceCassandraClusterCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	body := managedcassandras.ClusterResource{
 		Identity: expandedIdentity,
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &managedcassandras.ClusterResourceProperties{
 			AuthenticationMethod:          &authenticationMethod,
-			CassandraVersion:              utils.String(d.Get("version").(string)),
-			DelegatedManagementSubnetId:   utils.String(d.Get("delegated_management_subnet_id").(string)),
-			HoursBetweenBackups:           utils.Int64(int64(d.Get("hours_between_backups").(int))),
-			InitialCassandraAdminPassword: utils.String(d.Get("default_admin_password").(string)),
-			RepairEnabled:                 utils.Bool(d.Get("repair_enabled").(bool)),
+			CassandraVersion:              pointer.To(d.Get("version").(string)),
+			DelegatedManagementSubnetId:   pointer.To(d.Get("delegated_management_subnet_id").(string)),
+			HoursBetweenBackups:           pointer.To(int64(d.Get("hours_between_backups").(int))),
+			InitialCassandraAdminPassword: pointer.To(d.Get("default_admin_password").(string)),
+			RepairEnabled:                 pointer.To(d.Get("repair_enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -287,14 +285,14 @@ func resourceCassandraClusterUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	body := managedcassandras.ClusterResource{
 		Identity: expandedIdentity,
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &managedcassandras.ClusterResourceProperties{
 			AuthenticationMethod:          &authenticationMethod,
-			CassandraVersion:              utils.String(d.Get("version").(string)),
-			DelegatedManagementSubnetId:   utils.String(d.Get("delegated_management_subnet_id").(string)),
-			HoursBetweenBackups:           utils.Int64(int64(d.Get("hours_between_backups").(int))),
-			InitialCassandraAdminPassword: utils.String(d.Get("default_admin_password").(string)),
-			RepairEnabled:                 utils.Bool(d.Get("repair_enabled").(bool)),
+			CassandraVersion:              pointer.To(d.Get("version").(string)),
+			DelegatedManagementSubnetId:   pointer.To(d.Get("delegated_management_subnet_id").(string)),
+			HoursBetweenBackups:           pointer.To(int64(d.Get("hours_between_backups").(int))),
+			InitialCassandraAdminPassword: pointer.To(d.Get("default_admin_password").(string)),
+			RepairEnabled:                 pointer.To(d.Get("repair_enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -387,7 +385,7 @@ func expandCassandraClusterCertificate(input []interface{}) *[]managedcassandras
 
 	for _, pem := range input {
 		result := managedcassandras.Certificate{
-			Pem: utils.String(pem.(string)),
+			Pem: pointer.To(pem.(string)),
 		}
 		results = append(results, result)
 	}
@@ -400,7 +398,7 @@ func expandCassandraClusterExternalSeedNode(input []interface{}) *[]managedcassa
 
 	for _, ipAddress := range input {
 		result := managedcassandras.SeedNode{
-			IPAddress: utils.String(ipAddress.(string)),
+			IPAddress: pointer.To(ipAddress.(string)),
 		}
 		results = append(results, result)
 	}

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CassandraClusterResource struct{}
@@ -100,7 +100,7 @@ func (t CassandraClusterResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CassandraClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
@@ -9,12 +9,12 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/validate"
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceCassandraDatacenter() *pluginsdk.Resource {
@@ -155,29 +154,29 @@ func resourceCassandraDatacenterCreate(d *pluginsdk.ResourceData, meta interface
 
 	payload := managedcassandras.DataCenterResource{
 		Properties: &managedcassandras.DataCenterResourceProperties{
-			DelegatedSubnetId:  utils.String(d.Get("delegated_management_subnet_id").(string)),
-			NodeCount:          utils.Int64(int64(d.Get("node_count").(int))),
-			AvailabilityZone:   utils.Bool(d.Get("availability_zones_enabled").(bool)),
-			DiskCapacity:       utils.Int64(int64(d.Get("disk_count").(int))),
-			DiskSku:            utils.String(d.Get("disk_sku").(string)),
-			DataCenterLocation: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+			DelegatedSubnetId:  pointer.To(d.Get("delegated_management_subnet_id").(string)),
+			NodeCount:          pointer.To(int64(d.Get("node_count").(int))),
+			AvailabilityZone:   pointer.To(d.Get("availability_zones_enabled").(bool)),
+			DiskCapacity:       pointer.To(int64(d.Get("disk_count").(int))),
+			DiskSku:            pointer.To(d.Get("disk_sku").(string)),
+			DataCenterLocation: pointer.To(location.Normalize(d.Get("location").(string))),
 		},
 	}
 
 	if v, ok := d.GetOk("backup_storage_customer_key_uri"); ok {
-		payload.Properties.BackupStorageCustomerKeyUri = utils.String(v.(string))
+		payload.Properties.BackupStorageCustomerKeyUri = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("base64_encoded_yaml_fragment"); ok {
-		payload.Properties.Base64EncodedCassandraYamlFragment = utils.String(v.(string))
+		payload.Properties.Base64EncodedCassandraYamlFragment = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("managed_disk_customer_key_uri"); ok {
-		payload.Properties.ManagedDiskCustomerKeyUri = utils.String(v.(string))
+		payload.Properties.ManagedDiskCustomerKeyUri = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("sku_name"); ok {
-		payload.Properties.Sku = utils.String(v.(string))
+		payload.Properties.Sku = pointer.To(v.(string))
 	}
 
 	if err = client.CassandraDataCentersCreateUpdateThenPoll(ctx, id, payload); err != nil {
@@ -245,24 +244,24 @@ func resourceCassandraDatacenterUpdate(d *pluginsdk.ResourceData, meta interface
 
 	payload := managedcassandras.DataCenterResource{
 		Properties: &managedcassandras.DataCenterResourceProperties{
-			DelegatedSubnetId:  utils.String(d.Get("delegated_management_subnet_id").(string)),
-			NodeCount:          utils.Int64(int64(d.Get("node_count").(int))),
-			Sku:                utils.String(d.Get("sku_name").(string)),
-			DataCenterLocation: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
-			DiskSku:            utils.String(d.Get("disk_sku").(string)),
+			DelegatedSubnetId:  pointer.To(d.Get("delegated_management_subnet_id").(string)),
+			NodeCount:          pointer.To(int64(d.Get("node_count").(int))),
+			Sku:                pointer.To(d.Get("sku_name").(string)),
+			DataCenterLocation: pointer.To(location.Normalize(d.Get("location").(string))),
+			DiskSku:            pointer.To(d.Get("disk_sku").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("backup_storage_customer_key_uri"); ok {
-		payload.Properties.BackupStorageCustomerKeyUri = utils.String(v.(string))
+		payload.Properties.BackupStorageCustomerKeyUri = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("base64_encoded_yaml_fragment"); ok {
-		payload.Properties.Base64EncodedCassandraYamlFragment = utils.String(v.(string))
+		payload.Properties.Base64EncodedCassandraYamlFragment = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("managed_disk_customer_key_uri"); ok {
-		payload.Properties.ManagedDiskCustomerKeyUri = utils.String(v.(string))
+		payload.Properties.ManagedDiskCustomerKeyUri = pointer.To(v.(string))
 	}
 
 	if err := client.CassandraDataCentersCreateUpdateThenPoll(ctx, *id, payload); err != nil {

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/managedcassandras"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CassandraDatacenterResource struct{}
@@ -101,7 +101,7 @@ func (t CassandraDatacenterResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CassandraDatacenterResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_keyspace_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbCassandraKeyspaceResource struct{}
@@ -132,7 +132,7 @@ func (t CosmosDbCassandraKeyspaceResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading Cosmos Cassandra Keyspace (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (CosmosDbCassandraKeyspaceResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -125,11 +126,11 @@ func resourceCosmosDbCassandraTableCreate(d *pluginsdk.ResourceData, meta interf
 	table.Resource.Schema = expandTableSchema(d)
 
 	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
-		table.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
+		table.Resource.DefaultTTL = pointer.To(int32(defaultTTL.(int)))
 	}
 
 	if analyticalTTL, ok := d.GetOk("analytical_storage_ttl"); ok {
-		table.Resource.AnalyticalStorageTTL = utils.Int32(int32(analyticalTTL.(int)))
+		table.Resource.AnalyticalStorageTTL = pointer.To(int32(analyticalTTL.(int)))
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
@@ -183,7 +184,7 @@ func resourceCosmosDbCassandraTableUpdate(d *pluginsdk.ResourceData, meta interf
 	table.Resource.Schema = expandTableSchema(d)
 
 	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
-		table.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
+		table.Resource.DefaultTTL = pointer.To(int32(defaultTTL.(int)))
 	}
 
 	future, err := client.CreateUpdateCassandraTable(ctx, id.ResourceGroup, id.DatabaseAccountName, id.CassandraKeyspaceName, id.TableName, table)
@@ -337,8 +338,8 @@ func expandTableSchemaColumns(input []interface{}) *[]documentdb.Column {
 	for _, col := range input {
 		data := col.(map[string]interface{})
 		column := documentdb.Column{
-			Name: utils.String(data["name"].(string)),
-			Type: utils.String(data["type"].(string)),
+			Name: pointer.To(data["name"].(string)),
+			Type: pointer.To(data["type"].(string)),
 		}
 		columns = append(columns, column)
 	}
@@ -351,7 +352,7 @@ func expandTableSchemaPartitionKeys(input []interface{}) *[]documentdb.Cassandra
 	for _, key := range input {
 		data := key.(map[string]interface{})
 		k := documentdb.CassandraPartitionKey{
-			Name: utils.String(data["name"].(string)),
+			Name: pointer.To(data["name"].(string)),
 		}
 		keys = append(keys, k)
 	}
@@ -364,8 +365,8 @@ func expandTableSchemaClusterKeys(input []interface{}) *[]documentdb.ClusterKey 
 	for _, key := range input {
 		data := key.(map[string]interface{})
 		k := documentdb.ClusterKey{
-			Name:    utils.String(data["name"].(string)),
-			OrderBy: utils.String(data["order_by"].(string)),
+			Name:    pointer.To(data["name"].(string)),
+			OrderBy: pointer.To(data["order_by"].(string)),
 		}
 		keys = append(keys, k)
 	}

--- a/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_table_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDBCassandraTableResource struct{}
@@ -29,7 +29,7 @@ func (t CosmosDBCassandraTableResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("reading Cosmos Cassandra Table (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func TestAccCosmosDbCassandraTable_basic(t *testing.T) {

--- a/internal/services/cosmos/cosmosdb_gremlin_database_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_database_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosGremlinDatabaseResource struct{}
@@ -133,7 +133,7 @@ func (t CosmosGremlinDatabaseResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading Cosmos Gremlin Database (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosGremlinDatabaseResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
@@ -226,7 +227,7 @@ func resourceCosmosDbGremlinGraphCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if v, ok := d.GetOk("analytical_storage_ttl"); ok {
-		db.Properties.Resource.AnalyticalStorageTtl = utils.Int64(int64(v.(int)))
+		db.Properties.Resource.AnalyticalStorageTtl = pointer.To(int64(v.(int)))
 	}
 
 	if partitionkeypaths != "" {
@@ -236,7 +237,7 @@ func resourceCosmosDbGremlinGraphCreate(d *pluginsdk.ResourceData, meta interfac
 			Kind:  &partitionKindHash,
 		}
 		if partitionKeyVersion, ok := d.GetOk("partition_key_version"); ok {
-			db.Properties.Resource.PartitionKey.Version = utils.Int64(int64(partitionKeyVersion.(int)))
+			db.Properties.Resource.PartitionKey.Version = pointer.To(int64(partitionKeyVersion.(int)))
 		}
 	}
 
@@ -248,7 +249,7 @@ func resourceCosmosDbGremlinGraphCreate(d *pluginsdk.ResourceData, meta interfac
 
 	if defaultTTL, hasDefaultTTL := d.GetOk("default_ttl"); hasDefaultTTL {
 		if defaultTTL != 0 {
-			db.Properties.Resource.DefaultTtl = utils.Int64(int64(defaultTTL.(int)))
+			db.Properties.Resource.DefaultTtl = pointer.To(int64(defaultTTL.(int)))
 		}
 	}
 
@@ -307,7 +308,7 @@ func resourceCosmosDbGremlinGraphUpdate(d *pluginsdk.ResourceData, meta interfac
 		}
 
 		if partitionKeyVersion, ok := d.GetOk("partition_key_version"); ok {
-			db.Properties.Resource.PartitionKey.Version = utils.Int64(int64(partitionKeyVersion.(int)))
+			db.Properties.Resource.PartitionKey.Version = pointer.To(int64(partitionKeyVersion.(int)))
 		}
 	}
 
@@ -318,11 +319,11 @@ func resourceCosmosDbGremlinGraphUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if v, ok := d.GetOk("analytical_storage_ttl"); ok {
-		db.Properties.Resource.AnalyticalStorageTtl = utils.Int64(int64(v.(int)))
+		db.Properties.Resource.AnalyticalStorageTtl = pointer.To(int64(v.(int)))
 	}
 
 	if defaultTTL, hasDefaultTTL := d.GetOk("default_ttl"); hasDefaultTTL {
-		db.Properties.Resource.DefaultTtl = utils.Int64(int64(defaultTTL.(int)))
+		db.Properties.Resource.DefaultTtl = pointer.To(int64(defaultTTL.(int)))
 	}
 
 	err = client.GremlinResourcesCreateUpdateGremlinGraphThenPoll(ctx, *id, db)
@@ -476,7 +477,7 @@ func expandAzureRmCosmosDbGremlinGraphIndexingPolicy(d *pluginsdk.ResourceData) 
 	policy.SpatialIndexes = common.ExpandAzureRmCosmosDBIndexingPolicySpatialIndexes(input["spatial_index"].([]interface{}))
 
 	if automatic, ok := input["automatic"].(bool); ok {
-		policy.Automatic = utils.Bool(automatic)
+		policy.Automatic = pointer.To(automatic)
 	}
 
 	return policy
@@ -489,7 +490,7 @@ func expandAzureRmCosmosDbGremlinGraphIncludedPath(input map[string]interface{})
 	for i, pathConfig := range includedPath {
 		attrs := pathConfig.(string)
 		path := cosmosdb.IncludedPath{
-			Path: utils.String(attrs),
+			Path: pointer.To(attrs),
 		}
 		paths[i] = path
 	}
@@ -504,7 +505,7 @@ func expandAzureRmCosmosDbGremlinGraphExcludedPath(input map[string]interface{})
 	for i, pathConfig := range excludedPath {
 		attrs := pathConfig.(string)
 		path := cosmosdb.ExcludedPath{
-			Path: utils.String(attrs),
+			Path: pointer.To(attrs),
 		}
 		paths[i] = path
 	}

--- a/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_gremlin_graph_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosGremlinGraphResource struct{}
@@ -224,7 +224,7 @@ func (t CosmosGremlinGraphResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("reading Cosmos Gremlin Graph (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (CosmosGremlinGraphResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -205,7 +205,7 @@ func resourceCosmosDbMongoCollectionCreate(d *pluginsdk.ResourceData, meta inter
 
 	if shardKey := d.Get("shard_key").(string); shardKey != "" {
 		db.Resource.ShardKey = map[string]*string{
-			shardKey: utils.String("Hash"), // looks like only hash is supported for now
+			shardKey: pointer.To("Hash"), // looks like only hash is supported for now
 		}
 	}
 
@@ -264,7 +264,7 @@ func resourceCosmosDbMongoCollectionUpdate(d *pluginsdk.ResourceData, meta inter
 
 	if shardKey := d.Get("shard_key").(string); shardKey != "" {
 		db.Resource.ShardKey = map[string]*string{
-			shardKey: utils.String("Hash"), // looks like only hash is supported for now
+			shardKey: pointer.To("Hash"), // looks like only hash is supported for now
 		}
 	}
 
@@ -431,7 +431,7 @@ func expandCosmosMongoCollectionIndex(indexes []interface{}, defaultTtl *int) (*
 					Keys: utils.ExpandStringSlice(index["keys"].([]interface{})),
 				},
 				Options: &documentdb.MongoIndexOptions{
-					Unique: utils.Bool(index["unique"].(bool)),
+					Unique: pointer.To(index["unique"].(bool)),
 				},
 			})
 		}

--- a/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_mongo_collection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosMongoCollectionResource struct{}
@@ -243,7 +243,7 @@ func (t CosmosMongoCollectionResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (CosmosMongoCollectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_mongo_database_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_mongo_database_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosMongoDatabaseResource struct{}
@@ -110,7 +110,7 @@ func (t CosmosMongoDatabaseResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading Cosmos Mongo Database (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (CosmosMongoDatabaseResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_mongo_role_definition_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_mongo_role_definition_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-11-15/mongorbacs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosMongoRoleDefinitionResource struct{}
@@ -96,7 +96,7 @@ func (r CosmosMongoRoleDefinitionResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosMongoRoleDefinitionResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_mongo_user_definition_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_mongo_user_definition_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-11-15/mongorbacs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosMongoUserDefinitionResource struct{}
@@ -96,7 +96,7 @@ func (r CosmosMongoUserDefinitionResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosMongoUserDefinitionResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var CosmosDbPostgreSQLClusterResourceName = "azurerm_cosmosdb_postgresql_cluster"
@@ -375,11 +374,11 @@ func (r CosmosDbPostgreSQLClusterResource) Create() sdk.ResourceFunc {
 			}
 
 			if v := model.NodeStorageQuotaInMb; v != 0 {
-				parameters.Properties.NodeStorageQuotaInMb = utils.Int64(model.NodeStorageQuotaInMb)
+				parameters.Properties.NodeStorageQuotaInMb = pointer.To(model.NodeStorageQuotaInMb)
 			}
 
 			if v := model.NodeVCores; v != 0 {
-				parameters.Properties.NodeVCores = utils.Int64(model.NodeVCores)
+				parameters.Properties.NodeVCores = pointer.To(model.NodeVCores)
 			}
 
 			if v := model.PointInTimeInUTC; v != "" {
@@ -414,7 +413,7 @@ func (r CosmosDbPostgreSQLClusterResource) Create() sdk.ResourceFunc {
 			// As `shards_on_coordinator_enabled` is `bool` and it's always set to `false` as zero value when it isn't set, so we cannot use `model.ShardsOnCoordinatorEnabled` to check if this property is set in tf config.
 			// nolint staticcheck
 			if v, ok := metadata.ResourceData.GetOkExists("shards_on_coordinator_enabled"); ok {
-				parameters.Properties.EnableShardsOnCoordinator = utils.Bool(v.(bool))
+				parameters.Properties.EnableShardsOnCoordinator = pointer.To(v.(bool))
 			}
 
 			if v := model.Tags; v != nil {
@@ -508,11 +507,11 @@ func (r CosmosDbPostgreSQLClusterResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("node_storage_quota_in_mb") {
-				parameters.Properties.NodeStorageQuotaInMb = utils.Int64(model.NodeStorageQuotaInMb)
+				parameters.Properties.NodeStorageQuotaInMb = pointer.To(model.NodeStorageQuotaInMb)
 			}
 
 			if metadata.ResourceData.HasChange("node_vcores") {
-				parameters.Properties.NodeVCores = utils.Int64(model.NodeVCores)
+				parameters.Properties.NodeVCores = pointer.To(model.NodeVCores)
 			}
 
 			if metadata.ResourceData.HasChange("preferred_primary_zone") {

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbPostgreSQLClusterResource struct{}
@@ -122,11 +122,11 @@ func (r CosmosDbPostgreSQLClusterResource) Exists(ctx context.Context, clients *
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosDbPostgreSQLClusterResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbPostgreSQLCoordinatorConfigurationResource struct{}
@@ -66,11 +66,11 @@ func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Exists(ctx context.C
 	resp, err := client.GetCoordinator(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_postgresql_firewall_rule_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_firewall_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/firewallrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbPostgreSQLFirewallRuleResource struct{}
@@ -85,11 +85,11 @@ func (r CosmosDbPostgreSQLFirewallRuleResource) Exists(ctx context.Context, clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosDbPostgreSQLFirewallRuleResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_postgresql_node_configuration_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_node_configuration_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbPostgreSQLNodeConfigurationResource struct{}
@@ -66,11 +66,11 @@ func (r CosmosDbPostgreSQLNodeConfigurationResource) Exists(ctx context.Context,
 	resp, err := client.GetNode(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosDbPostgreSQLNodeConfigurationResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_postgresql_role_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_role_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/roles"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbPostgreSQLRoleResource struct{}
@@ -59,11 +59,11 @@ func (r CosmosDbPostgreSQLRoleResource) Exists(ctx context.Context, clients *cli
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosDbPostgreSQLRoleResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -205,7 +205,7 @@ func resourceCosmosDbSQLContainerCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if partitionKeyVersion, ok := d.GetOk("partition_key_version"); ok {
-		db.Properties.Resource.PartitionKey.Version = utils.Int64(int64(partitionKeyVersion.(int)))
+		db.Properties.Resource.PartitionKey.Version = pointer.To(int64(partitionKeyVersion.(int)))
 	}
 
 	if keys := expandCosmosSQLContainerUniqueKeys(d.Get("unique_key").(*pluginsdk.Set)); keys != nil {
@@ -215,11 +215,11 @@ func resourceCosmosDbSQLContainerCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if analyticalStorageTTL, ok := d.GetOk("analytical_storage_ttl"); ok {
-		db.Properties.Resource.AnalyticalStorageTtl = utils.Int64(int64(analyticalStorageTTL.(int)))
+		db.Properties.Resource.AnalyticalStorageTtl = pointer.To(int64(analyticalStorageTTL.(int)))
 	}
 
 	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
-		db.Properties.Resource.DefaultTtl = utils.Int64(int64(defaultTTL.(int)))
+		db.Properties.Resource.DefaultTtl = pointer.To(int64(defaultTTL.(int)))
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
@@ -282,7 +282,7 @@ func resourceCosmosDbSQLContainerUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if partitionKeyVersion, ok := d.GetOk("partition_key_version"); ok {
-		db.Properties.Resource.PartitionKey.Version = utils.Int64(int64(partitionKeyVersion.(int)))
+		db.Properties.Resource.PartitionKey.Version = pointer.To(int64(partitionKeyVersion.(int)))
 	}
 
 	if keys := expandCosmosSQLContainerUniqueKeys(d.Get("unique_key").(*pluginsdk.Set)); keys != nil {
@@ -292,11 +292,11 @@ func resourceCosmosDbSQLContainerUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if analyticalStorageTTL, ok := d.GetOk("analytical_storage_ttl"); ok {
-		db.Properties.Resource.AnalyticalStorageTtl = utils.Int64(int64(analyticalStorageTTL.(int)))
+		db.Properties.Resource.AnalyticalStorageTtl = pointer.To(int64(analyticalStorageTTL.(int)))
 	}
 
 	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
-		db.Properties.Resource.DefaultTtl = utils.Int64(int64(defaultTTL.(int)))
+		db.Properties.Resource.DefaultTtl = pointer.To(int64(defaultTTL.(int)))
 	}
 
 	err = client.SqlResourcesCreateUpdateSqlContainerThenPoll(ctx, *id, db)

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosSqlContainerResource struct{}
@@ -249,7 +249,7 @@ func (t CosmosSqlContainerResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("reading Cosmos SQL Container (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (CosmosSqlContainerResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_database_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_database_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosSqlDatabaseResource struct{}
@@ -116,7 +116,7 @@ func (t CosmosSqlDatabaseResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("reading Cosmos SQL Database (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (CosmosSqlDatabaseResource) basic(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_dedicated_gateway_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_dedicated_gateway_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosDbSqlDedicatedGatewayResource struct{}
@@ -81,11 +81,11 @@ func (r CosmosDbSqlDedicatedGatewayResource) Exists(ctx context.Context, clients
 	resp, err := client.ServiceGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CosmosDbSqlDedicatedGatewayResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_function_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_function_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -83,11 +84,11 @@ func (r CosmosDbSQLFunctionResource) Exists(ctx context.Context, client *clients
 	resp, err := client.Cosmos.SqlResourceClient.GetSQLUserDefinedFunction(ctx, id.ResourceGroup, id.DatabaseAccountName, id.SqlDatabaseName, id.ContainerName, id.UserDefinedFunctionName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving CosmosDb SQLFunction %q: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CosmosDbSQLFunctionResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -118,9 +119,9 @@ func resourceCosmosDbSQLRoleAssignmentCreate(d *pluginsdk.ResourceData, meta int
 
 	parameters := documentdb.SQLRoleAssignmentCreateUpdateParameters{
 		SQLRoleAssignmentResource: &documentdb.SQLRoleAssignmentResource{
-			PrincipalID:      utils.String(d.Get("principal_id").(string)),
-			RoleDefinitionID: utils.String(d.Get("role_definition_id").(string)),
-			Scope:            utils.String(d.Get("scope").(string)),
+			PrincipalID:      pointer.To(d.Get("principal_id").(string)),
+			RoleDefinitionID: pointer.To(d.Get("role_definition_id").(string)),
+			Scope:            pointer.To(d.Get("scope").(string)),
 		},
 	}
 
@@ -186,9 +187,9 @@ func resourceCosmosDbSQLRoleAssignmentUpdate(d *pluginsdk.ResourceData, meta int
 
 	parameters := documentdb.SQLRoleAssignmentCreateUpdateParameters{
 		SQLRoleAssignmentResource: &documentdb.SQLRoleAssignmentResource{
-			PrincipalID:      utils.String(d.Get("principal_id").(string)),
-			RoleDefinitionID: utils.String(d.Get("role_definition_id").(string)),
-			Scope:            utils.String(d.Get("scope").(string)),
+			PrincipalID:      pointer.To(d.Get("principal_id").(string)),
+			RoleDefinitionID: pointer.To(d.Get("role_definition_id").(string)),
+			Scope:            pointer.To(d.Get("scope").(string)),
 		},
 	}
 

--- a/internal/services/cosmos/cosmosdb_sql_role_assignment_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_assignment_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -103,11 +104,11 @@ func (r CosmosDbSQLRoleAssignmentResource) Exists(ctx context.Context, client *c
 	resp, err := client.Cosmos.SqlResourceClient.GetSQLRoleAssignment(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CosmosDbSQLRoleAssignmentResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_role_definition_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_definition_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -141,7 +142,7 @@ func resourceCosmosDbSQLRoleDefinitionCreate(d *pluginsdk.ResourceData, meta int
 
 	parameters := documentdb.SQLRoleDefinitionCreateUpdateParameters{
 		SQLRoleDefinitionResource: &documentdb.SQLRoleDefinitionResource{
-			RoleName:         utils.String(d.Get("name").(string)),
+			RoleName:         pointer.To(d.Get("name").(string)),
 			AssignableScopes: utils.ExpandStringSlice(d.Get("assignable_scopes").(*pluginsdk.Set).List()),
 			Permissions:      expandSqlRoleDefinitionPermissions(d.Get("permissions").(*pluginsdk.Set).List()),
 			Type:             documentdb.RoleDefinitionType(d.Get("type").(string)),
@@ -214,7 +215,7 @@ func resourceCosmosDbSQLRoleDefinitionUpdate(d *pluginsdk.ResourceData, meta int
 
 	parameters := documentdb.SQLRoleDefinitionCreateUpdateParameters{
 		SQLRoleDefinitionResource: &documentdb.SQLRoleDefinitionResource{
-			RoleName:         utils.String(d.Get("name").(string)),
+			RoleName:         pointer.To(d.Get("name").(string)),
 			AssignableScopes: utils.ExpandStringSlice(d.Get("assignable_scopes").(*pluginsdk.Set).List()),
 			Permissions:      expandSqlRoleDefinitionPermissions(d.Get("permissions").(*pluginsdk.Set).List()),
 			Type:             documentdb.RoleDefinitionType(d.Get("type").(string)),

--- a/internal/services/cosmos/cosmosdb_sql_role_definition_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_role_definition_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -119,11 +120,11 @@ func (r CosmosDbSQLRoleDefinitionResource) Exists(ctx context.Context, client *c
 	resp, err := client.Cosmos.SqlResourceClient.GetSQLRoleDefinition(ctx, id.Name, id.ResourceGroup, id.DatabaseAccountName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CosmosDbSQLRoleDefinitionResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource.go
+++ b/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -144,8 +145,8 @@ func resourceCosmosDbSQLStoredProcedureUpdate(d *pluginsdk.ResourceData, meta in
 	storedProcParams := documentdb.SQLStoredProcedureCreateUpdateParameters{
 		SQLStoredProcedureCreateUpdateProperties: &documentdb.SQLStoredProcedureCreateUpdateProperties{
 			Resource: &documentdb.SQLStoredProcedureResource{
-				ID:   utils.String(name),
-				Body: utils.String(d.Get("body").(string)),
+				ID:   pointer.To(name),
+				Body: pointer.To(d.Get("body").(string)),
 			},
 			Options: &documentdb.CreateUpdateOptions{},
 		},

--- a/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_stored_procedure_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosSqlStoredProcedureResource struct{}
@@ -67,7 +67,7 @@ func (t CosmosSqlStoredProcedureResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading Cosmos SQL Stored Procedure (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (CosmosSqlStoredProcedureResource) base(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_sql_trigger_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_trigger_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-10-15/documentdb" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -83,11 +84,11 @@ func (r CosmosDbSQLTriggerResource) Exists(ctx context.Context, client *clients.
 	resp, err := client.Cosmos.SqlResourceClient.GetSQLTrigger(ctx, id.ResourceGroup, id.DatabaseAccountName, id.SqlDatabaseName, id.ContainerName, id.TriggerName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving CosmosDb SQLTrigger %q: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r CosmosDbSQLTriggerResource) template(data acceptance.TestData) string {

--- a/internal/services/cosmos/cosmosdb_table_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_table_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2024-08-15/cosmosdb"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cosmos/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CosmosTableResource struct{}
@@ -116,7 +116,7 @@ func (t CosmosTableResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, fmt.Errorf("reading Cosmos Table (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (CosmosTableResource) basic(data acceptance.TestData) string {

--- a/internal/services/costmanagement/billing_account_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/billing_account_cost_management_export_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BillingAccountCostManagementExport struct{}
@@ -106,7 +106,7 @@ func (t BillingAccountCostManagementExport) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BillingAccountCostManagementExport) basic(data acceptance.TestData) string {

--- a/internal/services/costmanagement/cost_anomaly_alert_resource.go
+++ b/internal/services/costmanagement/cost_anomaly_alert_resource.go
@@ -140,7 +140,7 @@ func (r AnomalyAlertResource) Create() sdk.ResourceFunc {
 					NotificationEmail: &notificationEmail,
 					Notification: scheduledactions.NotificationProperties{
 						Subject: metadata.ResourceData.Get("email_subject").(string),
-						Message: utils.String(metadata.ResourceData.Get("message").(string)),
+						Message: pointer.To(metadata.ResourceData.Get("message").(string)),
 						To:      *emailAddresses,
 					},
 					Schedule: schedule,
@@ -209,7 +209,7 @@ func (r AnomalyAlertResource) Update() sdk.ResourceFunc {
 					NotificationEmail: &notificationEmail,
 					Notification: scheduledactions.NotificationProperties{
 						Subject: metadata.ResourceData.Get("email_subject").(string),
-						Message: utils.String(metadata.ResourceData.Get("message").(string)),
+						Message: pointer.To(metadata.ResourceData.Get("message").(string)),
 						To:      *emailAddresses,
 					},
 					Schedule: schedule,

--- a/internal/services/costmanagement/cost_anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/cost_anomaly_alert_resource_test.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/scheduledactions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AnomalyAlertResource struct{}
@@ -72,7 +72,7 @@ func (AnomalyAlertResource) Exists(ctx context.Context, client *clients.Client, 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (AnomalyAlertResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/costmanagement/cost_management_scheduled_action_resource.go
+++ b/internal/services/costmanagement/cost_management_scheduled_action_resource.go
@@ -184,8 +184,8 @@ func (r CostManagementScheduledActionResource) Create() sdk.ResourceFunc {
 				Frequency:    scheduledactions.ScheduleFrequency(metadata.ResourceData.Get("frequency").(string)),
 				WeeksOfMonth: &weeksOfMonth,
 				DaysOfWeek:   &daysOfWeek,
-				HourOfDay:    utils.Int64(int64(metadata.ResourceData.Get("hour_of_day").(int))),
-				DayOfMonth:   utils.Int64(int64(metadata.ResourceData.Get("day_of_month").(int))),
+				HourOfDay:    pointer.To(int64(metadata.ResourceData.Get("hour_of_day").(int))),
+				DayOfMonth:   pointer.To(int64(metadata.ResourceData.Get("day_of_month").(int))),
 				StartDate:    metadata.ResourceData.Get("start_date").(string),
 				EndDate:      metadata.ResourceData.Get("end_date").(string),
 			}
@@ -199,10 +199,10 @@ func (r CostManagementScheduledActionResource) Create() sdk.ResourceFunc {
 					FileDestination: &scheduledactions.FileDestination{
 						FileFormats: &[]scheduledactions.FileFormat{},
 					},
-					NotificationEmail: utils.String(metadata.ResourceData.Get("email_address_sender").(string)),
+					NotificationEmail: pointer.To(metadata.ResourceData.Get("email_address_sender").(string)),
 					Notification: scheduledactions.NotificationProperties{
 						Subject: metadata.ResourceData.Get("email_subject").(string),
-						Message: utils.String(metadata.ResourceData.Get("message").(string)),
+						Message: pointer.To(metadata.ResourceData.Get("message").(string)),
 						To:      *utils.ExpandStringSlice(metadata.ResourceData.Get("email_addresses").([]interface{})),
 					},
 					Schedule: schedule,
@@ -327,7 +327,7 @@ func (r CostManagementScheduledActionResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("email_address_sender") {
-					model.Properties.NotificationEmail = utils.String(metadata.ResourceData.Get("email_address_sender").(string))
+					model.Properties.NotificationEmail = pointer.To(metadata.ResourceData.Get("email_address_sender").(string))
 				}
 
 				if metadata.ResourceData.HasChange("email_subject") {
@@ -339,7 +339,7 @@ func (r CostManagementScheduledActionResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("message") {
-					model.Properties.Notification.Message = utils.String(metadata.ResourceData.Get("message").(string))
+					model.Properties.Notification.Message = pointer.To(metadata.ResourceData.Get("message").(string))
 				}
 
 				if metadata.ResourceData.HasChange("frequency") {
@@ -377,11 +377,11 @@ func (r CostManagementScheduledActionResource) Update() sdk.ResourceFunc {
 				}
 
 				if metadata.ResourceData.HasChange("hour_of_day") {
-					model.Properties.Schedule.HourOfDay = utils.Int64(int64(metadata.ResourceData.Get("hour_of_day").(int)))
+					model.Properties.Schedule.HourOfDay = pointer.To(int64(metadata.ResourceData.Get("hour_of_day").(int)))
 				}
 
 				if metadata.ResourceData.HasChange("day_of_month") {
-					model.Properties.Schedule.DayOfMonth = utils.Int64(int64(metadata.ResourceData.Get("day_of_month").(int)))
+					model.Properties.Schedule.DayOfMonth = pointer.To(int64(metadata.ResourceData.Get("day_of_month").(int)))
 				}
 
 				if _, err = client.CreateOrUpdateByScope(ctx, *id, *model, scheduledactions.CreateOrUpdateByScopeOperationOptions{}); err != nil {

--- a/internal/services/costmanagement/cost_management_scheduled_action_resource_test.go
+++ b/internal/services/costmanagement/cost_management_scheduled_action_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/scheduledactions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CostManagementScheduledAction struct{}
@@ -121,7 +121,7 @@ func (t CostManagementScheduledAction) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (CostManagementScheduledAction) daily(data acceptance.TestData) string {

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type costManagementExportBaseResource struct{}
@@ -288,7 +287,7 @@ func createOrUpdateCostManagementExport(ctx context.Context, client *exports.Exp
 				Recurrence: &recurrenceType,
 				RecurrencePeriod: &exports.ExportRecurrencePeriod{
 					From: metadata.ResourceData.Get("recurrence_period_start_date").(string),
-					To:   utils.String(metadata.ResourceData.Get("recurrence_period_end_date").(string)),
+					To:   pointer.To(metadata.ResourceData.Get("recurrence_period_end_date").(string)),
 				},
 				Status: &status,
 			},
@@ -318,9 +317,9 @@ func expandExportDataStorageLocation(input []interface{}) (*exports.ExportDelive
 
 	deliveryInfo := &exports.ExportDeliveryInfo{
 		Destination: exports.ExportDeliveryDestination{
-			ResourceId:     utils.String(storageId.ID()),
+			ResourceId:     pointer.To(storageId.ID()),
 			Container:      containerId.ContainerName,
-			RootFolderPath: utils.String(attrs["root_folder_path"].(string)),
+			RootFolderPath: pointer.To(attrs["root_folder_path"].(string)),
 		},
 	}
 

--- a/internal/services/costmanagement/resource_group_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/resource_group_cost_management_export_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceGroupCostManagementExport struct{}
@@ -93,7 +93,7 @@ func (t ResourceGroupCostManagementExport) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ResourceGroupCostManagementExport) basic(data acceptance.TestData) string {

--- a/internal/services/costmanagement/resource_group_cost_management_view_resource_test.go
+++ b/internal/services/costmanagement/resource_group_cost_management_view_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceGroupCostManagementView struct{}
@@ -106,7 +106,7 @@ func (t ResourceGroupCostManagementView) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ResourceGroupCostManagementView) basic(data acceptance.TestData) string {

--- a/internal/services/costmanagement/subscription_cost_management_export_resource_test.go
+++ b/internal/services/costmanagement/subscription_cost_management_export_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubscriptionCostManagementExport struct{}
@@ -93,7 +93,7 @@ func (t SubscriptionCostManagementExport) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (SubscriptionCostManagementExport) basic(data acceptance.TestData) string {

--- a/internal/services/costmanagement/subscription_cost_management_view_resource_test.go
+++ b/internal/services/costmanagement/subscription_cost_management_view_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubscriptionCostManagementView struct{}
@@ -106,7 +106,7 @@ func (t SubscriptionCostManagementView) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (SubscriptionCostManagementView) basic(data acceptance.TestData) string {

--- a/internal/services/costmanagement/view_resource_base.go
+++ b/internal/services/costmanagement/view_resource_base.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type costManagementViewBaseResource struct{}
@@ -193,7 +192,7 @@ func (br costManagementViewBaseResource) createFunc(resourceName, scopeFieldName
 			props := views.View{
 				Properties: &views.ViewProperties{
 					Accumulated: pointer.To(accumulated),
-					DisplayName: utils.String(metadata.ResourceData.Get("display_name").(string)),
+					DisplayName: pointer.To(metadata.ResourceData.Get("display_name").(string)),
 					Chart:       pointer.To(views.ChartType(metadata.ResourceData.Get("chart_type").(string))),
 					Query: &views.ReportConfigDefinition{
 						DataSet:   expandDataset(metadata.ResourceData.Get("dataset").([]interface{})),
@@ -317,7 +316,7 @@ func (br costManagementViewBaseResource) updateFunc() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("display_name") {
-				model.Properties.DisplayName = utils.String(metadata.ResourceData.Get("display_name").(string))
+				model.Properties.DisplayName = pointer.To(metadata.ResourceData.Get("display_name").(string))
 			}
 
 			if metadata.ResourceData.HasChange("chart_type") {
@@ -436,7 +435,7 @@ func expandKpis(input []interface{}) *[]views.KpiProperties {
 		v := item.(map[string]interface{})
 		outputKpis = append(outputKpis, views.KpiProperties{
 			Type:    pointer.To(views.KpiTypeType(v["type"].(string))),
-			Enabled: utils.Bool(true),
+			Enabled: pointer.To(true),
 		})
 	}
 
@@ -453,7 +452,7 @@ func expandPivots(input []interface{}) *[]views.PivotProperties {
 		v := item.(map[string]interface{})
 		outputPivots = append(outputPivots, views.PivotProperties{
 			Type: pointer.To(views.PivotTypeType(v["type"].(string))),
-			Name: utils.String((v["name"].(string))),
+			Name: pointer.To((v["name"].(string))),
 		})
 	}
 

--- a/internal/services/customproviders/custom_provider_resource.go
+++ b/internal/services/customproviders/custom_provider_resource.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/customproviders/validate"
@@ -125,7 +125,7 @@ func resourceCustomProviderCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	id := customresourceprovider.NewResourceProviderID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
@@ -183,7 +183,7 @@ func resourceCustomProviderRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		if props := model.Properties; props != nil {
 			if err := d.Set("resource_type", flattenCustomProviderResourceType(props.ResourceTypes)); err != nil {

--- a/internal/services/customproviders/custom_provider_resource_test.go
+++ b/internal/services/customproviders/custom_provider_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomProviderResource struct{}
@@ -100,12 +100,12 @@ func (r CustomProviderResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.CustomProviders.CustomProviderClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CustomProviderResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
