### PR TITLE
services `H*`/`I*` - deprecated function clean up

### DIFF
--- a/internal/services/hdinsight/common_hdinsight.go
+++ b/internal/services/hdinsight/common_hdinsight.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/hdinsight/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func hdinsightClusterUpdate(clusterKind string, readFunc pluginsdk.ReadFunc) pluginsdk.UpdateFunc {
@@ -293,15 +292,15 @@ func createHDInsightEdgeNodes(ctx context.Context, client *applications.Applicat
 		Properties: &applications.ApplicationProperties{
 			ComputeProfile: &applications.ComputeProfile{
 				Roles: &[]applications.Role{{
-					Name: utils.String("edgenode"),
+					Name: pointer.To("edgenode"),
 					HardwareProfile: &applications.HardwareProfile{
-						VMSize: utils.String(input["vm_size"].(string)),
+						VMSize: pointer.To(input["vm_size"].(string)),
 					},
 					TargetInstanceCount: pointer.To(int64(input["target_instance_count"].(int))),
 				}},
 			},
 			InstallScriptActions: installScriptActions,
-			ApplicationType:      utils.String("CustomApplication"),
+			ApplicationType:      pointer.To("CustomApplication"),
 		},
 	}
 

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // NOTE: this isn't a recommended way of building resources in Terraform
@@ -271,12 +270,12 @@ func resourceHDInsightHadoopClusterCreate(d *pluginsdk.ResourceData, meta interf
 
 	var configurationsRaw interface{} = configurations
 	payload := clusters.ClusterCreateParametersExtended{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &clusters.ClusterCreateProperties{
 			Tier:                      pointer.To(tier),
 			OsType:                    pointer.To(clusters.OSTypeLinux),
-			ClusterVersion:            utils.String(clusterVersion),
-			MinSupportedTlsVersion:    utils.String(tls),
+			ClusterVersion:            pointer.To(clusterVersion),
+			MinSupportedTlsVersion:    pointer.To(tls),
 			NetworkProperties:         networkProperties,
 			PrivateLinkConfigurations: privateLinkConfigurations,
 			ClusterDefinition: &clusters.ClusterDefinition{
@@ -609,7 +608,7 @@ func expandHDInsightApplicationEdgeNodeInstallScriptActions(input []interface{})
 			Name: name,
 			Uri:  uri,
 			// The only role available for edge nodes is edgenode
-			Parameters: utils.String(parameters),
+			Parameters: pointer.To(parameters),
 			Roles:      []string{"edgenode"},
 		}
 
@@ -637,9 +636,9 @@ func expandHDInsightApplicationEdgeNodeHttpsEndpoints(input []interface{}) *[]ap
 		endPoint := applications.ApplicationGetHTTPSEndpoint{
 			AccessModes:        &accessModes,
 			DestinationPort:    pointer.To(destinationPort),
-			PrivateIPAddress:   utils.String(privateIpAddress),
-			SubDomainSuffix:    utils.String(subDomainSuffix),
-			DisableGatewayAuth: utils.Bool(disableGatewayAuth),
+			PrivateIPAddress:   pointer.To(privateIpAddress),
+			SubDomainSuffix:    pointer.To(subDomainSuffix),
+			DisableGatewayAuth: pointer.To(disableGatewayAuth),
 		}
 
 		endpoints = append(endpoints, endPoint)
@@ -664,7 +663,7 @@ func expandHDInsightApplicationEdgeNodeUninstallScriptActions(input []interface{
 		action := applications.RuntimeScriptAction{
 			Name:       name,
 			Uri:        uri,
-			Parameters: utils.String(parameters),
+			Parameters: pointer.To(parameters),
 			Roles:      []string{"edgenode"},
 		}
 

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HDInsightHadoopClusterResource struct{}
@@ -806,7 +806,7 @@ func (r HDInsightHadoopClusterResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving Hadoop %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HDInsightHadoopClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // NOTE: this isn't a recommended way of building resources in Terraform
@@ -212,12 +211,12 @@ func resourceHDInsightHBaseClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	var configurationsRaw interface{} = configurations
 	params := clusters.ClusterCreateParametersExtended{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &clusters.ClusterCreateProperties{
 			Tier:                      pointer.To(tier),
 			OsType:                    pointer.To(clusters.OSTypeLinux),
-			ClusterVersion:            utils.String(clusterVersion),
-			MinSupportedTlsVersion:    utils.String(tls),
+			ClusterVersion:            pointer.To(clusterVersion),
+			MinSupportedTlsVersion:    pointer.To(tls),
 			NetworkProperties:         networkProperties,
 			PrivateLinkConfigurations: privateLinkConfigurations,
 			ClusterDefinition: &clusters.ClusterDefinition{

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HDInsightHBaseClusterResource struct{}
@@ -592,7 +592,7 @@ func (r HDInsightHBaseClusterResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading HBase %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HDInsightHBaseClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // NOTE: this isn't a recommended way of building resources in Terraform
@@ -222,12 +221,12 @@ func resourceHDInsightInteractiveQueryClusterCreate(d *pluginsdk.ResourceData, m
 
 	var configurationsRaw interface{} = configurations
 	params := clusters.ClusterCreateParametersExtended{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &clusters.ClusterCreateProperties{
 			Tier:                      pointer.To(tier),
 			OsType:                    pointer.To(clusters.OSTypeLinux),
-			ClusterVersion:            utils.String(clusterVersion),
-			MinSupportedTlsVersion:    utils.String(tls),
+			ClusterVersion:            pointer.To(clusterVersion),
+			MinSupportedTlsVersion:    pointer.To(tls),
 			NetworkProperties:         networkProperties,
 			PrivateLinkConfigurations: privateLinkConfigurations,
 			EncryptionInTransitProperties: &clusters.EncryptionInTransitProperties{

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HDInsightInteractiveQueryClusterResource struct{}
@@ -637,7 +637,7 @@ func (r HDInsightInteractiveQueryClusterResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("reading HDInsight Interactive Query Cluster (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HDInsightInteractiveQueryClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // NOTE: this isn't a recommended way of building resources in Terraform
@@ -263,12 +262,12 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	var configurationsRaw interface{} = configurations
 	payload := clusters.ClusterCreateParametersExtended{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &clusters.ClusterCreateProperties{
 			Tier:                      pointer.To(tier),
 			OsType:                    pointer.To(clusters.OSTypeLinux),
-			ClusterVersion:            utils.String(clusterVersion),
-			MinSupportedTlsVersion:    utils.String(tls),
+			ClusterVersion:            pointer.To(clusterVersion),
+			MinSupportedTlsVersion:    pointer.To(tls),
 			NetworkProperties:         networkProperties,
 			PrivateLinkConfigurations: privateLinkConfigurations,
 			ClusterDefinition: &clusters.ClusterDefinition{
@@ -291,7 +290,7 @@ func resourceHDInsightKafkaClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	if encryptionInTransit, ok := d.GetOk("encryption_in_transit_enabled"); ok {
 		payload.Properties.EncryptionInTransitProperties = &clusters.EncryptionInTransitProperties{
-			IsEncryptionInTransitEnabled: utils.Bool(encryptionInTransit.(bool)),
+			IsEncryptionInTransitEnabled: pointer.To(encryptionInTransit.(bool)),
 		}
 	}
 

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HDInsightKafkaClusterResource struct{}
@@ -618,7 +618,7 @@ func (r HDInsightKafkaClusterResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading Kafka %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HDInsightKafkaClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // NOTE: this isn't a recommended way of building resources in Terraform
@@ -226,15 +225,15 @@ func resourceHDInsightSparkClusterCreate(d *pluginsdk.ResourceData, meta interfa
 
 	var configurationsRaw interface{} = configurations
 	payload := clusters.ClusterCreateParametersExtended{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &clusters.ClusterCreateProperties{
 			Tier:           pointer.To(tier),
 			OsType:         pointer.To(clusters.OSTypeLinux),
-			ClusterVersion: utils.String(clusterVersion),
+			ClusterVersion: pointer.To(clusterVersion),
 			EncryptionInTransitProperties: &clusters.EncryptionInTransitProperties{
 				IsEncryptionInTransitEnabled: &encryptionInTransit,
 			},
-			MinSupportedTlsVersion:    utils.String(tls),
+			MinSupportedTlsVersion:    pointer.To(tls),
 			NetworkProperties:         networkProperties,
 			PrivateLinkConfigurations: privateLinkConfigurations,
 			ClusterDefinition: &clusters.ClusterDefinition{

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HDInsightSparkClusterResource struct{}
@@ -687,7 +687,7 @@ func (r HDInsightSparkClusterResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading Spark %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HDInsightSparkClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
+++ b/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
@@ -10,13 +10,13 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/fhirservices"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/healthcare/migration"
@@ -117,7 +117,7 @@ func resourceHealthcareApisMedTechServiceFhirDestinationCreate(d *pluginsdk.Reso
 	}
 
 	iotFhirServiceParameters := iotconnectors.IotFhirDestination{
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: iotconnectors.IotFhirDestinationProperties{
 			FhirServiceResourceId:          d.Get("destination_fhir_service_id").(string),
 			ResourceIdentityResolutionType: iotconnectors.IotIdentityResolutionType(d.Get("destination_identity_resolution_type").(string)),
@@ -209,7 +209,7 @@ func resourceHealthcareApisMedTechServiceFhirDestinationUpdate(d *pluginsdk.Reso
 	id := iotconnectors.NewFhirDestinationID(medTechService.SubscriptionId, medTechService.ResourceGroupName, medTechService.WorkspaceName, medTechService.IotConnectorName, d.Get("name").(string))
 
 	medTechFhirServiceParameters := iotconnectors.IotFhirDestination{
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: iotconnectors.IotFhirDestinationProperties{
 			FhirServiceResourceId:          d.Get("destination_fhir_service_id").(string),
 			ResourceIdentityResolutionType: iotconnectors.IotIdentityResolutionType(d.Get("destination_identity_resolution_type").(string)),

--- a/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource_test.go
+++ b/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HealthCareMedTechServiceFhirDestinationResource struct{}
@@ -101,7 +101,7 @@ func (r HealthCareMedTechServiceFhirDestinationResource) Exists(ctx context.Cont
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s, %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r HealthCareMedTechServiceFhirDestinationResource) basic(data acceptance.TestData) string {

--- a/internal/services/hsm/dedicated_hardware_security_module_resource.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceDedicatedHardwareSecurityModule() *pluginsdk.Resource {
@@ -177,7 +177,7 @@ func resourceDedicatedHardwareSecurityModuleCreate(d *pluginsdk.ResourceData, me
 	}
 
 	if v, ok := d.GetOk("stamp_id"); ok {
-		parameters.Properties.StampId = utils.String(v.(string))
+		parameters.Properties.StampId = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("zones"); ok {
@@ -296,7 +296,7 @@ func expandDedicatedHsmNetworkProfile(input []interface{}) *dedicatedhsms.Networ
 
 	result := dedicatedhsms.NetworkProfile{
 		Subnet: &dedicatedhsms.ApiEntityReference{
-			Id: utils.String(v["subnet_id"].(string)),
+			Id: pointer.To(v["subnet_id"].(string)),
 		},
 		NetworkInterfaces: expandDedicatedHsmNetworkInterfacePrivateIPAddresses(v["network_interface_private_ip_addresses"].(*pluginsdk.Set).List()),
 	}
@@ -310,7 +310,7 @@ func expandDedicatedHsmNetworkInterfacePrivateIPAddresses(input []interface{}) *
 	for _, item := range input {
 		if item != nil {
 			results = append(results, dedicatedhsms.NetworkInterface{
-				PrivateIPAddress: utils.String(item.(string)),
+				PrivateIPAddress: pointer.To(item.(string)),
 			})
 		}
 	}

--- a/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
+++ b/internal/services/hsm/dedicated_hardware_security_module_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DedicatedHardwareSecurityModuleResource struct{}
@@ -115,7 +115,7 @@ func (DedicatedHardwareSecurityModuleResource) Exists(ctx context.Context, clien
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (DedicatedHardwareSecurityModuleResource) template(data acceptance.TestData) string {

--- a/internal/services/iotcentral/iotcentral_application_network_rule_set_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_network_rule_set_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -17,7 +18,6 @@ import (
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotCentralApplicationNetworkRuleSetResource struct{}
@@ -137,9 +137,9 @@ func (r IotCentralApplicationNetworkRuleSetResource) Create() sdk.ResourceFunc {
 			}
 
 			model.Properties.NetworkRuleSets = &apps.NetworkRuleSets{
-				ApplyToDevices: utils.Bool(state.ApplyToDevice),
+				ApplyToDevices: pointer.To(state.ApplyToDevice),
 				// ApplyToIoTCentral must be set to false explicitly
-				ApplyToIoTCentral: utils.Bool(false),
+				ApplyToIoTCentral: pointer.To(false),
 				DefaultAction:     &state.DefaultAction,
 				IPRules:           expandIotCentralApplicationNetworkRuleSetIPRule(state.IPRule),
 			}
@@ -229,10 +229,10 @@ func (r IotCentralApplicationNetworkRuleSetResource) Update() sdk.ResourceFunc {
 			}
 
 			// ApplyToIoTCentral must be set to false explicitly
-			existing.Model.Properties.NetworkRuleSets.ApplyToIoTCentral = utils.Bool(false)
+			existing.Model.Properties.NetworkRuleSets.ApplyToIoTCentral = pointer.To(false)
 
 			if metadata.ResourceData.HasChange("apply_to_device") {
-				existing.Model.Properties.NetworkRuleSets.ApplyToDevices = utils.Bool(state.ApplyToDevice)
+				existing.Model.Properties.NetworkRuleSets.ApplyToDevices = pointer.To(state.ApplyToDevice)
 			}
 
 			if metadata.ResourceData.HasChange("default_action") {
@@ -287,8 +287,8 @@ func expandIotCentralApplicationNetworkRuleSetIPRule(input []IPRule) *[]apps.Net
 	results := make([]apps.NetworkRuleSetIPRule, 0)
 	for _, item := range input {
 		results = append(results, apps.NetworkRuleSetIPRule{
-			FilterName: utils.String(item.Name),
-			IPMask:     utils.String(item.IPMask),
+			FilterName: pointer.To(item.Name),
+			IPMask:     pointer.To(item.IPMask),
 		})
 	}
 	return &results

--- a/internal/services/iotcentral/iotcentral_application_network_rule_set_resource_test.go
+++ b/internal/services/iotcentral/iotcentral_application_network_rule_set_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IoTCentralApplicationNetworkRuleSetResource struct{}
@@ -186,7 +186,7 @@ func (IoTCentralApplicationNetworkRuleSetResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil && resp.Model.Properties != nil && resp.Model.Properties.NetworkRuleSets != nil), nil
+	return pointer.To(resp.Model != nil && resp.Model.Properties != nil && resp.Model.Properties.NetworkRuleSets != nil), nil
 }
 
 func (r IoTCentralApplicationNetworkRuleSetResource) basic(data acceptance.TestData) string {

--- a/internal/services/iotcentral/iotcentral_application_resource.go
+++ b/internal/services/iotcentral/iotcentral_application_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceIotCentralApplication() *pluginsdk.Resource {
@@ -204,11 +204,11 @@ func resourceIotCentralAppUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("sub_domain") {
-		existing.Model.Properties.Subdomain = utils.String(d.Get("sub_domain").(string))
+		existing.Model.Properties.Subdomain = pointer.To(d.Get("sub_domain").(string))
 	}
 
 	if d.HasChange("display_name") {
-		existing.Model.Properties.DisplayName = utils.String(d.Get("display_name").(string))
+		existing.Model.Properties.DisplayName = pointer.To(d.Get("display_name").(string))
 	}
 
 	if d.HasChange("sku") {
@@ -218,7 +218,7 @@ func resourceIotCentralAppUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("template") {
-		existing.Model.Properties.Template = utils.String(d.Get("template").(string))
+		existing.Model.Properties.Template = pointer.To(d.Get("template").(string))
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/iotcentral/iotcentral_application_resource_test.go
+++ b/internal/services/iotcentral/iotcentral_application_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IoTCentralApplicationResource struct{}
@@ -267,7 +267,7 @@ func (IoTCentralApplicationResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (IoTCentralApplicationResource) basic(data acceptance.TestData) string {

--- a/internal/services/iotcentral/iotcentral_organization_resource_test.go
+++ b/internal/services/iotcentral/iotcentral_organization_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iotcentral/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IoTCentralOrganizationResource struct{}
@@ -103,7 +103,7 @@ func (IoTCentralOrganizationResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil || *resp.ID == ""), nil
+	return pointer.To(resp.ID != nil || *resp.ID == ""), nil
 }
 
 func (r IoTCentralOrganizationResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_certificate_resource.go
+++ b/internal/services/iothub/iothub_certificate_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -98,8 +99,8 @@ func resourceIotHubCertificateCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	certificate := devices.CertificateDescription{
 		Properties: &devices.CertificateProperties{
-			IsVerified:  utils.Bool(d.Get("is_verified").(bool)),
-			Certificate: utils.String(d.Get("certificate_content").(string)),
+			IsVerified:  pointer.To(d.Get("is_verified").(bool)),
+			Certificate: pointer.To(d.Get("certificate_content").(string)),
 		},
 	}
 
@@ -162,11 +163,11 @@ func resourceIotHubCertificateUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if d.HasChange("is_verified") {
-		existing.Properties.IsVerified = utils.Bool(d.Get("is_verified").(bool))
+		existing.Properties.IsVerified = pointer.To(d.Get("is_verified").(bool))
 	}
 
 	if d.HasChange("certificate_content") {
-		existing.Properties.Certificate = utils.String(d.Get("certificate_content").(string))
+		existing.Properties.Certificate = pointer.To(d.Get("certificate_content").(string))
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IotHubName, id.CertificateName, existing, etag); err != nil {
@@ -198,7 +199,7 @@ func resourceIotHubCertificateDelete(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("deleting  %s because Etag is nil", *id)
 	}
 
-	if _, err := client.Delete(ctx, id.ResourceGroup, id.IotHubName, id.CertificateName, *utils.String(*resp.Etag)); err != nil {
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.IotHubName, id.CertificateName, *pointer.To(*resp.Etag)); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 	return nil

--- a/internal/services/iothub/iothub_certificate_resource_test.go
+++ b/internal/services/iothub/iothub_certificate_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubCertificateResource struct{}
@@ -87,7 +87,7 @@ func (t IotHubCertificateResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (IotHubCertificateResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_consumer_group_resource_test.go
+++ b/internal/services/iothub/iothub_consumer_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubConsumerGroupResource struct{}
@@ -94,7 +94,7 @@ func (t IotHubConsumerGroupResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading IotHuB Consumer Group (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (IotHubConsumerGroupResource) basic(data acceptance.TestData, eventName string) string {

--- a/internal/services/iothub/iothub_device_update_account_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_account_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubDeviceUpdateAccountResource struct{}
@@ -151,11 +151,11 @@ func (r IotHubDeviceUpdateAccountResource) Exists(ctx context.Context, clients *
 	resp, err := client.AccountsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r IotHubDeviceUpdateAccountResource) template(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_device_update_instance_resource_test.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubDeviceUpdateInstanceResource struct{}
@@ -142,11 +142,11 @@ func (r IotHubDeviceUpdateInstanceResource) Exists(ctx context.Context, clients 
 	resp, err := client.InstancesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r IotHubDeviceUpdateInstanceResource) template(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_dps_certificate_resource.go
+++ b/internal/services/iothub/iothub_dps_certificate_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceIotHubDPSCertificate() *pluginsdk.Resource {
@@ -80,7 +80,7 @@ func resourceIotHubDPSCertificateCreate(d *pluginsdk.ResourceData, meta interfac
 
 	id := dpscertificate.NewCertificateID(subscriptionId, d.Get("resource_group_name").(string), d.Get("iot_dps_name").(string), d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id, dpscertificate.GetOperationOptions{IfMatch: utils.String("")})
+	existing, err := client.Get(ctx, id, dpscertificate.GetOperationOptions{IfMatch: pointer.To("")})
 	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
 			return fmt.Errorf("checking for presence of existing IoT Device Provisioning Service Certificate %s: %+v", id.String(), err)
@@ -93,14 +93,14 @@ func resourceIotHubDPSCertificateCreate(d *pluginsdk.ResourceData, meta interfac
 
 	certificate := dpscertificate.CertificateResponse{
 		Properties: &dpscertificate.CertificateProperties{
-			Certificate: utils.String(d.Get("certificate_content").(string)),
+			Certificate: pointer.To(d.Get("certificate_content").(string)),
 		},
 	}
 	if d.Get("is_verified").(bool) {
-		certificate.Properties.IsVerified = utils.Bool(true)
+		certificate.Properties.IsVerified = pointer.To(true)
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, id, certificate, dpscertificate.CreateOrUpdateOperationOptions{IfMatch: utils.String("")}); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, id, certificate, dpscertificate.CreateOrUpdateOperationOptions{IfMatch: pointer.To("")}); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -119,7 +119,7 @@ func resourceIotHubDPSCertificateRead(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
-	resp, err := client.Get(ctx, *id, dpscertificate.GetOperationOptions{IfMatch: utils.String("")})
+	resp, err := client.Get(ctx, *id, dpscertificate.GetOperationOptions{IfMatch: pointer.To("")})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
@@ -153,7 +153,7 @@ func resourceIotHubDPSCertificateUpdate(d *pluginsdk.ResourceData, meta interfac
 
 	id := dpscertificate.NewCertificateID(subscriptionId, d.Get("resource_group_name").(string), d.Get("iot_dps_name").(string), d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id, dpscertificate.GetOperationOptions{IfMatch: utils.String("")})
+	existing, err := client.Get(ctx, id, dpscertificate.GetOperationOptions{IfMatch: pointer.To("")})
 	if err != nil {
 		return fmt.Errorf("reading %s: %+v", id, err)
 	}
@@ -164,14 +164,14 @@ func resourceIotHubDPSCertificateUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	if d.HasChange("is_verified") {
-		existing.Model.Properties.IsVerified = utils.Bool(d.Get("is_verified").(bool))
+		existing.Model.Properties.IsVerified = pointer.To(d.Get("is_verified").(bool))
 	}
 
 	if d.HasChange("certificate_content") {
-		existing.Model.Properties.Certificate = utils.String(d.Get("certificate_content").(string))
+		existing.Model.Properties.Certificate = pointer.To(d.Get("certificate_content").(string))
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, id, *existing.Model, dpscertificate.CreateOrUpdateOperationOptions{IfMatch: utils.String(etag)}); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, id, *existing.Model, dpscertificate.CreateOrUpdateOperationOptions{IfMatch: pointer.To(etag)}); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
@@ -188,7 +188,7 @@ func resourceIotHubDPSCertificateDelete(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	resp, err := client.Get(ctx, *id, dpscertificate.GetOperationOptions{IfMatch: utils.String("")})
+	resp, err := client.Get(ctx, *id, dpscertificate.GetOperationOptions{IfMatch: pointer.To("")})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return nil
@@ -202,7 +202,7 @@ func resourceIotHubDPSCertificateDelete(d *pluginsdk.ResourceData, meta interfac
 
 	deleteOptions := dpscertificate.DeleteOperationOptions{
 		IfMatch:         resp.Model.Etag,
-		CertificateName: utils.String(id.CertificateName),
+		CertificateName: pointer.To(id.CertificateName),
 	}
 	if _, err := client.Delete(ctx, *id, deleteOptions); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/iothub/iothub_dps_certificate_resource_test.go
+++ b/internal/services/iothub/iothub_dps_certificate_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubDPSCertificateResource struct{}
@@ -94,12 +94,12 @@ func (t IotHubDPSCertificateResource) Exists(ctx context.Context, clients *clien
 		return nil, err
 	}
 
-	resp, err := clients.IoTHub.DPSCertificateClient.Get(ctx, *id, dpscertificate.GetOperationOptions{IfMatch: utils.String("")})
+	resp, err := clients.IoTHub.DPSCertificateClient.Get(ctx, *id, dpscertificate.GetOperationOptions{IfMatch: pointer.To("")})
 	if err != nil {
 		return nil, fmt.Errorf("reading IotHuB DPS Certificate (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (IotHubDPSCertificateResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_dps_resource_test.go
+++ b/internal/services/iothub/iothub_dps_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubDPSResource struct{}
@@ -172,7 +172,7 @@ func (t IotHubDPSResource) Exists(ctx context.Context, clients *clients.Client, 
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (IotHubDPSResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_dps_shared_access_policy_resource_test.go
+++ b/internal/services/iothub/iothub_dps_shared_access_policy_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubDpsSharedAccessPolicyResource struct{}
@@ -214,5 +214,5 @@ func (t IotHubDpsSharedAccessPolicyResource) Exists(ctx context.Context, clients
 		return nil, fmt.Errorf("loading Shared Access Policy (%s): %+v", id, err)
 	}
 
-	return utils.Bool(accessPolicy.Model != nil && accessPolicy.Model.PrimaryKey != nil), nil
+	return pointer.To(accessPolicy.Model != nil && accessPolicy.Model.PrimaryKey != nil), nil
 }

--- a/internal/services/iothub/iothub_endpoint_eventhub_resource.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource.go
@@ -164,8 +164,8 @@ func resourceIotHubEndpointEventHubCreateUpdate(d *pluginsdk.ResourceData, meta 
 
 	eventhubEndpoint := devices.RoutingEventHubProperties{
 		AuthenticationType: authenticationType,
-		Name:               utils.String(id.EndpointName),
-		ResourceGroup:      utils.String(endpointRG),
+		Name:               pointer.To(id.EndpointName),
+		ResourceGroup:      pointer.To(endpointRG),
 	}
 
 	// To align with the previous TF behavior, `subscription_id` needs to be set with the provider's subscription Id when it isn't specified in the tf config, otherwise TF behavior is different than before and it may block the existing users
@@ -179,21 +179,21 @@ func resourceIotHubEndpointEventHubCreateUpdate(d *pluginsdk.ResourceData, meta 
 
 	if authenticationType == devices.AuthenticationTypeKeyBased {
 		if v, ok := d.GetOk("connection_string"); ok {
-			eventhubEndpoint.ConnectionString = utils.String(v.(string))
+			eventhubEndpoint.ConnectionString = pointer.To(v.(string))
 		} else {
 			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
 		}
 	} else {
 		if v, ok := d.GetOk("endpoint_uri"); ok {
-			eventhubEndpoint.EndpointURI = utils.String(v.(string))
-			eventhubEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+			eventhubEndpoint.EndpointURI = pointer.To(v.(string))
+			eventhubEndpoint.EntityPath = pointer.To(d.Get("entity_path").(string))
 		} else {
 			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
 		}
 
 		if v, ok := d.GetOk("identity_id"); ok {
 			eventhubEndpoint.Identity = &devices.ManagedIdentity{
-				UserAssignedIdentity: utils.String(v.(string)),
+				UserAssignedIdentity: pointer.To(v.(string)),
 			}
 		}
 	}

--- a/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_eventhub_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubEndpointEventHubResource struct{}
@@ -302,13 +302,13 @@ func (t IotHubEndpointEventHubResource) Exists(ctx context.Context, clients *cli
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					return utils.Bool(true), nil
+					return pointer.To(true), nil
 				}
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r IotHubEndpointEventHubResource) authenticationTypeDefault(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
@@ -167,8 +167,8 @@ func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData
 
 	queueEndpoint := devices.RoutingServiceBusQueueEndpointProperties{
 		AuthenticationType: authenticationType,
-		Name:               utils.String(id.EndpointName),
-		ResourceGroup:      utils.String(endpointRG),
+		Name:               pointer.To(id.EndpointName),
+		ResourceGroup:      pointer.To(endpointRG),
 	}
 
 	// To align with the previous TF behavior, `subscription_id` needs to be set with the provider's subscription Id when it isn't specified in the tf config, otherwise TF behavior is different than before and it may block the existing users
@@ -182,21 +182,21 @@ func resourceIotHubEndpointServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData
 
 	if authenticationType == devices.AuthenticationTypeKeyBased {
 		if v, ok := d.GetOk("connection_string"); ok {
-			queueEndpoint.ConnectionString = utils.String(v.(string))
+			queueEndpoint.ConnectionString = pointer.To(v.(string))
 		} else {
 			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
 		}
 	} else {
 		if v, ok := d.GetOk("endpoint_uri"); ok {
-			queueEndpoint.EndpointURI = utils.String(v.(string))
-			queueEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+			queueEndpoint.EndpointURI = pointer.To(v.(string))
+			queueEndpoint.EntityPath = pointer.To(d.Get("entity_path").(string))
 		} else {
 			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
 		}
 
 		if v, ok := d.GetOk("identity_id"); ok {
 			queueEndpoint.Identity = &devices.ManagedIdentity{
-				UserAssignedIdentity: utils.String(v.(string)),
+				UserAssignedIdentity: pointer.To(v.(string)),
 			}
 		}
 	}

--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubEndpointServiceBusQueueResource struct{}
@@ -296,13 +296,13 @@ func (t IotHubEndpointServiceBusQueueResource) Exists(ctx context.Context, clien
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					return utils.Bool(true), nil
+					return pointer.To(true), nil
 				}
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r IotHubEndpointServiceBusQueueResource) authenticationTypeDefault(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_endpoint_servicebus_topic_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_topic_resource.go
@@ -165,8 +165,8 @@ func resourceIotHubEndpointServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData
 
 	topicEndpoint := devices.RoutingServiceBusTopicEndpointProperties{
 		AuthenticationType: authenticationType,
-		Name:               utils.String(id.EndpointName),
-		ResourceGroup:      utils.String(endpointRG),
+		Name:               pointer.To(id.EndpointName),
+		ResourceGroup:      pointer.To(endpointRG),
 	}
 
 	// To align with the previous TF behavior, `subscription_id` needs to be set with the provider's subscription Id when it isn't specified in the tf config, otherwise TF behavior is different than before and it may block the existing users
@@ -180,21 +180,21 @@ func resourceIotHubEndpointServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData
 
 	if authenticationType == devices.AuthenticationTypeKeyBased {
 		if v, ok := d.GetOk("connection_string"); ok {
-			topicEndpoint.ConnectionString = utils.String(v.(string))
+			topicEndpoint.ConnectionString = pointer.To(v.(string))
 		} else {
 			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
 		}
 	} else {
 		if v, ok := d.GetOk("endpoint_uri"); ok {
-			topicEndpoint.EndpointURI = utils.String(v.(string))
-			topicEndpoint.EntityPath = utils.String(d.Get("entity_path").(string))
+			topicEndpoint.EndpointURI = pointer.To(v.(string))
+			topicEndpoint.EntityPath = pointer.To(d.Get("entity_path").(string))
 		} else {
 			return fmt.Errorf("`endpoint_uri` and `entity_path` must be specified when `authentication_type` is `identityBased`")
 		}
 
 		if v, ok := d.GetOk("identity_id"); ok {
 			topicEndpoint.Identity = &devices.ManagedIdentity{
-				UserAssignedIdentity: utils.String(v.(string)),
+				UserAssignedIdentity: pointer.To(v.(string)),
 			}
 		}
 	}

--- a/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_topic_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubEndpointServiceBusTopicResource struct{}
@@ -292,13 +292,13 @@ func (t IotHubEndpointServiceBusTopicResource) Exists(ctx context.Context, clien
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					return utils.Bool(true), nil
+					return pointer.To(true), nil
 				}
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r IotHubEndpointServiceBusTopicResource) authenticationTypeDefault(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource.go
@@ -221,20 +221,20 @@ func resourceIotHubEndpointStorageContainerCreateUpdate(d *pluginsdk.ResourceDat
 
 	if authenticationType == devices.AuthenticationTypeKeyBased {
 		if v, ok := d.GetOk("connection_string"); ok {
-			storageContainerEndpoint.ConnectionString = utils.String(v.(string))
+			storageContainerEndpoint.ConnectionString = pointer.To(v.(string))
 		} else {
 			return fmt.Errorf("`connection_string` must be specified when `authentication_type` is `keyBased`")
 		}
 	} else {
 		if v, ok := d.GetOk("endpoint_uri"); ok {
-			storageContainerEndpoint.EndpointURI = utils.String(v.(string))
+			storageContainerEndpoint.EndpointURI = pointer.To(v.(string))
 		} else {
 			return fmt.Errorf("`endpoint_uri` must be specified when `authentication_type` is `identityBased`")
 		}
 
 		if v, ok := d.GetOk("identity_id"); ok {
 			storageContainerEndpoint.Identity = &devices.ManagedIdentity{
-				UserAssignedIdentity: utils.String(v.(string)),
+				UserAssignedIdentity: pointer.To(v.(string)),
 			}
 		}
 	}

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubEndpointStorageContainerResource struct{}
@@ -365,13 +365,13 @@ func (t IotHubEndpointStorageContainerResource) Exists(ctx context.Context, clie
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
-					return utils.Bool(true), nil
+					return pointer.To(true), nil
 				}
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r IotHubEndpointStorageContainerResource) authenticationTypeDefault(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_enrichment_resource_test.go
+++ b/internal/services/iothub/iothub_enrichment_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -81,7 +82,7 @@ func (IotHubEnrichmentResource) Exists(ctx context.Context, client *clients.Clie
 	iothub, err := client.IoTHub.ResourceClient.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil {
 		if utils.ResponseWasNotFound(iothub.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
@@ -98,11 +99,11 @@ func (IotHubEnrichmentResource) Exists(ctx context.Context, client *clients.Clie
 
 	for _, enrichment := range *enrichments {
 		if strings.EqualFold(*enrichment.Key, id.Name) {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (IotHubEnrichmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_fallback_route_resource.go
+++ b/internal/services/iothub/iothub_fallback_route_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -126,10 +127,10 @@ func resourceIotHubFallbackRouteCreateUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	routing.FallbackRoute = &devices.FallbackRouteProperties{
-		Source:        utils.String(d.Get("source").(string)),
-		Condition:     utils.String(d.Get("condition").(string)),
+		Source:        pointer.To(d.Get("source").(string)),
+		Condition:     pointer.To(d.Get("condition").(string)),
 		EndpointNames: utils.ExpandStringSlice(d.Get("endpoint_names").([]interface{})),
-		IsEnabled:     utils.Bool(d.Get("enabled").(bool)),
+		IsEnabled:     pointer.To(d.Get("enabled").(bool)),
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.IotHubName, iothub, "")

--- a/internal/services/iothub/iothub_fallback_route_resource_test.go
+++ b/internal/services/iothub/iothub_fallback_route_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubFallbackRouteResource struct{}
@@ -69,7 +69,7 @@ func (t IotHubFallbackRouteResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading IotHuB Route (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Properties.Routing.FallbackRoute.Name != nil), nil
+	return pointer.To(resp.Properties.Routing.FallbackRoute.Name != nil), nil
 }
 
 func (IotHubFallbackRouteResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_file_upload_resource.go
+++ b/internal/services/iothub/iothub_file_upload_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -167,16 +168,16 @@ func (r IotHubFileUploadResource) Create() sdk.ResourceFunc {
 			storageEndpointProperties := make(map[string]*devices.StorageEndpointProperties)
 
 			messagingEndpointProperties["fileNotifications"] = &devices.MessagingEndpointProperties{
-				LockDurationAsIso8601: utils.String(state.LockDuration),
-				MaxDeliveryCount:      utils.Int32(int32(state.MaxDeliveryCount)),
-				TTLAsIso8601:          utils.String(state.DefaultTTL),
+				LockDurationAsIso8601: pointer.To(state.LockDuration),
+				MaxDeliveryCount:      pointer.To(int32(state.MaxDeliveryCount)),
+				TTLAsIso8601:          pointer.To(state.DefaultTTL),
 			}
 
 			storageEndpointProperties["$default"] = &devices.StorageEndpointProperties{
 				AuthenticationType: devices.AuthenticationType(state.AuthenticationType),
-				ConnectionString:   utils.String(state.ConnectionString),
-				ContainerName:      utils.String(state.ContainerName),
-				SasTTLAsIso8601:    utils.String(state.SasTTL),
+				ConnectionString:   pointer.To(state.ConnectionString),
+				ContainerName:      pointer.To(state.ContainerName),
+				SasTTLAsIso8601:    pointer.To(state.SasTTL),
 			}
 
 			if state.IdentityId != "" {
@@ -184,7 +185,7 @@ func (r IotHubFileUploadResource) Create() sdk.ResourceFunc {
 					return fmt.Errorf("`identity_id` can only be specified when `authentication_type` is `identityBased`")
 				}
 				storageEndpointProperties["$default"].Identity = &devices.ManagedIdentity{
-					UserAssignedIdentity: utils.String(state.IdentityId),
+					UserAssignedIdentity: pointer.To(state.IdentityId),
 				}
 			}
 
@@ -192,7 +193,7 @@ func (r IotHubFileUploadResource) Create() sdk.ResourceFunc {
 				iotHub.Properties = &devices.IotHubProperties{}
 			}
 
-			iotHub.Properties.EnableFileUploadNotifications = utils.Bool(state.NotificationsEnabled)
+			iotHub.Properties.EnableFileUploadNotifications = pointer.To(state.NotificationsEnabled)
 			iotHub.Properties.MessagingEndpoints = messagingEndpointProperties
 			iotHub.Properties.StorageEndpoints = storageEndpointProperties
 
@@ -334,19 +335,19 @@ func (r IotHubFileUploadResource) Update() sdk.ResourceFunc {
 			storageEndpoint := existing.Properties.StorageEndpoints["$default"]
 
 			if metadata.ResourceData.HasChange("notifications_enabled") {
-				existing.Properties.EnableFileUploadNotifications = utils.Bool(state.NotificationsEnabled)
+				existing.Properties.EnableFileUploadNotifications = pointer.To(state.NotificationsEnabled)
 			}
 
 			if metadata.ResourceData.HasChange("default_ttl") {
-				messagingEndpoint.TTLAsIso8601 = utils.String(state.DefaultTTL)
+				messagingEndpoint.TTLAsIso8601 = pointer.To(state.DefaultTTL)
 			}
 
 			if metadata.ResourceData.HasChange("lock_duration") {
-				messagingEndpoint.LockDurationAsIso8601 = utils.String(state.LockDuration)
+				messagingEndpoint.LockDurationAsIso8601 = pointer.To(state.LockDuration)
 			}
 
 			if metadata.ResourceData.HasChange("max_delivery_count") {
-				messagingEndpoint.MaxDeliveryCount = utils.Int32(int32(state.MaxDeliveryCount))
+				messagingEndpoint.MaxDeliveryCount = pointer.To(int32(state.MaxDeliveryCount))
 			}
 
 			if metadata.ResourceData.HasChange("authentication_type") {
@@ -354,11 +355,11 @@ func (r IotHubFileUploadResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("connection_string") {
-				storageEndpoint.ConnectionString = utils.String(state.ConnectionString)
+				storageEndpoint.ConnectionString = pointer.To(state.ConnectionString)
 			}
 
 			if metadata.ResourceData.HasChange("container_name") {
-				storageEndpoint.ContainerName = utils.String(state.ContainerName)
+				storageEndpoint.ContainerName = pointer.To(state.ContainerName)
 			}
 
 			if metadata.ResourceData.HasChange("identity_id") {
@@ -367,7 +368,7 @@ func (r IotHubFileUploadResource) Update() sdk.ResourceFunc {
 						return fmt.Errorf("`identity_id` can only be specified when `authentication_type` is `identityBased`")
 					}
 					storageEndpoint.Identity = &devices.ManagedIdentity{
-						UserAssignedIdentity: utils.String(state.IdentityId),
+						UserAssignedIdentity: pointer.To(state.IdentityId),
 					}
 				} else {
 					storageEndpoint.Identity = nil
@@ -375,7 +376,7 @@ func (r IotHubFileUploadResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("sas_ttl") {
-				storageEndpoint.SasTTLAsIso8601 = utils.String(state.SasTTL)
+				storageEndpoint.SasTTLAsIso8601 = pointer.To(state.SasTTL)
 			}
 
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, existing, "")

--- a/internal/services/iothub/iothub_file_upload_resource_test.go
+++ b/internal/services/iothub/iothub_file_upload_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubFileUploadResource struct{}
@@ -254,12 +254,12 @@ func (IotHubFileUploadResource) Exists(ctx context.Context, clients *clients.Cli
 	if iotHub.Properties != nil && iotHub.Properties.MessagingEndpoints != nil {
 		if storageEndpoint, ok := iotHub.Properties.StorageEndpoints["$default"]; ok {
 			if storageEndpoint.ConnectionString != nil && *storageEndpoint.ConnectionString != "" && storageEndpoint.ContainerName != nil && *storageEndpoint.ContainerName != "" {
-				return utils.Bool(true), nil
+				return pointer.To(true), nil
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r IotHubFileUploadResource) basic(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -691,10 +691,10 @@ func resourceIotHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		routingProperties.FallbackRoute = expandIoTHubFallbackRoute(d)
 	} else {
 		routingProperties.FallbackRoute = &devices.FallbackRouteProperties{
-			Source:        utils.String(string(devices.RoutingSourceDeviceMessages)),
-			Condition:     utils.String("true"),
+			Source:        pointer.To(string(devices.RoutingSourceDeviceMessages)),
+			Condition:     pointer.To("true"),
 			EndpointNames: &[]string{"events"},
-			IsEnabled:     utils.Bool(true),
+			IsEnabled:     pointer.To(true),
 		}
 	}
 
@@ -722,8 +722,8 @@ func resourceIotHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	props := devices.IotHubDescription{
-		Name:     utils.String(id.Name),
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Name:     pointer.To(id.Name),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Sku:      expandIoTHubSku(d),
 		Properties: &devices.IotHubProperties{
 			Routing:                       &routingProperties,
@@ -754,10 +754,10 @@ func resourceIotHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	if partitionOk || retentionOk {
 		eh := devices.EventHubProperties{}
 		if retentionOk {
-			eh.RetentionTimeInDays = utils.Int64(int64(retention.(int)))
+			eh.RetentionTimeInDays = pointer.To(int64(retention.(int)))
 		}
 		if partitionOk {
-			eh.PartitionCount = utils.Int32(int32(partition.(int)))
+			eh.PartitionCount = pointer.To(int32(partition.(int)))
 		}
 
 		props.Properties.EventHubEndpoints = map[string]*devices.EventHubProperties{
@@ -765,10 +765,10 @@ func resourceIotHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 
-	props.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_authentication_enabled").(bool))
+	props.Properties.DisableLocalAuth = pointer.To(!d.Get("local_authentication_enabled").(bool))
 
 	if v, ok := d.GetOk("min_tls_version"); ok {
-		props.Properties.MinTLSVersion = utils.String(v.(string))
+		props.Properties.MinTLSVersion = pointer.To(v.(string))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, props, "")
@@ -848,10 +848,10 @@ func resourceIotHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			prop.Routing.FallbackRoute = expandIoTHubFallbackRoute(d)
 		} else {
 			prop.Routing.FallbackRoute = &devices.FallbackRouteProperties{
-				Source:        utils.String(string(devices.RoutingSourceDeviceMessages)),
-				Condition:     utils.String("true"),
+				Source:        pointer.To(string(devices.RoutingSourceDeviceMessages)),
+				Condition:     pointer.To("true"),
 				EndpointNames: &[]string{"events"},
-				IsEnabled:     utils.Bool(true),
+				IsEnabled:     pointer.To(true),
 			}
 		}
 	}
@@ -1098,8 +1098,8 @@ func resourceIotHubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
-	if location := hub.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := hub.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 	sku := flattenIoTHubSku(hub.Sku)
 	if err := d.Set("sku", sku); err != nil {
@@ -1265,17 +1265,17 @@ func expandIoTHubEndpoints(d *pluginsdk.ResourceData, subscriptionId string) (*d
 		var connectionStr *string
 		if v := endpoint["identity_id"].(string); v != "" {
 			identity = &devices.ManagedIdentity{
-				UserAssignedIdentity: utils.String(v),
+				UserAssignedIdentity: pointer.To(v),
 			}
 		}
 		if v := endpoint["endpoint_uri"].(string); v != "" {
-			endpointUri = utils.String(v)
+			endpointUri = pointer.To(v)
 		}
 		if v := endpoint["entity_path"].(string); v != "" {
-			entityPath = utils.String(v)
+			entityPath = pointer.To(v)
 		}
 		if v := endpoint["connection_string"].(string); v != "" {
-			connectionStr = utils.String(v)
+			connectionStr = pointer.To(v)
 		}
 
 		if authenticationType == devices.AuthenticationTypeKeyBased {
@@ -1402,7 +1402,7 @@ func expandIoTHubSku(d *pluginsdk.ResourceData) *devices.IotHubSkuInfo {
 
 	return &devices.IotHubSkuInfo{
 		Name:     devices.IotHubSku(skuMap["name"].(string)),
-		Capacity: utils.Int64(int64(skuMap["capacity"].(int))),
+		Capacity: pointer.To(int64(skuMap["capacity"].(int))),
 	}
 }
 
@@ -1416,7 +1416,7 @@ func expandIoTHubCloudToDevice(d *pluginsdk.ResourceData) *devices.CloudToDevice
 	defaultTimeToLive := ctdMap["default_ttl"].(string)
 
 	cloudToDevice.DefaultTTLAsIso8601 = &defaultTimeToLive
-	cloudToDevice.MaxDeliveryCount = utils.Int32(int32(ctdMap["max_delivery_count"].(int)))
+	cloudToDevice.MaxDeliveryCount = pointer.To(int32(ctdMap["max_delivery_count"].(int)))
 	feedback := ctdMap["feedback"].([]interface{})
 
 	cloudToDeviceFeedback := devices.FeedbackProperties{}
@@ -1428,7 +1428,7 @@ func expandIoTHubCloudToDevice(d *pluginsdk.ResourceData) *devices.CloudToDevice
 
 		cloudToDeviceFeedback.TTLAsIso8601 = &timeToLive
 		cloudToDeviceFeedback.LockDurationAsIso8601 = &lockDuration
-		cloudToDeviceFeedback.MaxDeliveryCount = utils.Int32(int32(feedbackMap["max_delivery_count"].(int)))
+		cloudToDeviceFeedback.MaxDeliveryCount = pointer.To(int32(feedbackMap["max_delivery_count"].(int)))
 	}
 
 	cloudToDevice.Feedback = &cloudToDeviceFeedback
@@ -1849,7 +1849,7 @@ func expandNetworkRuleSetProperties(d *pluginsdk.ResourceData) *devices.NetworkR
 	nrsMap := networkRuleSet[0].(map[string]interface{})
 
 	networkRuleSetProps.DefaultAction = devices.DefaultAction(nrsMap["default_action"].(string))
-	networkRuleSetProps.ApplyToBuiltInEventHubEndpoint = utils.Bool(nrsMap["apply_to_builtin_eventhub_endpoint"].(bool))
+	networkRuleSetProps.ApplyToBuiltInEventHubEndpoint = pointer.To(nrsMap["apply_to_builtin_eventhub_endpoint"].(bool))
 	ipRules := nrsMap["ip_rule"].([]interface{})
 
 	if len(ipRules) != 0 {
@@ -1858,9 +1858,9 @@ func expandNetworkRuleSetProperties(d *pluginsdk.ResourceData) *devices.NetworkR
 		for _, r := range ipRules {
 			rawRule := r.(map[string]interface{})
 			rule := &devices.NetworkRuleSetIPRule{
-				FilterName: utils.String(rawRule["name"].(string)),
+				FilterName: pointer.To(rawRule["name"].(string)),
 				Action:     devices.NetworkRuleIPAction(rawRule["action"].(string)),
-				IPMask:     utils.String(rawRule["ip_mask"].(string)),
+				IPMask:     pointer.To(rawRule["ip_mask"].(string)),
 			}
 			rules = append(rules, *rule)
 		}

--- a/internal/services/iothub/iothub_route_resource_test.go
+++ b/internal/services/iothub/iothub_route_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotHubRouteResource struct{}
@@ -89,12 +89,12 @@ func (t IotHubRouteResource) Exists(ctx context.Context, clients *clients.Client
 	if routes := resp.Properties.Routing.Routes; routes != nil {
 		for _, route := range *routes {
 			if route.Name != nil {
-				return utils.Bool(true), nil
+				return pointer.To(true), nil
 			}
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r IotHubRouteResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/iothub/iothub_shared_access_policy_resource_test.go
+++ b/internal/services/iothub/iothub_shared_access_policy_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IoTHubSharedAccessPolicyResource struct{}
@@ -168,5 +168,5 @@ func (t IoTHubSharedAccessPolicyResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("loading IotHub Shared Access Policy %q: %+v", id, err)
 	}
 
-	return utils.Bool(accessPolicy.PrimaryKey != nil), nil
+	return pointer.To(accessPolicy.PrimaryKey != nil), nil
 }

--- a/internal/services/iothub/transition.go
+++ b/internal/services/iothub/transition.go
@@ -3,7 +3,7 @@
 
 package iothub
 
-import "github.com/hashicorp/terraform-provider-azurerm/utils"
+import "github.com/hashicorp/go-azure-helpers/lang/pointer"
 
 func expandTags(input map[string]interface{}) *map[string]string {
 	output := make(map[string]string)
@@ -18,7 +18,7 @@ func flattenTags(input *map[string]string) map[string]*string {
 
 	if input != nil {
 		for k, v := range *input {
-			output[k] = utils.String(v)
+			output[k] = pointer.To(v)
 		}
 	}
 


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
