### PR TITLE
services `E*`/`F*`/`G*` - deprecated function clean up

### DIFF
--- a/internal/services/elastic/elastic_cloud_elasticsearch_resource.go
+++ b/internal/services/elastic/elastic_cloud_elasticsearch_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceElasticsearch() *pluginsdk.Resource {
@@ -185,7 +185,7 @@ func resourceElasticsearchCreate(d *pluginsdk.ResourceData, meta interface{}) er
 		Properties: &monitorsresource.MonitorProperties{
 			MonitoringStatus: &monitoringStatus,
 			UserInfo: &monitorsresource.UserInfo{
-				EmailAddress: utils.String(d.Get("elastic_cloud_email_address").(string)),
+				EmailAddress: pointer.To(d.Get("elastic_cloud_email_address").(string)),
 			},
 		},
 		Sku: &monitorsresource.ResourceSku{
@@ -360,8 +360,8 @@ func expandTagRule(input []interface{}) *rules.LogRules {
 		action := rules.TagAction(item["action"].(string))
 		filteringTags = append(filteringTags, rules.FilteringTag{
 			Action: &action,
-			Name:   utils.String(item["name"].(string)),
-			Value:  utils.String(item["value"].(string)),
+			Name:   pointer.To(item["name"].(string)),
+			Value:  pointer.To(item["value"].(string)),
 		})
 	}
 
@@ -371,9 +371,9 @@ func expandTagRule(input []interface{}) *rules.LogRules {
 
 	return &rules.LogRules{
 		FilteringTags:        &filteringTags,
-		SendAadLogs:          utils.Bool(sendAzureAdLogs),
-		SendActivityLogs:     utils.Bool(sendActivityLogs),
-		SendSubscriptionLogs: utils.Bool(sendSubscriptionLogs),
+		SendAadLogs:          pointer.To(sendAzureAdLogs),
+		SendActivityLogs:     pointer.To(sendActivityLogs),
+		SendSubscriptionLogs: pointer.To(sendSubscriptionLogs),
 	}
 }
 

--- a/internal/services/elasticsan/elastic_san_resource_test.go
+++ b/internal/services/elasticsan/elastic_san_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/elasticsans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ElasticSANTestResource struct{}
@@ -163,7 +163,7 @@ func (r ElasticSANTestResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ElasticSANTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/elasticsan/elastic_san_volume_group_resource_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_group_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/volumegroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ElasticSANVolumeGroupTestResource struct{}
@@ -174,7 +174,7 @@ func (r ElasticSANVolumeGroupTestResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ElasticSANVolumeGroupTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/elasticsan/elastic_san_volume_resource_test.go
+++ b/internal/services/elasticsan/elastic_san_volume_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/elasticsan/2023-01-01/volumes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ElasticSANVolumeTestResource struct{}
@@ -120,7 +120,7 @@ func (r ElasticSANVolumeTestResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ElasticSANVolumeTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_authorization_rule_resource_test.go
+++ b/internal/services/eventhub/eventhub_authorization_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/eventhubs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubAuthorizationRuleResource struct{}
@@ -183,7 +183,7 @@ func (EventHubAuthorizationRuleResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/internal/services/eventhub/eventhub_cluster_resource.go
@@ -12,18 +12,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/eventhubsclusters"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceEventHubCluster() *pluginsdk.Resource {
@@ -97,7 +96,7 @@ func resourceEventHubClusterCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	sku := expandEventHubClusterSkuName(d.Get("sku_name").(string))
 	cluster := eventhubsclusters.Cluster{
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Sku:      &sku,
 	}
@@ -178,7 +177,7 @@ func expandEventHubClusterSkuName(skuName string) eventhubsclusters.ClusterSku {
 	capacity, _ := strconv.Atoi(skuParts[1])
 	return eventhubsclusters.ClusterSku{
 		Name:     eventhubsclusters.ClusterSkuName(name),
-		Capacity: utils.Int64(int64(capacity)),
+		Capacity: pointer.To(int64(capacity)),
 	}
 }
 

--- a/internal/services/eventhub/eventhub_cluster_resource_test.go
+++ b/internal/services/eventhub/eventhub_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/eventhubsclusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubClusterResource struct{}
@@ -73,7 +73,7 @@ func (EventHubClusterResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_consumer_group_resource.go
+++ b/internal/services/eventhub/eventhub_consumer_group_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ConsumerGroupObject struct {
@@ -100,9 +99,9 @@ func (r ConsumerGroupResource) Create() sdk.ResourceFunc {
 			}
 
 			parameters := consumergroups.ConsumerGroup{
-				Name: utils.String(state.Name),
+				Name: pointer.To(state.Name),
 				Properties: &consumergroups.ConsumerGroupProperties{
-					UserMetadata: utils.String(state.UserMetadata),
+					UserMetadata: pointer.To(state.UserMetadata),
 				},
 			}
 
@@ -135,9 +134,9 @@ func (r ConsumerGroupResource) Update() sdk.ResourceFunc {
 			client := metadata.Client.Eventhub.ConsumerGroupClient
 
 			parameters := consumergroups.ConsumerGroup{
-				Name: utils.String(id.ConsumerGroupName),
+				Name: pointer.To(id.ConsumerGroupName),
 				Properties: &consumergroups.ConsumerGroupProperties{
-					UserMetadata: utils.String(state.UserMetadata),
+					UserMetadata: pointer.To(state.UserMetadata),
 				},
 			}
 

--- a/internal/services/eventhub/eventhub_consumer_group_resource_test.go
+++ b/internal/services/eventhub/eventhub_consumer_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/consumergroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubConsumerGroupResource struct{}
@@ -99,7 +99,7 @@ func (EventHubConsumerGroupResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubConsumerGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_namespace_authorization_rule_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_authorization_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/authorizationrulesnamespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubNamespaceAuthorizationRuleResource struct{}
@@ -183,7 +183,7 @@ func (EventHubNamespaceAuthorizationRuleResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
@@ -20,7 +21,6 @@ import (
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceEventHubNamespaceCustomerManagedKey() *pluginsdk.Resource {
@@ -170,7 +170,7 @@ func resourceEventHubNamespaceCustomerManagedKeyCreateUpdate(d *pluginsdk.Resour
 	}
 
 	namespace.Properties.Encryption.KeyVaultProperties = keyVaultProps
-	namespace.Properties.Encryption.RequireInfrastructureEncryption = utils.Bool(d.Get("infrastructure_encryption_enabled").(bool))
+	namespace.Properties.Encryption.RequireInfrastructureEncryption = pointer.To(d.Get("infrastructure_encryption_enabled").(bool))
 
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, *namespace); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", *id, err)
@@ -258,9 +258,9 @@ func expandEventHubNamespaceKeyVaultKeyIds(input []interface{}) (*[]namespaces.K
 		}
 
 		results = append(results, namespaces.KeyVaultProperties{
-			KeyName:     utils.String(keyId.Name),
-			KeyVaultUri: utils.String(keyId.KeyVaultBaseUrl),
-			KeyVersion:  utils.String(keyId.Version),
+			KeyName:     pointer.To(keyId.Name),
+			KeyVaultUri: pointer.To(keyId.KeyVaultBaseUrl),
+			KeyVersion:  pointer.To(keyId.Version),
 		})
 	}
 

--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubNamespaceCustomerManagedKeyResource struct{}
@@ -115,10 +115,10 @@ func (r EventHubNamespaceCustomerManagedKeyResource) Exists(ctx context.Context,
 	}
 
 	if resp.Model.Properties == nil || resp.Model.Properties.Encryption == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r EventHubNamespaceCustomerManagedKeyResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/checknameavailabilitydisasterrecoveryconfigs"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceEventHubNamespaceDisasterRecoveryConfig() *pluginsdk.Resource {
@@ -97,7 +97,7 @@ func resourceEventHubNamespaceDisasterRecoveryConfigCreate(d *pluginsdk.Resource
 
 	parameters := disasterrecoveryconfigs.ArmDisasterRecovery{
 		Properties: &disasterrecoveryconfigs.ArmDisasterRecoveryProperties{
-			PartnerNamespace: utils.String(d.Get("partner_namespace_id").(string)),
+			PartnerNamespace: pointer.To(d.Get("partner_namespace_id").(string)),
 		},
 	}
 
@@ -154,7 +154,7 @@ func resourceEventHubNamespaceDisasterRecoveryConfigUpdate(d *pluginsdk.Resource
 
 	parameters := disasterrecoveryconfigs.ArmDisasterRecovery{
 		Properties: &disasterrecoveryconfigs.ArmDisasterRecoveryProperties{
-			PartnerNamespace: utils.String(d.Get("partner_namespace_id").(string)),
+			PartnerNamespace: pointer.To(d.Get("partner_namespace_id").(string)),
 		},
 	}
 

--- a/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/disasterrecoveryconfigs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubNamespaceDisasterRecoveryConfigResource struct{}
@@ -68,7 +68,7 @@ func (EventHubNamespaceDisasterRecoveryConfigResource) Exists(ctx context.Contex
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceDisasterRecoveryConfigResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/eventhubsclusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/networkrulesets"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -301,7 +300,7 @@ func resourceEventHubNamespaceCreate(d *pluginsdk.ResourceData, meta interface{}
 		return tf.ImportAsExistsError("azurerm_eventhub_namespace", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	sku := d.Get("sku").(string)
 	capacity := int32(d.Get("capacity").(int))
 	t := d.Get("tags").(map[string]interface{})
@@ -394,7 +393,7 @@ func resourceEventHubNamespaceUpdate(d *pluginsdk.ResourceData, meta interface{}
 	locks.ByName(id.NamespaceName, eventHubNamespaceResourceName)
 	defer locks.UnlockByName(id.NamespaceName, eventHubNamespaceResourceName)
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	sku := d.Get("sku").(string)
 	capacity := int32(d.Get("capacity").(int))
 	t := d.Get("tags").(map[string]interface{})

--- a/internal/services/eventhub/eventhub_namespace_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubNamespaceResource struct{}
@@ -545,7 +545,7 @@ func (EventHubNamespaceResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_namespace_schema_group_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_schema_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/schemaregistry"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubNamespaceSchemaRegistryResource struct{}
@@ -57,7 +57,7 @@ func (EventHubNamespaceSchemaRegistryResource) Exists(ctx context.Context, clien
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubNamespaceSchemaRegistryResource) basic(data acceptance.TestData) string {

--- a/internal/services/eventhub/eventhub_resource.go
+++ b/internal/services/eventhub/eventhub_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var eventHubResourceName = "azurerm_eventhub"
@@ -272,7 +271,7 @@ func resourceEventHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	eventhubStatus := eventhubs.EntityStatus(d.Get("status").(string))
 	parameters := eventhubs.Eventhub{
 		Properties: &eventhubs.EventhubProperties{
-			PartitionCount: utils.Int64(int64(d.Get("partition_count").(int))),
+			PartitionCount: pointer.To(int64(d.Get("partition_count").(int))),
 			Status:         &eventhubStatus,
 		},
 	}
@@ -333,9 +332,9 @@ func resourceEventHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	eventhubStatus := eventhubs.EntityStatus(d.Get("status").(string))
 	parameters := eventhubs.Eventhub{
 		Properties: &eventhubs.EventhubProperties{
-			PartitionCount:         utils.Int64(int64(d.Get("partition_count").(int))),
+			PartitionCount:         pointer.To(int64(d.Get("partition_count").(int))),
 			Status:                 &eventhubStatus,
-			MessageRetentionInDays: utils.Int64(int64(d.Get("message_retention").(int))),
+			MessageRetentionInDays: pointer.To(int64(d.Get("message_retention").(int))),
 			CaptureDescription:     expandEventHubCaptureDescription(d),
 		},
 	}
@@ -448,10 +447,10 @@ func expandEventHubRetentionDescription(d *pluginsdk.ResourceData) *eventhubs.Re
 
 	if cleanupPolicy == string(eventhubs.CleanupPolicyRetentionDescriptionDelete) {
 		retentionTimeInHours := input["retention_time_in_hours"].(int)
-		retentionDescription.RetentionTimeInHours = pointer.FromInt64(int64(retentionTimeInHours))
+		retentionDescription.RetentionTimeInHours = pointer.To(int64(retentionTimeInHours))
 	} else {
 		tombstoneRetentionTimeInHours := input["tombstone_retention_time_in_hours"].(int)
-		retentionDescription.TombstoneRetentionTimeInHours = pointer.FromInt64(int64(tombstoneRetentionTimeInHours))
+		retentionDescription.TombstoneRetentionTimeInHours = pointer.To(int64(tombstoneRetentionTimeInHours))
 	}
 
 	return pointer.To(retentionDescription)
@@ -471,14 +470,14 @@ func expandEventHubCaptureDescription(d *pluginsdk.ResourceData) *eventhubs.Capt
 	skipEmptyArchives := input["skip_empty_archives"].(bool)
 
 	captureDescription := eventhubs.CaptureDescription{
-		Enabled: utils.Bool(enabled),
+		Enabled: pointer.To(enabled),
 		Encoding: func() *eventhubs.EncodingCaptureDescription {
 			v := eventhubs.EncodingCaptureDescription(encoding)
 			return &v
 		}(),
-		IntervalInSeconds: utils.Int64(int64(intervalInSeconds)),
-		SizeLimitInBytes:  utils.Int64(int64(sizeLimitInBytes)),
-		SkipEmptyArchives: utils.Bool(skipEmptyArchives),
+		IntervalInSeconds: pointer.To(int64(intervalInSeconds)),
+		SizeLimitInBytes:  pointer.To(int64(sizeLimitInBytes)),
+		SkipEmptyArchives: pointer.To(skipEmptyArchives),
 	}
 
 	if v, ok := input["destination"]; ok {
@@ -492,11 +491,11 @@ func expandEventHubCaptureDescription(d *pluginsdk.ResourceData) *eventhubs.Capt
 			storageAccountId := destination["storage_account_id"].(string)
 
 			captureDescription.Destination = &eventhubs.Destination{
-				Name: utils.String(destinationName),
+				Name: pointer.To(destinationName),
 				Properties: &eventhubs.DestinationProperties{
-					ArchiveNameFormat:        utils.String(archiveNameFormat),
-					BlobContainer:            utils.String(blobContainerName),
-					StorageAccountResourceId: utils.String(storageAccountId),
+					ArchiveNameFormat:        pointer.To(archiveNameFormat),
+					BlobContainer:            pointer.To(blobContainerName),
+					StorageAccountResourceId: pointer.To(storageAccountId),
 				},
 			}
 		}

--- a/internal/services/eventhub/eventhub_resource_test.go
+++ b/internal/services/eventhub/eventhub_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2024-01-01/eventhubs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type EventHubResource struct{}
@@ -407,7 +407,7 @@ func (EventHubResource) Exists(ctx context.Context, clients *clients.Client, sta
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (EventHubResource) basic(data acceptance.TestData, partitionCount int) string {

--- a/internal/services/eventhub/migration/consumer_group_test.go
+++ b/internal/services/eventhub/migration/consumer_group_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestConsumerGroupsV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestConsumerGroupsV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumergroups/consumergroup1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1"),
 		},
 		{
 			name: "old id - mixed case (shared)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/ConsumerGroups/consumergroup1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1"),
 		},
 		{
 			name: "new id (shared)",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumerGroups/consumergroup1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/extendedlocation/extended_custom_location_resource_test.go
+++ b/internal/services/extendedlocation/extended_custom_location_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomLocationResource struct{}
@@ -35,11 +35,11 @@ func (r CustomLocationResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.ExtendedLocation.CustomLocationsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccExtendedLocationCustomLocations_basic(t *testing.T) {

--- a/internal/services/extendedlocation/extended_location_custom_location_resource_test.go
+++ b/internal/services/extendedlocation/extended_location_custom_location_resource_test.go
@@ -14,13 +14,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/extendedlocation/2021-08-15/customlocations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ExtendedLocationCustomLocationResource struct{}
@@ -34,11 +34,11 @@ func (r ExtendedLocationCustomLocationResource) Exists(ctx context.Context, clie
 	resp, err := client.ExtendedLocation.CustomLocationsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccExtendedLocationCustomLocation_basic(t *testing.T) {

--- a/internal/services/firewall/firewall_application_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_application_rule_collection_resource.go
@@ -179,12 +179,12 @@ func resourceFirewallApplicationRuleCollectionCreateUpdate(d *pluginsdk.Resource
 
 	priority := d.Get("priority").(int)
 	newRuleCollection := azurefirewalls.AzureFirewallApplicationRuleCollection{
-		Name: utils.String(name),
+		Name: pointer.To(name),
 		Properties: &azurefirewalls.AzureFirewallApplicationRuleCollectionPropertiesFormat{
 			Action: &azurefirewalls.AzureFirewallRCAction{
 				Type: pointer.To(azurefirewalls.AzureFirewallRCActionType(d.Get("action").(string))),
 			},
-			Priority: utils.Int64(int64(priority)),
+			Priority: pointer.To(int64(priority)),
 			Rules:    applicationRules,
 		},
 	}
@@ -401,8 +401,8 @@ func expandFirewallApplicationRules(inputs []interface{}) (*[]azurefirewalls.Azu
 		ruleTargetFqdns := rule["target_fqdns"].([]interface{})
 
 		output := azurefirewalls.AzureFirewallApplicationRule{
-			Name:            utils.String(ruleName),
-			Description:     utils.String(ruleDescription),
+			Name:            pointer.To(ruleName),
+			Description:     pointer.To(ruleDescription),
 			SourceAddresses: utils.ExpandStringSlice(ruleSourceAddresses),
 			SourceIPGroups:  utils.ExpandStringSlice(ruleSourceIpGroups),
 			FqdnTags:        utils.ExpandStringSlice(ruleFqdnTags),
@@ -414,7 +414,7 @@ func expandFirewallApplicationRules(inputs []interface{}) (*[]azurefirewalls.Azu
 			protocol := v.(map[string]interface{})
 			port := protocol["port"].(int)
 			ruleProtocol := azurefirewalls.AzureFirewallApplicationRuleProtocol{
-				Port:         utils.Int64(int64(port)),
+				Port:         pointer.To(int64(port)),
 				ProtocolType: pointer.To(azurefirewalls.AzureFirewallApplicationRuleProtocolType(protocol["type"].(string))),
 			}
 			ruleProtocols = append(ruleProtocols, ruleProtocol)

--- a/internal/services/firewall/firewall_application_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_application_rule_collection_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/azurefirewalls"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FirewallApplicationRuleCollectionResource struct{}
@@ -409,10 +409,10 @@ func (FirewallApplicationRuleCollectionResource) Exists(ctx context.Context, cli
 		}
 
 		if *rule.Name == id.ApplicationRuleCollectionName {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 	}
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (t FirewallApplicationRuleCollectionResource) doesNotExist(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/firewall/firewall_nat_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_nat_rule_collection_resource.go
@@ -176,12 +176,12 @@ func resourceFirewallNatRuleCollectionCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 	priority := d.Get("priority").(int)
 	newRuleCollection := azurefirewalls.AzureFirewallNatRuleCollection{
-		Name: utils.String(name),
+		Name: pointer.To(name),
 		Properties: &azurefirewalls.AzureFirewallNatRuleCollectionProperties{
 			Action: &azurefirewalls.AzureFirewallNatRCAction{
 				Type: pointer.To(azurefirewalls.AzureFirewallNatRCActionType(d.Get("action").(string))),
 			},
-			Priority: utils.Int64(int64(priority)),
+			Priority: pointer.To(int64(priority)),
 			Rules:    natRules,
 		},
 	}
@@ -423,8 +423,8 @@ func expandFirewallNatRules(input []interface{}) (*[]azurefirewalls.AzureFirewal
 		translatedPort := rule["translated_port"].(string)
 
 		ruleToAdd := azurefirewalls.AzureFirewallNatRule{
-			Name:                 utils.String(name),
-			Description:          utils.String(description),
+			Name:                 pointer.To(name),
+			Description:          pointer.To(description),
 			SourceAddresses:      &sourceAddresses,
 			SourceIPGroups:       &sourceIpGroups,
 			DestinationAddresses: &destinationAddresses,

--- a/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_nat_rule_collection_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/azurefirewalls"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FirewallNatRuleCollectionResource struct{}
@@ -249,10 +249,10 @@ func (FirewallNatRuleCollectionResource) Exists(ctx context.Context, clients *cl
 		}
 
 		if *rule.Name == id.NatRuleCollectionName {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 	}
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (t FirewallNatRuleCollectionResource) doesNotExist(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/firewall/firewall_network_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_network_rule_collection_resource.go
@@ -178,12 +178,12 @@ func resourceFirewallNetworkRuleCollectionCreateUpdate(d *pluginsdk.ResourceData
 	}
 	priority := d.Get("priority").(int)
 	newRuleCollection := azurefirewalls.AzureFirewallNetworkRuleCollection{
-		Name: utils.String(name),
+		Name: pointer.To(name),
 		Properties: &azurefirewalls.AzureFirewallNetworkRuleCollectionPropertiesFormat{
 			Action: &azurefirewalls.AzureFirewallRCAction{
 				Type: pointer.To(azurefirewalls.AzureFirewallRCActionType(d.Get("action").(string))),
 			},
-			Priority: utils.Int64(int64(priority)),
+			Priority: pointer.To(int64(priority)),
 			Rules:    networkRules,
 		},
 	}
@@ -436,8 +436,8 @@ func expandFirewallNetworkRules(input []interface{}) (*[]azurefirewalls.AzureFir
 		}
 
 		ruleToAdd := azurefirewalls.AzureFirewallNetworkRule{
-			Name:                 utils.String(name),
-			Description:          utils.String(description),
+			Name:                 pointer.To(name),
+			Description:          pointer.To(description),
 			SourceAddresses:      &sourceAddresses,
 			SourceIPGroups:       &sourceIpGroups,
 			DestinationAddresses: &destinationAddresses,

--- a/internal/services/firewall/firewall_network_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_network_rule_collection_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/azurefirewalls"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FirewallNetworkRuleCollectionResource struct{}
@@ -357,10 +357,10 @@ func (FirewallNetworkRuleCollectionResource) Exists(ctx context.Context, clients
 		}
 
 		if *rule.Name == id.NetworkRuleCollectionName {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 	}
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r FirewallNetworkRuleCollectionResource) checkFirewallNetworkRuleCollectionDoesNotExist(collectionName string) acceptance.ClientCheckFunc {
@@ -404,11 +404,11 @@ func (FirewallNetworkRuleCollectionResource) Destroy(ctx context.Context, client
 
 	read, err := clients.Network.AzureFirewalls.Get(ctx, firewallId)
 	if err != nil {
-		return utils.Bool(false), err
+		return pointer.To(false), err
 	}
 
 	if read.Model == nil || read.Model.Properties == nil || read.Model.Properties.NetworkRuleCollections == nil {
-		return utils.Bool(false), fmt.Errorf("one of model/properties/networkRuleCollections was nil for %s", firewallId)
+		return pointer.To(false), fmt.Errorf("one of model/properties/networkRuleCollections was nil for %s", firewallId)
 	}
 
 	rules := make([]azurefirewalls.AzureFirewallNetworkRuleCollection, 0)
@@ -421,10 +421,10 @@ func (FirewallNetworkRuleCollectionResource) Destroy(ctx context.Context, client
 	read.Model.Properties.NetworkRuleCollections = &rules
 
 	if err = clients.Network.AzureFirewalls.CreateOrUpdateThenPoll(ctx, firewallId, *read.Model); err != nil {
-		return utils.Bool(false), fmt.Errorf("removing Network Rule Collection from Firewall: %+v", err)
+		return pointer.To(false), fmt.Errorf("removing Network Rule Collection from Firewall: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (FirewallNetworkRuleCollectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -87,7 +87,7 @@ func resourceFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 			Insights:             expandFirewallPolicyInsights(d.Get("insights").([]interface{})),
 			ExplicitProxy:        expandFirewallPolicyExplicitProxy(d.Get("explicit_proxy").([]interface{})),
 		},
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
@@ -101,7 +101,7 @@ func resourceFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if id, ok := d.GetOk("base_policy_id"); ok {
-		props.Properties.BasePolicy = &firewallpolicies.SubResource{Id: utils.String(id.(string))}
+		props.Properties.BasePolicy = &firewallpolicies.SubResource{Id: pointer.To(id.(string))}
 	}
 
 	if v, ok := d.GetOk("sku"); ok {
@@ -112,7 +112,7 @@ func resourceFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("sql_redirect_allowed"); ok {
 		props.Properties.Sql = &firewallpolicies.FirewallPolicySQL{
-			AllowSqlRedirect: utils.Bool(v.(bool)),
+			AllowSqlRedirect: pointer.To(v.(bool)),
 		}
 	}
 
@@ -363,8 +363,8 @@ func expandFirewallPolicyTransportSecurity(input []interface{}) *firewallpolicie
 
 	return &firewallpolicies.FirewallPolicyTransportSecurity{
 		CertificateAuthority: &firewallpolicies.FirewallPolicyCertificateAuthority{
-			KeyVaultSecretId: utils.String(raw["key_vault_secret_id"].(string)),
-			Name:             utils.String(raw["name"].(string)),
+			KeyVaultSecretId: pointer.To(raw["key_vault_secret_id"].(string)),
+			Name:             pointer.To(raw["name"].(string)),
 		},
 	}
 }
@@ -376,8 +376,8 @@ func expandFirewallPolicyInsights(input []interface{}) *firewallpolicies.Firewal
 
 	raw := input[0].(map[string]interface{})
 	output := &firewallpolicies.FirewallPolicyInsights{
-		IsEnabled:             utils.Bool(raw["enabled"].(bool)),
-		RetentionDays:         utils.Int64(int64(raw["retention_in_days"].(int))),
+		IsEnabled:             pointer.To(raw["enabled"].(bool)),
+		RetentionDays:         pointer.To(int64(raw["retention_in_days"].(int))),
 		LogAnalyticsResources: expandFirewallPolicyLogAnalyticsResources(raw["default_log_analytics_workspace_id"].(string), raw["log_analytics_workspace"].([]interface{})),
 	}
 
@@ -395,15 +395,15 @@ func expandFirewallPolicyExplicitProxy(input []interface{}) *firewallpolicies.Ex
 	}
 
 	output := &firewallpolicies.ExplicitProxy{
-		EnableExplicitProxy: utils.Bool(raw["enabled"].(bool)),
-		HTTPPort:            utils.Int64(int64(raw["http_port"].(int))),
-		HTTPSPort:           utils.Int64(int64(raw["https_port"].(int))),
-		PacFilePort:         utils.Int64(int64(raw["pac_file_port"].(int))),
-		PacFile:             utils.String(raw["pac_file"].(string)),
+		EnableExplicitProxy: pointer.To(raw["enabled"].(bool)),
+		HTTPPort:            pointer.To(int64(raw["http_port"].(int))),
+		HTTPSPort:           pointer.To(int64(raw["https_port"].(int))),
+		PacFilePort:         pointer.To(int64(raw["pac_file_port"].(int))),
+		PacFile:             pointer.To(raw["pac_file"].(string)),
 	}
 
 	if val, ok := raw["enable_pac_file"]; ok {
-		output.EnablePacFile = utils.Bool(val.(bool))
+		output.EnablePacFile = pointer.To(val.(bool))
 	}
 
 	return output
@@ -420,9 +420,9 @@ func expandFirewallPolicyLogAnalyticsResources(defaultWorkspaceId string, worksp
 	for _, workspace := range workspaces {
 		workspace := workspace.(map[string]interface{})
 		workspaceList = append(workspaceList, firewallpolicies.FirewallPolicyLogAnalyticsWorkspace{
-			Region: utils.String(location.Normalize(workspace["firewall_location"].(string))),
+			Region: pointer.To(location.Normalize(workspace["firewall_location"].(string))),
 			WorkspaceId: &firewallpolicies.SubResource{
-				Id: utils.String(workspace["id"].(string)),
+				Id: pointer.To(workspace["id"].(string)),
 			},
 		})
 	}

--- a/internal/services/firewall/firewall_policy_resource_test.go
+++ b/internal/services/firewall/firewall_policy_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/firewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FirewallPolicyResource struct{}
@@ -205,7 +205,7 @@ func (FirewallPolicyResource) Exists(ctx context.Context, clients *clients.Clien
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (FirewallPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -484,7 +484,7 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 
 	param := firewallpolicyrulecollectiongroups.FirewallPolicyRuleCollectionGroup{
 		Properties: &firewallpolicyrulecollectiongroups.FirewallPolicyRuleCollectionGroupProperties{
-			Priority: utils.Int64(int64(d.Get("priority").(int))),
+			Priority: pointer.To(int64(d.Get("priority").(int))),
 		},
 	}
 	var rulesCollections []firewallpolicyrulecollectiongroups.FirewallPolicyRuleCollection
@@ -592,8 +592,8 @@ func expandFirewallPolicyRuleCollectionNat(input []interface{}) ([]firewallpolic
 			return nil, err
 		}
 		output := &firewallpolicyrulecollectiongroups.FirewallPolicyNatRuleCollection{
-			Name:     utils.String(rule["name"].(string)),
-			Priority: utils.Int64(int64(rule["priority"].(int))),
+			Name:     pointer.To(rule["name"].(string)),
+			Priority: pointer.To(int64(rule["priority"].(int))),
 			Action: &firewallpolicyrulecollectiongroups.FirewallPolicyNatRuleCollectionAction{
 				Type: pointer.To(firewallpolicyrulecollectiongroups.FirewallPolicyNatRuleCollectionActionType(rule["action"].(string))),
 			},
@@ -612,8 +612,8 @@ func expandFirewallPolicyFilterRuleCollection(input []interface{}, f func(input 
 			Action: &firewallpolicyrulecollectiongroups.FirewallPolicyFilterRuleCollectionAction{
 				Type: pointer.To(firewallpolicyrulecollectiongroups.FirewallPolicyFilterRuleCollectionActionType(rule["action"].(string))),
 			},
-			Name:     utils.String(rule["name"].(string)),
-			Priority: utils.Int64(int64(rule["priority"].(int))),
+			Name:     pointer.To(rule["name"].(string)),
+			Priority: pointer.To(int64(rule["priority"].(int))),
 			Rules:    f(rule["rule"].([]interface{})),
 		}
 		result = append(result, output)
@@ -630,7 +630,7 @@ func expandFirewallPolicyRuleApplication(input []interface{}) *[]firewallpolicyr
 			proto := p.(map[string]interface{})
 			protocols = append(protocols, firewallpolicyrulecollectiongroups.FirewallPolicyRuleApplicationProtocol{
 				ProtocolType: pointer.To(firewallpolicyrulecollectiongroups.FirewallPolicyRuleApplicationProtocolType(proto["type"].(string))),
-				Port:         utils.Int64(int64(proto["port"].(int))),
+				Port:         pointer.To(int64(proto["port"].(int))),
 			})
 		}
 
@@ -644,8 +644,8 @@ func expandFirewallPolicyRuleApplication(input []interface{}) *[]firewallpolicyr
 		}
 
 		output := &firewallpolicyrulecollectiongroups.ApplicationRule{
-			Name:                 utils.String(condition["name"].(string)),
-			Description:          utils.String(condition["description"].(string)),
+			Name:                 pointer.To(condition["name"].(string)),
+			Description:          pointer.To(condition["description"].(string)),
 			Protocols:            &protocols,
 			HTTPHeadersToInsert:  &httpHeader,
 			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].([]interface{})),
@@ -654,7 +654,7 @@ func expandFirewallPolicyRuleApplication(input []interface{}) *[]firewallpolicyr
 			TargetFqdns:          utils.ExpandStringSlice(condition["destination_fqdns"].([]interface{})),
 			TargetURLs:           utils.ExpandStringSlice(condition["destination_urls"].([]interface{})),
 			FqdnTags:             utils.ExpandStringSlice(condition["destination_fqdn_tags"].([]interface{})),
-			TerminateTLS:         utils.Bool(condition["terminate_tls"].(bool)),
+			TerminateTLS:         pointer.To(condition["terminate_tls"].(bool)),
 			WebCategories:        utils.ExpandStringSlice(condition["web_categories"].([]interface{})),
 		}
 		result = append(result, output)
@@ -671,7 +671,7 @@ func expandFirewallPolicyRuleNetwork(input []interface{}) *[]firewallpolicyrulec
 			protocols = append(protocols, firewallpolicyrulecollectiongroups.FirewallPolicyRuleNetworkProtocol(p.(string)))
 		}
 		output := &firewallpolicyrulecollectiongroups.NetworkRule{
-			Name:                 utils.String(condition["name"].(string)),
+			Name:                 pointer.To(condition["name"].(string)),
 			IPProtocols:          &protocols,
 			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].([]interface{})),
 			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].([]interface{})),
@@ -704,20 +704,20 @@ func expandFirewallPolicyRuleNat(input []interface{}) (*[]firewallpolicyrulecoll
 			return nil, fmt.Errorf("should specify either `translated_address` or `translated_fqdn` in rule %s", condition["name"].(string))
 		}
 		output := &firewallpolicyrulecollectiongroups.NatRule{
-			Name:                 utils.String(condition["name"].(string)),
+			Name:                 pointer.To(condition["name"].(string)),
 			IPProtocols:          &protocols,
 			SourceAddresses:      utils.ExpandStringSlice(condition["source_addresses"].([]interface{})),
 			SourceIPGroups:       utils.ExpandStringSlice(condition["source_ip_groups"].([]interface{})),
 			DestinationAddresses: &destinationAddresses,
 			DestinationPorts:     utils.ExpandStringSlice(condition["destination_ports"].([]interface{})),
-			TranslatedPort:       utils.String(strconv.Itoa(condition["translated_port"].(int))),
+			TranslatedPort:       pointer.To(strconv.Itoa(condition["translated_port"].(int))),
 			Description:          pointer.To(condition["description"].(string)),
 		}
 		if condition["translated_address"].(string) != "" {
-			output.TranslatedAddress = utils.String(condition["translated_address"].(string))
+			output.TranslatedAddress = pointer.To(condition["translated_address"].(string))
 		}
 		if condition["translated_fqdn"].(string) != "" {
-			output.TranslatedFqdn = utils.String(condition["translated_fqdn"].(string))
+			output.TranslatedFqdn = pointer.To(condition["translated_fqdn"].(string))
 		}
 		result = append(result, output)
 	}

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/firewallpolicyrulecollectiongroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FirewallPolicyRuleCollectionGroupResource struct{}
@@ -147,7 +147,7 @@ func (FirewallPolicyRuleCollectionGroupResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (FirewallPolicyRuleCollectionGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/virtualwans"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/azurefirewalls"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -258,7 +257,7 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("validating %s: %+v", id, err)
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 	i := d.Get("ip_configuration").([]interface{})
 	ipConfigs, subnetToLock, vnetToLock, err := expandFirewallIPConfigurations(i)
@@ -590,13 +589,13 @@ func expandFirewallIPConfigurations(configs []interface{}) (*[]azurefirewalls.Az
 		pubID := data["public_ip_address_id"].(string)
 
 		ipConfig := azurefirewalls.AzureFirewallIPConfiguration{
-			Name:       utils.String(name),
+			Name:       pointer.To(name),
 			Properties: &azurefirewalls.AzureFirewallIPConfigurationPropertiesFormat{},
 		}
 
 		if pubID != "" {
 			ipConfig.Properties.PublicIPAddress = &azurefirewalls.SubResource{
-				Id: utils.String(pubID),
+				Id: pointer.To(pubID),
 			}
 		}
 
@@ -615,7 +614,7 @@ func expandFirewallIPConfigurations(configs []interface{}) (*[]azurefirewalls.Az
 			}
 
 			ipConfig.Properties.Subnet = &azurefirewalls.SubResource{
-				Id: utils.String(subnetId),
+				Id: pointer.To(subnetId),
 			}
 		}
 		ipConfigs = append(ipConfigs, ipConfig)
@@ -762,10 +761,10 @@ func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, inp
 		}
 	}
 
-	vhub = &azurefirewalls.SubResource{Id: utils.String(b["virtual_hub_id"].(string))}
+	vhub = &azurefirewalls.SubResource{Id: pointer.To(b["virtual_hub_id"].(string))}
 	ipAddresses = &azurefirewalls.HubIPAddresses{
 		PublicIPs: &azurefirewalls.HubPublicIPAddresses{
-			Count:     utils.Int64(int64(b["public_ip_count"].(int))),
+			Count:     pointer.To(int64(b["public_ip_count"].(int))),
 			Addresses: addresses,
 		},
 	}

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/azurefirewalls"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FirewallResource struct{}
@@ -385,7 +385,7 @@ func (FirewallResource) Exists(ctx context.Context, clients *clients.Client, sta
 		return nil, fmt.Errorf("retrieving Azure Firewall %s : %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (FirewallResource) Destroy(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -398,7 +398,7 @@ func (FirewallResource) Destroy(ctx context.Context, clients *clients.Client, st
 		return nil, fmt.Errorf("deleting Azure Firewall %q: %+v", id.AzureFirewallName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (FirewallResource) basic(data acceptance.TestData) string {

--- a/internal/services/fluidrelay/fluid_relay_server_resource_test.go
+++ b/internal/services/fluidrelay/fluid_relay_server_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelayservers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FluidRelayResource struct{}
@@ -185,12 +185,12 @@ func (f FluidRelayResource) Exists(ctx context.Context, client *clients.Client, 
 	resp, err := client.FluidRelay.FluidRelayServers.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (f FluidRelayResource) template(data acceptance.TestData) string {

--- a/internal/services/frontdoor/frontdoor_custom_https_configuration_resource.go
+++ b/internal/services/frontdoor/frontdoor_custom_https_configuration_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceFrontDoorCustomHTTPSConfiguration() *pluginsdk.Resource {
@@ -298,10 +298,10 @@ func makeCustomHTTPSConfiguration(customHttpsConfiguration map[string]interface{
 		customHTTPSConfigurationUpdate.CertificateSource = frontdoors.FrontDoorCertificateSourceAzureKeyVault
 		customHTTPSConfigurationUpdate.KeyVaultCertificateSourceParameters = &frontdoors.KeyVaultCertificateSourceParameters{
 			Vault: &frontdoors.KeyVaultCertificateSourceParametersVault{
-				Id: utils.String(vaultId),
+				Id: pointer.To(vaultId),
 			},
-			SecretName:    utils.String(vaultSecret),
-			SecretVersion: utils.String(vaultVersion),
+			SecretName:    pointer.To(vaultSecret),
+			SecretVersion: pointer.To(vaultVersion),
 		}
 	} else {
 		customHTTPSConfigurationUpdate.CertificateSource = frontdoors.FrontDoorCertificateSourceFrontDoor

--- a/internal/services/frontdoor/frontdoor_custom_https_configuration_resource_test.go
+++ b/internal/services/frontdoor/frontdoor_custom_https_configuration_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FrontDoorCustomHttpsConfigurationResource struct{}
@@ -54,7 +54,7 @@ func (FrontDoorCustomHttpsConfigurationResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r FrontDoorCustomHttpsConfigurationResource) Enabled(data acceptance.TestData) string {

--- a/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
+++ b/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
@@ -9,11 +9,12 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor/migration"
@@ -470,7 +471,7 @@ func resourceFrontDoorFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	location := azure.NormalizeLocation("Global")
+	location := location.Normalize("Global")
 	enabled := webapplicationfirewallpolicies.PolicyEnabledStateDisabled
 	if d.Get("enabled").(bool) {
 		enabled = webapplicationfirewallpolicies.PolicyEnabledStateEnabled
@@ -485,8 +486,8 @@ func resourceFrontDoorFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta
 	t := d.Get("tags").(map[string]interface{})
 
 	frontdoorWebApplicationFirewallPolicy := webapplicationfirewallpolicies.WebApplicationFirewallPolicy{
-		Name:     utils.String(name),
-		Location: utils.String(location),
+		Name:     pointer.To(name),
+		Location: pointer.To(location),
 		Properties: &webapplicationfirewallpolicies.WebApplicationFirewallPolicyProperties{
 			PolicySettings: &webapplicationfirewallpolicies.PolicySettings{
 				EnabledState: &enabled,
@@ -499,13 +500,13 @@ func resourceFrontDoorFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta
 	}
 
 	if redirectUrl != "" {
-		frontdoorWebApplicationFirewallPolicy.Properties.PolicySettings.RedirectURL = utils.String(redirectUrl)
+		frontdoorWebApplicationFirewallPolicy.Properties.PolicySettings.RedirectURL = pointer.To(redirectUrl)
 	}
 	if customBlockResponseBody != "" {
-		frontdoorWebApplicationFirewallPolicy.Properties.PolicySettings.CustomBlockResponseBody = utils.String(customBlockResponseBody)
+		frontdoorWebApplicationFirewallPolicy.Properties.PolicySettings.CustomBlockResponseBody = pointer.To(customBlockResponseBody)
 	}
 	if customBlockResponseStatusCode > 0 {
-		frontdoorWebApplicationFirewallPolicy.Properties.PolicySettings.CustomBlockResponseStatusCode = utils.Int64(int64(customBlockResponseStatusCode))
+		frontdoorWebApplicationFirewallPolicy.Properties.PolicySettings.CustomBlockResponseStatusCode = pointer.To(int64(customBlockResponseStatusCode))
 	}
 
 	if err := client.PoliciesCreateOrUpdateThenPoll(ctx, id, frontdoorWebApplicationFirewallPolicy); err != nil {
@@ -540,8 +541,8 @@ func resourceFrontDoorFirewallPolicyRead(d *pluginsdk.ResourceData, meta interfa
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		if location := model.Location; location != nil {
-			d.Set("location", azure.NormalizeLocation(*location))
+		if loc := model.Location; loc != nil {
+			d.Set("location", location.Normalize(*loc))
 		}
 		if properties := model.Properties; properties != nil {
 			if policy := properties.PolicySettings; policy != nil {
@@ -615,12 +616,12 @@ func expandFrontDoorFirewallCustomRules(input []interface{}) *webapplicationfire
 		action := custom["action"].(string)
 
 		customRule := webapplicationfirewallpolicies.CustomRule{
-			Name:                       utils.String(name),
+			Name:                       pointer.To(name),
 			Priority:                   priority,
 			EnabledState:               &enabled,
 			RuleType:                   webapplicationfirewallpolicies.RuleType(ruleType),
-			RateLimitDurationInMinutes: utils.Int64(rateLimitDurationInMinutes),
-			RateLimitThreshold:         utils.Int64(rateLimitThreshold),
+			RateLimitDurationInMinutes: pointer.To(rateLimitDurationInMinutes),
+			RateLimitThreshold:         pointer.To(rateLimitThreshold),
 			MatchConditions:            matchConditions,
 			Action:                     webapplicationfirewallpolicies.ActionType(action),
 		}
@@ -660,7 +661,7 @@ func expandFrontDoorFirewallMatchConditions(input []interface{}) []webapplicatio
 			matchCondition.MatchVariable = webapplicationfirewallpolicies.MatchVariable(matchVariable)
 		}
 		if selector != "" {
-			matchCondition.Selector = utils.String(selector)
+			matchCondition.Selector = pointer.To(selector)
 		}
 
 		result = append(result, matchCondition)

--- a/internal/services/frontdoor/frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/frontdoor/frontdoor_firewall_policy_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FrontDoorFirewallPolicyResource struct{}
@@ -47,7 +47,7 @@ func (FrontDoorFirewallPolicyResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (FrontDoorFirewallPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -10,11 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -24,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceFrontDoor() *pluginsdk.Resource {
@@ -101,9 +101,9 @@ func resourceFrontDoorCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 	t := d.Get("tags").(map[string]interface{})
 
 	frontDoorParameters := frontdoors.FrontDoor{
-		Location: utils.String("Global"),
+		Location: pointer.To("Global"),
 		Properties: &frontdoors.FrontDoorProperties{
-			FriendlyName:          utils.String(friendlyName),
+			FriendlyName:          pointer.To(friendlyName),
 			RoutingRules:          expandFrontDoorRoutingRule(routingRules, id, nil),
 			BackendPools:          expandFrontDoorBackendPools(backendPools, id),
 			BackendPoolsSettings:  expandFrontDoorBackendPoolsSettings(backendCertNameCheck, backendPoolsSendReceiveTimeoutSeconds),
@@ -138,26 +138,26 @@ func resourceFrontDoorUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 	// remove in 3.0
 	// due to a change in the RP, if a Frontdoor exists in a location other than 'Global' it may continue to
 	// exist in that location, if this is a brand new Frontdoor it must be created in the 'Global' location
-	var location string
+	var loc string
 
 	exists, err := client.Get(ctx, id)
 	if err != nil || exists.Model == nil {
 		return fmt.Errorf("locating %s: %+v", id, err)
 	} else {
-		location = azure.NormalizeLocation(*exists.Model.Location)
+		loc = location.Normalize(*exists.Model.Location)
 	}
 
 	cfgLocation, hasLocation := d.GetOk("location")
 	if hasLocation {
-		if location != azure.NormalizeLocation(cfgLocation) {
-			return fmt.Errorf("the Front Door %q (Resource Group %q) already exists in %q and cannot be moved to the %q location", name, resourceGroup, location, cfgLocation)
+		if loc != location.Normalize(cfgLocation.(string)) {
+			return fmt.Errorf("the Front Door %q (Resource Group %q) already exists in %q and cannot be moved to the %q location", name, resourceGroup, loc, cfgLocation)
 		}
 	}
 
 	existingModel := *exists.Model
 
 	if d.HasChange("friendly_name") {
-		existingModel.Properties.FriendlyName = utils.String(d.Get("friendly_name").(string))
+		existingModel.Properties.FriendlyName = pointer.To(d.Get("friendly_name").(string))
 	}
 
 	routingRules := d.Get("routing_rule").([]interface{})
@@ -449,15 +449,15 @@ func expandFrontDoorBackendPools(input []interface{}, frontDoorId frontdoors.Fro
 		loadBalancingId := parse.NewLoadBalancingID(frontDoorId.SubscriptionId, frontDoorId.ResourceGroupName, frontDoorId.FrontDoorName, backendPoolLoadBalancingName).ID()
 
 		result := frontdoors.BackendPool{
-			Id:   utils.String(backendPoolId),
-			Name: utils.String(backendPoolName),
+			Id:   pointer.To(backendPoolId),
+			Name: pointer.To(backendPoolName),
 			Properties: &frontdoors.BackendPoolProperties{
 				Backends: expandFrontDoorBackend(backends),
 				HealthProbeSettings: &frontdoors.SubResource{
-					Id: utils.String(healthProbeId),
+					Id: pointer.To(healthProbeId),
 				},
 				LoadBalancingSettings: &frontdoors.SubResource{
-					Id: utils.String(loadBalancingId),
+					Id: pointer.To(loadBalancingId),
 				},
 			},
 		}
@@ -485,13 +485,13 @@ func expandFrontDoorBackend(input []interface{}) *[]frontdoors.Backend {
 		weight := int64(backend["weight"].(int))
 
 		result := frontdoors.Backend{
-			Address:           utils.String(address),
-			BackendHostHeader: utils.String(hostHeader),
+			Address:           pointer.To(address),
+			BackendHostHeader: pointer.To(hostHeader),
 			EnabledState:      &enabled,
-			HTTPPort:          utils.Int64(httpPort),
-			HTTPSPort:         utils.Int64(httpsPort),
-			Priority:          utils.Int64(priority),
-			Weight:            utils.Int64(weight),
+			HTTPPort:          pointer.To(httpPort),
+			HTTPSPort:         pointer.To(httpsPort),
+			Priority:          pointer.To(priority),
+			Weight:            pointer.To(weight),
 		}
 		output = append(output, result)
 	}
@@ -515,7 +515,7 @@ func expandFrontDoorBackendPoolsSettings(enforceCertificateNameCheck bool, backe
 
 	result := frontdoors.BackendPoolsSettings{
 		EnforceCertificateNameCheck: &enforceCheck,
-		SendRecvTimeoutSeconds:      utils.Int64(backendPoolsSendReceiveTimeoutSeconds),
+		SendRecvTimeoutSeconds:      pointer.To(backendPoolsSendReceiveTimeoutSeconds),
 	}
 
 	return &result
@@ -543,18 +543,18 @@ func expandFrontDoorFrontendEndpoint(input []interface{}, frontDoorId frontdoors
 		}
 
 		result := frontdoors.FrontendEndpoint{
-			Id:   utils.String(id),
-			Name: utils.String(name),
+			Id:   pointer.To(id),
+			Name: pointer.To(name),
 			Properties: &frontdoors.FrontendEndpointProperties{
-				HostName:                    utils.String(hostName),
+				HostName:                    pointer.To(hostName),
 				SessionAffinityEnabledState: &sessionAffinityEnabled,
-				SessionAffinityTtlSeconds:   utils.Int64(sessionAffinityTtlSeconds),
+				SessionAffinityTtlSeconds:   pointer.To(sessionAffinityTtlSeconds),
 			},
 		}
 
 		if waf != "" {
 			result.Properties.WebApplicationFirewallPolicyLink = &frontdoors.FrontendEndpointUpdateParametersWebApplicationFirewallPolicyLink{
-				Id: utils.String(waf),
+				Id: pointer.To(waf),
 			}
 		}
 		output = append(output, result)
@@ -587,11 +587,11 @@ func expandFrontDoorHealthProbeSettingsModel(input []interface{}, frontDoorId fr
 		probeMethod := frontdoors.FrontDoorHealthProbeMethod(v["probe_method"].(string))
 
 		result := frontdoors.HealthProbeSettingsModel{
-			Id:   utils.String(healthProbeId),
-			Name: utils.String(name),
+			Id:   pointer.To(healthProbeId),
+			Name: pointer.To(name),
 			Properties: &frontdoors.HealthProbeSettingsProperties{
-				IntervalInSeconds: utils.Int64(intervalInSeconds),
-				Path:              utils.String(path),
+				IntervalInSeconds: pointer.To(intervalInSeconds),
+				Path:              pointer.To(path),
 				Protocol:          &protocol,
 				HealthProbeMethod: &probeMethod,
 				EnabledState:      &healthProbeEnabled,
@@ -620,12 +620,12 @@ func expandFrontDoorLoadBalancingSettingsModel(input []interface{}, frontDoorId 
 		loadBalancingId := parse.NewLoadBalancingID(frontDoorId.SubscriptionId, frontDoorId.ResourceGroupName, frontDoorId.FrontDoorName, name).ID()
 
 		result := frontdoors.LoadBalancingSettingsModel{
-			Id:   utils.String(loadBalancingId),
-			Name: utils.String(name),
+			Id:   pointer.To(loadBalancingId),
+			Name: pointer.To(name),
 			Properties: &frontdoors.LoadBalancingSettingsProperties{
-				SampleSize:                    utils.Int64(sampleSize),
-				SuccessfulSamplesRequired:     utils.Int64(successfulSamplesRequired),
-				AdditionalLatencyMilliseconds: utils.Int64(additionalLatencyMilliseconds),
+				SampleSize:                    pointer.To(sampleSize),
+				SuccessfulSamplesRequired:     pointer.To(successfulSamplesRequired),
+				AdditionalLatencyMilliseconds: pointer.To(additionalLatencyMilliseconds),
 			},
 		}
 		output = append(output, result)
@@ -663,8 +663,8 @@ func expandFrontDoorRoutingRule(input []interface{}, frontDoorId frontdoors.Fron
 		routingRuleId := parse.NewRoutingRuleID(frontDoorId.SubscriptionId, frontDoorId.ResourceGroupName, frontDoorId.FrontDoorName, name).ID()
 
 		currentRoutingRule := frontdoors.RoutingRule{
-			Id:   utils.String(routingRuleId),
-			Name: utils.String(name),
+			Id:   pointer.To(routingRuleId),
+			Name: pointer.To(name),
 			Properties: &frontdoors.RoutingRuleProperties{
 				FrontendEndpoints:  expandFrontDoorFrontEndEndpoints(frontendEndpoints, frontDoorId),
 				AcceptedProtocols:  expandFrontDoorAcceptedProtocols(acceptedProtocols),
@@ -716,7 +716,7 @@ func expandFrontDoorFrontEndEndpoints(input []interface{}, frontDoorId frontdoor
 	for _, name := range input {
 		frontendEndpointId := parse.NewFrontendEndpointID(frontDoorId.SubscriptionId, frontDoorId.ResourceGroupName, frontDoorId.FrontDoorName, name.(string)).ID()
 		result := frontdoors.SubResource{
-			Id: utils.String(frontendEndpointId),
+			Id: pointer.To(frontendEndpointId),
 		}
 		output = append(output, result)
 	}
@@ -745,23 +745,23 @@ func expandFrontDoorRedirectConfiguration(input []interface{}) frontdoors.Redire
 	customQueryString := v["custom_query_string"].(string)
 
 	redirectConfiguration := frontdoors.RedirectConfiguration{
-		CustomHost:       utils.String(customHost),
+		CustomHost:       pointer.To(customHost),
 		RedirectType:     &redirectType,
 		RedirectProtocol: &redirectProtocol,
 	}
 	// The way the API works is if you don't include the attribute in the structure
 	// it is treated as Preserve instead of Replace...
 	if customHost != "" {
-		redirectConfiguration.CustomHost = utils.String(customHost)
+		redirectConfiguration.CustomHost = pointer.To(customHost)
 	}
 	if customPath != "" {
-		redirectConfiguration.CustomPath = utils.String(customPath)
+		redirectConfiguration.CustomPath = pointer.To(customPath)
 	}
 	if customFragment != "" {
-		redirectConfiguration.CustomFragment = utils.String(customFragment)
+		redirectConfiguration.CustomFragment = pointer.To(customFragment)
 	}
 	if customQueryString != "" {
-		redirectConfiguration.CustomQueryString = utils.String(customQueryString)
+		redirectConfiguration.CustomQueryString = pointer.To(customQueryString)
 	}
 	return redirectConfiguration
 }
@@ -790,7 +790,7 @@ func expandFrontDoorForwardingConfiguration(input []interface{}, frontDoorId fro
 
 	backendPoolId := parse.NewBackendPoolID(frontDoorId.SubscriptionId, frontDoorId.ResourceGroupName, frontDoorId.FrontDoorName, backendPoolName).ID()
 	backend := &frontdoors.SubResource{
-		Id: utils.String(backendPoolId),
+		Id: pointer.To(backendPoolId),
 	}
 
 	forwardingConfiguration := frontdoors.ForwardingConfiguration{
@@ -819,19 +819,19 @@ func expandFrontDoorForwardingConfiguration(input []interface{}, frontDoorId fro
 		if cacheDuration == "" {
 			duration = nil
 		} else {
-			duration = utils.String(cacheDuration)
+			duration = pointer.To(cacheDuration)
 		}
 
 		forwardingConfiguration.CacheConfiguration = &frontdoors.CacheConfiguration{
 			DynamicCompression:           &dynamicCompression,
 			QueryParameterStripDirective: &cacheQueryParameterStripDirective,
-			QueryParameters:              utils.String(queryParametersString),
+			QueryParameters:              pointer.To(queryParametersString),
 			CacheDuration:                duration,
 		}
 	}
 
 	if customForwardingPath != "" {
-		forwardingConfiguration.CustomForwardingPath = utils.String(customForwardingPath)
+		forwardingConfiguration.CustomForwardingPath = pointer.To(customForwardingPath)
 	}
 
 	return forwardingConfiguration
@@ -1603,7 +1603,7 @@ func flattenRoutingRuleForwardingConfiguration(config frontdoors.RouteConfigurat
 							ofc := oldConfigs[0].(map[string]interface{})
 							cacheQueryParameterStripDirective = ofc["cache_query_parameter_strip_directive"].(string)
 							cacheUseDynamicCompression = ofc["cache_use_dynamic_compression"].(bool)
-							cacheDuration = utils.String(ofc["cache_duration"].(string))
+							cacheDuration = pointer.To(ofc["cache_duration"].(string))
 
 							cacheQueryParameters = ofc["cache_query_parameters"].([]interface{})
 							for _, p := range cacheQueryParameters {

--- a/internal/services/frontdoor/frontdoor_resource_test.go
+++ b/internal/services/frontdoor/frontdoor_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/frontdoor"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FrontDoorResource struct{}
@@ -47,7 +47,7 @@ func (FrontDoorResource) Exists(ctx context.Context, clients *clients.Client, st
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (FrontDoorResource) basic(data acceptance.TestData) string {

--- a/internal/services/frontdoor/frontdoor_rules_engine_resource.go
+++ b/internal/services/frontdoor/frontdoor_rules_engine_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceFrontDoorRulesEngine() *pluginsdk.Resource {
@@ -281,7 +281,7 @@ func resourceFrontDoorRulesEngineCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	frontdoorRulesEngine := frontdoors.RulesEngine{
-		Name:       utils.String(rulesEngineName),
+		Name:       pointer.To(rulesEngineName),
 		Properties: &frontdoorRulesEngineProperties,
 	}
 
@@ -326,7 +326,7 @@ func expandHeaderAction(input []interface{}) *[]frontdoors.HeaderAction {
 
 		frontdoorRulesEngineRuleHeaderAction := frontdoors.HeaderAction{
 			HeaderName:       headerName,
-			Value:            utils.String(value),
+			Value:            pointer.To(value),
 			HeaderActionType: frontdoors.HeaderActionType(headerActionType),
 		}
 
@@ -387,7 +387,7 @@ func expandFrontDoorRulesEngineMatchCondition(input []interface{}) *[]frontdoors
 
 		matchCondition := frontdoors.RulesEngineMatchCondition{
 			RulesEngineMatchVariable: frontdoors.RulesEngineMatchVariable(matchVariable),
-			Selector:                 utils.String(selector),
+			Selector:                 pointer.To(selector),
 			RulesEngineOperator:      frontdoors.RulesEngineOperator(operator),
 			NegateCondition:          &negateCondition,
 			RulesEngineMatchValue:    matchValueArray,

--- a/internal/services/frontdoor/migration/custom_https_configuration_test.go
+++ b/internal/services/frontdoor/migration/custom_https_configuration_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestCustomHttpsConfigurationV0ToV1(t *testing.T) {
@@ -28,14 +28,14 @@ func TestCustomHttpsConfigurationV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/mygroup1/providers/Microsoft.Network/frontdoors/frontdoor1/customHttpsConfiguration/config2",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/mygroup1/providers/Microsoft.Network/frontDoors/frontdoor1/customHttpsConfiguration/config2"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/mygroup1/providers/Microsoft.Network/frontDoors/frontdoor1/customHttpsConfiguration/config2"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/mygroup1/providers/Microsoft.Network/Frontdoors/frontdoor1/CustomHttpsConfiguration/config2",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/mygroup1/providers/Microsoft.Network/frontDoors/frontdoor1/customHttpsConfiguration/config2"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/mygroup1/providers/Microsoft.Network/frontDoors/frontdoor1/customHttpsConfiguration/config2"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/frontdoor/migration/frontdoor_test.go
+++ b/internal/services/frontdoor/migration/frontdoor_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestFrontDoorV1ToV2(t *testing.T) {
@@ -28,28 +28,28 @@ func TestFrontDoorV1ToV2(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Network/frontdoors/frontdoor1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
 		},
 		{
 			name: "old id - lower case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Network/frontdoors/frontdoor1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Network/FrontDoors/frontdoor1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoors/frontdoor1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/frontdoor/migration/web_application_firewall_policy_test.go
+++ b/internal/services/frontdoor/migration/web_application_firewall_policy_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestWebApplicationFirewallPolicyV0ToV1(t *testing.T) {
@@ -28,21 +28,21 @@ func TestWebApplicationFirewallPolicyV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Network/frontdoorwebapplicationfirewallpolicies/policy1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/policy1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/policy1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/graphservices/graph_services_account_resource_test.go
+++ b/internal/services/graphservices/graph_services_account_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/graphservices/2023-04-13/graphservicesprods"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestAccGraphServicesAccount(t *testing.T) {
@@ -117,7 +117,7 @@ func (r AccountTestResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r AccountTestResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
