### PR TITLE
services `K*`/`L*` - deprecated function clean up

### DIFF
--- a/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKeyVaultAccessPolicy() *pluginsdk.Resource {
@@ -152,7 +151,7 @@ func resourceKeyVaultAccessPolicyCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	parameters := vaults.VaultAccessPolicyParameters{
-		Name: utils.String(keyVaultId.VaultName),
+		Name: pointer.To(keyVaultId.VaultName),
 		Properties: vaults.VaultAccessPolicyProperties{
 			AccessPolicies: []vaults.AccessPolicyEntry{
 				accessPolicy,
@@ -226,7 +225,7 @@ func resourceKeyVaultAccessPolicyUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	parameters := vaults.VaultAccessPolicyParameters{
-		Name: utils.String(keyVaultId.VaultName),
+		Name: pointer.To(keyVaultId.VaultName),
 		Properties: vaults.VaultAccessPolicyProperties{
 			AccessPolicies: []vaults.AccessPolicyEntry{
 				accessPolicy,
@@ -352,7 +351,7 @@ func resourceKeyVaultAccessPolicyDelete(d *pluginsdk.ResourceData, meta interfac
 		accessPolicy.ApplicationId = pointer.To(id.ApplicationId())
 	}
 	parameters := vaults.VaultAccessPolicyParameters{
-		Name: utils.String(vaultId.VaultName),
+		Name: pointer.To(vaultId.VaultName),
 		Properties: vaults.VaultAccessPolicyProperties{
 			AccessPolicies: []vaults.AccessPolicyEntry{
 				accessPolicy,

--- a/internal/services/keyvault/key_vault_certificate_contacts_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -268,9 +269,9 @@ func expandKeyVaultCertificateContactsContact(input []Contact) *[]keyvault.Conta
 
 	for _, item := range input {
 		results = append(results, keyvault.Contact{
-			EmailAddress: utils.String(item.Email),
-			Name:         utils.String(item.Name),
-			Phone:        utils.String(item.Phone),
+			EmailAddress: pointer.To(item.Email),
+			Name:         pointer.To(item.Name),
+			Phone:        pointer.To(item.Phone),
 		})
 	}
 

--- a/internal/services/keyvault/key_vault_certificate_issuer_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_issuer_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -138,12 +139,12 @@ func resourceKeyVaultCertificateIssuerCreateOrUpdate(d *pluginsdk.ResourceData, 
 	}
 
 	parameter := keyvault.CertificateIssuerSetParameters{
-		Provider:            utils.String(d.Get("provider_name").(string)),
+		Provider:            pointer.To(d.Get("provider_name").(string)),
 		OrganizationDetails: &keyvault.OrganizationDetails{},
 	}
 
 	if orgIdRaw, ok := d.GetOk("org_id"); ok {
-		parameter.OrganizationDetails.ID = utils.String(orgIdRaw.(string))
+		parameter.OrganizationDetails.ID = pointer.To(orgIdRaw.(string))
 	}
 
 	if adminsRaw, ok := d.GetOk("admin"); ok {
@@ -155,8 +156,8 @@ func resourceKeyVaultCertificateIssuerCreateOrUpdate(d *pluginsdk.ResourceData, 
 
 	if gotAccountId && gotPassword {
 		parameter.Credentials = &keyvault.IssuerCredentials{
-			AccountID: utils.String(accountId.(string)),
-			Password:  utils.String(password.(string)),
+			AccountID: pointer.To(accountId.(string)),
+			Password:  pointer.To(password.(string)),
 		}
 	}
 
@@ -280,16 +281,16 @@ func expandKeyVaultCertificateIssuerOrganizationDetailsAdminDetails(vs []interfa
 		administratorDetails := keyvault.AdministratorDetails{}
 		args := v.(map[string]interface{})
 		if firstName, ok := args["first_name"]; ok {
-			administratorDetails.FirstName = utils.String(firstName.(string))
+			administratorDetails.FirstName = pointer.To(firstName.(string))
 		}
 		if lastName, ok := args["last_name"]; ok {
-			administratorDetails.LastName = utils.String(lastName.(string))
+			administratorDetails.LastName = pointer.To(lastName.(string))
 		}
 		if emailAddress, ok := args["email_address"]; ok {
-			administratorDetails.EmailAddress = utils.String(emailAddress.(string))
+			administratorDetails.EmailAddress = pointer.To(emailAddress.(string))
 		}
 		if phone, ok := args["phone"]; ok {
-			administratorDetails.Phone = utils.String(phone.(string))
+			administratorDetails.Phone = pointer.To(phone.(string))
 		}
 		results = append(results, administratorDetails)
 	}

--- a/internal/services/keyvault/key_vault_certificate_issuer_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_issuer_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -127,7 +128,7 @@ func (r KeyVaultCertificateIssuerResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("failed to make Read request on Azure KeyVault Certificate Issuer %s: %+v", id.Name, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r KeyVaultCertificateIssuerResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -142,7 +143,7 @@ func (r KeyVaultCertificateIssuerResource) Destroy(ctx context.Context, client *
 
 	vaultBaseUrl, err := keyVaultsClient.BaseUriForKeyVault(ctx, *keyVaultId)
 	if err != nil {
-		return utils.Bool(false), fmt.Errorf("failed to look up base URI from id %q: %+v", keyVaultId, err)
+		return pointer.To(false), fmt.Errorf("failed to look up base URI from id %q: %+v", keyVaultId, err)
 	}
 
 	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
@@ -150,19 +151,19 @@ func (r KeyVaultCertificateIssuerResource) Destroy(ctx context.Context, client *
 		return nil, fmt.Errorf("failed to check if key vault %q for Certificate Issuer %q in Vault at url %q exists: %v", keyVaultId.ID(), name, *vaultBaseUrl, err)
 	}
 	if !ok {
-		return utils.Bool(false), fmt.Errorf("Certificate Issuer %q Key Vault %q was not found in Key Vault at URI %q", name, keyVaultId.ID(), *vaultBaseUrl)
+		return pointer.To(false), fmt.Errorf("Certificate Issuer %q Key Vault %q was not found in Key Vault at URI %q", name, keyVaultId.ID(), *vaultBaseUrl)
 	}
 
 	resp, err := dataPlaneClient.DeleteCertificateIssuer(ctx, *vaultBaseUrl, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 
 		return nil, fmt.Errorf("Bad: Delete on keyVaultManagementClient: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (KeyVaultCertificateIssuerResource) basic(data acceptance.TestData) string {

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -507,8 +507,8 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 		// Import
 		certificate := expandKeyVaultCertificate(v)
 		importParameters := keyvault.CertificateImportParameters{
-			Base64EncodedCertificate: utils.String(certificate.CertificateData),
-			Password:                 utils.String(certificate.CertificatePassword),
+			Base64EncodedCertificate: pointer.To(certificate.CertificateData),
+			Password:                 pointer.To(certificate.CertificatePassword),
 			CertificatePolicy:        policy,
 			Tags:                     tags.Expand(t),
 		}
@@ -605,8 +605,8 @@ func resourceKeyVaultCertificateUpdate(d *schema.ResourceData, meta interface{})
 			// Import new version of certificate
 			certificate := expandKeyVaultCertificate(v)
 			importParameters := keyvault.CertificateImportParameters{
-				Base64EncodedCertificate: utils.String(certificate.CertificateData),
-				Password:                 utils.String(certificate.CertificatePassword),
+				Base64EncodedCertificate: pointer.To(certificate.CertificateData),
+				Password:                 pointer.To(certificate.CertificatePassword),
 			}
 			resp, err := client.ImportCertificate(ctx, id.KeyVaultBaseUrl, id.Name, importParameters)
 			if err != nil {
@@ -903,7 +903,7 @@ func expandKeyVaultCertificatePolicy(d *pluginsdk.ResourceData) (*keyvault.Certi
 	issuers := policyRaw["issuer_parameters"].([]interface{})
 	issuer := issuers[0].(map[string]interface{})
 	policy.IssuerParameters = &keyvault.IssuerParameters{
-		Name: utils.String(issuer["name"].(string)),
+		Name: pointer.To(issuer["name"].(string)),
 	}
 
 	properties := policyRaw["key_properties"].([]interface{})
@@ -936,10 +936,10 @@ func expandKeyVaultCertificatePolicy(d *pluginsdk.ResourceData) (*keyvault.Certi
 
 	policy.KeyProperties = &keyvault.KeyProperties{
 		Curve:      keyvault.JSONWebKeyCurveName(curve),
-		Exportable: utils.Bool(props["exportable"].(bool)),
-		KeySize:    utils.Int32(int32(keySize)),
+		Exportable: pointer.To(props["exportable"].(bool)),
+		KeySize:    pointer.To(int32(keySize)),
 		KeyType:    keyvault.JSONWebKeyType(keyType),
-		ReuseKey:   utils.Bool(props["reuse_key"].(bool)),
+		ReuseKey:   pointer.To(props["reuse_key"].(bool)),
 	}
 
 	policy.LifetimeActions = expandKeyVaultCertificatePolicyLifetimeAction(policyRaw["lifetime_action"])
@@ -947,7 +947,7 @@ func expandKeyVaultCertificatePolicy(d *pluginsdk.ResourceData) (*keyvault.Certi
 	secrets := policyRaw["secret_properties"].([]interface{})
 	secret := secrets[0].(map[string]interface{})
 	policy.SecretProperties = &keyvault.SecretProperties{
-		ContentType: utils.String(secret["content_type"].(string)),
+		ContentType: pointer.To(secret["content_type"].(string)),
 	}
 
 	certificateProperties := policyRaw["x509_certificate_properties"].([]interface{})
@@ -988,8 +988,8 @@ func expandKeyVaultCertificatePolicy(d *pluginsdk.ResourceData) (*keyvault.Certi
 		}
 
 		policy.X509CertificateProperties = &keyvault.X509CertificateProperties{
-			ValidityInMonths:        utils.Int32(int32(cert["validity_in_months"].(int))),
-			Subject:                 utils.String(cert["subject"].(string)),
+			ValidityInMonths:        pointer.To(int32(cert["validity_in_months"].(int))),
+			Subject:                 pointer.To(cert["subject"].(string)),
 			KeyUsage:                &keyUsage,
 			Ekus:                    extendedKeyUsage,
 			SubjectAlternativeNames: subjectAlternativeNames,
@@ -1025,12 +1025,12 @@ func expandKeyVaultCertificatePolicyLifetimeAction(actions interface{}) *[]keyva
 
 				d := trigger["days_before_expiry"].(int)
 				if d > 0 {
-					lifetimeAction.Trigger.DaysBeforeExpiry = utils.Int32(int32(d))
+					lifetimeAction.Trigger.DaysBeforeExpiry = pointer.To(int32(d))
 				}
 
 				p := trigger["lifetime_percentage"].(int)
 				if p > 0 {
-					lifetimeAction.Trigger.LifetimePercentage = utils.Int32(int32(p))
+					lifetimeAction.Trigger.LifetimePercentage = pointer.To(int32(p))
 				}
 			}
 		}

--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultCertificateResource struct{}
@@ -452,7 +452,7 @@ func (t KeyVaultCertificateResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading Key Vault Certificate: %+v", err)
 	}
 
-	return utils.Bool(cert.ID != nil), nil
+	return pointer.To(cert.ID != nil), nil
 }
 
 func (KeyVaultCertificateResource) destroyParentKeyVault(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
@@ -484,7 +484,7 @@ func (KeyVaultCertificateResource) Destroy(ctx context.Context, client *clients.
 		return nil, fmt.Errorf("Bad: Delete on keyVaultManagementClient: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r KeyVaultCertificateResource) basicImportPFX(data acceptance.TestData) string {

--- a/internal/services/keyvault/key_vault_certificates_data_source.go
+++ b/internal/services/keyvault/key_vault_certificates_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
@@ -90,7 +90,7 @@ func dataSourceKeyVaultCertificatesRead(d *pluginsdk.ResourceData, meta interfac
 		return fmt.Errorf("fetching base vault url from id %q: %+v", *keyVaultId, err)
 	}
 
-	certificateList, err := client.GetCertificatesComplete(ctx, *keyVaultBaseUri, utils.Int32(25), &includePending)
+	certificateList, err := client.GetCertificatesComplete(ctx, *keyVaultBaseUri, pointer.To(int32(25)), &includePending)
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *keyVaultId, err)
 	}

--- a/internal/services/keyvault/key_vault_encrypted_value_data_source.go
+++ b/internal/services/keyvault/key_vault_encrypted_value_data_source.go
@@ -11,12 +11,12 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
@@ -104,7 +104,7 @@ func (EncryptedValueDataSource) Read() sdk.ResourceFunc {
 			if model.EncryptedData != "" {
 				params := keyvault.KeyOperationsParameters{
 					Algorithm: keyvault.JSONWebKeyEncryptionAlgorithm(model.Algorithm),
-					Value:     utils.String(model.EncryptedData),
+					Value:     pointer.To(model.EncryptedData),
 				}
 				result, err := client.Decrypt(ctx, keyVaultKeyId.KeyVaultBaseUrl, keyVaultKeyId.Name, keyVaultKeyId.Version, params)
 				if err != nil {
@@ -122,7 +122,7 @@ func (EncryptedValueDataSource) Read() sdk.ResourceFunc {
 			} else {
 				params := keyvault.KeyOperationsParameters{
 					Algorithm: keyvault.JSONWebKeyEncryptionAlgorithm(model.Algorithm),
-					Value:     utils.String(model.PlainTextValue),
+					Value:     pointer.To(model.PlainTextValue),
 				}
 				result, err := client.Encrypt(ctx, keyVaultKeyId.KeyVaultBaseUrl, keyVaultKeyId.Name, keyVaultKeyId.Version, params)
 				if err != nil {

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -316,7 +316,7 @@ func resourceKeyVaultKeyCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		Kty:    keyvault.JSONWebKeyType(keyType),
 		KeyOps: keyOptions,
 		KeyAttributes: &keyvault.KeyAttributes{
-			Enabled: utils.Bool(true),
+			Enabled: pointer.To(true),
 		},
 
 		Tags: tags.Expand(t),
@@ -331,7 +331,7 @@ func resourceKeyVaultKeyCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if !ok {
 			return errors.New("key_size is required when creating an RSA key")
 		}
-		parameters.KeySize = utils.Int32(int32(keySize.(int)))
+		parameters.KeySize = pointer.To(int32(keySize.(int)))
 	}
 	// TODO: support `oct` once this is fixed
 	// https://github.com/Azure/azure-rest-api-specs/issues/1739#issuecomment-332236257
@@ -437,7 +437,7 @@ func resourceKeyVaultKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	parameters := keyvault.KeyUpdateParameters{
 		KeyOps: keyOptions,
 		KeyAttributes: &keyvault.KeyAttributes{
-			Enabled: utils.Bool(true),
+			Enabled: pointer.To(true),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -731,14 +731,14 @@ func expandKeyVaultKeyRotationPolicy(v []interface{}) keyvault.KeyRotationPolicy
 
 	var expiryTime *string = nil // needs to be set to nil if not set
 	if rawExpiryTime := policy["expire_after"]; rawExpiryTime != nil && rawExpiryTime.(string) != "" {
-		expiryTime = utils.String(rawExpiryTime.(string))
+		expiryTime = pointer.To(rawExpiryTime.(string))
 	}
 
 	lifetimeActions := make([]keyvault.LifetimeActions, 0)
 	if rawNotificationTime := policy["notify_before_expiry"]; rawNotificationTime != nil && rawNotificationTime.(string) != "" {
 		lifetimeActionNotify := keyvault.LifetimeActions{
 			Trigger: &keyvault.LifetimeActionsTrigger{
-				TimeBeforeExpiry: utils.String(rawNotificationTime.(string)), // for Type: keyvault.Notify always TimeBeforeExpiry
+				TimeBeforeExpiry: pointer.To(rawNotificationTime.(string)), // for Type: keyvault.Notify always TimeBeforeExpiry
 			},
 			Action: &keyvault.LifetimeActionsType{
 				Type: keyvault.ActionTypeNotify,

--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -11,13 +11,13 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
@@ -467,7 +467,7 @@ func (r KeyVaultKeyResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, fmt.Errorf("retrieving Key Vault Key %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Key != nil), nil
+	return pointer.To(resp.Key != nil), nil
 }
 
 func (KeyVaultKeyResource) destroyParentKeyVault(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
@@ -530,7 +530,7 @@ func (KeyVaultKeyResource) Destroy(ctx context.Context, client *clients.Client, 
 		return nil, fmt.Errorf("deleting keyVaultManagementClient: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r KeyVaultKeyResource) basicEC(data acceptance.TestData) string {

--- a/internal/services/keyvault/key_vault_managed_storage_account_resource.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -119,10 +120,10 @@ func resourceKeyVaultManagedStorageAccountCreateUpdate(d *pluginsdk.ResourceData
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := keyvault.StorageAccountCreateParameters{
-		ResourceID:         utils.String(d.Get("storage_account_id").(string)),
-		ActiveKeyName:      utils.String(d.Get("storage_account_key").(string)),
-		AutoRegenerateKey:  utils.Bool(d.Get("regenerate_key_automatically").(bool)),
-		RegenerationPeriod: utils.String(d.Get("regeneration_period").(string)),
+		ResourceID:         pointer.To(d.Get("storage_account_id").(string)),
+		ActiveKeyName:      pointer.To(d.Get("storage_account_key").(string)),
+		AutoRegenerateKey:  pointer.To(d.Get("regenerate_key_automatically").(bool)),
+		RegenerationPeriod: pointer.To(d.Get("regeneration_period").(string)),
 		Tags:               tags.Expand(t),
 	}
 

--- a/internal/services/keyvault/key_vault_managed_storage_account_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultManagedStorageAccountResource struct{}
@@ -300,5 +300,5 @@ func (KeyVaultManagedStorageAccountResource) Exists(ctx context.Context, client 
 		return nil, fmt.Errorf("retrieving Key Vault Managed Storage Account %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }

--- a/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -129,11 +130,11 @@ func resourceKeyVaultManagedStorageAccountSasTokenDefinitionCreateUpdate(d *plug
 
 	t := d.Get("tags").(map[string]interface{})
 	parameters := keyvault.SasDefinitionCreateParameters{
-		TemplateURI:    utils.String(d.Get("sas_template_uri").(string)),
+		TemplateURI:    pointer.To(d.Get("sas_template_uri").(string)),
 		SasType:        keyvault.SasTokenType(d.Get("sas_type").(string)),
-		ValidityPeriod: utils.String(d.Get("validity_period").(string)),
+		ValidityPeriod: pointer.To(d.Get("validity_period").(string)),
 		SasDefinitionAttributes: &keyvault.SasDefinitionAttributes{
-			Enabled: utils.Bool(true),
+			Enabled: pointer.To(true),
 		},
 		Tags: tags.Expand(t),
 	}

--- a/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account_sas_token_definition_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultManagedStorageAccountSasTokenDefinitionResource struct{}
@@ -348,5 +348,5 @@ func (KeyVaultManagedStorageAccountSasTokenDefinitionResource) Exists(ctx contex
 		return nil, fmt.Errorf("retrieving Key Vault Managed Storage Account Sas Definition %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -165,8 +165,8 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := keyvault.SecretSetParameters{
-		Value:            utils.String(value),
-		ContentType:      utils.String(contentType),
+		Value:            pointer.To(value),
+		ContentType:      pointer.To(contentType),
 		Tags:             tags.Expand(t),
 		SecretAttributes: &keyvault.SecretAttributes{},
 	}
@@ -297,8 +297,8 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 		// for changing the value of the secret we need to create a new version
 		parameters := keyvault.SecretSetParameters{
-			Value:            utils.String(value),
-			ContentType:      utils.String(contentType),
+			Value:            pointer.To(value),
+			ContentType:      pointer.To(contentType),
 			Tags:             tags.Expand(t),
 			SecretAttributes: secretAttributes,
 		}
@@ -308,7 +308,7 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	} else {
 		parameters := keyvault.SecretUpdateParameters{
-			ContentType:      utils.String(contentType),
+			ContentType:      pointer.To(contentType),
 			Tags:             tags.Expand(t),
 			SecretAttributes: secretAttributes,
 		}

--- a/internal/services/keyvault/key_vault_secret_resource_test.go
+++ b/internal/services/keyvault/key_vault_secret_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
@@ -326,7 +326,7 @@ func (KeyVaultSecretResource) Exists(ctx context.Context, clients *clients.Clien
 		return nil, fmt.Errorf("making Read request on Azure KeyVault Secret %s: %+v", id.Name, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (KeyVaultSecretResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -346,7 +346,7 @@ func (KeyVaultSecretResource) Destroy(ctx context.Context, client *clients.Clien
 		return nil, fmt.Errorf("Bad: Delete on keyVaultManagementClient: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (KeyVaultSecretResource) destroyParentKeyVault(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
@@ -378,7 +378,7 @@ func (r KeyVaultSecretResource) updateSecretValue(value string) acceptance.Clien
 		}
 
 		updated := keyvault.SecretSetParameters{
-			Value: utils.String(value),
+			Value: pointer.To(value),
 		}
 		if _, err = dataPlaneClient.SetSecret(ctx, *vaultBaseUrl, name, updated); err != nil {
 			return fmt.Errorf("updating secret: %+v", err)

--- a/internal/services/keyvault/key_vault_secrets_data_source.go
+++ b/internal/services/keyvault/key_vault_secrets_data_source.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
@@ -83,7 +83,7 @@ func dataSourceKeyVaultSecretsRead(d *pluginsdk.ResourceData, meta interface{}) 
 		return fmt.Errorf("fetching base vault url from id %q: %+v", *keyVaultId, err)
 	}
 
-	secretList, err := client.GetSecretsComplete(ctx, *keyVaultBaseUri, utils.Int32(25))
+	secretList, err := client.GetSecretsComplete(ctx, *keyVaultBaseUri, pointer.To(int32(25)))
 	if err != nil {
 		return fmt.Errorf("making Read request on Azure KeyVault %q: %+v", *keyVaultId, err)
 	}

--- a/internal/services/kusto/identity.go
+++ b/internal/services/kusto/identity.go
@@ -4,8 +4,8 @@
 package kusto
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/clusters"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func expandTrustedExternalTenants(input []interface{}) *[]clusters.TrustedExternalTenant {
@@ -13,7 +13,7 @@ func expandTrustedExternalTenants(input []interface{}) *[]clusters.TrustedExtern
 
 	for _, v := range input {
 		output = append(output, clusters.TrustedExternalTenant{
-			Value: utils.String(v.(string)),
+			Value: pointer.To(v.(string)),
 		})
 	}
 

--- a/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KustoClusterCustomerManagedKeyResource struct{}
@@ -178,10 +178,10 @@ func (KustoClusterCustomerManagedKeyResource) Exists(ctx context.Context, client
 	}
 
 	if resp.Model.Properties == nil || resp.Model.Properties.KeyVaultProperties == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (KustoClusterCustomerManagedKeyResource) basic(data acceptance.TestData) string {

--- a/internal/services/kusto/kusto_cluster_managed_private_endpoint_resource.go
+++ b/internal/services/kusto/kusto_cluster_managed_private_endpoint_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/managedprivateendpoints"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoClusterManagedPrivateEndpoint() *pluginsdk.Resource {
@@ -122,11 +122,11 @@ func resourceKustoClusterManagedPrivateEndpointCreateUpdate(d *schema.ResourceDa
 	}
 
 	if v, ok := d.GetOk("private_link_resource_region"); ok {
-		managedPrivateEndpoint.Properties.PrivateLinkResourceRegion = utils.String(v.(string))
+		managedPrivateEndpoint.Properties.PrivateLinkResourceRegion = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("request_message"); ok {
-		managedPrivateEndpoint.Properties.RequestMessage = utils.String(v.(string))
+		managedPrivateEndpoint.Properties.RequestMessage = pointer.To(v.(string))
 	}
 
 	err := client.CreateOrUpdateThenPoll(ctx, id, managedPrivateEndpoint)

--- a/internal/services/kusto/kusto_cluster_managed_private_endpoint_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_managed_private_endpoint_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/managedprivateendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KustoClusterManagedPrivateEndpointResource struct{}
@@ -67,7 +67,7 @@ func (KustoClusterManagedPrivateEndpointResource) Exists(ctx context.Context, cl
 	if resp.Model == nil {
 		return nil, fmt.Errorf("response model is empty")
 	}
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r KustoClusterManagedPrivateEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/kusto/kusto_database_principal_assignment_resource.go
+++ b/internal/services/kusto/kusto_database_principal_assignment_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/databaseprincipalassignments"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoDatabasePrincipalAssignment() *pluginsdk.Resource {
@@ -127,7 +127,7 @@ func resourceKustoDatabasePrincipalAssignmentCreate(d *pluginsdk.ResourceData, m
 
 	principalAssignment := databaseprincipalassignments.DatabasePrincipalAssignment{
 		Properties: &databaseprincipalassignments.DatabasePrincipalProperties{
-			TenantId:      utils.String(d.Get("tenant_id").(string)),
+			TenantId:      pointer.To(d.Get("tenant_id").(string)),
 			PrincipalId:   d.Get("principal_id").(string),
 			PrincipalType: databaseprincipalassignments.PrincipalType(d.Get("principal_type").(string)),
 			Role:          databaseprincipalassignments.DatabasePrincipalRole(d.Get("role").(string)),

--- a/internal/services/kusto/kusto_database_resource.go
+++ b/internal/services/kusto/kusto_database_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -19,7 +20,6 @@ import (
 	kustoValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoDatabase() *pluginsdk.Resource {
@@ -108,7 +108,7 @@ func resourceKustoDatabaseCreateUpdate(d *pluginsdk.ResourceData, meta interface
 	databaseProperties := expandKustoDatabaseProperties(d)
 
 	readWriteDatabase := databases.ReadWriteDatabase{
-		Location:   utils.String(location.Normalize(d.Get("location").(string))),
+		Location:   pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: databaseProperties,
 	}
 
@@ -188,11 +188,11 @@ func expandKustoDatabaseProperties(d *pluginsdk.ResourceData) *databases.ReadWri
 	databaseProperties := &databases.ReadWriteDatabaseProperties{}
 
 	if softDeletePeriod, ok := d.GetOk("soft_delete_period"); ok {
-		databaseProperties.SoftDeletePeriod = utils.String(softDeletePeriod.(string))
+		databaseProperties.SoftDeletePeriod = pointer.To(softDeletePeriod.(string))
 	}
 
 	if hotCachePeriod, ok := d.GetOk("hot_cache_period"); ok {
-		databaseProperties.HotCachePeriod = utils.String(hotCachePeriod.(string))
+		databaseProperties.HotCachePeriod = pointer.To(hotCachePeriod.(string))
 	}
 
 	return databaseProperties

--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2025-02-15/eventsubscriptions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/dataconnections"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -26,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoEventGridDataConnection() *pluginsdk.Resource {
@@ -209,12 +207,12 @@ func resourceKustoEventGridDataConnectionCreateUpdate(d *pluginsdk.ResourceData,
 	}
 
 	dataConnection := dataconnections.EventGridDataConnection{
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &dataconnections.EventGridConnectionProperties{
 			StorageAccountResourceId: d.Get("storage_account_id").(string),
 			EventHubResourceId:       d.Get("eventhub_id").(string),
 			ConsumerGroup:            d.Get("eventhub_consumer_group_name").(string),
-			IgnoreFirstRecord:        utils.Bool(d.Get("skip_first_record").(bool)),
+			IgnoreFirstRecord:        pointer.To(d.Get("skip_first_record").(bool)),
 		},
 	}
 
@@ -222,11 +220,11 @@ func resourceKustoEventGridDataConnectionCreateUpdate(d *pluginsdk.ResourceData,
 	dataConnection.Properties.BlobStorageEventType = &blobStorageEventType
 
 	if tableName, ok := d.GetOk("table_name"); ok {
-		dataConnection.Properties.TableName = utils.String(tableName.(string))
+		dataConnection.Properties.TableName = pointer.To(tableName.(string))
 	}
 
 	if mappingRuleName, ok := d.GetOk("mapping_rule_name"); ok {
-		dataConnection.Properties.MappingRuleName = utils.String(mappingRuleName.(string))
+		dataConnection.Properties.MappingRuleName = pointer.To(mappingRuleName.(string))
 	}
 
 	if df, ok := d.GetOk("data_format"); ok {
@@ -240,19 +238,19 @@ func resourceKustoEventGridDataConnectionCreateUpdate(d *pluginsdk.ResourceData,
 	}
 
 	if eventGridRID, ok := d.GetOk("eventgrid_event_subscription_id"); ok {
-		dataConnection.Properties.EventGridResourceId = utils.String(eventGridRID.(string))
+		dataConnection.Properties.EventGridResourceId = pointer.To(eventGridRID.(string))
 	}
 
 	if eventGridRID, ok := d.GetOk("eventgrid_resource_id"); !features.FivePointOh() && ok {
-		dataConnection.Properties.EventGridResourceId = utils.String(eventGridRID.(string))
+		dataConnection.Properties.EventGridResourceId = pointer.To(eventGridRID.(string))
 	}
 
 	if managedIdentityRID, ok := d.GetOk("managed_identity_id"); ok {
-		dataConnection.Properties.ManagedIdentityResourceId = utils.String(managedIdentityRID.(string))
+		dataConnection.Properties.ManagedIdentityResourceId = pointer.To(managedIdentityRID.(string))
 	}
 
 	if managedIdentityRID, ok := d.GetOk("managed_identity_resource_id"); !features.FivePointOh() && ok {
-		dataConnection.Properties.ManagedIdentityResourceId = utils.String(managedIdentityRID.(string))
+		dataConnection.Properties.ManagedIdentityResourceId = pointer.To(managedIdentityRID.(string))
 	}
 
 	err := client.CreateOrUpdateThenPoll(ctx, id, dataConnection)

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/dataconnections"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	eventhubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoEventHubDataConnection() *pluginsdk.Resource {
@@ -171,7 +170,7 @@ func resourceKustoEventHubDataConnectionCreateUpdate(d *pluginsdk.ResourceData, 
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 
 	eventHubDataConnectionProperties := expandKustoEventHubDataConnectionProperties(d)
 
@@ -222,8 +221,8 @@ func resourceKustoEventHubDataConnectionRead(d *pluginsdk.ResourceData, meta int
 
 	if resp.Model != nil {
 		if dataConnection, ok := resp.Model.(dataconnections.EventHubDataConnection); ok {
-			if location := dataConnection.Location; location != nil {
-				d.Set("location", azure.NormalizeLocation(*location))
+			if loc := dataConnection.Location; loc != nil {
+				d.Set("location", location.Normalize(*loc))
 			}
 
 			if props := dataConnection.Properties; props != nil {
@@ -289,11 +288,11 @@ func expandKustoEventHubDataConnectionProperties(d *pluginsdk.ResourceData) *dat
 	}
 
 	if tableName, ok := d.GetOk("table_name"); ok {
-		eventHubConnectionProperties.TableName = utils.String(tableName.(string))
+		eventHubConnectionProperties.TableName = pointer.To(tableName.(string))
 	}
 
 	if mappingRuleName, ok := d.GetOk("mapping_rule_name"); ok {
-		eventHubConnectionProperties.MappingRuleName = utils.String(mappingRuleName.(string))
+		eventHubConnectionProperties.MappingRuleName = pointer.To(mappingRuleName.(string))
 	}
 
 	if df, ok := d.GetOk("data_format"); ok {
@@ -315,7 +314,7 @@ func expandKustoEventHubDataConnectionProperties(d *pluginsdk.ResourceData) *dat
 	}
 
 	if identityId, ok := d.GetOk("identity_id"); ok {
-		eventHubConnectionProperties.ManagedIdentityResourceId = utils.String(identityId.(string))
+		eventHubConnectionProperties.ManagedIdentityResourceId = pointer.To(identityId.(string))
 	}
 
 	return eventHubConnectionProperties

--- a/internal/services/kusto/kusto_iothub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_iothub_data_connection_resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/dataconnections"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	iotHubParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
@@ -160,7 +159,7 @@ func resourceKustoIotHubDataConnectionCreate(d *pluginsdk.ResourceData, meta int
 	iotHubDataConnectionProperties := expandKustoIotHubDataConnectionProperties(d)
 
 	dataConnection := dataconnections.IotHubDataConnection{
-		Location:   utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location:   pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: iotHubDataConnectionProperties,
 	}
 
@@ -251,11 +250,11 @@ func expandKustoIotHubDataConnectionProperties(d *pluginsdk.ResourceData) *datac
 	}
 
 	if tableName, ok := d.GetOk("table_name"); ok {
-		iotHubDataConnectionProperties.TableName = utils.String(tableName.(string))
+		iotHubDataConnectionProperties.TableName = pointer.To(tableName.(string))
 	}
 
 	if mappingRuleName, ok := d.GetOk("mapping_rule_name"); ok {
-		iotHubDataConnectionProperties.MappingRuleName = utils.String(mappingRuleName.(string))
+		iotHubDataConnectionProperties.MappingRuleName = pointer.To(mappingRuleName.(string))
 	}
 
 	if df, ok := d.GetOk("data_format"); ok {

--- a/internal/services/kusto/kusto_script_resource.go
+++ b/internal/services/kusto/kusto_script_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2024-04-13/scripts"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceKustoDatabaseScript() *pluginsdk.Resource {
@@ -135,21 +135,21 @@ func resourceKustoDatabaseScriptCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	parameters := scripts.Script{
 		Properties: &scripts.ScriptProperties{
-			ContinueOnErrors: utils.Bool(d.Get("continue_on_errors_enabled").(bool)),
-			ForceUpdateTag:   utils.String(forceUpdateTag),
+			ContinueOnErrors: pointer.To(d.Get("continue_on_errors_enabled").(bool)),
+			ForceUpdateTag:   pointer.To(forceUpdateTag),
 		},
 	}
 
 	if scriptURL, ok := d.GetOk("url"); ok {
-		parameters.Properties.ScriptURL = utils.String(scriptURL.(string))
+		parameters.Properties.ScriptURL = pointer.To(scriptURL.(string))
 	}
 
 	if scriptURLSasToken, ok := d.GetOk("sas_token"); ok {
-		parameters.Properties.ScriptURLSasToken = utils.String(scriptURLSasToken.(string))
+		parameters.Properties.ScriptURLSasToken = pointer.To(scriptURLSasToken.(string))
 	}
 
 	if scriptContent, ok := d.GetOk("script_content"); ok {
-		parameters.Properties.ScriptContent = utils.String(scriptContent.(string))
+		parameters.Properties.ScriptContent = pointer.To(scriptContent.(string))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -1635,7 +1635,7 @@ func expandAzureRmVirtualMachineDataDisk(d *pluginsdk.ResourceData) ([]virtualma
 		}
 
 		if v, ok := config["write_accelerator_enabled"].(bool); ok {
-			data_disk.WriteAcceleratorEnabled = utils.Bool(v)
+			data_disk.WriteAcceleratorEnabled = pointer.To(v)
 		}
 
 		data_disks = append(data_disks, data_disk)
@@ -1652,7 +1652,7 @@ func expandAzureRmVirtualMachineDiagnosticsProfile(d *pluginsdk.ResourceData) *v
 		bootDiagnostic := bootDiagnostics[0].(map[string]interface{})
 
 		diagnostic := &virtualmachines.BootDiagnostics{
-			Enabled:    utils.Bool(bootDiagnostic["enabled"].(bool)),
+			Enabled:    pointer.To(bootDiagnostic["enabled"].(bool)),
 			StorageUri: pointer.To(bootDiagnostic["storage_uri"].(string)),
 		}
 
@@ -1672,7 +1672,7 @@ func expandAzureRmVirtualMachineAdditionalCapabilities(d *pluginsdk.ResourceData
 
 	additionalCapability := additionalCapabilities[0].(map[string]interface{})
 	capability := &virtualmachines.AdditionalCapabilities{
-		UltraSSDEnabled: utils.Bool(additionalCapability["ultra_ssd_enabled"].(bool)),
+		UltraSSDEnabled: pointer.To(additionalCapability["ultra_ssd_enabled"].(bool)),
 	}
 
 	return capability
@@ -1802,7 +1802,7 @@ func expandAzureRmVirtualMachineOsDisk(d *pluginsdk.ResourceData) (*virtualmachi
 	}
 
 	if v, ok := config["write_accelerator_enabled"].(bool); ok {
-		osDisk.WriteAcceleratorEnabled = utils.Bool(v)
+		osDisk.WriteAcceleratorEnabled = pointer.To(v)
 	}
 
 	return osDisk, nil

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -1680,7 +1680,7 @@ func expandVirtualMachineScaleSetSku(d *pluginsdk.ResourceData) *virtualmachines
 
 	sku := &virtualmachinescalesets.Sku{
 		Name:     pointer.To(config["name"].(string)),
-		Capacity: utils.Int64(int64(config["capacity"].(int))),
+		Capacity: pointer.To(int64(config["capacity"].(int))),
 	}
 
 	if tier, ok := config["tier"].(string); ok && tier != "" {

--- a/internal/services/lighthouse/lighthouse_assignment_resource.go
+++ b/internal/services/lighthouse/lighthouse_assignment_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationassignments"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLighthouseAssignment() *pluginsdk.Resource {
@@ -82,7 +82,7 @@ func resourceLighthouseAssignmentCreate(d *pluginsdk.ResourceData, meta interfac
 
 	id := registrationassignments.NewScopedRegistrationAssignmentID(d.Get("scope").(string), lighthouseAssignmentName)
 	options := registrationassignments.GetOperationOptions{
-		ExpandRegistrationDefinition: utils.Bool(false),
+		ExpandRegistrationDefinition: pointer.To(false),
 	}
 	existing, err := client.Get(ctx, id, options)
 	if err != nil {
@@ -120,7 +120,7 @@ func resourceLighthouseAssignmentRead(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	options := registrationassignments.GetOperationOptions{
-		ExpandRegistrationDefinition: utils.Bool(false),
+		ExpandRegistrationDefinition: pointer.To(false),
 	}
 	resp, err := client.Get(ctx, *id, options)
 	if err != nil {
@@ -177,7 +177,7 @@ func resourceLighthouseAssignmentDelete(d *pluginsdk.ResourceData, meta interfac
 func lighthouseAssignmentDeleteRefreshFunc(ctx context.Context, client *registrationassignments.RegistrationAssignmentsClient, id registrationassignments.ScopedRegistrationAssignmentId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		options := registrationassignments.GetOperationOptions{
-			ExpandRegistrationDefinition: utils.Bool(true),
+			ExpandRegistrationDefinition: pointer.To(true),
 		}
 		resp, err := client.Get(ctx, id, options)
 		if err != nil {

--- a/internal/services/lighthouse/lighthouse_assignment_resource_test.go
+++ b/internal/services/lighthouse/lighthouse_assignment_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LighthouseAssignmentResource struct{}
@@ -120,14 +120,14 @@ func (LighthouseAssignmentResource) Exists(ctx context.Context, clients *clients
 	}
 
 	options := registrationassignments.GetOperationOptions{
-		ExpandRegistrationDefinition: utils.Bool(false),
+		ExpandRegistrationDefinition: pointer.To(false),
 	}
 	resp, err := clients.Lighthouse.AssignmentsClient.Get(ctx, *id, options)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LighthouseAssignmentResource) basic(id string, secondTenantID string, principalID string, data acceptance.TestData) string {

--- a/internal/services/lighthouse/lighthouse_definition_resource.go
+++ b/internal/services/lighthouse/lighthouse_definition_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions"
@@ -249,9 +250,9 @@ func resourceLighthouseDefinitionCreateUpdate(d *pluginsdk.ResourceData, meta in
 	parameters := registrationdefinitions.RegistrationDefinition{
 		Plan: expandLighthouseDefinitionPlan(d.Get("plan").([]interface{})),
 		Properties: &registrationdefinitions.RegistrationDefinitionProperties{
-			Description:                utils.String(d.Get("description").(string)),
+			Description:                pointer.To(d.Get("description").(string)),
 			Authorizations:             authorizations,
-			RegistrationDefinitionName: utils.String(d.Get("name").(string)),
+			RegistrationDefinitionName: pointer.To(d.Get("name").(string)),
 			ManagedByTenantId:          d.Get("managing_tenant_id").(string),
 		},
 	}
@@ -358,7 +359,7 @@ func expandLighthouseDefinitionAuthorization(input []interface{}) []registration
 		result := registrationdefinitions.Authorization{
 			RoleDefinitionId:           v["role_definition_id"].(string),
 			PrincipalId:                v["principal_id"].(string),
-			PrincipalIdDisplayName:     utils.String(v["principal_display_name"].(string)),
+			PrincipalIdDisplayName:     pointer.To(v["principal_display_name"].(string)),
 			DelegatedRoleDefinitionIds: delegatedRoleDefinitionIds,
 		}
 		results = append(results, result)
@@ -411,7 +412,7 @@ func expandLighthouseDefinitionEligibleAuthorization(input []interface{}) *[]reg
 		}
 
 		if principalDisplayName := v["principal_display_name"].(string); principalDisplayName != "" {
-			result.PrincipalIdDisplayName = utils.String(principalDisplayName)
+			result.PrincipalIdDisplayName = pointer.To(principalDisplayName)
 		}
 
 		results = append(results, result)
@@ -428,7 +429,7 @@ func expandLighthouseDefinitionJustInTimeAccessPolicy(input []interface{}) *regi
 	justInTimeAccessPolicy := input[0].(map[string]interface{})
 
 	result := registrationdefinitions.JustInTimeAccessPolicy{
-		MaximumActivationDuration: utils.String(justInTimeAccessPolicy["maximum_activation_duration"].(string)),
+		MaximumActivationDuration: pointer.To(justInTimeAccessPolicy["maximum_activation_duration"].(string)),
 		ManagedByTenantApprovers:  expandLighthouseDefinitionApprover(justInTimeAccessPolicy["approver"].(*pluginsdk.Set).List()),
 	}
 
@@ -455,7 +456,7 @@ func expandLighthouseDefinitionApprover(input []interface{}) *[]registrationdefi
 		}
 
 		if principalDisplayName := eligibleApprover["principal_display_name"].(string); principalDisplayName != "" {
-			result.PrincipalIdDisplayName = utils.String(principalDisplayName)
+			result.PrincipalIdDisplayName = pointer.To(principalDisplayName)
 		}
 
 		results = append(results, result)

--- a/internal/services/lighthouse/lighthouse_definition_resource_test.go
+++ b/internal/services/lighthouse/lighthouse_definition_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LighthouseDefinitionResource struct{}
@@ -228,7 +228,7 @@ func (LighthouseDefinitionResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LighthouseDefinitionResource) basic(id string, secondTenantID string, principalID string, data acceptance.TestData) string {

--- a/internal/services/loadbalancer/lb_nat_pool_resource.go
+++ b/internal/services/loadbalancer/lb_nat_pool_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmLoadBalancerNatPool() *pluginsdk.Resource {
@@ -301,11 +300,11 @@ func expandAzureRmLoadBalancerNatPool(d *pluginsdk.ResourceData, lb *loadbalance
 	}
 
 	if v, ok := d.GetOk("floating_ip_enabled"); ok {
-		properties.EnableFloatingIP = utils.Bool(v.(bool))
+		properties.EnableFloatingIP = pointer.To(v.(bool))
 	}
 
 	if v, ok := d.GetOk("tcp_reset_enabled"); ok {
-		properties.EnableTcpReset = utils.Bool(v.(bool))
+		properties.EnableTcpReset = pointer.To(v.(bool))
 	}
 
 	properties.IdleTimeoutInMinutes = pointer.To(int64(d.Get("idle_timeout_in_minutes").(int)))

--- a/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_cluster_customer_managed_key_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsClusterCustomerManagedKeyResource struct{}
@@ -86,7 +86,7 @@ func (t LogAnalyticsClusterCustomerManagedKeyResource) Exists(ctx context.Contex
 		}
 	}
 
-	return utils.Bool(enabled), nil
+	return pointer.To(enabled), nil
 }
 
 func (LogAnalyticsClusterCustomerManagedKeyResource) template(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_cluster_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_cluster_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsClusterResource struct{}
@@ -117,7 +117,7 @@ func (t LogAnalyticsClusterResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogAnalyticsClusterResource) template(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_data_export_rule_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_data_export_rule_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/dataexport"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsDataExportRuleResource struct{}
@@ -129,7 +129,7 @@ func (t LogAnalyticsDataExportRuleResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogAnalyticsDataExportRuleResource) template(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_datasource_windows_event_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_datasource_windows_event_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/datasources"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsDataSourceWindowsEventResource struct{}
@@ -103,7 +103,7 @@ func (t LogAnalyticsDataSourceWindowsEventResource) Exists(ctx context.Context, 
 		return nil, fmt.Errorf("readingLog Analytics Data Source Windows Event (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogAnalyticsDataSourceWindowsEventResource) basic(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_datasource_windows_performance_counter_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_datasource_windows_performance_counter_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/datasources"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsDataSourceWindowsPerformanceCounterResource struct{}
@@ -112,7 +112,7 @@ func (t LogAnalyticsDataSourceWindowsPerformanceCounterResource) Exists(ctx cont
 		return nil, fmt.Errorf("readingLog Analytics Data Source Windows Event (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogAnalyticsDataSourceWindowsPerformanceCounterResource) basic(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2022-08-08/automationaccount"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedservices"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogAnalyticsLinkedService() *pluginsdk.Resource {
@@ -111,11 +111,11 @@ func resourceLogAnalyticsLinkedServiceCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if id.LinkedServiceName == "Automation" {
-		parameters.Properties.ResourceId = utils.String(readAccess)
+		parameters.Properties.ResourceId = pointer.To(readAccess)
 	}
 
 	if id.LinkedServiceName == "Cluster" {
-		parameters.Properties.WriteAccessResourceId = utils.String(writeAccess)
+		parameters.Properties.WriteAccessResourceId = pointer.To(writeAccess)
 	}
 
 	err = client.CreateOrUpdateThenPoll(ctx, id, parameters)

--- a/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsLinkedServiceResource struct{}
@@ -98,7 +98,7 @@ func (r LogAnalyticsLinkedServiceResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogAnalyticsLinkedServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_query_pack_query_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_query_pack_query_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypackqueries"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsQueryPackQueryResource struct{ uuid string }
@@ -29,11 +29,11 @@ func (r LogAnalyticsQueryPackQueryResource) Exists(ctx context.Context, client *
 	resp, err := client.LogAnalytics.QueryPackQueriesClient.QueriesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccLogAnalyticsQueryPackQuery_basic(t *testing.T) {

--- a/internal/services/loganalytics/log_analytics_query_pack_resource.go
+++ b/internal/services/loganalytics/log_analytics_query_pack_resource.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsQueryPackModel struct {
@@ -175,7 +175,7 @@ func (r LogAnalyticsQueryPackResource) Read() sdk.ResourceFunc {
 			state := LogAnalyticsQueryPackModel{
 				Name:              id.QueryPackName,
 				ResourceGroupName: id.ResourceGroupName,
-				Location:          location.NormalizeNilable(utils.String(model.Location)),
+				Location:          location.NormalizeNilable(pointer.To(model.Location)),
 			}
 
 			if model.Tags != nil {

--- a/internal/services/loganalytics/log_analytics_query_pack_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_query_pack_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsQueryPackResource struct{}
@@ -28,11 +28,11 @@ func (r LogAnalyticsQueryPackResource) Exists(ctx context.Context, client *clien
 	resp, err := client.LogAnalytics.QueryPacksClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccLogAnalyticsQueryPack_basic(t *testing.T) {

--- a/internal/services/loganalytics/log_analytics_saved_search_resource.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogAnalyticsSavedSearch() *pluginsdk.Resource {
@@ -133,7 +133,7 @@ func resourceLogAnalyticsSavedSearchCreate(d *pluginsdk.ResourceData, meta inter
 			Category:      d.Get("category").(string),
 			DisplayName:   d.Get("display_name").(string),
 			Query:         d.Get("query").(string),
-			FunctionAlias: utils.String(d.Get("function_alias").(string)),
+			FunctionAlias: pointer.To(d.Get("function_alias").(string)),
 			Tags:          expandSavedSearchTag(d.Get("tags").(map[string]interface{})), // expand tags because it's defined as object set in service
 		},
 	}
@@ -146,7 +146,7 @@ func resourceLogAnalyticsSavedSearchCreate(d *pluginsdk.ResourceData, meta inter
 				result = append(result, item.(string))
 			}
 		}
-		parameters.Properties.FunctionParameters = utils.String(strings.Join(result, ", "))
+		parameters.Properties.FunctionParameters = pointer.To(strings.Join(result, ", "))
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {

--- a/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_saved_search_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsSavedSearchResource struct{}
@@ -93,7 +93,7 @@ func (t LogAnalyticsSavedSearchResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("readingLog Analytics Linked Service Saved Search (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogAnalyticsSavedSearchResource) basic(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_solution_resource.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsSolutionResource struct{}
@@ -169,7 +169,7 @@ func (s LogAnalyticsSolutionResource) Create() sdk.ResourceFunc {
 
 			parameters := solution.Solution{
 				Name:     pointer.To(id.SolutionName),
-				Location: pointer.To(azure.NormalizeLocation(config.Location)),
+				Location: pointer.To(location.Normalize(config.Location)),
 				Properties: &solution.SolutionProperties{
 					WorkspaceResourceId: workspaceID.ID(),
 				},
@@ -218,8 +218,8 @@ func (s LogAnalyticsSolutionResource) Read() sdk.ResourceFunc {
 			}
 
 			if model := resp.Model; model != nil {
-				if location := model.Location; location != nil {
-					state.Location = azure.NormalizeLocation(*location)
+				if loc := model.Location; loc != nil {
+					state.Location = location.Normalize(*loc)
 				}
 
 				// Reversing the mapping used to get .solution_name
@@ -325,10 +325,10 @@ func expandAzureRmLogAnalyticsSolutionPlan(plans []SolutionPlanModel) solution.S
 	product := plan.Product
 
 	expandedPlan := solution.SolutionPlan{
-		Name:          utils.String(name),
-		PromotionCode: utils.String(promotionCode),
-		Publisher:     utils.String(publisher),
-		Product:       utils.String(product),
+		Name:          pointer.To(name),
+		PromotionCode: pointer.To(promotionCode),
+		Publisher:     pointer.To(publisher),
+		Product:       pointer.To(product),
 	}
 
 	return expandedPlan

--- a/internal/services/loganalytics/log_analytics_solution_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_solution_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsSolutionResource struct{}
@@ -99,7 +99,7 @@ func (t LogAnalyticsSolutionResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogAnalyticsSolutionResource) containerMonitoring(data acceptance.TestData) string {

--- a/internal/services/loganalytics/log_analytics_workspace_data_source.go
+++ b/internal/services/loganalytics/log_analytics_workspace_data_source.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceLogAnalyticsWorkspace() *pluginsdk.Resource {
@@ -122,7 +122,7 @@ func dataSourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interfa
 			if props.WorkspaceCapping != nil && props.WorkspaceCapping.DailyQuotaGb != nil {
 				d.Set("daily_quota_gb", props.WorkspaceCapping.DailyQuotaGb)
 			} else {
-				d.Set("daily_quota_gb", utils.Float(-1))
+				d.Set("daily_quota_gb", pointer.To(-1))
 			}
 		}
 

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsWorkspaceTableResource struct{}
@@ -132,7 +131,7 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 
 			if model.Plan == string(tables.TablePlanEnumAnalytics) {
 				// The service will return HTTP 400 if it's specified `0` in payload, to keep it as default, we need to pass `-1`
-				updateInput.Properties.RetentionInDays = pointer.FromInt64(-1)
+				updateInput.Properties.RetentionInDays = pointer.To(int64(-1))
 				// `0` is not a valid value for `retention_in_days`, so we can use it to validate if it's specified.
 				if model.RetentionInDays != 0 {
 					updateInput.Properties.RetentionInDays = pointer.To(model.RetentionInDays)
@@ -193,7 +192,7 @@ func (r LogAnalyticsWorkspaceTableResource) Update() sdk.ResourceFunc {
 							// `0` is not a valid value for `retention_in_days`, and the service will return HTTP 400
 							// to reset it to its default value, we need to pass `-1`
 							if state.RetentionInDays == 0 {
-								updateInput.Properties.RetentionInDays = pointer.FromInt64(-1)
+								updateInput.Properties.RetentionInDays = pointer.To(int64(-1))
 							}
 						}
 					}
@@ -273,8 +272,8 @@ func (r LogAnalyticsWorkspaceTableResource) Delete() sdk.ResourceFunc {
 
 			// We do not delete the resource here, just set the retention to workspace default value, which is
 			// achieved by setting the value to `-1`
-			retentionInDays := utils.Int64(-1)
-			totalRetentionInDays := utils.Int64(-1)
+			retentionInDays := pointer.To(int64(-1))
+			totalRetentionInDays := pointer.To(int64(-1))
 
 			updateInput := tables.Table{
 				Properties: &tables.TableProperties{

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/tables"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogAnalyticsWorkspaceTableResource struct{}
@@ -66,7 +66,7 @@ func (t LogAnalyticsWorkspaceTableResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("reading Log Analytics Workspace Table (%s): %+v", id.ID(), err)
 	}
 
-	return utils.Bool(resp.Model.Id != nil), nil
+	return pointer.To(resp.Model.Id != nil), nil
 }
 
 func (LogAnalyticsWorkspaceTableResource) updateRetention(data acceptance.TestData) string {

--- a/internal/services/loganalytics/transition.go
+++ b/internal/services/loganalytics/transition.go
@@ -3,7 +3,7 @@
 
 package loganalytics
 
-import "github.com/hashicorp/terraform-provider-azurerm/utils"
+import "github.com/hashicorp/go-azure-helpers/lang/pointer"
 
 func expandTags(input map[string]interface{}) *map[string]string {
 	output := make(map[string]string)
@@ -18,7 +18,7 @@ func flattenTags(input *map[string]string) map[string]*string {
 
 	if input != nil {
 		for k, v := range *input {
-			output[k] = utils.String(v)
+			output[k] = pointer.To(v)
 		}
 	}
 

--- a/internal/services/logic/logic_app_integration_account_agreement_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_agreement_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountagreements"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountAgreementResource struct{}
@@ -94,11 +94,11 @@ func (r LogicAppIntegrationAccountAgreementResource) Exists(ctx context.Context,
 	resp, err := client.Logic.IntegrationAccountAgreementClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountAgreementResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_assembly_resource.go
+++ b/internal/services/logic/logic_app_integration_account_assembly_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountassemblies"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogicAppIntegrationAccountAssembly() *pluginsdk.Resource {
@@ -118,8 +118,8 @@ func resourceLogicAppIntegrationAccountAssemblyCreateUpdate(d *pluginsdk.Resourc
 	parameters := integrationaccountassemblies.AssemblyDefinition{
 		Properties: integrationaccountassemblies.AssemblyProperties{
 			AssemblyName:    d.Get("assembly_name").(string),
-			AssemblyVersion: utils.String(d.Get("assembly_version").(string)),
-			ContentType:     utils.String("application/octet-stream"),
+			AssemblyVersion: pointer.To(d.Get("assembly_version").(string)),
+			ContentType:     pointer.To("application/octet-stream"),
 		},
 	}
 
@@ -129,7 +129,7 @@ func resourceLogicAppIntegrationAccountAssemblyCreateUpdate(d *pluginsdk.Resourc
 
 	if v, ok := d.GetOk("content_link_uri"); ok {
 		parameters.Properties.ContentLink = &integrationaccountassemblies.ContentLink{
-			Uri: utils.String(v.(string)),
+			Uri: pointer.To(v.(string)),
 		}
 	}
 

--- a/internal/services/logic/logic_app_integration_account_assembly_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_assembly_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountassemblies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountAssemblyResource struct{}
@@ -94,11 +94,11 @@ func (r LogicAppIntegrationAccountAssemblyResource) Exists(ctx context.Context, 
 	resp, err := client.Logic.IntegrationAccountAssemblyClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountAssemblyResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_batch_configuration_resource.go
+++ b/internal/services/logic/logic_app_integration_account_batch_configuration_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountbatchconfigurations"
@@ -342,11 +343,11 @@ func expandIntegrationAccountBatchConfigurationBatchReleaseCriteria(input []inte
 	v := input[0].(map[string]interface{})
 
 	if batchSize := v["batch_size"].(int); batchSize != 0 {
-		result.BatchSize = utils.Int64(int64(batchSize))
+		result.BatchSize = pointer.To(int64(batchSize))
 	}
 
 	if messageCount := v["message_count"].(int); messageCount != 0 {
-		result.MessageCount = utils.Int64(int64(messageCount))
+		result.MessageCount = pointer.To(int64(messageCount))
 	}
 
 	if recurrence := v["recurrence"].([]interface{}); len(recurrence) != 0 {
@@ -365,19 +366,19 @@ func expandIntegrationAccountBatchConfigurationWorkflowTriggerRecurrence(input [
 	frequency := integrationaccountbatchconfigurations.RecurrenceFrequency(v["frequency"].(string))
 	result := integrationaccountbatchconfigurations.WorkflowTriggerRecurrence{
 		Frequency: &frequency,
-		Interval:  utils.Int64(int64(v["interval"].(int))),
+		Interval:  pointer.To(int64(v["interval"].(int))),
 	}
 
 	if startTime := v["start_time"].(string); startTime != "" {
-		result.StartTime = utils.String(startTime)
+		result.StartTime = pointer.To(startTime)
 	}
 
 	if endTime := v["end_time"].(string); endTime != "" {
-		result.EndTime = utils.String(endTime)
+		result.EndTime = pointer.To(endTime)
 	}
 
 	if timeZone := v["time_zone"].(string); timeZone != "" {
-		result.TimeZone = utils.String(timeZone)
+		result.TimeZone = pointer.To(timeZone)
 	}
 
 	if schedule := v["schedule"].([]interface{}); len(schedule) != 0 {
@@ -431,7 +432,7 @@ func expandIntegrationAccountBatchConfigurationRecurrenceScheduleOccurrences(inp
 		day := integrationaccountbatchconfigurations.DayOfWeek(v["weekday"].(string))
 		results = append(results, integrationaccountbatchconfigurations.RecurrenceScheduleOccurrence{
 			Day:        &day,
-			Occurrence: utils.Int64(int64(v["week"].(int))),
+			Occurrence: pointer.To(int64(v["week"].(int))),
 		})
 	}
 

--- a/internal/services/logic/logic_app_integration_account_batch_configuration_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_batch_configuration_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountbatchconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountBatchConfigurationResource struct{}
@@ -94,11 +94,11 @@ func (r LogicAppIntegrationAccountBatchConfigurationResource) Exists(ctx context
 	resp, err := client.Logic.IntegrationAccountBatchConfigurationClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountBatchConfigurationResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_certificate_resource.go
+++ b/internal/services/logic/logic_app_integration_account_certificate_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogicAppIntegrationAccountCertificate() *pluginsdk.Resource {
@@ -132,7 +132,7 @@ func resourceLogicAppIntegrationAccountCertificateCreateUpdate(d *pluginsdk.Reso
 	}
 
 	if v, ok := d.GetOk("public_certificate"); ok {
-		parameters.Properties.PublicCertificate = utils.String(v.(string))
+		parameters.Properties.PublicCertificate = pointer.To(v.(string))
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {
@@ -209,13 +209,13 @@ func expandIntegrationAccountCertificateKeyVaultKey(input []interface{}) *integr
 
 	result := integrationaccountcertificates.KeyVaultKeyReference{
 		KeyVault: integrationaccountcertificates.KeyVaultKeyReferenceKeyVault{
-			Id: utils.String(v["key_vault_id"].(string)),
+			Id: pointer.To(v["key_vault_id"].(string)),
 		},
 		KeyName: v["key_name"].(string),
 	}
 
 	if keyVersion := v["key_version"].(string); keyVersion != "" {
-		result.KeyVersion = utils.String(keyVersion)
+		result.KeyVersion = pointer.To(keyVersion)
 	}
 
 	return &result

--- a/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountcertificates"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountCertificateResource struct{}
@@ -94,12 +94,12 @@ func (r LogicAppIntegrationAccountCertificateResource) Exists(ctx context.Contex
 	resp, err := client.Logic.IntegrationAccountCertificateClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r LogicAppIntegrationAccountCertificateResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_map_resource.go
+++ b/internal/services/logic/logic_app_integration_account_map_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountmaps"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogicAppIntegrationAccountMap() *pluginsdk.Resource {
@@ -103,14 +103,14 @@ func resourceLogicAppIntegrationAccountMapCreateUpdate(d *pluginsdk.ResourceData
 	parameters := integrationaccountmaps.IntegrationAccountMap{
 		Properties: integrationaccountmaps.IntegrationAccountMapProperties{
 			MapType: integrationaccountmaps.MapType(d.Get("map_type").(string)),
-			Content: utils.String(d.Get("content").(string)),
+			Content: pointer.To(d.Get("content").(string)),
 		},
 	}
 
 	if parameters.Properties.MapType == integrationaccountmaps.MapTypeLiquid {
-		parameters.Properties.ContentType = utils.String("text/plain")
+		parameters.Properties.ContentType = pointer.To("text/plain")
 	} else {
-		parameters.Properties.ContentType = utils.String("application/xml")
+		parameters.Properties.ContentType = pointer.To("application/xml")
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {

--- a/internal/services/logic/logic_app_integration_account_map_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_map_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountmaps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountMapResource struct{}
@@ -110,12 +110,12 @@ func (r LogicAppIntegrationAccountMapResource) Exists(ctx context.Context, clien
 	resp, err := client.Logic.IntegrationAccountMapClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountMapResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_partner_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_partner_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountpartners"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountPartnerResource struct{}
@@ -95,12 +95,12 @@ func (r LogicAppIntegrationAccountPartnerResource) Exists(ctx context.Context, c
 	resp, err := client.Logic.IntegrationAccountPartnerClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountPartnerResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_resource.go
+++ b/internal/services/logic/logic_app_integration_account_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogicAppIntegrationAccount() *pluginsdk.Resource {
@@ -96,7 +96,7 @@ func resourceLogicAppIntegrationAccountCreateUpdate(d *pluginsdk.ResourceData, m
 
 	account := integrationaccounts.IntegrationAccount{
 		Properties: &integrationaccounts.IntegrationAccountProperties{},
-		Location:   utils.String(location.Normalize(d.Get("location").(string))),
+		Location:   pointer.To(location.Normalize(d.Get("location").(string))),
 		Sku: &integrationaccounts.IntegrationAccountSku{
 			Name: integrationaccounts.IntegrationAccountSkuName(d.Get("sku_name").(string)),
 		},
@@ -105,7 +105,7 @@ func resourceLogicAppIntegrationAccountCreateUpdate(d *pluginsdk.ResourceData, m
 
 	if v, ok := d.GetOk("integration_service_environment_id"); ok {
 		account.Properties.IntegrationServiceEnvironment = &integrationaccounts.ResourceReference{
-			Id: utils.String(v.(string)),
+			Id: pointer.To(v.(string)),
 		}
 	}
 

--- a/internal/services/logic/logic_app_integration_account_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountResource struct{}
@@ -109,7 +109,7 @@ func (LogicAppIntegrationAccountResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("retrieving %s: %v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_schema_resource.go
+++ b/internal/services/logic/logic_app_integration_account_schema_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountschemas"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceLogicAppIntegrationAccountSchema() *pluginsdk.Resource {
@@ -101,13 +101,13 @@ func resourceLogicAppIntegrationAccountSchemaCreateUpdate(d *pluginsdk.ResourceD
 	parameters := integrationaccountschemas.IntegrationAccountSchema{
 		Properties: integrationaccountschemas.IntegrationAccountSchemaProperties{
 			SchemaType:  integrationaccountschemas.SchemaTypeXml,
-			Content:     utils.String(d.Get("content").(string)),
-			ContentType: utils.String("application/xml"),
+			Content:     pointer.To(d.Get("content").(string)),
+			ContentType: pointer.To("application/xml"),
 		},
 	}
 
 	if v, ok := d.GetOk("file_name"); ok {
-		parameters.Properties.FileName = utils.String(v.(string))
+		parameters.Properties.FileName = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {

--- a/internal/services/logic/logic_app_integration_account_schema_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_schema_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountschemas"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountSchemaResource struct{}
@@ -96,7 +96,7 @@ func (LogicAppIntegrationAccountSchemaResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountSchemaResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_integration_account_session_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_session_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountsessions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppIntegrationAccountSessionResource struct{}
@@ -84,7 +84,7 @@ func (LogicAppIntegrationAccountSessionResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r LogicAppIntegrationAccountSessionResource) template(data acceptance.TestData) string {

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -11,21 +11,21 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationserviceenvironments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var logicAppResourceName = "azurerm_logic_app"
@@ -300,7 +300,7 @@ func resourceLogicAppWorkflowCreate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 
 	workflowSchema := d.Get("workflow_schema").(string)
 	workflowVersion := d.Get("workflow_version").(string)
@@ -337,7 +337,7 @@ func resourceLogicAppWorkflowCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	properties := workflows.Workflow{
 		Identity: identity,
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &workflows.WorkflowProperties{
 			Definition: &definition,
 			Parameters: parameters,
@@ -352,13 +352,13 @@ func resourceLogicAppWorkflowCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	if iseID, ok := d.GetOk("integration_service_environment_id"); ok {
 		properties.Properties.IntegrationServiceEnvironment = &workflows.ResourceReference{
-			Id: utils.String(iseID.(string)),
+			Id: pointer.To(iseID.(string)),
 		}
 	}
 
 	if v, ok := d.GetOk("logic_app_integration_account_id"); ok {
 		properties.Properties.IntegrationAccount = &workflows.ResourceReference{
-			Id: utils.String(v.(string)),
+			Id: pointer.To(v.(string)),
 		}
 	}
 
@@ -399,7 +399,7 @@ func resourceLogicAppWorkflowUpdate(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("[ERROR] Error parsing Logic App Workflow - `WorkflowProperties` is nil")
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	workflowParameters, err := expandLogicAppWorkflowWorkflowParameters(d.Get("workflow_parameters").(map[string]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `workflow_parameters`: %+v", err)
@@ -431,7 +431,7 @@ func resourceLogicAppWorkflowUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	properties := workflows.Workflow{
 		Identity: identity,
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &workflows.WorkflowProperties{
 			Definition: &definition,
 			Parameters: parameters,
@@ -446,13 +446,13 @@ func resourceLogicAppWorkflowUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("logic_app_integration_account_id"); ok {
 		properties.Properties.IntegrationAccount = &workflows.ResourceReference{
-			Id: utils.String(v.(string)),
+			Id: pointer.To(v.(string)),
 		}
 	}
 
 	if iseID, ok := d.GetOk("integration_service_environment_id"); ok {
 		properties.Properties.IntegrationServiceEnvironment = &workflows.ResourceReference{
-			Id: utils.String(iseID.(string)),
+			Id: pointer.To(iseID.(string)),
 		}
 	}
 
@@ -487,8 +487,8 @@ func resourceLogicAppWorkflowRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		if location := model.Location; location != nil {
-			d.Set("location", azure.NormalizeLocation(*location))
+		if loc := model.Location; loc != nil {
+			d.Set("location", location.Normalize(*loc))
 		}
 
 		identity, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)
@@ -867,7 +867,7 @@ func expandLogicAppWorkflowIPAddressRanges(input []interface{}) *[]workflows.IPA
 
 	for _, item := range input {
 		results = append(results, workflows.IPAddressRange{
-			AddressRange: utils.String(item.(string)),
+			AddressRange: pointer.To(item.(string)),
 		})
 	}
 
@@ -904,8 +904,8 @@ func expandLogicAppWorkflowOpenAuthenticationPolicyClaim(input []interface{}) *[
 		v := item.(map[string]interface{})
 
 		results = append(results, workflows.OpenAuthenticationPolicyClaim{
-			Name:  utils.String(v["name"].(string)),
-			Value: utils.String(v["value"].(string)),
+			Name:  pointer.To(v["name"].(string)),
+			Value: pointer.To(v["value"].(string)),
 		})
 	}
 	return &results

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LogicAppWorkflowResource struct{}
@@ -203,7 +203,7 @@ func (LogicAppWorkflowResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("retrieving Logic App Workflow %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (LogicAppWorkflowResource) empty(data acceptance.TestData) string {

--- a/internal/services/logic/logic_apps_test.go
+++ b/internal/services/logic/logic_apps_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func actionExists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -55,11 +55,11 @@ func componentExists(ctx context.Context, clients *clients.Client, state *plugin
 	}
 
 	if resp.Model == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	if resp.Model.Properties == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	if resp.Model.Properties.Definition == nil {
@@ -78,5 +78,5 @@ func componentExists(ctx context.Context, clients *clients.Client, state *plugin
 		}
 	}
 
-	return utils.Bool(exists), nil
+	return pointer.To(exists), nil
 }


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
