### PR TITLE
services `M*` - deprecated function clean up

### DIFF
--- a/internal/services/machinelearning/identity.go
+++ b/internal/services/machinelearning/identity.go
@@ -4,8 +4,8 @@
 package machinelearning
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func expandIdentity(input []interface{}) (*identity.LegacySystemAndUserAssignedMap, error) {
@@ -55,10 +55,10 @@ func flattenIdentity(input *identity.LegacySystemAndUserAssignedMap) (*[]interfa
 				details := identity.UserAssignedIdentityDetails{}
 
 				if v.ClientId != nil {
-					details.ClientId = utils.String(*v.ClientId)
+					details.ClientId = pointer.To(*v.ClientId)
 				}
 				if v.PrincipalId != nil {
-					details.PrincipalId = utils.String(*v.PrincipalId)
+					details.PrincipalId = pointer.To(*v.PrincipalId)
 				}
 
 				identityIds[k] = details

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -10,17 +10,16 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceComputeCluster() *pluginsdk.Resource {
@@ -212,7 +211,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	vmPriority := machinelearningcomputes.VMPriority(d.Get("vm_priority").(string))
 	computeClusterAmlComputeProperties := machinelearningcomputes.AmlComputeProperties{
-		VMSize:                 utils.String(d.Get("vm_size").(string)),
+		VMSize:                 pointer.To(d.Get("vm_size").(string)),
 		VMPriority:             &vmPriority,
 		ScaleSettings:          expandScaleSettings(d.Get("scale_settings").([]interface{})),
 		UserAccountCredentials: expandUserAccountCredentials(d.Get("ssh").([]interface{})),
@@ -232,9 +231,9 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// to configuration files 'location' field...
 	computeClusterProperties := machinelearningcomputes.AmlCompute{
 		Properties:       &computeClusterAmlComputeProperties,
-		ComputeLocation:  utils.String(d.Get("location").(string)),
-		Description:      utils.String(d.Get("description").(string)),
-		DisableLocalAuth: utils.Bool(!d.Get("local_auth_enabled").(bool)),
+		ComputeLocation:  pointer.To(d.Get("location").(string)),
+		Description:      pointer.To(d.Get("description").(string)),
+		DisableLocalAuth: pointer.To(!d.Get("local_auth_enabled").(bool)),
 	}
 
 	// NOTE: The 'ComputeResource' 'Location' field should always point
@@ -318,8 +317,8 @@ func resourceComputeClusterRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	}
 
-	if location := computeResource.Model.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := computeResource.Model.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	identity, err := flattenIdentity(computeResource.Model.Identity)
@@ -426,8 +425,8 @@ func expandUserAccountCredentials(input []interface{}) *machinelearningcomputes.
 
 	return &machinelearningcomputes.UserAccountCredentials{
 		AdminUserName:         v["admin_username"].(string),
-		AdminUserPassword:     utils.String(v["admin_password"].(string)),
-		AdminUserSshPublicKey: utils.String(v["key_value"].(string)),
+		AdminUserPassword:     pointer.To(v["admin_password"].(string)),
+		AdminUserSshPublicKey: pointer.To(v["key_value"].(string)),
 	}
 }
 

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ComputeClusterResource struct{}
@@ -215,11 +215,11 @@ func (r ComputeClusterResource) Exists(ctx context.Context, client *clients.Clie
 	computeResource, err := computeClusterClient.ComputeGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(computeResource.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Compute Cluster %q: %+v", state.ID, err)
 	}
-	return utils.Bool(computeResource.Model.Properties != nil), nil
+	return pointer.To(computeResource.Model.Properties != nil), nil
 }
 
 func (r ComputeClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource.go
@@ -15,11 +15,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -223,7 +223,7 @@ func resourceComputeInstanceCreate(d *pluginsdk.ResourceData, meta interface{}) 
 
 	parameters := machinelearningcomputes.ComputeResource{
 		Identity: identity,
-		Location: pointer.To(azure.NormalizeLocation(*model.Location)),
+		Location: pointer.To(location.Normalize(*model.Location)),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 

--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/datastore"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MachineLearningDataStoreBlobStorage struct{}
@@ -125,12 +125,12 @@ func (r MachineLearningDataStoreBlobStorage) Exists(ctx context.Context, client 
 	resp, err := dataStoreClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Data Store %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r MachineLearningDataStoreBlobStorage) blobStorageAccountKey(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource.go
@@ -22,7 +22,6 @@ import (
 	storageAccountHelper "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MachineLearningDataStoreDataLakeGen2 struct{}
@@ -172,7 +171,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Create() sdk.ResourceFunc {
 			}
 
 			datastoreRaw := datastore.DatastoreResource{
-				Name: utils.String(model.Name),
+				Name: pointer.To(model.Name),
 				Type: pointer.To(string(datastore.DatastoreTypeAzureDataLakeGenTwo)),
 			}
 
@@ -182,7 +181,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Create() sdk.ResourceFunc {
 				AccountName:                   containerId.StorageAccountName,
 				Filesystem:                    containerId.ContainerName,
 				Endpoint:                      pointer.To(metadata.Client.Storage.StorageDomainSuffix),
-				Description:                   utils.String(model.Description),
+				Description:                   pointer.To(model.Description),
 				ServiceDataAccessAuthIdentity: pointer.To(datastore.ServiceDataAccessAuthIdentity(model.ServiceDataIdentity)),
 				Tags:                          pointer.To(model.Tags),
 			}
@@ -239,7 +238,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Update() sdk.ResourceFunc {
 			}
 
 			datastoreRaw := datastore.DatastoreResource{
-				Name: utils.String(id.DataStoreName),
+				Name: pointer.To(id.DataStoreName),
 				Type: pointer.To(string(datastore.DatastoreTypeAzureDataLakeGenTwo)),
 			}
 
@@ -248,7 +247,7 @@ func (r MachineLearningDataStoreDataLakeGen2) Update() sdk.ResourceFunc {
 				ResourceGroup:                 &containerId.ResourceGroupName,
 				AccountName:                   containerId.StorageAccountName,
 				Filesystem:                    containerId.ContainerName,
-				Description:                   utils.String(state.Description),
+				Description:                   pointer.To(state.Description),
 				ServiceDataAccessAuthIdentity: pointer.To(datastore.ServiceDataAccessAuthIdentity(state.ServiceDataIdentity)),
 				Tags:                          pointer.To(state.Tags),
 			}

--- a/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_datalake_gen2_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/datastore"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MachineLearningDataStoreDataLakeGen2 struct{}
@@ -116,12 +116,12 @@ func (r MachineLearningDataStoreDataLakeGen2) Exists(ctx context.Context, client
 	resp, err := dataStoreClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Data Store %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r MachineLearningDataStoreDataLakeGen2) dataLakeGen2Basic(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_datastore_fileshare_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_datastore_fileshare_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/datastore"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MachineLearningDataStoreFileShare struct{}
@@ -96,12 +96,12 @@ func (r MachineLearningDataStoreFileShare) Exists(ctx context.Context, client *c
 	resp, err := dataStoreClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Data Store File Share %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r MachineLearningDataStoreFileShare) fileShareAccountKey(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
@@ -11,18 +11,17 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-07-01/managedclusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAksInferenceCluster() *pluginsdk.Resource {
@@ -186,7 +185,7 @@ func resourceAksInferenceClusterCreate(d *pluginsdk.ResourceData, meta interface
 	inferenceClusterParameters := machinelearningcomputes.ComputeResource{
 		Properties: expandAksComputeProperties(aksID.ID(), aksModel, d),
 		Identity:   identity,
-		Location:   utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location:   pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
@@ -249,8 +248,8 @@ func resourceAksInferenceClusterRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("description", aksComputeProperties.Description)
 
 	// Retrieve location
-	if location := computeResource.Model.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := computeResource.Model.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	identity, err := flattenIdentity(computeResource.Model.Identity)
@@ -295,13 +294,13 @@ func expandAksComputeProperties(aksId string, aks *managedclusters.ManagedCluste
 
 	return machinelearningcomputes.AKS{
 		Properties: &machinelearningcomputes.AKSSchemaProperties{
-			ClusterFqdn:      utils.String(*fqdn),
+			ClusterFqdn:      pointer.To(*fqdn),
 			SslConfiguration: expandSSLConfig(d.Get("ssl").([]interface{})),
 			ClusterPurpose:   pointer.To(machinelearningcomputes.ClusterPurpose(d.Get("cluster_purpose").(string))),
 		},
-		ComputeLocation: utils.String(aks.Location),
-		Description:     utils.String(d.Get("description").(string)),
-		ResourceId:      utils.String(aksId),
+		ComputeLocation: pointer.To(aks.Location),
+		Description:     pointer.To(d.Get("description").(string)),
+		ResourceId:      pointer.To(aksId),
 	}
 }
 
@@ -326,10 +325,10 @@ func expandSSLConfig(input []interface{}) *machinelearningcomputes.SslConfigurat
 
 	return &machinelearningcomputes.SslConfiguration{
 		Status:                  pointer.To(machinelearningcomputes.SslConfigStatus(sslStatus)),
-		Cert:                    utils.String(v["cert"].(string)),
-		Key:                     utils.String(v["key"].(string)),
-		Cname:                   utils.String(v["cname"].(string)),
-		LeafDomainLabel:         utils.String(v["leaf_domain_label"].(string)),
-		OverwriteExistingDomain: utils.Bool(v["overwrite_existing_domain"].(bool)),
+		Cert:                    pointer.To(v["cert"].(string)),
+		Key:                     pointer.To(v["key"].(string)),
+		Cname:                   pointer.To(v["cname"].(string)),
+		LeafDomainLabel:         pointer.To(v["leaf_domain_label"].(string)),
+		OverwriteExistingDomain: pointer.To(v["overwrite_existing_domain"].(bool)),
 	}
 }

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type InferenceClusterResource struct{}
@@ -159,12 +159,12 @@ func (r InferenceClusterResource) Exists(ctx context.Context, client *clients.Cl
 	resp, err := inferenceClusterClient.ComputeGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Inference Cluster %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r InferenceClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_synapse_spark_resource.go
+++ b/internal/services/machinelearning/machine_learning_synapse_spark_resource.go
@@ -16,14 +16,12 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	synapseValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSynapseSpark() *pluginsdk.Resource {
@@ -118,13 +116,13 @@ func resourceSynapseSparkCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	parameters := machinelearningcomputes.ComputeResource{
 		Properties: &machinelearningcomputes.SynapseSpark{
 			Properties:       nil,
-			ComputeLocation:  utils.String(d.Get("location").(string)),
-			Description:      utils.String(d.Get("description").(string)),
-			ResourceId:       utils.String(d.Get("synapse_spark_pool_id").(string)),
-			DisableLocalAuth: utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			ComputeLocation:  pointer.To(d.Get("location").(string)),
+			Description:      pointer.To(d.Get("description").(string)),
+			ResourceId:       pointer.To(d.Get("synapse_spark_pool_id").(string)),
+			DisableLocalAuth: pointer.To(!d.Get("local_auth_enabled").(bool)),
 		},
 		Identity: identity,
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
@@ -166,8 +164,8 @@ func resourceSynapseSparkRead(d *pluginsdk.ResourceData, meta interface{}) error
 	workspaceId := workspaces.NewWorkspaceID(subscriptionId, id.ResourceGroupName, id.WorkspaceName)
 	d.Set("machine_learning_workspace_id", workspaceId.ID())
 
-	if location := resp.Model.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Model.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	identity, err := flattenIdentity(resp.Model.Identity)

--- a/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SynapseSparkResource struct{}
@@ -114,11 +114,11 @@ func (r SynapseSparkResource) Exists(ctx context.Context, client *clients.Client
 	computeResource, err := computeClient.ComputeGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(computeResource.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Compute Cluster %q: %+v", state.ID, err)
 	}
-	return utils.Bool(computeResource.Model.Properties != nil), nil
+	return pointer.To(computeResource.Model.Properties != nil), nil
 }
 
 func (r SynapseSparkResource) basic(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_fqdn_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_network_outbound_rule_fqdn_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/managednetwork"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkspaceNetworkOutboundRuleFqdnResource struct{}
@@ -84,12 +84,12 @@ func (r WorkspaceNetworkOutboundRuleFqdnResource) Exists(ctx context.Context, cl
 	resp, err := client.MachineLearning.ManagedNetwork.SettingsRuleGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Workspace Outbound Rule FQDN %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r WorkspaceNetworkOutboundRuleFqdnResource) template(data acceptance.TestData) string {

--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkspaceSku string
@@ -351,7 +350,7 @@ func resourceMachineLearningWorkspaceCreate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("high_business_impact"); ok {
-		workspace.Properties.HbiWorkspace = utils.Bool(v.(bool))
+		workspace.Properties.HbiWorkspace = pointer.To(v.(bool))
 	}
 
 	if v, ok := d.GetOk("image_build_compute_name"); ok {

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkspaceResource struct{}
@@ -417,12 +417,12 @@ func (r WorkspaceResource) Exists(ctx context.Context, client *clients.Client, s
 	resp, err := workspacesClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Machine Learning Workspace %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r WorkspaceResource) basic(data acceptance.TestData) string {

--- a/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dedicated_host_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmMaintenanceAssignmentDedicatedHost() *pluginsdk.Resource {
@@ -103,10 +103,10 @@ func resourceArmMaintenanceAssignmentDedicatedHostCreate(d *pluginsdk.ResourceDa
 
 	// set assignment name to configuration name
 	configurationAssignment := configurationassignments.ConfigurationAssignment{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &configurationassignments.ConfigurationAssignmentProperties{
-			MaintenanceConfigurationId: utils.String(configurationId.ID()),
-			ResourceId:                 utils.String(dedicatedHostId.ID()),
+			MaintenanceConfigurationId: pointer.To(configurationId.ID()),
+			ResourceId:                 pointer.To(dedicatedHostId.ID()),
 		},
 	}
 

--- a/internal/services/maintenance/maintenance_assignment_dedicated_host_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dedicated_host_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MaintenanceAssignmentDedicatedHostResource struct{}
@@ -59,7 +59,7 @@ func (MaintenanceAssignmentDedicatedHostResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MaintenanceAssignmentDedicatedHostResource) basic(data acceptance.TestData) string {

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MaintenanceDynamicScopeResource struct{}
@@ -103,7 +103,7 @@ func (MaintenanceDynamicScopeResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MaintenanceDynamicScopeResource) basic(data acceptance.TestData) string {

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmMaintenanceAssignmentVirtualMachine() *pluginsdk.Resource {
@@ -103,11 +103,11 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 	// set assignment name to configuration name
 	assignmentName := configurationId.MaintenanceConfigurationName
 	configurationAssignment := configurationassignments.ConfigurationAssignment{
-		Name:     utils.String(assignmentName),
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Name:     pointer.To(assignmentName),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &configurationassignments.ConfigurationAssignmentProperties{
-			MaintenanceConfigurationId: utils.String(configurationId.ID()),
-			ResourceId:                 utils.String(virtualMachineId.ID()),
+			MaintenanceConfigurationId: pointer.To(configurationId.ID()),
+			ResourceId:                 pointer.To(virtualMachineId.ID()),
 		},
 	}
 

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MaintenanceAssignmentVirtualMachineResource struct{}
@@ -76,7 +76,7 @@ func (MaintenanceAssignmentVirtualMachineResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("retrieving %s: %v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MaintenanceAssignmentVirtualMachineResource) basic(data acceptance.TestData) string {

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_scale_set_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_scale_set_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmMaintenanceAssignmentVirtualMachineScaleSet() *pluginsdk.Resource {
@@ -102,11 +102,11 @@ func resourceArmMaintenanceAssignmentVirtualMachineScaleSetCreate(d *pluginsdk.R
 	}
 
 	configurationAssignment := configurationassignments.ConfigurationAssignment{
-		Name:     utils.String(maintenanceConfigurationId.MaintenanceConfigurationName),
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Name:     pointer.To(maintenanceConfigurationId.MaintenanceConfigurationName),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &configurationassignments.ConfigurationAssignmentProperties{
-			MaintenanceConfigurationId: utils.String(maintenanceConfigurationId.ID()),
-			ResourceId:                 utils.String(virtualMachineScaleSetId.ID()),
+			MaintenanceConfigurationId: pointer.To(maintenanceConfigurationId.ID()),
+			ResourceId:                 pointer.To(virtualMachineScaleSetId.ID()),
 		},
 	}
 

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_scale_set_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MaintenanceAssignmentVirtualMachineScaleSetResource struct{}
@@ -59,7 +59,7 @@ func (MaintenanceAssignmentVirtualMachineScaleSetResource) Exists(ctx context.Co
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MaintenanceAssignmentVirtualMachineScaleSetResource) basic(data acceptance.TestData) string {

--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -279,12 +279,12 @@ func resourceMaintenanceConfigurationCreate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	configuration := maintenanceconfigurations.MaintenanceConfiguration{
-		Name:     utils.String(id.MaintenanceConfigurationName),
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Name:     pointer.To(id.MaintenanceConfigurationName),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &maintenanceconfigurations.MaintenanceConfigurationProperties{
 			MaintenanceScope:    &scope,
 			Visibility:          &visibility,
-			Namespace:           utils.String("Microsoft.Maintenance"),
+			Namespace:           pointer.To("Microsoft.Maintenance"),
 			MaintenanceWindow:   window,
 			ExtensionProperties: extensionProperties,
 			InstallPatches:      installPatches,
@@ -439,11 +439,11 @@ func expandMaintenanceConfigurationWindow(input []interface{}) *maintenanceconfi
 	timeZone := v["time_zone"].(string)
 	recurEvery := v["recur_every"].(string)
 	window := maintenanceconfigurations.MaintenanceWindow{
-		StartDateTime:      utils.String(startDateTime),
-		ExpirationDateTime: utils.String(expirationDateTime),
-		Duration:           utils.String(duration),
-		TimeZone:           utils.String(timeZone),
-		RecurEvery:         utils.String(recurEvery),
+		StartDateTime:      pointer.To(startDateTime),
+		ExpirationDateTime: pointer.To(expirationDateTime),
+		Duration:           pointer.To(duration),
+		TimeZone:           pointer.To(timeZone),
+		RecurEvery:         pointer.To(recurEvery),
 	}
 	return &window
 }

--- a/internal/services/maintenance/maintenance_configuration_resource_test.go
+++ b/internal/services/maintenance/maintenance_configuration_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/maintenanceconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MaintenanceConfigurationResource struct{}
@@ -183,7 +183,7 @@ func (MaintenanceConfigurationResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil && resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model != nil && resp.Model.Properties != nil), nil
 }
 
 func (MaintenanceConfigurationResource) basic(data acceptance.TestData) string {

--- a/internal/services/maintenance/public_maintenance_configurations_data_source.go
+++ b/internal/services/maintenance/public_maintenance_configurations_data_source.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/publicmaintenanceconfigurations"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -36,7 +36,7 @@ func dataSourcePublicMaintenanceConfigurations() *pluginsdk.Resource {
 			"location": {
 				Type:      pluginsdk.TypeString,
 				Optional:  true,
-				StateFunc: azure.NormalizeLocation,
+				StateFunc: location.StateFunc,
 			},
 
 			"scope": {
@@ -138,7 +138,7 @@ func dataSourcePublicMaintenanceConfigurationsRead(d *pluginsdk.ResourceData, me
 		recurEveryFilter = "week Monday, Tuesday, Wednesday, Thursday"
 	}
 
-	locationFilter := azure.NormalizeLocation(d.Get("location").(string))
+	locationFilter := location.Normalize(d.Get("location").(string))
 	scopeFilter := d.Get("scope").(string)
 
 	if resp.Model != nil {
@@ -146,7 +146,7 @@ func dataSourcePublicMaintenanceConfigurationsRead(d *pluginsdk.ResourceData, me
 			for _, maintenanceConfig := range *resp.Model.Value {
 				var configLocation, configRecurEvery, configScope string
 				if maintenanceConfig.Location != nil {
-					configLocation = azure.NormalizeLocation(*maintenanceConfig.Location)
+					configLocation = location.Normalize(*maintenanceConfig.Location)
 				}
 				if props := maintenanceConfig.Properties; props != nil {
 					if props.MaintenanceWindow != nil && props.MaintenanceWindow.RecurEvery != nil {
@@ -200,7 +200,7 @@ func flattenPublicMaintenanceConfiguration(config publicmaintenanceconfiguration
 
 	output["location"] = ""
 	if config.Location != nil {
-		output["location"] = azure.NormalizeLocation(*config.Location)
+		output["location"] = location.Normalize(*config.Location)
 	}
 
 	var description, recurEvery, timeZone, duration, scope string

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource.go
@@ -219,7 +219,7 @@ func (r KeyVaultMHSMKeyResource) Create() sdk.ResourceFunc {
 				Kty:    keyvault.JSONWebKeyType(config.KeyType),
 				KeyOps: expandKeyVaultKeyOptions(config.KeyOpts),
 				KeyAttributes: &keyvault.KeyAttributes{
-					Enabled: utils.Bool(true),
+					Enabled: pointer.To(true),
 				},
 
 				Tags: tags.Expand(config.Tags),
@@ -383,7 +383,7 @@ func (r KeyVaultMHSMKeyResource) Update() sdk.ResourceFunc {
 			parameters := keyvault.KeyUpdateParameters{
 				KeyOps: expandKeyVaultKeyOptions(config.KeyOpts),
 				KeyAttributes: &keyvault.KeyAttributes{
-					Enabled: utils.Bool(true),
+					Enabled: pointer.To(true),
 				},
 
 				Tags: tags.Expand(config.Tags),

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultMHSMKeyTestResource struct{}
@@ -138,7 +138,7 @@ func (r KeyVaultMHSMKeyTestResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Key != nil), nil
+	return pointer.To(resp.Key != nil), nil
 }
 
 func (r KeyVaultMHSMKeyTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MHSMKeyRotationPolicyTestResource struct{}
@@ -65,7 +65,7 @@ func (r MHSMKeyRotationPolicyTestResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Attributes != nil), nil
+	return pointer.To(resp.Attributes != nil), nil
 }
 
 func (r MHSMKeyRotationPolicyTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
@@ -198,13 +197,13 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 		publicNetworkAccessEnabled = managedhsms.PublicNetworkAccessDisabled
 	}
 	hsm := managedhsms.ManagedHsm{
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &managedhsms.ManagedHsmProperties{
 			InitialAdminObjectIds:     utils.ExpandStringSlice(d.Get("admin_object_ids").(*pluginsdk.Set).List()),
 			CreateMode:                pointer.To(managedhsms.CreateModeDefault),
-			EnableSoftDelete:          utils.Bool(true),
-			SoftDeleteRetentionInDays: utils.Int64(int64(d.Get("soft_delete_retention_days").(int))),
-			EnablePurgeProtection:     utils.Bool(d.Get("purge_protection_enabled").(bool)),
+			EnableSoftDelete:          pointer.To(true),
+			SoftDeleteRetentionInDays: pointer.To(int64(d.Get("soft_delete_retention_days").(int))),
+			EnablePurgeProtection:     pointer.To(d.Get("purge_protection_enabled").(bool)),
 			PublicNetworkAccess:       pointer.To(publicNetworkAccessEnabled),
 			NetworkAcls:               expandMHSMNetworkAcls(d.Get("network_acls").([]interface{})),
 		},

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultManagedHardwareSecurityModuleResource struct{}
@@ -146,7 +146,7 @@ func (KeyVaultManagedHardwareSecurityModuleResource) Exists(ctx context.Context,
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r KeyVaultManagedHardwareSecurityModuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultManagedHSMRoleAssignmentResource struct{}
@@ -64,7 +64,7 @@ func (r KeyVaultManagedHSMRoleAssignmentResource) Exists(ctx context.Context, cl
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r KeyVaultManagedHSMRoleAssignmentResource) builtInRole(data acceptance.TestData) string {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_data_source.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_data_source.go
@@ -186,7 +186,7 @@ func (k KeyvaultMHSMRoleDefinitionDataSource) Read() sdk.ResourceFunc {
 			}
 
 			if prop := result.RoleDefinitionProperties; prop != nil {
-				config.Description = pointer.ToString(prop.Description)
+				config.Description = pointer.From(prop.Description)
 				config.RoleType = string(prop.RoleType)
 				config.RoleName = pointer.From(prop.RoleName)
 

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource.go
@@ -320,7 +320,7 @@ func (r KeyVaultMHSMRoleDefinitionResource) Read() sdk.ResourceFunc {
 			}
 
 			if prop := result.RoleDefinitionProperties; prop != nil {
-				state.Description = pointer.ToString(prop.Description)
+				state.Description = pointer.From(prop.Description)
 				state.RoleType = string(prop.RoleType)
 				state.RoleName = pointer.From(prop.RoleName)
 				state.Permission = flattenKeyVaultMHSMRolePermission(prop.Permissions)

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type KeyVaultMHSMRoleDefinitionResource struct{}
@@ -55,7 +55,7 @@ func (r KeyVaultMHSMRoleDefinitionResource) Exists(ctx context.Context, client *
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Type %s: %+v", id, err)
 	}
-	return utils.Bool(resp.RoleDefinitionProperties != nil), nil
+	return pointer.To(resp.RoleDefinitionProperties != nil), nil
 }
 
 func (r KeyVaultMHSMRoleDefinitionResource) basic(data acceptance.TestData) string {

--- a/internal/services/managedidentity/federated_identity_credential_resource_test.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2024-11-30/federatedidentitycredentials"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FederatedIdentityCredentialTestResource struct{}
@@ -71,7 +71,7 @@ func (r FederatedIdentityCredentialTestResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r FederatedIdentityCredentialTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/managedidentity/user_assigned_identity_data_source_test.go
+++ b/internal/services/managedidentity/user_assigned_identity_data_source_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -24,7 +24,7 @@ func TestAccDataSourceAzureRMUserAssignedIdentity_basic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").HasValue(fmt.Sprintf("acctest%s-uai", data.RandomString)),
 				check.That(data.ResourceName).Key("resource_group_name").HasValue(fmt.Sprintf("acctestRG-%d", data.RandomInteger)),
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("principal_id").IsUUID(),
 				check.That(data.ResourceName).Key("client_id").IsUUID(),
 				check.That(data.ResourceName).Key("tenant_id").IsUUID(),

--- a/internal/services/managedidentity/user_assigned_identity_resource_test.go
+++ b/internal/services/managedidentity/user_assigned_identity_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type UserAssignedIdentityTestResource struct{}
@@ -103,7 +103,7 @@ func (r UserAssignedIdentityTestResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r UserAssignedIdentityTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var managementGroupCacheControl = "no-cache"
@@ -134,19 +133,19 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	log.Printf("[INFO] Creating Management Group %q", groupName)
 
 	properties := managementgroups.CreateManagementGroupRequest{
-		Name: utils.String(groupName),
+		Name: pointer.To(groupName),
 		Properties: &managementgroups.CreateManagementGroupProperties{
-			TenantId: utils.String(armTenantID),
+			TenantId: pointer.To(armTenantID),
 			Details: &managementgroups.CreateManagementGroupDetails{
 				Parent: &managementgroups.CreateParentGroupInfo{
-					Id: utils.String(parentManagementGroupId),
+					Id: pointer.To(parentManagementGroupId),
 				},
 			},
 		},
 	}
 
 	if v := d.Get("display_name"); v != "" {
-		properties.Properties.DisplayName = utils.String(v.(string))
+		properties.Properties.DisplayName = pointer.To(v.(string))
 	}
 
 	err := client.CreateOrUpdateThenPoll(ctx, id, properties, managementgroups.CreateOrUpdateOperationOptions{
@@ -242,7 +241,7 @@ func resourceManagementGroupRead(d *pluginsdk.ResourceData, meta interface{}) er
 	tenantScopedID := parse.NewTenantScopedManagementGroupID(tenantID, id.GroupId)
 	d.Set("tenant_scoped_id", tenantScopedID.TenantScopedID())
 
-	recurse := pointer.FromBool(true)
+	recurse := pointer.To(true)
 	resp, err := client.Get(ctx, *id, managementgroups.GetOperationOptions{
 		CacheControl: &managementGroupCacheControl,
 		Filter:       pointer.To("children.childType eq Subscription"),
@@ -430,7 +429,7 @@ func managementGroupCreateStateRefreshFunc(ctx context.Context, client *manageme
 		resp, err := client.Get(ctx, id, managementgroups.GetOperationOptions{
 			CacheControl: &managementGroupCacheControl,
 			Expand:       pointer.To(managementgroups.ExpandChildren),
-			Recurse:      pointer.FromBool(true),
+			Recurse:      pointer.To(true),
 		})
 		if err != nil {
 			if response.WasForbidden(resp.HttpResponse) {

--- a/internal/services/managementgroup/management_group_resource_test.go
+++ b/internal/services/managementgroup/management_group_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagementGroupResource struct{}
@@ -200,13 +199,13 @@ func (ManagementGroupResource) Exists(ctx context.Context, clients *clients.Clie
 	resp, err := clients.ManagementGroups.GroupsClient.Get(ctx, *id, managementgroups.GetOperationOptions{
 		CacheControl: pointer.To("no-cache"),
 		Expand:       pointer.To(managementgroups.ExpandChildren),
-		Recurse:      pointer.FromBool(false),
+		Recurse:      pointer.To(false),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Management Group %s: %v", id.GroupId, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model.Properties != nil), nil
 }
 
 func (r ManagementGroupResource) basic() string {

--- a/internal/services/managementgroup/management_group_subscription_association_resource.go
+++ b/internal/services/managementgroup/management_group_subscription_association_resource.go
@@ -83,7 +83,7 @@ func resourceManagementGroupSubscriptionAssociationCreate(d *pluginsdk.ResourceD
 	existing, err := client.Get(ctx, commonids.NewManagementGroupID(id.GroupId), managementgroups.GetOperationOptions{
 		CacheControl: &managementGroupCacheControl,
 		Expand:       pointer.To(managementgroups.ExpandChildren),
-		Recurse:      pointer.FromBool(false),
+		Recurse:      pointer.To(false),
 	})
 	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
@@ -129,7 +129,7 @@ func resourceManagementGroupSubscriptionAssociationRead(d *pluginsdk.ResourceDat
 	managementGroup, err := client.Get(ctx, commonids.NewManagementGroupID(id.GroupId), managementgroups.GetOperationOptions{
 		CacheControl: &managementGroupCacheControl,
 		Expand:       pointer.To(managementgroups.ExpandChildren),
-		Recurse:      pointer.FromBool(false),
+		Recurse:      pointer.To(false),
 	})
 	if err != nil {
 		return fmt.Errorf("reading Management Group %q for Subscription Associations: %+v", id.GroupId, err)
@@ -206,7 +206,7 @@ func subscriptionAssociationRefreshFunc(ctx context.Context, client *managementg
 		managementGroup, err := client.Get(ctx, commonids.NewManagementGroupID(id.GroupId), managementgroups.GetOperationOptions{
 			CacheControl: &managementGroupCacheControl,
 			Expand:       pointer.To(managementgroups.ExpandChildren),
-			Recurse:      pointer.FromBool(false),
+			Recurse:      pointer.To(false),
 		})
 		if err != nil {
 			return nil, "", fmt.Errorf("reading Management Group %q for Subscription Associations: %+v", id.GroupId, err)

--- a/internal/services/managementgroup/management_group_subscription_association_resource_test.go
+++ b/internal/services/managementgroup/management_group_subscription_association_resource_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagementGroupSubscriptionAssociation struct{}
@@ -118,14 +117,14 @@ func (r ManagementGroupSubscriptionAssociation) Exists(ctx context.Context, clie
 	resp, err := client.ManagementGroups.GroupsClient.Get(ctx, commonids.NewManagementGroupID(id.GroupId), managementgroups.GetOperationOptions{
 		CacheControl: pointer.To("no-cache"),
 		Expand:       pointer.To(managementgroups.ExpandChildren),
-		Recurse:      pointer.FromBool(false),
+		Recurse:      pointer.To(false),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Management Group to check for Subscription Association: %+v", err)
 	}
 
 	if resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.Children == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	present := false
@@ -135,5 +134,5 @@ func (r ManagementGroupSubscriptionAssociation) Exists(ctx context.Context, clie
 		}
 	}
 
-	return utils.Bool(present), nil
+	return pointer.To(present), nil
 }

--- a/internal/services/maps/maps_account_resource_test.go
+++ b/internal/services/maps/maps_account_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maps/2023-06-01/accounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MapsAccountResource struct{}
@@ -108,7 +108,7 @@ func (MapsAccountResource) Exists(ctx context.Context, clients *clients.Client, 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MapsAccountResource) basic(data acceptance.TestData) string {

--- a/internal/services/maps/maps_creator_resource_test.go
+++ b/internal/services/maps/maps_creator_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maps/2023-06-01/creators"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MapsCreatorResource struct{}
@@ -105,11 +105,11 @@ func (r MapsCreatorResource) Exists(ctx context.Context, clients *clients.Client
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r MapsCreatorResource) template(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_attached_data_network_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_attached_data_network_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/attacheddatanetwork"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkAttachedDataNetworkResource struct{}
@@ -113,11 +113,11 @@ func (r MobileNetworkAttachedDataNetworkResource) Exists(ctx context.Context, cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkAttachedDataNetworkResource) template(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_data_network_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_data_network_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/datanetwork"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkDataNetworkResource struct{}
@@ -92,11 +92,11 @@ func (r MobileNetworkDataNetworkResource) Exists(ctx context.Context, clients *c
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkDataNetworkResource) basic(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcorecontrolplane"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkPacketCoreControlPlaneResource struct{}
@@ -148,11 +148,11 @@ func (r MobileNetworkPacketCoreControlPlaneResource) Exists(ctx context.Context,
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkPacketCoreControlPlaneResource) template(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkPacketCoreDataPlaneResource struct{}
@@ -106,11 +106,11 @@ func (r MobileNetworkPacketCoreDataPlaneResource) Exists(ctx context.Context, cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkPacketCoreDataPlaneResource) basic(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkResource struct{}
@@ -92,11 +92,11 @@ func (r MobileNetworkResource) Exists(ctx context.Context, clients *clients.Clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkResource) basic(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_service_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/service"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkServiceResource struct{}
@@ -121,11 +121,11 @@ func (r MobileNetworkServiceResource) Exists(ctx context.Context, clients *clien
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_sim_group_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simgroup"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkSimGroupResource struct{}
@@ -106,11 +106,11 @@ func (r MobileNetworkSimGroupResource) Exists(ctx context.Context, clients *clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkSimGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/mobilenetwork/mobile_network_site_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_site_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/site"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MobileNetworkSiteResource struct{}
@@ -96,11 +96,11 @@ func (r MobileNetworkSiteResource) Exists(ctx context.Context, clients *clients.
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MobileNetworkSiteResource) basic(data acceptance.TestData) string {

--- a/internal/services/monitor/alert_processing_rule.go
+++ b/internal/services/monitor/alert_processing_rule.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AlertProcessingRuleConditionModel struct {
@@ -457,18 +457,18 @@ func expandAlertProcessingRuleSchedule(input []AlertProcessingRuleScheduleModel)
 	var effectiveFrom, effectiveUntil *string
 
 	if v.EffectiveFrom != "" {
-		effectiveFrom = utils.String(v.EffectiveFrom)
+		effectiveFrom = pointer.To(v.EffectiveFrom)
 	}
 
 	if v.EffectiveUntil != "" {
-		effectiveUntil = utils.String(v.EffectiveUntil)
+		effectiveUntil = pointer.To(v.EffectiveUntil)
 	}
 
 	schedule := alertprocessingrules.Schedule{
 		EffectiveFrom:  effectiveFrom,
 		EffectiveUntil: effectiveUntil,
 		Recurrences:    expandAlertProcessingRuleScheduleRecurrences(v.Recurrence),
-		TimeZone:       utils.String(v.TimeZone),
+		TimeZone:       pointer.To(v.TimeZone),
 	}
 
 	return &schedule
@@ -485,10 +485,10 @@ func expandAlertProcessingRuleScheduleRecurrences(input []AlertProcessingRuleRec
 	for _, item := range v.Daily {
 		var startTime, endTime *string
 		if item.StartTime != "" {
-			startTime = utils.String(item.StartTime)
+			startTime = pointer.To(item.StartTime)
 		}
 		if item.EndTime != "" {
-			endTime = utils.String(item.EndTime)
+			endTime = pointer.To(item.EndTime)
 		}
 
 		recurrences = append(recurrences, alertprocessingrules.DailyRecurrence{
@@ -500,10 +500,10 @@ func expandAlertProcessingRuleScheduleRecurrences(input []AlertProcessingRuleRec
 	for _, item := range v.Weekly {
 		var startTime, endTime *string
 		if item.StartTime != "" {
-			startTime = utils.String(item.StartTime)
+			startTime = pointer.To(item.StartTime)
 		}
 		if item.EndTime != "" {
-			endTime = utils.String(item.EndTime)
+			endTime = pointer.To(item.EndTime)
 		}
 
 		recurrences = append(recurrences, alertprocessingrules.WeeklyRecurrence{
@@ -516,10 +516,10 @@ func expandAlertProcessingRuleScheduleRecurrences(input []AlertProcessingRuleRec
 	for _, item := range v.Monthly {
 		var startTime, endTime *string
 		if item.StartTime != "" {
-			startTime = utils.String(item.StartTime)
+			startTime = pointer.To(item.StartTime)
 		}
 		if item.EndTime != "" {
-			endTime = utils.String(item.EndTime)
+			endTime = pointer.To(item.EndTime)
 		}
 
 		recurrences = append(recurrences, alertprocessingrules.MonthlyRecurrence{

--- a/internal/services/monitor/common_monitor.go
+++ b/internal/services/monitor/common_monitor.go
@@ -33,7 +33,7 @@ func expandMonitorScheduledQueryRulesCommonSource(d *pluginsdk.ResourceData) sch
 	}
 
 	if query, ok := d.GetOk("query"); ok {
-		source.Query = utils.String(query.(string))
+		source.Query = pointer.To(query.(string))
 	}
 	if queryType, ok := d.GetOk("query_type"); ok {
 		source.QueryType = pointer.To(scheduledqueryrules.QueryType(queryType.(string)))

--- a/internal/services/monitor/migration/action_group_test.go
+++ b/internal/services/monitor/migration/action_group_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestActionGroupV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestActionGroupV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/actionGroups/group1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/ActionGroups/group1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/actionGroups/group1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/monitor/migration/activity_log_alert_test.go
+++ b/internal/services/monitor/migration/activity_log_alert_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestActivityLogAlertV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestActivityLogAlertV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/activityLogAlerts/alert1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/ActivityLogAlerts/alert1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/activityLogAlerts/alert1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/monitor/migration/autoscale_setting_test.go
+++ b/internal/services/monitor/migration/autoscale_setting_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestAutoscaleSettingV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestAutoscaleSettingV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/autoScaleSettings/setting1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/AutoscaleSettings/setting1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/autoScaleSettings/setting1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/monitor/migration/metric_alert_test.go
+++ b/internal/services/monitor/migration/metric_alert_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestMetricAlertV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestMetricAlertV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/metricAlerts/alert1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/MetricAlerts/alert1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/metricAlerts/alert1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/monitor/migration/scheduled_query_rules_alert_test.go
+++ b/internal/services/monitor/migration/scheduled_query_rules_alert_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestScheduledQueryRulesAlertV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestScheduledQueryRulesAlertV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/scheduledQueryRules/rule1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/ScheduledQueryRules/rule1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/monitor/migration/scheduled_query_rules_log_test.go
+++ b/internal/services/monitor/migration/scheduled_query_rules_log_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 func TestScheduledQueryRulesLogV0ToV1(t *testing.T) {
@@ -21,21 +21,21 @@ func TestScheduledQueryRulesLogV0ToV1(t *testing.T) {
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/scheduledQueryRules/rule1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
 		},
 		{
 			name: "old id - mixed case",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/microsoft.insights/ScheduledQueryRules/rule1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
 		},
 		{
 			name: "new id",
 			input: map[string]interface{}{
 				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1",
 			},
-			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
+			expected: pointer.To("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Insights/scheduledQueryRules/rule1"),
 		},
 	}
 	for _, test := range testData {

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/azureactivedirectory/2017-04-01/diagnosticsettings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorAADDiagnosticSettingResource struct{}
@@ -200,7 +200,7 @@ func (t MonitorAADDiagnosticSettingResource) Exists(ctx context.Context, clients
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MonitorAADDiagnosticSettingResource) eventhub(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2022-08-08/automationaccount"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-01-01/actiongroupsapis"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/migration"
@@ -622,7 +622,7 @@ func expandMonitorActionGroupEmailReceiver(v []interface{}) *[]actiongroupsapis.
 		receiver := actiongroupsapis.EmailReceiver{
 			Name:                 val["name"].(string),
 			EmailAddress:         val["email_address"].(string),
-			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
+			UseCommonAlertSchema: pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 		receivers = append(receivers, receiver)
 	}
@@ -639,7 +639,7 @@ func expandMonitorActionGroupItsmReceiver(v []interface{}) (*[]actiongroupsapis.
 			WorkspaceId:         val["workspace_id"].(string),
 			ConnectionId:        val["connection_id"].(string),
 			TicketConfiguration: ticketConfiguration,
-			Region:              azure.NormalizeLocation(val["region"].(string)),
+			Region:              location.Normalize(val["region"].(string)),
 		}
 
 		// https://github.com/Azure/azure-rest-api-specs/issues/20488 ticket_configuration should have `PayloadRevision` and `WorkItemType` keys
@@ -694,17 +694,17 @@ func expandMonitorActionGroupWebHookReceiver(tenantId string, v []interface{}) *
 		receiver := actiongroupsapis.WebhookReceiver{
 			Name:                 val["name"].(string),
 			ServiceUri:           val["service_uri"].(string),
-			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
+			UseCommonAlertSchema: pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 		if v, ok := val["aad_auth"].([]interface{}); ok && len(v) > 0 {
 			secureWebhook := v[0].(map[string]interface{})
-			receiver.UseAadAuth = utils.Bool(true)
-			receiver.ObjectId = utils.String(secureWebhook["object_id"].(string))
-			receiver.IdentifierUri = utils.String(secureWebhook["identifier_uri"].(string))
+			receiver.UseAadAuth = pointer.To(true)
+			receiver.ObjectId = pointer.To(secureWebhook["object_id"].(string))
+			receiver.IdentifierUri = pointer.To(secureWebhook["identifier_uri"].(string))
 			if v := secureWebhook["tenant_id"].(string); v != "" {
-				receiver.TenantId = utils.String(v)
+				receiver.TenantId = pointer.To(v)
 			} else {
-				receiver.TenantId = utils.String(tenantId)
+				receiver.TenantId = pointer.To(tenantId)
 			}
 		}
 		receivers = append(receivers, receiver)
@@ -717,13 +717,13 @@ func expandMonitorActionGroupAutomationRunbookReceiver(v []interface{}) *[]actio
 	for _, receiverValue := range v {
 		val := receiverValue.(map[string]interface{})
 		receiver := actiongroupsapis.AutomationRunbookReceiver{
-			Name:                 utils.String(val["name"].(string)),
+			Name:                 pointer.To(val["name"].(string)),
 			AutomationAccountId:  val["automation_account_id"].(string),
 			RunbookName:          val["runbook_name"].(string),
 			WebhookResourceId:    val["webhook_resource_id"].(string),
 			IsGlobalRunbook:      val["is_global_runbook"].(bool),
-			ServiceUri:           utils.String(val["service_uri"].(string)),
-			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
+			ServiceUri:           pointer.To(val["service_uri"].(string)),
+			UseCommonAlertSchema: pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 		receivers = append(receivers, receiver)
 	}
@@ -752,7 +752,7 @@ func expandMonitorActionGroupLogicAppReceiver(v []interface{}) *[]actiongroupsap
 			Name:                 val["name"].(string),
 			ResourceId:           val["resource_id"].(string),
 			CallbackURL:          val["callback_url"].(string),
-			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
+			UseCommonAlertSchema: pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 		receivers = append(receivers, receiver)
 	}
@@ -768,7 +768,7 @@ func expandMonitorActionGroupAzureFunctionReceiver(v []interface{}) *[]actiongro
 			FunctionAppResourceId: val["function_app_resource_id"].(string),
 			FunctionName:          val["function_name"].(string),
 			HTTPTriggerURL:        val["http_trigger_url"].(string),
-			UseCommonAlertSchema:  utils.Bool(val["use_common_alert_schema"].(bool)),
+			UseCommonAlertSchema:  pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 		receivers = append(receivers, receiver)
 	}
@@ -782,7 +782,7 @@ func expandMonitorActionGroupRoleReceiver(v []interface{}) *[]actiongroupsapis.A
 		receiver := actiongroupsapis.ArmRoleReceiver{
 			Name:                 val["name"].(string),
 			RoleId:               val["role_id"].(string),
-			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
+			UseCommonAlertSchema: pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 		receivers = append(receivers, receiver)
 	}
@@ -800,13 +800,13 @@ func expandMonitorActionGroupEventHubReceiver(tenantId string, subscriptionId st
 			EventHubNameSpace:    eventHubNameSpace,
 			EventHubName:         eventHubName,
 			Name:                 val["name"].(string),
-			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
+			UseCommonAlertSchema: pointer.To(val["use_common_alert_schema"].(bool)),
 		}
 
 		if v := val["tenant_id"].(string); v != "" {
-			receiver.TenantId = utils.String(v)
+			receiver.TenantId = pointer.To(v)
 		} else {
-			receiver.TenantId = utils.String(tenantId)
+			receiver.TenantId = pointer.To(tenantId)
 		}
 
 		if subId != "" {
@@ -848,7 +848,7 @@ func flattenMonitorActionGroupItsmReceiver(receivers *[]actiongroupsapis.ItsmRec
 			val["workspace_id"] = receiver.WorkspaceId
 			val["connection_id"] = receiver.ConnectionId
 			val["ticket_configuration"] = receiver.TicketConfiguration
-			val["region"] = azure.NormalizeLocation(receiver.Region)
+			val["region"] = location.Normalize(receiver.Region)
 
 			result = append(result, val)
 		}

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-01-01/actiongroupsapis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorActionGroupResource struct{}
@@ -1132,7 +1132,7 @@ func (t MonitorActionGroupResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("reading (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MonitorActionGroupResource) location(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -400,8 +400,8 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 				// Validate location constraints for Activity Log Alert resources
-				location := diff.Get("location").(string)
-				normalizedLocation := azure.NormalizeLocation(location)
+				loc := diff.Get("location").(string)
+				normalizedLocation := location.Normalize(loc)
 
 				supportedLocations := []string{"global", "westeurope", "northeurope", "eastus2euap"}
 				supported := false
@@ -413,7 +413,7 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 				}
 
 				if !supported {
-					return fmt.Errorf("`azurerm_monitor_activity_log_alert` resources are only supported in the following regions: [%s], got `%s`", strings.Join(supportedLocations, ", "), location)
+					return fmt.Errorf("`azurerm_monitor_activity_log_alert` resources are only supported in the following regions: [%s], got `%s`", strings.Join(supportedLocations, ", "), loc)
 				}
 
 				return nil
@@ -453,8 +453,8 @@ func resourceMonitorActivityLogAlertCreateUpdate(d *pluginsdk.ResourceData, meta
 	parameters := activitylogalertsapis.ActivityLogAlertResource{
 		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &activitylogalertsapis.AlertRuleProperties{
-			Enabled:     utils.Bool(enabled),
-			Description: utils.String(description),
+			Enabled:     pointer.To(enabled),
+			Description: pointer.To(description),
 			Scopes:      expandStringValues(scopesRaw),
 			Condition:   expandMonitorActivityLogAlertCriteria(criteriaRaw),
 			Actions:     expandMonitorActivityLogAlertAction(actionRaw),
@@ -548,29 +548,29 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if category := v["category"].(string); category != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("category"),
-			Equals: utils.String(category),
+			Field:  pointer.To("category"),
+			Equals: pointer.To(category),
 		})
 	}
 
 	if op := v["operation_name"].(string); op != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("operationName"),
-			Equals: utils.String(op),
+			Field:  pointer.To("operationName"),
+			Equals: pointer.To(op),
 		})
 	}
 
 	if caller := v["caller"].(string); caller != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("caller"),
-			Equals: utils.String(caller),
+			Field:  pointer.To("caller"),
+			Equals: pointer.To(caller),
 		})
 	}
 
 	if level := v["level"].(string); level != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("level"),
-			Equals: utils.String(level),
+			Field:  pointer.To("level"),
+			Equals: pointer.To(level),
 		})
 	}
 
@@ -582,8 +582,8 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if resourceProvider := v["resource_provider"].(string); resourceProvider != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("resourceProvider"),
-			Equals: utils.String(resourceProvider),
+			Field:  pointer.To("resourceProvider"),
+			Equals: pointer.To(resourceProvider),
 		})
 	}
 
@@ -595,8 +595,8 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if resourceType := v["resource_type"].(string); resourceType != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("resourceType"),
-			Equals: utils.String(resourceType),
+			Field:  pointer.To("resourceType"),
+			Equals: pointer.To(resourceType),
 		})
 	}
 
@@ -608,8 +608,8 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if resourceGroup := v["resource_group"].(string); resourceGroup != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("resourceGroup"),
-			Equals: utils.String(resourceGroup),
+			Field:  pointer.To("resourceGroup"),
+			Equals: pointer.To(resourceGroup),
 		})
 	}
 
@@ -621,8 +621,8 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if id := v["resource_id"].(string); id != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("resourceId"),
-			Equals: utils.String(id),
+			Field:  pointer.To("resourceId"),
+			Equals: pointer.To(id),
 		})
 	}
 
@@ -634,8 +634,8 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if status := v["status"].(string); status != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("status"),
-			Equals: utils.String(status),
+			Field:  pointer.To("status"),
+			Equals: pointer.To(status),
 		})
 	}
 
@@ -647,8 +647,8 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if subStatus := v["sub_status"].(string); subStatus != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("subStatus"),
-			Equals: utils.String(subStatus),
+			Field:  pointer.To("subStatus"),
+			Equals: pointer.To(subStatus),
 		})
 	}
 
@@ -660,22 +660,22 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 
 	if recommendationType := v["recommendation_type"].(string); recommendationType != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("properties.recommendationType"),
-			Equals: utils.String(recommendationType),
+			Field:  pointer.To("properties.recommendationType"),
+			Equals: pointer.To(recommendationType),
 		})
 	}
 
 	if recommendationCategory := v["recommendation_category"].(string); recommendationCategory != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("properties.recommendationCategory"),
-			Equals: utils.String(recommendationCategory),
+			Field:  pointer.To("properties.recommendationCategory"),
+			Equals: pointer.To(recommendationCategory),
 		})
 	}
 
 	if recommendationImpact := v["recommendation_impact"].(string); recommendationImpact != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			Field:  utils.String("properties.recommendationImpact"),
-			Equals: utils.String(recommendationImpact),
+			Field:  pointer.To("properties.recommendationImpact"),
+			Equals: pointer.To(recommendationImpact),
 		})
 	}
 
@@ -696,8 +696,8 @@ func expandAnyOfCondition(input []interface{}, field string) *[]activitylogalert
 	conditions := make([]activitylogalertsapis.AlertRuleLeafCondition, 0)
 	for _, v := range input {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleLeafCondition{
-			Field:  utils.String(field),
-			Equals: utils.String(v.(string)),
+			Field:  pointer.To(field),
+			Equals: pointer.To(v.(string)),
 		})
 	}
 	return &conditions
@@ -716,8 +716,8 @@ func expandResourceHealth(resourceHealth []interface{}, conditions []activitylog
 			for _, e := range cv.List() {
 				event := e.(string)
 				ruleLeafCondition = append(ruleLeafCondition, activitylogalertsapis.AlertRuleLeafCondition{
-					Field:  utils.String("properties.currentHealthStatus"),
-					Equals: utils.String(event),
+					Field:  pointer.To("properties.currentHealthStatus"),
+					Equals: pointer.To(event),
 				})
 			}
 			conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
@@ -731,8 +731,8 @@ func expandResourceHealth(resourceHealth []interface{}, conditions []activitylog
 			for _, e := range pv.List() {
 				event := e.(string)
 				ruleLeafCondition = append(ruleLeafCondition, activitylogalertsapis.AlertRuleLeafCondition{
-					Field:  utils.String("properties.previousHealthStatus"),
-					Equals: utils.String(event),
+					Field:  pointer.To("properties.previousHealthStatus"),
+					Equals: pointer.To(event),
 				})
 			}
 			conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
@@ -746,8 +746,8 @@ func expandResourceHealth(resourceHealth []interface{}, conditions []activitylog
 			for _, e := range rv.List() {
 				event := e.(string)
 				ruleLeafCondition = append(ruleLeafCondition, activitylogalertsapis.AlertRuleLeafCondition{
-					Field:  utils.String("properties.cause"),
-					Equals: utils.String(event),
+					Field:  pointer.To("properties.cause"),
+					Equals: pointer.To(event),
 				})
 			}
 			conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
@@ -767,7 +767,7 @@ func expandServiceHealth(serviceHealth []interface{}, conditions []activitylogal
 		rv := vs["locations"].(*pluginsdk.Set)
 		if len(rv.List()) > 0 {
 			conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-				Field:       utils.String("properties.impactedServices[*].ImpactedRegions[*].RegionName"),
+				Field:       pointer.To("properties.impactedServices[*].ImpactedRegions[*].RegionName"),
 				ContainsAny: utils.ExpandStringSlice(rv.List()),
 			})
 		}
@@ -778,8 +778,8 @@ func expandServiceHealth(serviceHealth []interface{}, conditions []activitylogal
 			for _, e := range ev.List() {
 				event := e.(string)
 				ruleLeafCondition = append(ruleLeafCondition, activitylogalertsapis.AlertRuleLeafCondition{
-					Field:  utils.String("properties.incidentType"),
-					Equals: utils.String(event),
+					Field:  pointer.To("properties.incidentType"),
+					Equals: pointer.To(event),
 				})
 			}
 			conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
@@ -790,7 +790,7 @@ func expandServiceHealth(serviceHealth []interface{}, conditions []activitylogal
 		sv := vs["services"].(*pluginsdk.Set)
 		if len(sv.List()) > 0 {
 			conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-				Field:       utils.String("properties.impactedServices[*].ServiceName"),
+				Field:       pointer.To("properties.impactedServices[*].ServiceName"),
 				ContainsAny: utils.ExpandStringSlice(sv.List()),
 			})
 		}

--- a/internal/services/monitor/monitor_alert_processing_rule_action_group_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_action_group_resource.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AlertProcessingRuleActionGroupModel struct {
@@ -91,8 +91,8 @@ func (r AlertProcessingRuleActionGroupResource) Create() sdk.ResourceFunc {
 						},
 					},
 					Conditions:  expandAlertProcessingRuleConditions(model.Condition),
-					Description: utils.String(model.Description),
-					Enabled:     utils.Bool(model.Enabled),
+					Description: pointer.To(model.Description),
+					Enabled:     pointer.To(model.Enabled),
 					Schedule:    expandAlertProcessingRuleSchedule(model.Schedule),
 					Scopes:      model.Scopes,
 				},
@@ -151,11 +151,11 @@ func (r AlertProcessingRuleActionGroupResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				model.Properties.Description = utils.String(resourceModel.Description)
+				model.Properties.Description = pointer.To(resourceModel.Description)
 			}
 
 			if metadata.ResourceData.HasChange("enabled") {
-				model.Properties.Enabled = utils.Bool(resourceModel.Enabled)
+				model.Properties.Enabled = pointer.To(resourceModel.Enabled)
 			}
 
 			if metadata.ResourceData.HasChange("schedule") {

--- a/internal/services/monitor/monitor_alert_processing_rule_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_action_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorAlertProcessingRuleActionGroupResource struct{}
@@ -109,7 +109,7 @@ func (r MonitorAlertProcessingRuleActionGroupResource) Exists(ctx context.Contex
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MonitorAlertProcessingRuleActionGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AlertProcessingRuleSuppressionModel struct {
@@ -79,8 +79,8 @@ func (r AlertProcessingRuleSuppressionResource) Create() sdk.ResourceFunc {
 						alertprocessingrules.RemoveAllActionGroups{},
 					},
 					Conditions:  expandAlertProcessingRuleConditions(model.Condition),
-					Description: utils.String(model.Description),
-					Enabled:     utils.Bool(model.Enabled),
+					Description: pointer.To(model.Description),
+					Enabled:     pointer.To(model.Enabled),
 					Schedule:    expandAlertProcessingRuleSchedule(model.Schedule),
 					Scopes:      model.Scopes,
 				},
@@ -131,11 +131,11 @@ func (r AlertProcessingRuleSuppressionResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				model.Properties.Description = utils.String(resourceModel.Description)
+				model.Properties.Description = pointer.To(resourceModel.Description)
 			}
 
 			if metadata.ResourceData.HasChange("enabled") {
-				model.Properties.Enabled = utils.Bool(resourceModel.Enabled)
+				model.Properties.Enabled = pointer.To(resourceModel.Enabled)
 			}
 
 			if metadata.ResourceData.HasChange("schedule") {

--- a/internal/services/monitor/monitor_alert_processing_rule_suppression_resource_test.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_suppression_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorAlertProcessingRuleSuppressionResource struct{}
@@ -109,7 +109,7 @@ func (r MonitorAlertProcessingRuleSuppressionResource) Exists(ctx context.Contex
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MonitorAlertProcessingRuleSuppressionResource) basic(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_alert_prometheus_rule_group_resource_test.go
+++ b/internal/services/monitor/monitor_alert_prometheus_rule_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2023-03-01/prometheusrulegroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AlertPrometheusRuleGroupTestResource struct{}
@@ -99,11 +99,11 @@ func (r AlertPrometheusRuleGroupTestResource) Exists(ctx context.Context, client
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r AlertPrometheusRuleGroupTestResource) template(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-10-01/autoscalesettings"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -456,7 +457,7 @@ func resourceMonitorAutoScaleSettingCreateUpdate(d *pluginsdk.ResourceData, meta
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	enabled := d.Get("enabled").(bool)
 	targetResourceId := d.Get("target_resource_id").(string)
 
@@ -519,7 +520,7 @@ func resourceMonitorAutoScaleSettingRead(d *pluginsdk.ResourceData, meta interfa
 	if model := resp.Model; model != nil {
 		props := model.Properties
 
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 		d.Set("enabled", props.Enabled)
 		d.Set("target_resource_id", props.TargetResourceUri)
 
@@ -639,7 +640,7 @@ func expandAzureRmMonitorAutoScaleSettingRule(input []interface{}) []autoscalese
 		triggerRaw := triggersRaw[0].(map[string]interface{})
 		metricTrigger := autoscalesettings.MetricTrigger{
 			MetricName:        triggerRaw["metric_name"].(string),
-			MetricNamespace:   utils.String(triggerRaw["metric_namespace"].(string)),
+			MetricNamespace:   pointer.To(triggerRaw["metric_namespace"].(string)),
 			MetricResourceUri: triggerRaw["metric_resource_id"].(string),
 			TimeGrain:         triggerRaw["time_grain"].(string),
 			Statistic:         autoscalesettings.MetricStatisticType(triggerRaw["statistic"].(string)),
@@ -648,7 +649,7 @@ func expandAzureRmMonitorAutoScaleSettingRule(input []interface{}) []autoscalese
 			Operator:          autoscalesettings.ComparisonOperationType(triggerRaw["operator"].(string)),
 			Threshold:         triggerRaw["threshold"].(float64),
 			Dimensions:        expandAzureRmMonitorAutoScaleSettingRuleDimensions(triggerRaw["dimensions"].([]interface{})),
-			DividePerInstance: utils.Bool(triggerRaw["divide_by_instance_count"].(bool)),
+			DividePerInstance: pointer.To(triggerRaw["divide_by_instance_count"].(bool)),
 		}
 
 		actionsRaw := ruleRaw["scale_action"].([]interface{})
@@ -656,7 +657,7 @@ func expandAzureRmMonitorAutoScaleSettingRule(input []interface{}) []autoscalese
 		scaleAction := autoscalesettings.ScaleAction{
 			Direction: autoscalesettings.ScaleDirection(actionRaw["direction"].(string)),
 			Type:      autoscalesettings.ScaleType(actionRaw["type"].(string)),
-			Value:     utils.String(strconv.Itoa(actionRaw["value"].(int))),
+			Value:     pointer.To(strconv.Itoa(actionRaw["value"].(int))),
 			Cooldown:  actionRaw["cooldown"].(string),
 		}
 
@@ -691,7 +692,7 @@ func expandAzureRmMonitorAutoScaleSettingFixedDate(input []interface{}) (*autosc
 
 	timeZone := raw["timezone"].(string)
 	timeWindow := autoscalesettings.TimeWindow{
-		TimeZone: utils.String(timeZone),
+		TimeZone: pointer.To(timeZone),
 	}
 
 	timeWindow.SetStartAsTime(startTime)
@@ -770,8 +771,8 @@ func expandAzureRmMonitorAutoScaleSettingNotificationEmail(input map[string]inte
 
 	email := autoscalesettings.EmailNotification{
 		CustomEmails:                       &customEmails,
-		SendToSubscriptionAdministrator:    utils.Bool(input["send_to_subscription_administrator"].(bool)),
-		SendToSubscriptionCoAdministrators: utils.Bool(input["send_to_subscription_co_administrator"].(bool)),
+		SendToSubscriptionAdministrator:    pointer.To(input["send_to_subscription_administrator"].(bool)),
+		SendToSubscriptionCoAdministrators: pointer.To(input["send_to_subscription_co_administrator"].(bool)),
 	}
 
 	return &email
@@ -787,7 +788,7 @@ func expandAzureRmMonitorAutoScaleSettingNotificationWebhook(input []interface{}
 		webhookRaw := v.(map[string]interface{})
 
 		webhook := autoscalesettings.WebhookNotification{
-			ServiceUri: utils.String(webhookRaw["service_uri"].(string)),
+			ServiceUri: pointer.To(webhookRaw["service_uri"].(string)),
 		}
 
 		if props, ok := webhookRaw["properties"]; ok {

--- a/internal/services/monitor/monitor_autoscale_setting_resource_test.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-10-01/autoscalesettings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorAutoScaleSettingResource struct{}
@@ -345,7 +345,7 @@ func (t MonitorAutoScaleSettingResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("reading (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MonitorAutoScaleSettingResource) basic(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -107,11 +107,11 @@ func (d DataCollectionEndpointDataSource) Read() sdk.ResourceFunc {
 			}
 
 			var publicNetWorkAccessEnabled bool
-			var description, kind, location, configurationAccessEndpoint, logsIngestionEndpoint, metricsIngestionEndpoint, immutableId string
+			var description, kind, loc, configurationAccessEndpoint, logsIngestionEndpoint, metricsIngestionEndpoint, immutableId string
 			var tag map[string]interface{}
 			if model := resp.Model; model != nil {
 				kind = flattenDataCollectionEndpointKind(model.Kind)
-				location = azure.NormalizeLocation(model.Location)
+				loc = location.Normalize(model.Location)
 				tag = tags.Flatten(model.Tags)
 				if prop := model.Properties; prop != nil {
 					description = flattenDataCollectionEndpointDescription(prop.Description)
@@ -144,7 +144,7 @@ func (d DataCollectionEndpointDataSource) Read() sdk.ResourceFunc {
 				Description:                 description,
 				Kind:                        kind,
 				ImmutableId:                 immutableId,
-				Location:                    location,
+				Location:                    loc,
 				LogsIngestionEndpoint:       logsIngestionEndpoint,
 				MetricsIngestionEndpoint:    metricsIngestionEndpoint,
 				Name:                        id.DataCollectionEndpointName,

--- a/internal/services/monitor/monitor_data_collection_endpoint_resource.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource.go
@@ -8,15 +8,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var (
@@ -136,10 +136,10 @@ func (r DataCollectionEndpointResource) Create() sdk.ResourceFunc {
 
 			input := datacollectionendpoints.DataCollectionEndpointResource{
 				Kind:     expandDataCollectionEndpointKind(state.Kind),
-				Location: azure.NormalizeLocation(state.Location),
-				Name:     utils.String(state.Name),
+				Location: location.Normalize(state.Location),
+				Name:     pointer.To(state.Name),
 				Properties: &datacollectionendpoints.DataCollectionEndpoint{
-					Description: utils.String(state.Description),
+					Description: pointer.To(state.Description),
 					NetworkAcls: &datacollectionendpoints.NetworkRuleSet{
 						PublicNetworkAccess: expandDataCollectionEndpointPublicNetworkAccess(state.PublicNetworkAccessEnabled),
 					},
@@ -177,11 +177,11 @@ func (r DataCollectionEndpointResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 			var publicNetWorkAccessEnabled bool
-			var description, kind, location, configurationAccessEndpoint, logsIngestionEndpoint, metricsIngestionEndpoint, immutableId string
+			var description, kind, loc, configurationAccessEndpoint, logsIngestionEndpoint, metricsIngestionEndpoint, immutableId string
 			var tag map[string]interface{}
 			if model := resp.Model; model != nil {
 				kind = flattenDataCollectionEndpointKind(model.Kind)
-				location = azure.NormalizeLocation(model.Location)
+				loc = location.Normalize(model.Location)
 				tag = tags.Flatten(model.Tags)
 				if prop := model.Properties; prop != nil {
 					description = flattenDataCollectionEndpointDescription(prop.Description)
@@ -212,7 +212,7 @@ func (r DataCollectionEndpointResource) Read() sdk.ResourceFunc {
 				Description:                 description,
 				Kind:                        kind,
 				ImmutableId:                 immutableId,
-				Location:                    location,
+				Location:                    loc,
 				LogsIngestionEndpoint:       logsIngestionEndpoint,
 				MetricsIngestionEndpoint:    metricsIngestionEndpoint,
 				Name:                        id.DataCollectionEndpointName,
@@ -253,7 +253,7 @@ func (r DataCollectionEndpointResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				existing.Properties.Description = utils.String(state.Description)
+				existing.Properties.Description = pointer.To(state.Description)
 			}
 
 			if metadata.ResourceData.HasChange("kind") {

--- a/internal/services/monitor/monitor_data_collection_endpoint_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorDataCollectionEndpointResource struct{}
@@ -28,11 +28,11 @@ func (r MonitorDataCollectionEndpointResource) Exists(ctx context.Context, clien
 	resp, err := client.Monitor.DataCollectionEndpointsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccMonitorDataCollectionEndpoint_basic(t *testing.T) {

--- a/internal/services/monitor/monitor_data_collection_rule_association_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_association_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionruleassociations"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DataCollectionRuleAssociationModel struct {
@@ -108,17 +108,17 @@ func (r DataCollectionRuleAssociationResource) Create() sdk.ResourceFunc {
 			}
 
 			input := datacollectionruleassociations.DataCollectionRuleAssociationProxyOnlyResource{
-				Name: utils.String(model.Name),
+				Name: pointer.To(model.Name),
 				Properties: &datacollectionruleassociations.DataCollectionRuleAssociation{
-					Description: utils.String(model.Description),
+					Description: pointer.To(model.Description),
 				},
 			}
 
 			if model.DataCollectionEndpointId != "" {
-				input.Properties.DataCollectionEndpointId = utils.String(model.DataCollectionEndpointId)
+				input.Properties.DataCollectionEndpointId = pointer.To(model.DataCollectionEndpointId)
 			}
 			if model.DataCollectionRuleId != "" {
-				input.Properties.DataCollectionRuleId = utils.String(model.DataCollectionRuleId)
+				input.Properties.DataCollectionRuleId = pointer.To(model.DataCollectionRuleId)
 			}
 
 			if _, err := client.Create(ctx, id, input); err != nil {
@@ -202,7 +202,7 @@ func (r DataCollectionRuleAssociationResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("data_collection_endpoint_id") {
 				if model.DataCollectionEndpointId != "" {
-					existing.Properties.DataCollectionEndpointId = utils.String(model.DataCollectionEndpointId)
+					existing.Properties.DataCollectionEndpointId = pointer.To(model.DataCollectionEndpointId)
 				} else {
 					existing.Properties.DataCollectionEndpointId = nil
 				}
@@ -210,14 +210,14 @@ func (r DataCollectionRuleAssociationResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("data_collection_rule_id") {
 				if model.DataCollectionRuleId != "" {
-					existing.Properties.DataCollectionRuleId = utils.String(model.DataCollectionRuleId)
+					existing.Properties.DataCollectionRuleId = pointer.To(model.DataCollectionRuleId)
 				} else {
 					existing.Properties.DataCollectionRuleId = nil
 				}
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				existing.Properties.Description = utils.String(model.Description)
+				existing.Properties.Description = pointer.To(model.Description)
 			}
 
 			if _, err := client.Create(ctx, *id, *existing); err != nil {

--- a/internal/services/monitor/monitor_data_collection_rule_association_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_association_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionruleassociations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorDataCollectionRuleAssociationResource struct{}
@@ -28,11 +28,11 @@ func (r MonitorDataCollectionRuleAssociationResource) Exists(ctx context.Context
 	resp, err := client.Monitor.DataCollectionRuleAssociationsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccMonitorDataCollectionRuleAssociation_basic(t *testing.T) {

--- a/internal/services/monitor/monitor_data_collection_rule_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source.go
@@ -11,10 +11,10 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionrules"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -615,7 +615,7 @@ func (d DataCollectionRuleDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			var dataCollectionEndpointId, description, immutableId, kind, location string
+			var dataCollectionEndpointId, description, immutableId, kind, loc string
 			var tag map[string]interface{}
 			var dataFlows []DataFlow
 			var dataSources []DataSource
@@ -624,7 +624,7 @@ func (d DataCollectionRuleDataSource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil {
 				kind = flattenDataCollectionRuleKind(model.Kind)
-				location = azure.NormalizeLocation(model.Location)
+				loc = location.Normalize(model.Location)
 				tag = tags.Flatten(model.Tags)
 
 				identityValue, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
@@ -659,7 +659,7 @@ func (d DataCollectionRuleDataSource) Read() sdk.ResourceFunc {
 				Destinations:             destinations,
 				ImmutableId:              immutableId,
 				Kind:                     kind,
-				Location:                 location,
+				Location:                 loc,
 				StreamDeclaration:        streamDeclaration,
 				Tags:                     tag,
 			})

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionendpoints"
@@ -23,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var (
@@ -963,12 +963,12 @@ func (r DataCollectionRuleResource) Create() sdk.ResourceFunc {
 			input := datacollectionrules.DataCollectionRuleResource{
 				Identity: identityValue,
 				Kind:     expandDataCollectionRuleKind(state.Kind),
-				Location: azure.NormalizeLocation(state.Location),
-				Name:     utils.String(state.Name),
+				Location: location.Normalize(state.Location),
+				Name:     pointer.To(state.Name),
 				Properties: &datacollectionrules.DataCollectionRule{
 					DataFlows:          expandDataCollectionRuleDataFlows(state.DataFlows),
 					DataSources:        dataSources,
-					Description:        utils.String(state.Description),
+					Description:        pointer.To(state.Description),
 					Destinations:       expandDataCollectionRuleDestinations(state.Destinations),
 					StreamDeclarations: expandDataCollectionRuleStreamDeclarations(state.StreamDeclaration),
 				},
@@ -976,7 +976,7 @@ func (r DataCollectionRuleResource) Create() sdk.ResourceFunc {
 			}
 
 			if state.DataCollectionEndpointId != "" {
-				input.Properties.DataCollectionEndpointId = utils.String(state.DataCollectionEndpointId)
+				input.Properties.DataCollectionEndpointId = pointer.To(state.DataCollectionEndpointId)
 			}
 
 			if _, err := client.Create(ctx, id, input); err != nil {
@@ -1009,7 +1009,7 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			var dataCollectionEndpointId, description, immutableId, kind, location string
+			var dataCollectionEndpointId, description, immutableId, kind, loc string
 			var tag map[string]interface{}
 			var dataFlows []DataFlow
 			var dataSources []DataSource
@@ -1018,7 +1018,7 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil {
 				kind = flattenDataCollectionRuleKind(model.Kind)
-				location = azure.NormalizeLocation(model.Location)
+				loc = location.Normalize(model.Location)
 				tag = tags.Flatten(model.Tags)
 
 				identityValue, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
@@ -1051,7 +1051,7 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 				Destinations:             destinations,
 				ImmutableId:              immutableId,
 				Kind:                     kind,
-				Location:                 location,
+				Location:                 loc,
 				StreamDeclaration:        streamDeclaration,
 				Tags:                     tag,
 			})
@@ -1109,14 +1109,14 @@ func (r DataCollectionRuleResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("data_collection_endpoint_id") {
 				if state.DataCollectionEndpointId != "" {
-					existing.Properties.DataCollectionEndpointId = utils.String(state.DataCollectionEndpointId)
+					existing.Properties.DataCollectionEndpointId = pointer.To(state.DataCollectionEndpointId)
 				} else {
 					existing.Properties.DataCollectionEndpointId = nil
 				}
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				existing.Properties.Description = utils.String(state.Description)
+				existing.Properties.Description = pointer.To(state.Description)
 			}
 
 			if metadata.ResourceData.HasChange("destinations") {
@@ -1186,15 +1186,15 @@ func expandDataCollectionRuleDataFlows(input []DataFlow) *[]datacollectionrules.
 		}
 
 		if v.BuiltInTransform != "" {
-			dataFlow.BuiltInTransform = utils.String(v.BuiltInTransform)
+			dataFlow.BuiltInTransform = pointer.To(v.BuiltInTransform)
 		}
 
 		if v.OutputStream != "" {
-			dataFlow.OutputStream = utils.String(v.OutputStream)
+			dataFlow.OutputStream = pointer.To(v.OutputStream)
 		}
 
 		if v.TransformKql != "" {
-			dataFlow.TransformKql = utils.String(v.TransformKql)
+			dataFlow.TransformKql = pointer.To(v.TransformKql)
 		}
 
 		result = append(result, dataFlow)
@@ -1245,13 +1245,13 @@ func expandDataCollectionRuleDataSourceDataImports(input []DataImport) *datacoll
 
 	result := &datacollectionrules.DataImportSources{
 		EventHub: &datacollectionrules.EventHubDataSource{
-			Name:   utils.String(input[0].EventHubDataSource[0].Name),
-			Stream: utils.String(input[0].EventHubDataSource[0].Stream),
+			Name:   pointer.To(input[0].EventHubDataSource[0].Name),
+			Stream: pointer.To(input[0].EventHubDataSource[0].Stream),
 		},
 	}
 
 	if consumerGroup := input[0].EventHubDataSource[0].ConsumerGroup; consumerGroup != "" {
-		result.EventHub.ConsumerGroup = utils.String(consumerGroup)
+		result.EventHub.ConsumerGroup = pointer.To(consumerGroup)
 	}
 
 	return result
@@ -1277,7 +1277,7 @@ func expandDataCollectionRuleDataSourceExtensions(input []Extension) (*[]datacol
 			ExtensionName:     v.ExtensionName,
 			ExtensionSettings: &extensionSettings,
 			InputDataSources:  pointer.To(v.InputDataSources),
-			Name:              utils.String(v.Name),
+			Name:              pointer.To(v.Name),
 			Streams:           expandDataCollectionRuleDataSourceExtensionStreams(v.Streams),
 		})
 	}
@@ -1304,7 +1304,7 @@ func expandDataCollectionRuleDataSourceIisLogs(input []IisLog) *[]datacollection
 	result := make([]datacollectionrules.IisLogsDataSource, 0)
 	for _, v := range input {
 		iisLog := datacollectionrules.IisLogsDataSource{
-			Name:    utils.String(v.Name),
+			Name:    pointer.To(v.Name),
 			Streams: v.Streams,
 		}
 
@@ -1326,7 +1326,7 @@ func expandDataCollectionRuleDataSourceLogFiles(input []LogFile) *[]datacollecti
 	result := make([]datacollectionrules.LogFilesDataSource, 0)
 	for _, v := range input {
 		logFile := datacollectionrules.LogFilesDataSource{
-			Name:         utils.String(v.Name),
+			Name:         pointer.To(v.Name),
 			Streams:      v.Streams,
 			FilePatterns: v.FilePatterns,
 			Format:       datacollectionrules.KnownLogFilesDataSourceFormat(v.Format),
@@ -1355,8 +1355,8 @@ func expandDataCollectionRuleDataSourcePerfCounters(input []PerfCounter) *[]data
 	for _, v := range input {
 		result = append(result, datacollectionrules.PerfCounterDataSource{
 			CounterSpecifiers:          pointer.To(v.CounterSpecifiers),
-			Name:                       utils.String(v.Name),
-			SamplingFrequencyInSeconds: utils.Int64(v.SamplingFrequencyInSeconds),
+			Name:                       pointer.To(v.Name),
+			SamplingFrequencyInSeconds: pointer.To(v.SamplingFrequencyInSeconds),
 			Streams:                    expandDataCollectionRuleDataSourcePerfCounterStreams(v.Streams),
 		})
 	}
@@ -1384,7 +1384,7 @@ func expandDataCollectionRuleDataSourcePlatformTelemetry(input []PlatformTelemet
 	result := make([]datacollectionrules.PlatformTelemetryDataSource, 0)
 	for _, v := range input {
 		platformTelemetry := datacollectionrules.PlatformTelemetryDataSource{
-			Name:    utils.String(v.Name),
+			Name:    pointer.To(v.Name),
 			Streams: v.Streams,
 		}
 
@@ -1407,7 +1407,7 @@ func expandDataCollectionRuleDataSourcePrometheusForwarder(input []PrometheusFor
 		}
 
 		prometheusForwarder := datacollectionrules.PrometheusForwarderDataSource{
-			Name:    utils.String(v.Name),
+			Name:    pointer.To(v.Name),
 			Streams: &streams,
 		}
 
@@ -1436,7 +1436,7 @@ func expandDataCollectionRuleDataSourceSyslog(input []Syslog) *[]datacollectionr
 		result = append(result, datacollectionrules.SyslogDataSource{
 			FacilityNames: expandDataCollectionRuleDataSourceSyslogFacilityNames(v.FacilityNames),
 			LogLevels:     expandDataCollectionRuleDataSourceSyslogLogLevels(v.LogLevels),
-			Name:          utils.String(v.Name),
+			Name:          pointer.To(v.Name),
 			Streams:       expandDataCollectionRuleDataSourceSyslogStreams(v.Streams),
 		})
 	}
@@ -1487,7 +1487,7 @@ func expandDataCollectionRuleDataSourceWindowsEventLogs(input []WindowsEventLog)
 	result := make([]datacollectionrules.WindowsEventLogDataSource, 0)
 	for _, v := range input {
 		result = append(result, datacollectionrules.WindowsEventLogDataSource{
-			Name:         utils.String(v.Name),
+			Name:         pointer.To(v.Name),
 			Streams:      expandDataCollectionRuleDataSourceWindowsEventLogsStreams(v.Streams),
 			XPathQueries: pointer.To(v.XPathQueries),
 		})
@@ -1515,7 +1515,7 @@ func expandDataCollectionRuleDataSourceWindowsFirewallLogs(input []WindowsFirewa
 	result := make([]datacollectionrules.WindowsFirewallLogsDataSource, 0)
 	for _, v := range input {
 		windowsFirewallLog := datacollectionrules.WindowsFirewallLogsDataSource{
-			Name:    utils.String(v.Name),
+			Name:    pointer.To(v.Name),
 			Streams: v.Streams,
 		}
 
@@ -1548,7 +1548,7 @@ func expandDataCollectionRuleDestinationMetrics(input []AzureMonitorMetric) *dat
 	}
 
 	return &datacollectionrules.AzureMonitorMetricsDestination{
-		Name: utils.String(input[0].Name),
+		Name: pointer.To(input[0].Name),
 	}
 }
 
@@ -1560,8 +1560,8 @@ func expandDataCollectionRuleDestinationEventHubs(input []EventHub) *[]datacolle
 	result := make([]datacollectionrules.EventHubDestination, 0)
 	for _, v := range input {
 		eventhub := datacollectionrules.EventHubDestination{
-			Name:               utils.String(v.Name),
-			EventHubResourceId: utils.String(v.EventHubResourceId),
+			Name:               pointer.To(v.Name),
+			EventHubResourceId: pointer.To(v.EventHubResourceId),
 		}
 
 		result = append(result, eventhub)
@@ -1578,8 +1578,8 @@ func expandDataCollectionRuleDestinationEventHubsDirect(input []EventHub) *[]dat
 	result := make([]datacollectionrules.EventHubDirectDestination, 0)
 	for _, v := range input {
 		eventhub := datacollectionrules.EventHubDirectDestination{
-			Name:               utils.String(v.Name),
-			EventHubResourceId: utils.String(v.EventHubResourceId),
+			Name:               pointer.To(v.Name),
+			EventHubResourceId: pointer.To(v.EventHubResourceId),
 		}
 
 		result = append(result, eventhub)
@@ -1596,8 +1596,8 @@ func expandDataCollectionRuleDestinationLogAnalytics(input []LogAnalytic) *[]dat
 	result := make([]datacollectionrules.LogAnalyticsDestination, 0)
 	for _, v := range input {
 		result = append(result, datacollectionrules.LogAnalyticsDestination{
-			Name:                utils.String(v.Name),
-			WorkspaceResourceId: utils.String(v.WorkspaceResourceId),
+			Name:                pointer.To(v.Name),
+			WorkspaceResourceId: pointer.To(v.WorkspaceResourceId),
 		})
 	}
 	return &result
@@ -1611,8 +1611,8 @@ func expandDataCollectionRuleDestinationMonitoringAccounts(input []MonitorAccoun
 	result := make([]datacollectionrules.MonitoringAccountDestination, 0)
 	for _, v := range input {
 		monitorAccount := datacollectionrules.MonitoringAccountDestination{
-			Name:              utils.String(v.Name),
-			AccountResourceId: utils.String(v.AccountId),
+			Name:              pointer.To(v.Name),
+			AccountResourceId: pointer.To(v.AccountId),
 		}
 
 		result = append(result, monitorAccount)
@@ -1629,9 +1629,9 @@ func expandDataCollectionRuleDestinationStorageBlobs(input []StorageBlob) *[]dat
 	result := make([]datacollectionrules.StorageBlobDestination, 0)
 	for _, v := range input {
 		monitorAccount := datacollectionrules.StorageBlobDestination{
-			Name:                     utils.String(v.Name),
-			StorageAccountResourceId: utils.String(v.StorageAccountId),
-			ContainerName:            utils.String(v.ContainerName),
+			Name:                     pointer.To(v.Name),
+			StorageAccountResourceId: pointer.To(v.StorageAccountId),
+			ContainerName:            pointer.To(v.ContainerName),
 		}
 
 		result = append(result, monitorAccount)
@@ -1648,9 +1648,9 @@ func expandDataCollectionRuleDestinationStorageTableDirect(input []StorageTableD
 	result := make([]datacollectionrules.StorageTableDestination, 0)
 	for _, v := range input {
 		monitorAccount := datacollectionrules.StorageTableDestination{
-			Name:                     utils.String(v.Name),
-			StorageAccountResourceId: utils.String(v.StorageAccountId),
-			TableName:                utils.String(v.TableName),
+			Name:                     pointer.To(v.Name),
+			StorageAccountResourceId: pointer.To(v.StorageAccountId),
+			TableName:                pointer.To(v.TableName),
 		}
 
 		result = append(result, monitorAccount)
@@ -1670,7 +1670,7 @@ func expandDataCollectionRuleStreamDeclarations(input []StreamDeclaration) *map[
 		for _, column := range v.Column {
 			columnType := datacollectionrules.KnownColumnDefinitionType(column.Type)
 			columns = append(columns, datacollectionrules.ColumnDefinition{
-				Name: utils.String(column.Name),
+				Name: pointer.To(column.Name),
 				Type: &columnType,
 			})
 		}

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-11/datacollectionrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorDataCollectionRuleResource struct{}
@@ -28,11 +28,11 @@ func (r MonitorDataCollectionRuleResource) Exists(ctx context.Context, client *c
 	resp, err := client.Monitor.DataCollectionRulesClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccMonitorDataCollectionRule_basic(t *testing.T) {

--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -442,19 +442,19 @@ func resourceMonitorMetricAlertCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	parameters := metricalerts.MetricAlertResource{
-		Location: azure.NormalizeLocation("Global"),
+		Location: location.Normalize("Global"),
 		Properties: metricalerts.MetricAlertProperties{
 			Enabled:              enabled,
-			AutoMitigate:         utils.Bool(autoMitigate),
-			Description:          utils.String(description),
+			AutoMitigate:         pointer.To(autoMitigate),
+			Description:          pointer.To(description),
 			Severity:             int64(severity),
 			EvaluationFrequency:  frequency,
 			WindowSize:           windowSize,
 			Scopes:               expandStringValues(scopesRaw),
 			Criteria:             criteria,
 			Actions:              expandMonitorMetricAlertAction(actionRaw),
-			TargetResourceType:   utils.String(targetResourceType),
-			TargetResourceRegion: utils.String(targetResourceLocation),
+			TargetResourceType:   pointer.To(targetResourceType),
+			TargetResourceRegion: pointer.To(targetResourceLocation),
 		},
 		Tags: utils.ExpandPtrMapStringString(t),
 	}
@@ -609,13 +609,13 @@ func expandMonitorMetricAlertSingleResourceMultiMetricCriteria(input []interface
 		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
 		criteria = append(criteria, metricalerts.MetricCriteria{
 			Name:                 fmt.Sprintf("Metric%d", i+1),
-			MetricNamespace:      utils.String(v["metric_namespace"].(string)),
+			MetricNamespace:      pointer.To(v["metric_namespace"].(string)),
 			MetricName:           v["metric_name"].(string),
 			TimeAggregation:      metricalerts.AggregationTypeEnum(v["aggregation"].(string)),
 			Dimensions:           &dimensions,
 			Operator:             metricalerts.Operator(v["operator"].(string)),
 			Threshold:            v["threshold"].(float64),
-			SkipMetricValidation: utils.Bool(v["skip_metric_validation"].(bool)),
+			SkipMetricValidation: pointer.To(v["skip_metric_validation"].(bool)),
 		})
 	}
 	return &metricalerts.MetricAlertSingleResourceMultipleMetricCriteria{
@@ -630,13 +630,13 @@ func expandMonitorMetricAlertMultiResourceMultiMetricForStaticMetricCriteria(inp
 		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
 		criteria = append(criteria, metricalerts.MetricCriteria{
 			Name:                 fmt.Sprintf("Metric%d", i+1),
-			MetricNamespace:      utils.String(v["metric_namespace"].(string)),
+			MetricNamespace:      pointer.To(v["metric_namespace"].(string)),
 			MetricName:           v["metric_name"].(string),
 			TimeAggregation:      metricalerts.AggregationTypeEnum(v["aggregation"].(string)),
 			Dimensions:           &dimensions,
 			Operator:             metricalerts.Operator(v["operator"].(string)),
 			Threshold:            v["threshold"].(float64),
-			SkipMetricValidation: utils.Bool(v["skip_metric_validation"].(bool)),
+			SkipMetricValidation: pointer.To(v["skip_metric_validation"].(bool)),
 		})
 	}
 	return &metricalerts.MetricAlertMultipleResourceMultipleMetricCriteria{
@@ -652,7 +652,7 @@ func expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(in
 
 		dynamicMetricCriteria := metricalerts.DynamicMetricCriteria{
 			Name:             fmt.Sprintf("Metric%d", i+1),
-			MetricNamespace:  utils.String(v["metric_namespace"].(string)),
+			MetricNamespace:  pointer.To(v["metric_namespace"].(string)),
 			MetricName:       v["metric_name"].(string),
 			TimeAggregation:  metricalerts.AggregationTypeEnum(v["aggregation"].(string)),
 			Dimensions:       &dimensions,
@@ -662,7 +662,7 @@ func expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(in
 				NumberOfEvaluationPeriods: float64(v["evaluation_total_count"].(int)),
 				MinFailingPeriodsToAlert:  float64(v["evaluation_failure_count"].(int)),
 			},
-			SkipMetricValidation: utils.Bool(v["skip_metric_validation"].(bool)),
+			SkipMetricValidation: pointer.To(v["skip_metric_validation"].(bool)),
 		}
 
 		if datetime := v["ignore_data_before"].(string); datetime != "" {
@@ -717,7 +717,7 @@ func expandMonitorMetricAlertAction(input []interface{}) *[]metricalerts.MetricA
 			}
 
 			actions = append(actions, metricalerts.MetricAlertAction{
-				ActionGroupId:     utils.String(agID),
+				ActionGroupId:     pointer.To(agID),
 				WebHookProperties: &props,
 			})
 		}

--- a/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorMetricAlertResource struct{}
@@ -177,7 +177,7 @@ func (t MonitorMetricAlertResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("reading (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MonitorMetricAlertResource) basic(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_private_link_scope_resource_test.go
+++ b/internal/services/monitor/monitor_private_link_scope_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-07-01-preview/privatelinkscopesapis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorPrivateLinkScopeResource struct{}
@@ -95,12 +95,12 @@ func (r MonitorPrivateLinkScopeResource) Exists(ctx context.Context, client *cli
 	resp, err := client.Monitor.PrivateLinkScopesClient.PrivateLinkScopesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MonitorPrivateLinkScopeResource) template(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_private_link_scoped_service_resource.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	components "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-02-02/componentsapis"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMonitorPrivateLinkScopedService() *pluginsdk.Resource {
@@ -95,7 +95,7 @@ func resourceMonitorPrivateLinkScopedServiceCreate(d *pluginsdk.ResourceData, me
 
 	parameters := privatelinkscopedresources.ScopedResource{
 		Properties: &privatelinkscopedresources.ScopedResourceProperties{
-			LinkedResourceId: utils.String(d.Get("linked_resource_id").(string)),
+			LinkedResourceId: pointer.To(d.Get("linked_resource_id").(string)),
 		},
 	}
 

--- a/internal/services/monitor/monitor_private_link_scoped_service_resource_test.go
+++ b/internal/services/monitor/monitor_private_link_scoped_service_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopedresources"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorPrivateLinkScopedServiceResource struct{}
@@ -73,12 +73,12 @@ func (r MonitorPrivateLinkScopedServiceResource) Exists(ctx context.Context, cli
 	resp, err := client.Monitor.PrivateLinkScopedResourcesClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MonitorPrivateLinkScopedServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -273,7 +274,7 @@ func resourceMonitorScheduledQueryRulesAlertCreateUpdate(d *pluginsdk.ResourceDa
 		enabled = scheduledqueryrules.EnabledFalse
 	}
 
-	location := azure.NormalizeLocation(d.Get("location"))
+	location := location.Normalize(d.Get("location").(string))
 
 	source := expandMonitorScheduledQueryRulesCommonSource(d)
 
@@ -282,12 +283,12 @@ func resourceMonitorScheduledQueryRulesAlertCreateUpdate(d *pluginsdk.ResourceDa
 	parameters := scheduledqueryrules.LogSearchRuleResource{
 		Location: location,
 		Properties: scheduledqueryrules.LogSearchRule{
-			Description:  utils.String(description),
+			Description:  pointer.To(description),
 			Enabled:      pointer.To(enabled),
 			Source:       source,
 			Schedule:     schedule,
 			Action:       action,
-			AutoMitigate: utils.Bool(autoMitigate),
+			AutoMitigate: pointer.To(autoMitigate),
 		},
 		Tags: utils.ExpandPtrMapStringString(t),
 	}
@@ -325,7 +326,7 @@ func resourceMonitorScheduledQueryRulesAlertRead(d *pluginsdk.ResourceData, meta
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		props := model.Properties
 		d.Set("auto_mitigation_enabled", props.AutoMitigate)
@@ -406,7 +407,7 @@ func expandMonitorScheduledQueryRulesAlertingAction(d *pluginsdk.ResourceData) *
 	}
 
 	if throttling, ok := d.Get("throttling").(int); ok && throttling != 0 {
-		action.ThrottlingInMin = utils.Int64(int64(throttling))
+		action.ThrottlingInMin = pointer.To(int64(throttling))
 	}
 
 	return &action
@@ -429,9 +430,9 @@ func expandMonitorScheduledQueryRulesAlertAction(input []interface{}) *scheduled
 		}
 		actionGroups := v["action_group"].(*pluginsdk.Set).List()
 		result.ActionGroup = utils.ExpandStringSlice(actionGroups)
-		result.EmailSubject = utils.String(v["email_subject"].(string))
+		result.EmailSubject = pointer.To(v["email_subject"].(string))
 		if v := v["custom_webhook_payload"].(string); v != "" {
-			result.CustomWebhookPayload = utils.String(v)
+			result.CustomWebhookPayload = pointer.To(v)
 		}
 	}
 
@@ -453,9 +454,9 @@ func expandMonitorScheduledQueryRulesAlertMetricTrigger(input []interface{}) *sc
 			continue
 		}
 		result.ThresholdOperator = pointer.To(scheduledqueryrules.ConditionalOperator(v["operator"].(string)))
-		result.Threshold = utils.Float(v["threshold"].(float64))
+		result.Threshold = pointer.To(v["threshold"].(float64))
 		result.MetricTriggerType = pointer.To(scheduledqueryrules.MetricTriggerType(v["metric_trigger_type"].(string)))
-		result.MetricColumn = utils.String(v["metric_column"].(string))
+		result.MetricColumn = pointer.To(v["metric_column"].(string))
 	}
 
 	return &result

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorScheduledQueryRulesAlertResource struct{}
@@ -479,5 +479,5 @@ func (t MonitorScheduledQueryRulesAlertResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("reading (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-03-15-preview/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorScheduledQueryRulesAlertV2Resource struct{}
@@ -162,11 +162,11 @@ func (r MonitorScheduledQueryRulesAlertV2Resource) Exists(ctx context.Context, c
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MonitorScheduledQueryRulesAlertV2Resource) template(data acceptance.TestData) string {

--- a/internal/services/monitor/monitor_scheduled_query_rules_log_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_log_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -162,7 +163,7 @@ func resourceMonitorScheduledQueryRulesLogCreateUpdate(d *pluginsdk.ResourceData
 		enabled = scheduledqueryrules.EnabledFalse
 	}
 
-	location := azure.NormalizeLocation(d.Get("location"))
+	location := location.Normalize(d.Get("location").(string))
 
 	source := expandMonitorScheduledQueryRulesCommonSource(d)
 
@@ -171,7 +172,7 @@ func resourceMonitorScheduledQueryRulesLogCreateUpdate(d *pluginsdk.ResourceData
 	parameters := scheduledqueryrules.LogSearchRuleResource{
 		Location: location,
 		Properties: scheduledqueryrules.LogSearchRule{
-			Description: utils.String(description),
+			Description: pointer.To(description),
 			Enabled:     pointer.To(enabled),
 			Source:      source,
 			Action:      action,
@@ -212,7 +213,7 @@ func resourceMonitorScheduledQueryRulesLogRead(d *pluginsdk.ResourceData, meta i
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		props := model.Properties
 

--- a/internal/services/monitor/monitor_scheduled_query_rules_log_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_log_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MonitorScheduledQueryRulesLogResource struct{}
@@ -235,5 +235,5 @@ func (t MonitorScheduledQueryRulesLogResource) Exists(ctx context.Context, clien
 		return nil, fmt.Errorf("reading (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
+++ b/internal/services/monitor/monitor_smart_detector_alert_rule_resource.go
@@ -185,7 +185,7 @@ func resourceMonitorSmartDetectorAlertRuleCreateUpdate(d *pluginsdk.ResourceData
 
 	actionRule := smartdetectoralertrules.AlertRule{
 		// the location is always global from the portal
-		Location: utils.String(location.Normalize("Global")),
+		Location: pointer.To(location.Normalize("Global")),
 		Properties: &smartdetectoralertrules.AlertRuleProperties{
 			Description: pointer.To(d.Get("description").(string)),
 			State:       state,
@@ -287,8 +287,8 @@ func expandMonitorSmartDetectorAlertRuleActionGroup(input []interface{}) *smartd
 	}
 	v := input[0].(map[string]interface{})
 	return &smartdetectoralertrules.ActionGroupsInformation{
-		CustomEmailSubject:   utils.String(v["email_subject"].(string)),
-		CustomWebhookPayload: utils.String(v["webhook_payload"].(string)),
+		CustomEmailSubject:   pointer.To(v["email_subject"].(string)),
+		CustomWebhookPayload: pointer.To(v["webhook_payload"].(string)),
 		GroupIds:             pointer.From(utils.ExpandStringSlice(v["ids"].(*pluginsdk.Set).List())),
 	}
 }

--- a/internal/services/monitor/monitor_workspace_data_source.go
+++ b/internal/services/monitor/monitor_workspace_data_source.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -101,11 +101,11 @@ func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
 			}
 
 			var enablePublicNetWorkAccess bool
-			var location, queryEndpoint, defaultDataCollectionEndpointId, defaultDataCollectionRuleId string
+			var loc, queryEndpoint, defaultDataCollectionEndpointId, defaultDataCollectionRuleId string
 			var tag map[string]string
 
 			if model := resp.Model; model != nil {
-				location = azure.NormalizeLocation(model.Location)
+				loc = location.Normalize(model.Location)
 				tag = pointer.From(model.Tags)
 
 				if props := model.Properties; props != nil {
@@ -129,7 +129,7 @@ func (d WorkspaceDataSource) Read() sdk.ResourceFunc {
 			metadata.SetID(id)
 
 			return metadata.Encode(&WorkspaceDataSourceModel{
-				Location:                        location,
+				Location:                        loc,
 				Name:                            id.AccountName,
 				PublicNetworkAccessEnabled:      enablePublicNetWorkAccess,
 				QueryEndpoint:                   queryEndpoint,

--- a/internal/services/monitor/monitor_workspace_resource_test.go
+++ b/internal/services/monitor/monitor_workspace_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkspaceTestResource struct{}
@@ -121,11 +121,11 @@ func (r WorkspaceTestResource) Exists(ctx context.Context, clients *clients.Clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WorkspaceTestResource) template(data acceptance.TestData) string {

--- a/internal/services/mssql/helper/database.go
+++ b/internal/services/mssql/helper/database.go
@@ -84,7 +84,7 @@ func FindDatabaseReplicationPartners(ctx context.Context, databasesClient *datab
 		listOptions := resources.ListOperationOptions{
 			Expand: nil,
 			Filter: pointer.To(filter),
-			Top:    pointer.FromInt64(100),
+			Top:    pointer.To(int64(100)),
 		}
 
 		resourcesIterator, err := resourcesClient.ListComplete(ctx, *linkSubscription, listOptions)

--- a/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/internal/services/mssql/helper/sql_extended_auditing.go
@@ -5,8 +5,8 @@ package helper
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v5.0/sql" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func FlattenSqlServerBlobAuditingPolicies(extendedServerBlobAuditingPolicy *sql.ExtendedServerBlobAuditingPolicy, d *pluginsdk.ResourceData) []interface{} {
@@ -62,15 +62,15 @@ func ExpandMsSqlDBBlobAuditingPolicies(input []interface{}) *sql.ExtendedDatabas
 
 	ExtendedDatabaseBlobAuditingPolicyProperties := sql.ExtendedDatabaseBlobAuditingPolicyProperties{
 		State:                       sql.BlobAuditingPolicyStateEnabled,
-		StorageAccountAccessKey:     utils.String(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
-		StorageEndpoint:             utils.String(dbBlobAuditingPolicies["storage_endpoint"].(string)),
-		IsAzureMonitorTargetEnabled: utils.Bool(dbBlobAuditingPolicies["log_monitoring_enabled"].(bool)),
+		StorageAccountAccessKey:     pointer.To(dbBlobAuditingPolicies["storage_account_access_key"].(string)),
+		StorageEndpoint:             pointer.To(dbBlobAuditingPolicies["storage_endpoint"].(string)),
+		IsAzureMonitorTargetEnabled: pointer.To(dbBlobAuditingPolicies["log_monitoring_enabled"].(bool)),
 	}
 	if v, ok := dbBlobAuditingPolicies["storage_account_access_key_is_secondary"]; ok {
-		ExtendedDatabaseBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = utils.Bool(v.(bool))
+		ExtendedDatabaseBlobAuditingPolicyProperties.IsStorageSecondaryKeyInUse = pointer.To(v.(bool))
 	}
 	if v, ok := dbBlobAuditingPolicies["retention_in_days"]; ok {
-		ExtendedDatabaseBlobAuditingPolicyProperties.RetentionDays = utils.Int32(int32(v.(int)))
+		ExtendedDatabaseBlobAuditingPolicyProperties.RetentionDays = pointer.To(int32(v.(int)))
 	}
 
 	return &ExtendedDatabaseBlobAuditingPolicyProperties

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlDatabaseExtendedAuditingPolicy() *pluginsdk.Resource {
@@ -117,10 +116,10 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resour
 
 	params := blobauditing.ExtendedDatabaseBlobAuditingPolicy{
 		Properties: &blobauditing.ExtendedDatabaseBlobAuditingPolicyProperties{
-			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
-			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
-			RetentionDays:               utils.Int64(int64(d.Get("retention_in_days").(int))),
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
+			StorageEndpoint:             pointer.To(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse:  pointer.To(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:               pointer.To(int64(d.Get("retention_in_days").(int))),
+			IsAzureMonitorTargetEnabled: pointer.To(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
@@ -131,7 +130,7 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resour
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		params.Properties.StorageAccountAccessKey = utils.String(v.(string))
+		params.Properties.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if _, err = client.ExtendedDatabaseBlobAuditingPoliciesCreateOrUpdate(ctx, *dbId, params); err != nil {

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -14,11 +14,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/publicmaintenanceconfigurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/databases"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/elasticpools"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/helper"
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlElasticPool() *pluginsdk.Resource {
@@ -252,7 +251,7 @@ func resourceMsSqlElasticPoolCreateUpdate(d *pluginsdk.ResourceData, meta interf
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	sku := expandMsSqlElasticPoolSku(d)
 
 	maintenanceConfigId := publicmaintenanceconfigurations.NewPublicMaintenanceConfigurationID(subscriptionId, d.Get("maintenance_configuration_name").(string))
@@ -278,7 +277,7 @@ func resourceMsSqlElasticPoolCreateUpdate(d *pluginsdk.ResourceData, meta interf
 	if d.HasChange("max_size_gb") {
 		if v, ok := d.GetOk("max_size_gb"); ok {
 			maxSizeBytes := v.(float64) * 1073741824
-			elasticPool.Properties.MaxSizeBytes = utils.Int64(int64(maxSizeBytes))
+			elasticPool.Properties.MaxSizeBytes = pointer.To(int64(maxSizeBytes))
 		}
 	} else if v, ok := d.GetOk("max_size_bytes"); ok {
 		elasticPool.Properties.MaxSizeBytes = pointer.To(int64(v.(int)))
@@ -392,8 +391,8 @@ func expandMsSqlElasticPoolPerDatabaseSettings(d *pluginsdk.ResourceData) *elast
 	maxCapacity := perDatabaseSetting["max_capacity"].(float64)
 
 	return &elasticpools.ElasticPoolPerDatabaseSettings{
-		MinCapacity: utils.Float(minCapacity),
-		MaxCapacity: utils.Float(maxCapacity),
+		MinCapacity: pointer.To(minCapacity),
+		MaxCapacity: pointer.To(maxCapacity),
 	}
 }
 

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlElasticPoolResource struct{}
@@ -437,7 +437,7 @@ func (MsSqlElasticPoolResource) Exists(ctx context.Context, client *clients.Clie
 		return nil, fmt.Errorf("reading SQL Elastic Pool %s: %v", id, err)
 	}
 
-	return utils.Bool(existing.Model.Id != nil), nil
+	return pointer.To(existing.Model.Id != nil), nil
 }
 
 func (r MsSqlElasticPoolResource) basicDTU(data acceptance.TestData, enclaveType string) string {

--- a/internal/services/mssql/mssql_failover_group_resource.go
+++ b/internal/services/mssql/mssql_failover_group_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlFailoverGroupModel struct {
@@ -226,7 +225,7 @@ func (r MsSqlFailoverGroupResource) Create() sdk.ResourceFunc {
 			if rwPolicy := model.ReadWriteEndpointFailurePolicy; len(rwPolicy) > 0 {
 				properties.Properties.ReadWriteEndpoint.FailoverPolicy = failovergroups.ReadWriteEndpointFailoverPolicy(rwPolicy[0].Mode)
 				if rwPolicy[0].Mode == string(failovergroups.ReadWriteEndpointFailoverPolicyAutomatic) {
-					properties.Properties.ReadWriteEndpoint.FailoverWithDataLossGracePeriodMinutes = utils.Int64(rwPolicy[0].GraceMinutes)
+					properties.Properties.ReadWriteEndpoint.FailoverWithDataLossGracePeriodMinutes = pointer.To(rwPolicy[0].GraceMinutes)
 				}
 			}
 

--- a/internal/services/mssql/mssql_firewall_rule_resource.go
+++ b/internal/services/mssql/mssql_firewall_rule_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/firewallrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlFirewallRule() *pluginsdk.Resource {
@@ -101,8 +101,8 @@ func resourceMsSqlFirewallRuleCreateUpdate(d *pluginsdk.ResourceData, meta inter
 
 	parameters := firewallrules.FirewallRule{
 		Properties: &firewallrules.ServerFirewallRuleProperties{
-			StartIPAddress: utils.String(d.Get("start_ip_address").(string)),
-			EndIPAddress:   utils.String(d.Get("end_ip_address").(string)),
+			StartIPAddress: pointer.To(d.Get("start_ip_address").(string)),
+			EndIPAddress:   pointer.To(d.Get("end_ip_address").(string)),
 		},
 	}
 

--- a/internal/services/mssql/mssql_server_dns_alias_resource_test.go
+++ b/internal/services/mssql/mssql_server_dns_alias_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServerDNSAliasResource struct{}
@@ -66,7 +65,7 @@ func (r ServerDNSAliasResource) Exists(ctx context.Context, client *clients.Clie
 	if response.WasNotFound(resp.HttpResponse) {
 		return pointer.To(false), nil
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // Configs

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -144,10 +144,10 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resource
 
 	params := blobauditing.ExtendedServerBlobAuditingPolicy{
 		Properties: &blobauditing.ExtendedServerBlobAuditingPolicyProperties{
-			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
-			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
-			RetentionDays:               utils.Int64(int64(d.Get("retention_in_days").(int))),
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
+			StorageEndpoint:             pointer.To(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse:  pointer.To(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:               pointer.To(int64(d.Get("retention_in_days").(int))),
+			IsAzureMonitorTargetEnabled: pointer.To(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
@@ -162,7 +162,7 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resource
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		params.Properties.StorageAccountAccessKey = utils.String(v.(string))
+		params.Properties.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("predicate_expression"); ok {

--- a/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlServerMicrosoftSupportAuditingPolicy() *pluginsdk.Resource {
@@ -113,12 +112,12 @@ func resourceMsSqlServerMicrosoftSupportAuditingPolicyCreateUpdate(d *pluginsdk.
 
 	params := serverdevopsaudit.ServerDevOpsAuditingSettings{
 		Properties: &serverdevopsaudit.ServerDevOpsAuditSettingsProperties{
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
+			IsAzureMonitorTargetEnabled: pointer.To(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
 	if v := d.Get("blob_storage_endpoint").(string); v != "" {
-		params.Properties.StorageEndpoint = utils.String(v)
+		params.Properties.StorageEndpoint = pointer.To(v)
 	}
 
 	if d.Get("enabled").(bool) {
@@ -132,7 +131,7 @@ func resourceMsSqlServerMicrosoftSupportAuditingPolicyCreateUpdate(d *pluginsdk.
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		params.Properties.StorageAccountAccessKey = utils.String(v.(string))
+		params.Properties.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	err = client.SettingsCreateOrUpdateThenPoll(ctx, *serverId, params)

--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/encryptionprotectors"
@@ -25,7 +26,6 @@ import (
 	mssqlValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlTransparentDataEncryption() *pluginsdk.Resource {
@@ -117,7 +117,7 @@ func resourceMsSqlTransparentDataEncryptionCreateUpdate(d *pluginsdk.ResourceDat
 		serverKeyProperties := serverkeys.ServerKeyProperties{
 			ServerKeyType:       serverKeyType,
 			Uri:                 &keyVaultKeyId,
-			AutoRotationEnabled: utils.Bool(d.Get("auto_rotation_enabled").(bool)),
+			AutoRotationEnabled: pointer.To(d.Get("auto_rotation_enabled").(bool)),
 		}
 		serverKey.Properties = &serverKeyProperties
 
@@ -157,7 +157,7 @@ func resourceMsSqlTransparentDataEncryptionCreateUpdate(d *pluginsdk.ResourceDat
 		serverKeyProperties := serverkeys.ServerKeyProperties{
 			ServerKeyType:       serverKeyType,
 			Uri:                 &mhsmKeyId,
-			AutoRotationEnabled: utils.Bool(d.Get("auto_rotation_enabled").(bool)),
+			AutoRotationEnabled: pointer.To(d.Get("auto_rotation_enabled").(bool)),
 		}
 		serverKey.Properties = &serverKeyProperties
 
@@ -189,7 +189,7 @@ func resourceMsSqlTransparentDataEncryptionCreateUpdate(d *pluginsdk.ResourceDat
 	encryptionProtectorProperties := encryptionprotectors.EncryptionProtectorProperties{
 		ServerKeyType:       keyType,
 		ServerKeyName:       &serverKeyName,
-		AutoRotationEnabled: utils.Bool(d.Get("auto_rotation_enabled").(bool)),
+		AutoRotationEnabled: pointer.To(d.Get("auto_rotation_enabled").(bool)),
 	}
 
 	keyId := serverkeys.NewKeyID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, serverKeyName)

--- a/internal/services/mssql/mssql_virtual_machine_availability_group_listener_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_availability_group_listener_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2023-10-01/availabilitygrouplisteners"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlVirtualMachineAvailabilityGroupListenerResource struct{}
@@ -70,14 +70,14 @@ func (MsSqlVirtualMachineAvailabilityGroupListenerResource) Exists(ctx context.C
 		return nil, err
 	}
 
-	resp, err := client.MSSQL.VirtualMachinesAvailabilityGroupListenersClient.Get(ctx, *id, availabilitygrouplisteners.GetOperationOptions{Expand: utils.String("*")})
+	resp, err := client.MSSQL.VirtualMachinesAvailabilityGroupListenersClient.Get(ctx, *id, availabilitygrouplisteners.GetOperationOptions{Expand: pointer.To("*")})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return nil, fmt.Errorf("%s does not exist", *id)
 		}
 		return nil, fmt.Errorf("reading %s: %v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MsSqlVirtualMachineAvailabilityGroupListenerResource) loadBalancerConfiguration(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_virtual_machine_group_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2023-10-01/sqlvirtualmachinegroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlVirtualMachineGroupResource struct{}
@@ -135,7 +135,7 @@ func (MsSqlVirtualMachineGroupResource) Exists(ctx context.Context, client *clie
 		}
 		return nil, fmt.Errorf("reading %s: %v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MsSqlVirtualMachineGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2023-10-01/sqlvirtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlVirtualMachineResource struct{}
@@ -395,7 +395,7 @@ func (MsSqlVirtualMachineResource) Exists(ctx context.Context, client *clients.C
 		return nil, err
 	}
 
-	resp, err := client.MSSQL.VirtualMachinesClient.Get(ctx, *id, sqlvirtualmachines.GetOperationOptions{Expand: utils.String("*")})
+	resp, err := client.MSSQL.VirtualMachinesClient.Get(ctx, *id, sqlvirtualmachines.GetOperationOptions{Expand: pointer.To("*")})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return nil, fmt.Errorf("%s does not exist", *id)
@@ -403,7 +403,7 @@ func (MsSqlVirtualMachineResource) Exists(ctx context.Context, client *clients.C
 		return nil, fmt.Errorf("reading %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MsSqlVirtualMachineResource) template(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_virtual_network_rule_resource.go
+++ b/internal/services/mssql/mssql_virtual_network_rule_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/virtualnetworkrules"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlVirtualNetworkRule() *pluginsdk.Resource {
@@ -102,7 +102,7 @@ func resourceMsSqlVirtualNetworkRuleCreateUpdate(d *pluginsdk.ResourceData, meta
 	parameters := virtualnetworkrules.VirtualNetworkRule{
 		Properties: &virtualnetworkrules.VirtualNetworkRuleProperties{
 			VirtualNetworkSubnetId:           subnetId.ID(),
-			IgnoreMissingVnetServiceEndpoint: utils.Bool(d.Get("ignore_missing_vnet_service_endpoint").(bool)),
+			IgnoreMissingVnetServiceEndpoint: pointer.To(d.Get("ignore_missing_vnet_service_endpoint").(bool)),
 		},
 	}
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_active_directory_administrator_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_active_directory_administrator_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceActiveDirectoryAdministratorResource struct{}
@@ -55,12 +55,12 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Exists(ctx con
 	resp, err := client.MSSQLManagedInstance.ManagedInstanceAdministratorsClient.Get(ctx, instanceId)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) template(data acceptance.TestData) string {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceFailoverGroupModel struct {
@@ -211,8 +210,8 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Create() sdk.ResourceFunc {
 					},
 					ManagedInstancePairs: []instancefailovergroups.ManagedInstancePairInfo{
 						{
-							PrimaryManagedInstanceId: utils.String(managedInstanceId.ID()),
-							PartnerManagedInstanceId: utils.String(partnerId.ID()),
+							PrimaryManagedInstanceId: pointer.To(managedInstanceId.ID()),
+							PartnerManagedInstanceId: pointer.To(partnerId.ID()),
 						},
 					},
 					SecondaryType: pointer.To(instancefailovergroups.SecondaryInstanceType(model.SecondaryType)),
@@ -291,8 +290,8 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Update() sdk.ResourceFunc {
 					},
 					ManagedInstancePairs: []instancefailovergroups.ManagedInstancePairInfo{
 						{
-							PrimaryManagedInstanceId: utils.String(managedInstanceId.ID()),
-							PartnerManagedInstanceId: utils.String(partnerId.ID()),
+							PrimaryManagedInstanceId: pointer.To(managedInstanceId.ID()),
+							PartnerManagedInstanceId: pointer.To(partnerId.ID()),
 						},
 					},
 					SecondaryType: pointer.To(instancefailovergroups.SecondaryInstanceType(state.SecondaryType)),

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/instancefailovergroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceFailoverGroupResource struct{}
@@ -50,12 +50,12 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Exists(ctx context.Context, c
 	resp, err := client.MSSQLManagedInstance.ManagedInstanceFailoverGroupsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r MsSqlManagedInstanceFailoverGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/managedinstances"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceResource struct{}
@@ -394,11 +394,11 @@ func (r MsSqlManagedInstanceResource) Exists(ctx context.Context, client *client
 	resp, err := client.MSSQLManagedInstance.ManagedInstancesClient.Get(ctx, *id, managedinstances.GetOperationOptions{})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r MsSqlManagedInstanceResource) basic(data acceptance.TestData) string {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlManagedInstanceSecurityAlertPolicy() *pluginsdk.Resource {
@@ -185,7 +184,7 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyUpdate(d *pluginsdk.Resource
 		}
 	}
 	if d.HasChange("email_account_admins_enabled") {
-		payload.Properties.EmailAccountAdmins = utils.Bool(d.Get("email_account_admins_enabled").(bool))
+		payload.Properties.EmailAccountAdmins = pointer.To(d.Get("email_account_admins_enabled").(bool))
 	}
 
 	if d.HasChange("retention_days") {
@@ -213,7 +212,7 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyUpdate(d *pluginsdk.Resource
 	}
 
 	if d.HasChange("storage_account_access_key") {
-		payload.Properties.StorageAccountAccessKey = utils.String(d.Get("storage_account_access_key").(string))
+		payload.Properties.StorageAccountAccessKey = pointer.To(d.Get("storage_account_access_key").(string))
 	}
 
 	// StorageAccountAccessKey cannot be passed in if it is empty. The api returns this as empty so we need to nil it before sending it back to the api
@@ -222,7 +221,7 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyUpdate(d *pluginsdk.Resource
 	}
 
 	if d.HasChange("storage_endpoint") {
-		payload.Properties.StorageEndpoint = utils.String(d.Get("storage_endpoint").(string))
+		payload.Properties.StorageEndpoint = pointer.To(d.Get("storage_endpoint").(string))
 	}
 
 	// StorageEndpoint cannot be passed in if it is empty. The api returns this as empty so we need to nil it before sending it back to the api
@@ -377,19 +376,19 @@ func expandManagedServerSecurityAlertPolicy(d *pluginsdk.ResourceData) *manageds
 	}
 
 	if v, ok := d.GetOk("email_account_admins_enabled"); ok {
-		props.EmailAccountAdmins = utils.Bool(v.(bool))
+		props.EmailAccountAdmins = pointer.To(v.(bool))
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
-		props.RetentionDays = utils.Int64(int64(v.(int)))
+		props.RetentionDays = pointer.To(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_endpoint"); ok {
-		props.StorageEndpoint = utils.String(v.(string))
+		props.StorageEndpoint = pointer.To(v.(string))
 	}
 
 	return &policy

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceSecurityAlertPolicyResource struct{}
@@ -73,7 +73,7 @@ func (MsSqlManagedInstanceSecurityAlertPolicyResource) Exists(ctx context.Contex
 		return nil, fmt.Errorf("reading SQL Managed Instance Security Alert Policy for server %q (Resource Group %q): %v", id.ManagedInstanceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MsSqlManagedInstanceSecurityAlertPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource {
@@ -182,7 +181,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionCreateUpdate(d *plugin
 	encryptionProtectorProperties := managedinstanceencryptionprotectors.ManagedInstanceEncryptionProtectorProperties{
 		ServerKeyType:       keyType,
 		ServerKeyName:       &managedInstanceKeyName,
-		AutoRotationEnabled: utils.Bool(d.Get("auto_rotation_enabled").(bool)),
+		AutoRotationEnabled: pointer.To(d.Get("auto_rotation_enabled").(bool)),
 	}
 	managedInstanceKeyId := managedinstancekeys.NewManagedInstanceKeyID(managedInstanceId.SubscriptionId, managedInstanceId.ResourceGroupName, managedInstanceId.ManagedInstanceName, managedInstanceKeyName)
 

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceTransparentDataEncryptionResource struct{}
@@ -142,7 +142,7 @@ func (MsSqlManagedInstanceTransparentDataEncryptionResource) Exists(ctx context.
 		return nil, fmt.Errorf("reading Encryption Protector for managed instance %q (Resource Group %q): %v", id.ManagedInstanceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MsSqlManagedInstanceTransparentDataEncryptionResource) keyVaultSystemAssignedIdentity(data acceptance.TestData) string {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_vulnerability_assessment_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_vulnerability_assessment_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/managedinstancevulnerabilityassessments"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceMsSqlManagedInstanceVulnerabilityAssessment() *pluginsdk.Resource {
@@ -116,8 +116,8 @@ func resourceMsSqlManagedInstanceVulnerabilityAssessmentCreate(d *pluginsdk.Reso
 	vulnerabilityAssessment := managedinstancevulnerabilityassessments.ManagedInstanceVulnerabilityAssessment{
 		Properties: &managedinstancevulnerabilityassessments.ManagedInstanceVulnerabilityAssessmentProperties{
 			StorageContainerPath:    d.Get("storage_container_path").(string),
-			StorageAccountAccessKey: utils.String(d.Get("storage_account_access_key").(string)),
-			StorageContainerSasKey:  utils.String(d.Get("storage_container_sas_key").(string)),
+			StorageAccountAccessKey: pointer.To(d.Get("storage_account_access_key").(string)),
+			StorageContainerSasKey:  pointer.To(d.Get("storage_container_sas_key").(string)),
 			RecurringScans:          expandRecurringScans(d),
 		},
 	}
@@ -146,8 +146,8 @@ func resourceMsSqlManagedInstanceVulnerabilityAssessmentUpdate(d *pluginsdk.Reso
 	vulnerabilityAssessment := managedinstancevulnerabilityassessments.ManagedInstanceVulnerabilityAssessment{
 		Properties: &managedinstancevulnerabilityassessments.ManagedInstanceVulnerabilityAssessmentProperties{
 			StorageContainerPath:    d.Get("storage_container_path").(string),
-			StorageAccountAccessKey: utils.String(d.Get("storage_account_access_key").(string)),
-			StorageContainerSasKey:  utils.String(d.Get("storage_container_sas_key").(string)),
+			StorageAccountAccessKey: pointer.To(d.Get("storage_account_access_key").(string)),
+			StorageContainerSasKey:  pointer.To(d.Get("storage_container_sas_key").(string)),
 			RecurringScans:          expandRecurringScans(d),
 		},
 	}
@@ -230,11 +230,11 @@ func expandRecurringScans(d *pluginsdk.ResourceData) *managedinstancevulnerabili
 	v := vs[0].(map[string]interface{})
 
 	if enabled, ok := v["enabled"]; ok {
-		props.IsEnabled = utils.Bool(enabled.(bool))
+		props.IsEnabled = pointer.To(enabled.(bool))
 	}
 
 	if emailSubscriptionAdmins, ok := v["email_subscription_admins"]; ok {
-		props.EmailSubscriptionAdmins = utils.Bool(emailSubscriptionAdmins.(bool))
+		props.EmailSubscriptionAdmins = pointer.To(emailSubscriptionAdmins.(bool))
 	}
 
 	if _, ok := v["emails"]; ok {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_vulnerability_assessment_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_vulnerability_assessment_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssqlmanagedinstance/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MsSqlManagedInstanceVulnerabilityAssessmentResource struct{}
@@ -74,7 +74,7 @@ func (MsSqlManagedInstanceVulnerabilityAssessmentResource) Exists(ctx context.Co
 		return nil, fmt.Errorf("reading %s: %v", id.ID(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MsSqlManagedInstanceVulnerabilityAssessmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_database_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_database_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MySQLFlexibleDatabaseResource struct{}
@@ -94,7 +94,7 @@ func (r MySQLFlexibleDatabaseResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MySQLFlexibleDatabaseResource) basic(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_server_active_directory_administrator_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_active_directory_administrator_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/azureadadministrators"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mysql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MySQLFlexibleServerAdministratorResource struct{}
@@ -84,11 +84,11 @@ func (r MySQLFlexibleServerAdministratorResource) Exists(ctx context.Context, cl
 	resp, err := client.Get(ctx, flexibleServerId)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MySQLFlexibleServerAdministratorResource) template(data acceptance.TestData) string {

--- a/internal/services/mysql/mysql_flexible_server_configuration_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_configuration_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/configurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/servers"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MySQLFlexibleServerConfigurationResource struct{}
@@ -137,7 +137,7 @@ func (t MySQLFlexibleServerConfigurationResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("reading %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r MySQLFlexibleServerConfigurationResource) checkReset(configurationName string) acceptance.ClientCheckFunc {

--- a/internal/services/mysql/mysql_flexible_server_firewall_rule_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_firewall_rule_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/firewallrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MySQLFlexibleServerFirewallRuleResource struct{}
@@ -59,7 +59,7 @@ func (t MySQLFlexibleServerFirewallRuleResource) Exists(ctx context.Context, cli
 		return nil, err
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (MySQLFlexibleServerFirewallRuleResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
