### PR TITLE
services `N*` - deprecated function clean up

### DIFF
--- a/internal/services/netapp/netapp_account_encryption_resource_test.go
+++ b/internal/services/netapp/netapp_account_encryption_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/netappaccounts"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppAccountEncryptionResource struct{}
@@ -96,7 +96,7 @@ func (t NetAppAccountEncryptionResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("reading Netapp Account (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NetAppAccountEncryptionResource) cmkSystemAssigned(data acceptance.TestData, tenantID string) string {

--- a/internal/services/netapp/netapp_account_resource.go
+++ b/internal/services/netapp/netapp_account_resource.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/netappaccounts"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -189,7 +189,7 @@ func resourceNetAppAccountCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	accountParameters := netappaccounts.NetAppAccount{
-		Location:   azure.NormalizeLocation(d.Get("location").(string)),
+		Location:   location.Normalize(d.Get("location").(string)),
 		Properties: &netappaccounts.AccountProperties{},
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -294,7 +294,7 @@ func resourceNetAppAccountRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		if model.Identity != nil {
 			anfAccountIdentity, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
@@ -358,20 +358,20 @@ func expandNetAppActiveDirectories(input []interface{}) *[]netappaccounts.Active
 		dns := strings.Join(*utils.ExpandStringSlice(v["dns_servers"].([]interface{})), ",")
 
 		result := netappaccounts.ActiveDirectory{
-			Dns:                        utils.String(dns),
-			Domain:                     utils.String(v["domain"].(string)),
-			OrganizationalUnit:         utils.String(v["organizational_unit"].(string)),
-			Password:                   utils.String(v["password"].(string)),
-			SmbServerName:              utils.String(v["smb_server_name"].(string)),
-			Username:                   utils.String(v["username"].(string)),
-			Site:                       utils.String(v["site_name"].(string)),
-			AdName:                     utils.String(v["kerberos_ad_name"].(string)),
-			KdcIP:                      utils.String(v["kerberos_kdc_ip"].(string)),
-			AesEncryption:              utils.Bool(v["aes_encryption_enabled"].(bool)),
-			AllowLocalNfsUsersWithLdap: utils.Bool(v["local_nfs_users_with_ldap_allowed"].(bool)),
-			LdapOverTLS:                utils.Bool(v["ldap_over_tls_enabled"].(bool)),
-			ServerRootCACertificate:    utils.String(v["server_root_ca_certificate"].(string)),
-			LdapSigning:                utils.Bool(v["ldap_signing_enabled"].(bool)),
+			Dns:                        pointer.To(dns),
+			Domain:                     pointer.To(v["domain"].(string)),
+			OrganizationalUnit:         pointer.To(v["organizational_unit"].(string)),
+			Password:                   pointer.To(v["password"].(string)),
+			SmbServerName:              pointer.To(v["smb_server_name"].(string)),
+			Username:                   pointer.To(v["username"].(string)),
+			Site:                       pointer.To(v["site_name"].(string)),
+			AdName:                     pointer.To(v["kerberos_ad_name"].(string)),
+			KdcIP:                      pointer.To(v["kerberos_kdc_ip"].(string)),
+			AesEncryption:              pointer.To(v["aes_encryption_enabled"].(bool)),
+			AllowLocalNfsUsersWithLdap: pointer.To(v["local_nfs_users_with_ldap_allowed"].(bool)),
+			LdapOverTLS:                pointer.To(v["ldap_over_tls_enabled"].(bool)),
+			ServerRootCACertificate:    pointer.To(v["server_root_ca_certificate"].(string)),
+			LdapSigning:                pointer.To(v["ldap_signing_enabled"].(bool)),
 		}
 
 		results = append(results, result)

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/netappaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppAccountResource struct{}
@@ -197,7 +197,7 @@ func (t NetAppAccountResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("reading Netapp Account (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NetAppAccountResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_backup_vault_test.go
+++ b/internal/services/netapp/netapp_backup_vault_test.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/backupvaults"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppBackupVaultResource struct{}
@@ -28,12 +28,12 @@ func (t NetAppBackupVaultResource) Exists(ctx context.Context, clients *clients.
 	resp, err := clients.NetApp.BackupVaultsClient.Get(ctx, *id)
 	if err != nil {
 		if resp.HttpResponse.StatusCode == http.StatusNotFound {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccNetAppBackupVault_basic(t *testing.T) {

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -13,16 +13,15 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/capacitypools"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceNetAppPool() *pluginsdk.Resource {
@@ -173,7 +172,7 @@ func resourceNetAppPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	encryptionType := capacitypools.EncryptionType(d.Get("encryption_type").(string))
 
 	capacityPoolParameters := capacitypools.CapacityPool{
-		Location: azure.NormalizeLocation(d.Get("location").(string)),
+		Location: location.Normalize(d.Get("location").(string)),
 		Properties: capacitypools.PoolProperties{
 			ServiceLevel:   capacitypools.ServiceLevel(d.Get("service_level").(string)),
 			Size:           sizeInBytes,
@@ -224,7 +223,7 @@ func resourceNetAppPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		sizeInMB := sizeInTB * 1024 * 1024
 		sizeInBytes := sizeInMB * 1024 * 1024
 
-		update.Properties.Size = utils.Int64(sizeInBytes)
+		update.Properties.Size = pointer.To(sizeInBytes)
 	}
 
 	if d.HasChange("qos_type") {
@@ -284,7 +283,7 @@ func resourceNetAppPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("account_name", id.NetAppAccountName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		poolProperties := model.Properties
 		d.Set("service_level", poolProperties.ServiceLevel)

--- a/internal/services/netapp/netapp_pool_resource_test.go
+++ b/internal/services/netapp/netapp_pool_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/capacitypools"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppPoolResource struct{}
@@ -204,7 +204,7 @@ func (t NetAppPoolResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, fmt.Errorf("reading Netapp Pool (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetAppPoolResource) basic(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_snapshot_policy_resource.go
+++ b/internal/services/netapp/netapp_snapshot_policy_resource.go
@@ -14,11 +14,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/capacitypools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/snapshotpolicies"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/volumes"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -237,14 +237,14 @@ func resourceNetAppSnapshotPolicyCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	parameters := snapshotpolicies.SnapshotPolicy{
-		Location: azure.NormalizeLocation(d.Get("location").(string)),
-		Name:     utils.String(id.SnapshotPolicyName),
+		Location: location.Normalize(d.Get("location").(string)),
+		Name:     pointer.To(id.SnapshotPolicyName),
 		Properties: snapshotpolicies.SnapshotPolicyProperties{
 			HourlySchedule:  expandNetAppSnapshotPolicyHourlySchedule(d.Get("hourly_schedule").([]interface{})),
 			DailySchedule:   expandNetAppSnapshotPolicyDailySchedule(d.Get("daily_schedule").([]interface{})),
 			WeeklySchedule:  expandNetAppSnapshotPolicyWeeklySchedule(d.Get("weekly_schedule").([]interface{})),
 			MonthlySchedule: expandNetAppSnapshotPolicyMonthlySchedule(d.Get("monthly_schedule").([]interface{})),
-			Enabled:         utils.Bool(d.Get("enabled").(bool)),
+			Enabled:         pointer.To(d.Get("enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -275,14 +275,14 @@ func resourceNetAppSnapshotPolicyUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	parameters := snapshotpolicies.SnapshotPolicyPatch{
-		Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
-		Name:     utils.String(id.SnapshotPolicyName),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
+		Name:     pointer.To(id.SnapshotPolicyName),
 		Properties: &snapshotpolicies.SnapshotPolicyProperties{
 			HourlySchedule:  expandNetAppSnapshotPolicyHourlySchedule(d.Get("hourly_schedule").([]interface{})),
 			DailySchedule:   expandNetAppSnapshotPolicyDailySchedule(d.Get("daily_schedule").([]interface{})),
 			WeeklySchedule:  expandNetAppSnapshotPolicyWeeklySchedule(d.Get("weekly_schedule").([]interface{})),
 			MonthlySchedule: expandNetAppSnapshotPolicyMonthlySchedule(d.Get("monthly_schedule").([]interface{})),
-			Enabled:         utils.Bool(d.Get("enabled").(bool)),
+			Enabled:         pointer.To(d.Get("enabled").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -319,7 +319,7 @@ func resourceNetAppSnapshotPolicyRead(d *pluginsdk.ResourceData, meta interface{
 	d.Set("account_name", id.NetAppAccountName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		props := model.Properties
 		d.Set("enabled", props.Enabled)
@@ -469,10 +469,10 @@ func expandNetAppSnapshotPolicyHourlySchedule(input []interface{}) *snapshotpoli
 	hourlyScheduleRaw := input[0].(map[string]interface{})
 
 	if v, ok := hourlyScheduleRaw["snapshots_to_keep"]; ok {
-		hourlyScheduleObject.SnapshotsToKeep = utils.Int64(int64(v.(int)))
+		hourlyScheduleObject.SnapshotsToKeep = pointer.To(int64(v.(int)))
 	}
 	if v, ok := hourlyScheduleRaw["minute"]; ok {
-		hourlyScheduleObject.Minute = utils.Int64(int64(v.(int)))
+		hourlyScheduleObject.Minute = pointer.To(int64(v.(int)))
 	}
 
 	return &hourlyScheduleObject
@@ -488,13 +488,13 @@ func expandNetAppSnapshotPolicyDailySchedule(input []interface{}) *snapshotpolic
 	dailyScheduleRaw := input[0].(map[string]interface{})
 
 	if v, ok := dailyScheduleRaw["snapshots_to_keep"]; ok {
-		dailyScheduleObject.SnapshotsToKeep = utils.Int64(int64(v.(int)))
+		dailyScheduleObject.SnapshotsToKeep = pointer.To(int64(v.(int)))
 	}
 	if v, ok := dailyScheduleRaw["hour"]; ok {
-		dailyScheduleObject.Hour = utils.Int64(int64(v.(int)))
+		dailyScheduleObject.Hour = pointer.To(int64(v.(int)))
 	}
 	if v, ok := dailyScheduleRaw["minute"]; ok {
-		dailyScheduleObject.Minute = utils.Int64(int64(v.(int)))
+		dailyScheduleObject.Minute = pointer.To(int64(v.(int)))
 	}
 
 	return &dailyScheduleObject
@@ -510,16 +510,16 @@ func expandNetAppSnapshotPolicyWeeklySchedule(input []interface{}) *snapshotpoli
 	weeklyScheduleRaw := input[0].(map[string]interface{})
 
 	if v, ok := weeklyScheduleRaw["snapshots_to_keep"]; ok {
-		weeklyScheduleObject.SnapshotsToKeep = utils.Int64(int64(v.(int)))
+		weeklyScheduleObject.SnapshotsToKeep = pointer.To(int64(v.(int)))
 	}
 	if _, ok := weeklyScheduleRaw["days_of_week"]; ok {
 		weeklyScheduleObject.Day = utils.ExpandStringSliceWithDelimiter(weeklyScheduleRaw["days_of_week"].(*pluginsdk.Set).List(), ",")
 	}
 	if v, ok := weeklyScheduleRaw["hour"]; ok {
-		weeklyScheduleObject.Hour = utils.Int64(int64(v.(int)))
+		weeklyScheduleObject.Hour = pointer.To(int64(v.(int)))
 	}
 	if v, ok := weeklyScheduleRaw["minute"]; ok {
-		weeklyScheduleObject.Minute = utils.Int64(int64(v.(int)))
+		weeklyScheduleObject.Minute = pointer.To(int64(v.(int)))
 	}
 
 	return &weeklyScheduleObject
@@ -535,16 +535,16 @@ func expandNetAppSnapshotPolicyMonthlySchedule(input []interface{}) *snapshotpol
 	monthlyScheduleRaw := input[0].(map[string]interface{})
 
 	if v, ok := monthlyScheduleRaw["snapshots_to_keep"]; ok {
-		monthlyScheduleObject.SnapshotsToKeep = utils.Int64(int64(v.(int)))
+		monthlyScheduleObject.SnapshotsToKeep = pointer.To(int64(v.(int)))
 	}
 	if _, ok := monthlyScheduleRaw["days_of_month"]; ok {
 		monthlyScheduleObject.DaysOfMonth = utils.ExpandIntSliceWithDelimiter(monthlyScheduleRaw["days_of_month"].(*pluginsdk.Set).List(), ",")
 	}
 	if v, ok := monthlyScheduleRaw["hour"]; ok {
-		monthlyScheduleObject.Hour = utils.Int64(int64(v.(int)))
+		monthlyScheduleObject.Hour = pointer.To(int64(v.(int)))
 	}
 	if v, ok := monthlyScheduleRaw["minute"]; ok {
-		monthlyScheduleObject.Minute = utils.Int64(int64(v.(int)))
+		monthlyScheduleObject.Minute = pointer.To(int64(v.(int)))
 	}
 
 	return &monthlyScheduleObject

--- a/internal/services/netapp/netapp_snapshot_policy_resource_test.go
+++ b/internal/services/netapp/netapp_snapshot_policy_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/snapshotpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppSnapshotPolicyResource struct{}
@@ -169,7 +169,7 @@ func (t NetAppSnapshotPolicyResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("reading Netapp SnapshotPolicy (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetAppSnapshotPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/snapshots"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
@@ -92,7 +92,7 @@ func resourceNetAppSnapshotCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 
 	parameters := snapshots.Snapshot{
 		Location: location,
@@ -133,7 +133,7 @@ func resourceNetAppSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("volume_name", id.VolumeName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 	}
 
 	return nil

--- a/internal/services/netapp/netapp_snapshot_resource_test.go
+++ b/internal/services/netapp/netapp_snapshot_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/snapshots"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppSnapshotResource struct{}
@@ -77,7 +77,7 @@ func (t NetAppSnapshotResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NetAppSnapshotResource) basic(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_volume_group_oracle_resource.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource.go
@@ -23,7 +23,6 @@ import (
 	netAppValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppVolumeGroupOracleResource struct{}
@@ -403,12 +402,12 @@ func (r NetAppVolumeGroupOracleResource) Create() sdk.ResourceFunc {
 			}
 
 			parameters := volumegroups.VolumeGroupDetails{
-				Location: utils.String(location.Normalize(model.Location)),
+				Location: pointer.To(location.Normalize(model.Location)),
 				Properties: &volumegroups.VolumeGroupProperties{
 					GroupMetaData: &volumegroups.VolumeGroupMetaData{
-						GroupDescription:      utils.String(model.GroupDescription),
+						GroupDescription:      pointer.To(model.GroupDescription),
 						ApplicationType:       pointer.To(volumegroups.ApplicationTypeORACLE),
-						ApplicationIdentifier: utils.String(model.ApplicationIdentifier),
+						ApplicationIdentifier: pointer.To(model.ApplicationIdentifier),
 					},
 					Volumes: volumeList,
 				},
@@ -477,7 +476,7 @@ func (r NetAppVolumeGroupOracleResource) Update() sdk.ResourceFunc {
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.storage_quota_in_gb", volumeItem)) {
 							storageQuotaInBytes := int64(metadata.ResourceData.Get(fmt.Sprintf("%v.storage_quota_in_gb", volumeItem)).(int) * 1073741824)
-							update.Properties.UsageThreshold = utils.Int64(storageQuotaInBytes)
+							update.Properties.UsageThreshold = pointer.To(storageQuotaInBytes)
 						}
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.export_policy_rule", volumeItem)) {
@@ -493,8 +492,8 @@ func (r NetAppVolumeGroupOracleResource) Update() sdk.ResourceFunc {
 									rule := volumegroups.ExportPolicyRule{}
 
 									v := ruleRaw.(map[string]interface{})
-									rule.Nfsv3 = utils.Bool(v["nfsv3_enabled"].(bool))
-									rule.Nfsv41 = utils.Bool(v["nfsv41_enabled"].(bool))
+									rule.Nfsv3 = pointer.To(v["nfsv3_enabled"].(bool))
+									rule.Nfsv41 = pointer.To(v["nfsv41_enabled"].(bool))
 
 									errors = append(errors, netAppValidate.ValidateNetAppVolumeGroupExportPolicyRule(rule, volumeProtocol)...)
 								}
@@ -546,7 +545,7 @@ func (r NetAppVolumeGroupOracleResource) Update() sdk.ResourceFunc {
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.throughput_in_mibps", volumeItem)) {
 							throughputMibps := metadata.ResourceData.Get(fmt.Sprintf("%v.throughput_in_mibps", volumeItem))
-							update.Properties.ThroughputMibps = utils.Float(throughputMibps.(float64))
+							update.Properties.ThroughputMibps = pointer.To(throughputMibps.(float64))
 						}
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.tags", volumeItem)) {

--- a/internal/services/netapp/netapp_volume_group_oracle_resource_test.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/volumegroups"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppVolumeGroupOracleResource struct{}
@@ -234,12 +234,12 @@ func (t NetAppVolumeGroupOracleResource) Exists(ctx context.Context, clients *cl
 	resp, err := clients.NetApp.VolumeGroupClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (NetAppVolumeGroupOracleResource) basicAvailabilityZone(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
@@ -23,7 +23,6 @@ import (
 	netAppValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppVolumeGroupSAPHanaResource struct{}
@@ -396,12 +395,12 @@ func (r NetAppVolumeGroupSAPHanaResource) Create() sdk.ResourceFunc {
 			}
 
 			parameters := volumegroups.VolumeGroupDetails{
-				Location: utils.String(location.Normalize(model.Location)),
+				Location: pointer.To(location.Normalize(model.Location)),
 				Properties: &volumegroups.VolumeGroupProperties{
 					GroupMetaData: &volumegroups.VolumeGroupMetaData{
-						GroupDescription:      utils.String(model.GroupDescription),
+						GroupDescription:      pointer.To(model.GroupDescription),
 						ApplicationType:       pointer.To(volumegroups.ApplicationTypeSAPNegativeHANA),
-						ApplicationIdentifier: utils.String(model.ApplicationIdentifier),
+						ApplicationIdentifier: pointer.To(model.ApplicationIdentifier),
 					},
 					Volumes: volumeList,
 				},
@@ -471,7 +470,7 @@ func (r NetAppVolumeGroupSAPHanaResource) Update() sdk.ResourceFunc {
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.storage_quota_in_gb", volumeItem)) {
 							storageQuotaInBytes := int64(metadata.ResourceData.Get(fmt.Sprintf("%v.storage_quota_in_gb", volumeItem)).(int) * 1073741824)
-							update.Properties.UsageThreshold = utils.Int64(storageQuotaInBytes)
+							update.Properties.UsageThreshold = pointer.To(storageQuotaInBytes)
 						}
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.export_policy_rule", volumeItem)) {
@@ -487,8 +486,8 @@ func (r NetAppVolumeGroupSAPHanaResource) Update() sdk.ResourceFunc {
 									rule := volumegroups.ExportPolicyRule{}
 
 									v := ruleRaw.(map[string]interface{})
-									rule.Nfsv3 = utils.Bool(v["nfsv3_enabled"].(bool))
-									rule.Nfsv41 = utils.Bool(v["nfsv41_enabled"].(bool))
+									rule.Nfsv3 = pointer.To(v["nfsv3_enabled"].(bool))
+									rule.Nfsv41 = pointer.To(v["nfsv41_enabled"].(bool))
 
 									errors = append(errors, netAppValidate.ValidateNetAppVolumeGroupExportPolicyRule(rule, volumeProtocol)...)
 								}
@@ -540,7 +539,7 @@ func (r NetAppVolumeGroupSAPHanaResource) Update() sdk.ResourceFunc {
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.throughput_in_mibps", volumeItem)) {
 							throughputMibps := metadata.ResourceData.Get(fmt.Sprintf("%v.throughput_in_mibps", volumeItem))
-							update.Properties.ThroughputMibps = utils.Float(throughputMibps.(float64))
+							update.Properties.ThroughputMibps = pointer.To(throughputMibps.(float64))
 						}
 
 						if metadata.ResourceData.HasChange(fmt.Sprintf("%v.tags", volumeItem)) {

--- a/internal/services/netapp/netapp_volume_helper.go
+++ b/internal/services/netapp/netapp_volume_helper.go
@@ -42,20 +42,20 @@ func expandNetAppVolumeGroupVolumeExportPolicyRule(input []netAppModels.ExportPo
 		kerberos5pReadWrite := false
 
 		result := volumegroups.ExportPolicyRule{
-			AllowedClients:      utils.String(item.AllowedClients),
-			Cifs:                utils.Bool(cifsEnabled),
-			Nfsv3:               utils.Bool(item.Nfsv3Enabled),
-			Nfsv41:              utils.Bool(item.Nfsv41Enabled),
-			RuleIndex:           utils.Int64(item.RuleIndex),
-			UnixReadOnly:        utils.Bool(item.UnixReadOnly),
-			UnixReadWrite:       utils.Bool(item.UnixReadWrite),
-			HasRootAccess:       utils.Bool(item.RootAccessEnabled),
-			Kerberos5ReadOnly:   utils.Bool(kerberos5ReadOnly),
-			Kerberos5ReadWrite:  utils.Bool(kerberos5ReadWrite),
-			Kerberos5iReadOnly:  utils.Bool(kerberos5iReadOnly),
-			Kerberos5iReadWrite: utils.Bool(kerberos5iReadWrite),
-			Kerberos5pReadOnly:  utils.Bool(kerberos5pReadOnly),
-			Kerberos5pReadWrite: utils.Bool(kerberos5pReadWrite),
+			AllowedClients:      pointer.To(item.AllowedClients),
+			Cifs:                pointer.To(cifsEnabled),
+			Nfsv3:               pointer.To(item.Nfsv3Enabled),
+			Nfsv41:              pointer.To(item.Nfsv41Enabled),
+			RuleIndex:           pointer.To(item.RuleIndex),
+			UnixReadOnly:        pointer.To(item.UnixReadOnly),
+			UnixReadWrite:       pointer.To(item.UnixReadWrite),
+			HasRootAccess:       pointer.To(item.RootAccessEnabled),
+			Kerberos5ReadOnly:   pointer.To(kerberos5ReadOnly),
+			Kerberos5ReadWrite:  pointer.To(kerberos5ReadWrite),
+			Kerberos5iReadOnly:  pointer.To(kerberos5iReadOnly),
+			Kerberos5iReadWrite: pointer.To(kerberos5iReadWrite),
+			Kerberos5pReadOnly:  pointer.To(kerberos5pReadOnly),
+			Kerberos5pReadWrite: pointer.To(kerberos5pReadWrite),
 		}
 
 		results = append(results, result)
@@ -130,9 +130,9 @@ func expandNetAppVolumeGroupSAPHanaVolumes(input []netAppModels.NetAppVolumeGrou
 		}
 
 		volumeProperties := &volumegroups.VolumeGroupVolumeProperties{
-			Name: utils.String(name),
+			Name: pointer.To(name),
 			Properties: volumegroups.VolumeProperties{
-				CapacityPoolResourceId:   utils.String(capacityPoolID),
+				CapacityPoolResourceId:   pointer.To(capacityPoolID),
 				CreationToken:            volumePath,
 				ServiceLevel:             &serviceLevel,
 				SubnetId:                 subnetID,
@@ -140,9 +140,9 @@ func expandNetAppVolumeGroupSAPHanaVolumes(input []netAppModels.NetAppVolumeGrou
 				SecurityStyle:            &securityStyle,
 				UsageThreshold:           storageQuotaInGB,
 				ExportPolicy:             exportPolicyRule,
-				SnapshotDirectoryVisible: utils.Bool(snapshotDirectoryVisible),
-				ThroughputMibps:          utils.Float(item.ThroughputInMibps),
-				VolumeSpecName:           utils.String(item.VolumeSpecName),
+				SnapshotDirectoryVisible: pointer.To(snapshotDirectoryVisible),
+				ThroughputMibps:          pointer.To(item.ThroughputInMibps),
+				VolumeSpecName:           pointer.To(item.VolumeSpecName),
 				DataProtection:           dataProtection,
 			},
 			Tags: &item.Tags,
@@ -156,7 +156,7 @@ func expandNetAppVolumeGroupSAPHanaVolumes(input []netAppModels.NetAppVolumeGrou
 			dataProtectionReplication.Replication != nil &&
 			dataProtectionReplication.Replication.EndpointType != nil &&
 			strings.EqualFold(string(pointer.From(dataProtectionReplication.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-			volumeProperties.Properties.VolumeType = utils.String("DataProtection")
+			volumeProperties.Properties.VolumeType = pointer.To("DataProtection")
 		}
 
 		results = append(results, *volumeProperties)
@@ -198,8 +198,8 @@ func expandNetAppVolumeGroupOracleVolumes(input []netAppModels.NetAppVolumeGroup
 				UsageThreshold:           storageQuotaInGB,
 				ExportPolicy:             expandNetAppVolumeGroupVolumeExportPolicyRule(item.ExportPolicy),
 				SnapshotDirectoryVisible: pointer.To(item.SnapshotDirectoryVisible),
-				ThroughputMibps:          utils.Float(item.ThroughputInMibps),
-				VolumeSpecName:           utils.String(item.VolumeSpecName),
+				ThroughputMibps:          pointer.To(item.ThroughputInMibps),
+				VolumeSpecName:           pointer.To(item.VolumeSpecName),
 				NetworkFeatures:          pointer.To(volumegroups.NetworkFeatures(item.NetworkFeatures)),
 				DataProtection:           dataProtection,
 			},
@@ -225,7 +225,7 @@ func expandNetAppVolumeGroupOracleVolumes(input []netAppModels.NetAppVolumeGroup
 		if dataProtectionReplication != nil && dataProtectionReplication.Replication != nil &&
 			dataProtectionReplication.Replication.EndpointType != nil &&
 			strings.EqualFold(string(pointer.From(dataProtectionReplication.Replication.EndpointType)), string(volumegroups.EndpointTypeDst)) {
-			volumeProperties.Properties.VolumeType = utils.String("DataProtection")
+			volumeProperties.Properties.VolumeType = pointer.To("DataProtection")
 		}
 
 		results = append(results, *volumeProperties)
@@ -285,20 +285,20 @@ func expandNetAppVolumeGroupVolumeExportPolicyRulePatchWithProtocolConversion(in
 			}
 
 			result := volumes.ExportPolicyRule{
-				AllowedClients:      utils.String(allowedClients),
-				Cifs:                utils.Bool(cifsEnabled),
-				Nfsv3:               utils.Bool(nfsv3Enabled),
-				Nfsv41:              utils.Bool(nfsv41Enabled),
-				RuleIndex:           utils.Int64(ruleIndex),
-				UnixReadOnly:        utils.Bool(unixReadOnly),
-				UnixReadWrite:       utils.Bool(unixReadWrite),
-				HasRootAccess:       utils.Bool(rootAccessEnabled),
-				Kerberos5ReadOnly:   utils.Bool(kerberos5ReadOnly),
-				Kerberos5ReadWrite:  utils.Bool(kerberos5ReadWrite),
-				Kerberos5iReadOnly:  utils.Bool(kerberos5iReadOnly),
-				Kerberos5iReadWrite: utils.Bool(kerberos5iReadWrite),
-				Kerberos5pReadOnly:  utils.Bool(kerberos5pReadOnly),
-				Kerberos5pReadWrite: utils.Bool(kerberos5pReadWrite),
+				AllowedClients:      pointer.To(allowedClients),
+				Cifs:                pointer.To(cifsEnabled),
+				Nfsv3:               pointer.To(nfsv3Enabled),
+				Nfsv41:              pointer.To(nfsv41Enabled),
+				RuleIndex:           pointer.To(ruleIndex),
+				UnixReadOnly:        pointer.To(unixReadOnly),
+				UnixReadWrite:       pointer.To(unixReadWrite),
+				HasRootAccess:       pointer.To(rootAccessEnabled),
+				Kerberos5ReadOnly:   pointer.To(kerberos5ReadOnly),
+				Kerberos5ReadWrite:  pointer.To(kerberos5ReadWrite),
+				Kerberos5iReadOnly:  pointer.To(kerberos5iReadOnly),
+				Kerberos5iReadWrite: pointer.To(kerberos5iReadWrite),
+				Kerberos5pReadOnly:  pointer.To(kerberos5pReadOnly),
+				Kerberos5pReadWrite: pointer.To(kerberos5pReadWrite),
 			}
 
 			results = append(results, result)
@@ -324,7 +324,7 @@ func expandNetAppVolumeDataProtectionReplication(input []interface{}) *volumes.V
 		replicationObject.EndpointType = pointer.To(endpointType)
 	}
 	if v, ok := replicationRaw["remote_volume_location"]; ok {
-		replicationObject.RemoteVolumeRegion = utils.String(v.(string))
+		replicationObject.RemoteVolumeRegion = pointer.To(v.(string))
 	}
 	if v, ok := replicationRaw["remote_volume_resource_id"]; ok {
 		replicationObject.RemoteVolumeResourceId = pointer.To(v.(string))
@@ -349,7 +349,7 @@ func expandNetAppVolumeDataProtectionSnapshotPolicy(input []interface{}) *volume
 	snapshotRaw := input[0].(map[string]interface{})
 
 	if v, ok := snapshotRaw["snapshot_policy_id"]; ok {
-		snapshotObject.SnapshotPolicyId = utils.String(v.(string))
+		snapshotObject.SnapshotPolicyId = pointer.To(v.(string))
 	}
 
 	return &volumes.VolumePropertiesDataProtection{
@@ -371,7 +371,7 @@ func expandNetAppVolumeDataProtectionSnapshotPolicyPatch(input []interface{}) *v
 	snapshotRaw := input[0].(map[string]interface{})
 
 	if v, ok := snapshotRaw["snapshot_policy_id"]; ok {
-		snapshotObject.SnapshotPolicyId = utils.String(v.(string))
+		snapshotObject.SnapshotPolicyId = pointer.To(v.(string))
 	}
 
 	return &volumes.VolumePatchPropertiesDataProtection{
@@ -389,15 +389,15 @@ func expandNetAppVolumeDataProtectionBackupPolicy(input []interface{}) *volumes.
 	backupRaw := input[0].(map[string]interface{})
 
 	if v, ok := backupRaw["backup_policy_id"]; ok {
-		backupPolicyObject.BackupPolicyId = utils.String(v.(string))
+		backupPolicyObject.BackupPolicyId = pointer.To(v.(string))
 	}
 
 	if v, ok := backupRaw["policy_enabled"]; ok {
-		backupPolicyObject.PolicyEnforced = utils.Bool(v.(bool))
+		backupPolicyObject.PolicyEnforced = pointer.To(v.(bool))
 	}
 
 	if v, ok := backupRaw["backup_vault_id"]; ok {
-		backupPolicyObject.BackupVaultId = utils.String(v.(string))
+		backupPolicyObject.BackupVaultId = pointer.To(v.(string))
 	}
 
 	return &volumes.VolumePropertiesDataProtection{
@@ -415,15 +415,15 @@ func expandNetAppVolumeDataProtectionBackupPolicyPatch(input []interface{}) *vol
 	backupRaw := input[0].(map[string]interface{})
 
 	if v, ok := backupRaw["backup_policy_id"]; ok {
-		backupPolicyObject.BackupPolicyId = utils.String(v.(string))
+		backupPolicyObject.BackupPolicyId = pointer.To(v.(string))
 	}
 
 	if v, ok := backupRaw["policy_enabled"]; ok {
-		backupPolicyObject.PolicyEnforced = utils.Bool(v.(bool))
+		backupPolicyObject.PolicyEnforced = pointer.To(v.(bool))
 	}
 
 	if v, ok := backupRaw["backup_vault_id"]; ok {
-		backupPolicyObject.BackupVaultId = utils.String(v.(string))
+		backupPolicyObject.BackupVaultId = pointer.To(v.(string))
 	}
 
 	return &volumes.VolumePatchPropertiesDataProtection{
@@ -715,7 +715,7 @@ func deleteVolume(ctx context.Context, metadata sdk.ResourceMetaData, volumeId s
 
 			// Breaking replication
 			if err = client.BreakReplicationThenPoll(ctx, pointer.From(replicaVolumeId), volumes.BreakReplicationRequest{
-				ForceBreakReplication: utils.Bool(true),
+				ForceBreakReplication: pointer.To(true),
 			}); err != nil {
 				return fmt.Errorf("breaking replication for %s: %+v", pointer.From(replicaVolumeId), err)
 			}
@@ -764,7 +764,7 @@ func deleteVolume(ctx context.Context, metadata sdk.ResourceMetaData, volumeId s
 	// Deleting volume and waiting for it to fully complete the operation
 	log.Printf("[INFO] Deleting volume %s", id.String())
 	if err = client.DeleteThenPoll(ctx, pointer.From(id), volumes.DeleteOperationOptions{
-		ForceDelete: utils.Bool(true),
+		ForceDelete: pointer.To(true),
 	}); err != nil {
 		return fmt.Errorf("deleting %s: %+v", pointer.From(id), err)
 	}
@@ -1133,7 +1133,7 @@ func authorizeVolumeReplication(ctx context.Context, volumeList *[]volumegroups.
 
 				// Authorizing
 				if err := client.AuthorizeReplicationThenPoll(ctx, pointer.From(primaryId), volumes.AuthorizeRequest{
-					RemoteVolumeResourceId: utils.String(secondaryId.ID()),
+					RemoteVolumeResourceId: pointer.To(secondaryId.ID()),
 				}); err != nil {
 					return fmt.Errorf("authorizing volume replication for volume %q: %+v", secondaryId.ID(), err)
 				}

--- a/internal/services/netapp/netapp_volume_quota_rule_resource.go
+++ b/internal/services/netapp/netapp_volume_quota_rule_resource.go
@@ -20,7 +20,6 @@ import (
 	netAppValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/netapp/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppVolumeQuotaRuleResource struct{}
@@ -124,7 +123,7 @@ func (r NetAppVolumeQuotaRuleResource) Create() sdk.ResourceFunc {
 				Properties: &volumequotarules.VolumeQuotaRulesProperties{
 					QuotaSizeInKiBs: pointer.To(model.QuotaSizeInKiB),
 					QuotaType:       pointer.To(volumequotarules.Type(model.QuotaType)),
-					QuotaTarget:     utils.String(model.QuotaTarget),
+					QuotaTarget:     pointer.To(model.QuotaTarget),
 				},
 			}
 
@@ -168,7 +167,7 @@ func (r NetAppVolumeQuotaRuleResource) Update() sdk.ResourceFunc {
 					Properties: &volumequotarules.VolumeQuotaRulesProperties{},
 				}
 
-				update.Properties.QuotaSizeInKiBs = utils.Int64(state.QuotaSizeInKiB)
+				update.Properties.QuotaSizeInKiBs = pointer.To(state.QuotaSizeInKiB)
 
 				if err := client.UpdateThenPoll(ctx, pointer.From(id), update); err != nil {
 					return fmt.Errorf("updating %s: %+v", id, err)

--- a/internal/services/netapp/netapp_volume_quota_rule_resource_test.go
+++ b/internal/services/netapp/netapp_volume_quota_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/volumequotarules"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetAppVolumeQuotaRuleResource struct{}
@@ -88,12 +88,12 @@ func (t NetAppVolumeQuotaRuleResource) Exists(ctx context.Context, clients *clie
 	resp, err := clients.NetApp.VolumeQuotaRules.Get(ctx, *id)
 	if err != nil {
 		if resp.HttpResponse.StatusCode == http.StatusNotFound {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (NetAppVolumeQuotaRuleResource) individualGroupQuotaType(data acceptance.TestData) string {

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -547,7 +547,7 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 				currentLocation := d.Get("location").(string)
 
 				// Check if this is cross-zone replication (same region)
-				if strings.EqualFold(azure.NormalizeLocation(remoteVolumeLocation), azure.NormalizeLocation(currentLocation)) {
+				if strings.EqualFold(location.Normalize(remoteVolumeLocation), location.Normalize(currentLocation)) {
 					// Cross-zone replication: both source and destination must have zones assigned
 					zone := d.Get("zone").(string)
 					if zone == "" {
@@ -619,7 +619,7 @@ func resourceNetAppVolumeCreate(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 
 	zones := &[]string{}
 	if v, ok := d.GetOk("zone"); ok {
@@ -1060,7 +1060,7 @@ func resourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) error
 	d.Set("pool_name", id.CapacityPoolName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		zone := ""
 		if model.Zones != nil {

--- a/internal/services/netapp/validate/volume_group_oracle_volumes_export_policy_validation_test.go
+++ b/internal/services/netapp/validate/volume_group_oracle_volumes_export_policy_validation_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/volumegroups"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
@@ -32,7 +31,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 0,
 		},
@@ -41,7 +40,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 2,
 		},
@@ -50,7 +49,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 2,
 		},
@@ -59,7 +58,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 1,
 		},
@@ -68,7 +67,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 1,
 		},
@@ -77,7 +76,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 1,
 		},
@@ -86,7 +85,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleOracle(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 1,
 		},

--- a/internal/services/netapp/validate/volume_group_sap_hana_volumes_export_policy_validation_test.go
+++ b/internal/services/netapp/validate/volume_group_sap_hana_volumes_export_policy_validation_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2025-06-01/volumegroups"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
@@ -23,7 +22,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 0,
 		},
@@ -32,7 +31,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 0,
 		},
@@ -41,7 +40,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 2,
 		},
@@ -50,7 +49,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 2,
 		},
@@ -59,7 +58,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 1,
 		},
@@ -68,7 +67,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 1,
 		},
@@ -77,7 +76,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV41),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(true),
-				Nfsv41: utils.Bool(false),
+				Nfsv41: pointer.To(false),
 			},
 			Errors: 1,
 		},
@@ -86,7 +85,7 @@ func TestValidateNetAppVolumeGroupExportPolicyRuleSAPHana(t *testing.T) {
 			Protocol: string(ProtocolTypeNfsV3),
 			Rule: volumegroups.ExportPolicyRule{
 				Nfsv3:  pointer.To(false),
-				Nfsv41: utils.Bool(true),
+				Nfsv41: pointer.To(true),
 			},
 			Errors: 1,
 		},

--- a/internal/services/network/application_security_group_resource_test.go
+++ b/internal/services/network/application_security_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/applicationsecuritygroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ApplicationSecurityGroupResource struct{}
@@ -101,7 +101,7 @@ func (t ApplicationSecurityGroupResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ApplicationSecurityGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/bastion_host_data_source.go
+++ b/internal/services/network/bastion_host_data_source.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-01-01/bastionhosts"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -127,8 +127,8 @@ func dataSourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if model := resp.Model; model != nil {
-		if location := model.Location; location != nil {
-			d.Set("location", azure.NormalizeLocation(*location))
+		if loc := model.Location; loc != nil {
+			d.Set("location", location.Normalize(*loc))
 		}
 
 		skuName := ""

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2024-01-01/bastionhosts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BastionHostResource struct{}
@@ -165,7 +165,7 @@ func (BastionHostResource) Exists(ctx context.Context, clients *clients.Client, 
 		return nil, fmt.Errorf("reading Bastion Host (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BastionHostResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var expressRouteCircuitResourceName = "azurerm_express_route_circuit"
@@ -224,7 +223,7 @@ func resourceExpressRouteCircuitCreate(d *pluginsdk.ResourceData, meta interface
 		erc.Properties.ServiceProviderProperties.BandwidthInMbps = pointer.To(int64(d.Get("bandwidth_in_mbps").(int)))
 	} else {
 		erc.Properties.ExpressRoutePort.Id = pointer.To(d.Get("express_route_port_id").(string))
-		erc.Properties.BandwidthInGbps = utils.Float(d.Get("bandwidth_in_gbps").(float64))
+		erc.Properties.BandwidthInGbps = pointer.To(d.Get("bandwidth_in_gbps").(float64))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, erc); err != nil {

--- a/internal/services/network/network_connection_monitor_resource.go
+++ b/internal/services/network/network_connection_monitor_resource.go
@@ -578,8 +578,8 @@ func resourceNetworkConnectionMonitorRead(d *pluginsdk.ResourceData, meta interf
 		networkWatcherId := networkwatchers.NewNetworkWatcherID(id.SubscriptionId, id.ResourceGroupName, id.NetworkWatcherName)
 		d.Set("network_watcher_id", networkWatcherId.ID())
 
-		if location := model.Location; location != nil {
-			d.Set("location", azure.NormalizeLocation(*location))
+		if loc := model.Location; loc != nil {
+			d.Set("location", location.Normalize(*loc))
 		}
 
 		if props := model.Properties; props != nil {
@@ -737,7 +737,7 @@ func expandNetworkConnectionMonitorTestConfiguration(input []interface{}) *[]con
 			Protocol:          connectionmonitors.ConnectionMonitorTestConfigurationProtocol(v["protocol"].(string)),
 			SuccessThreshold:  expandNetworkConnectionMonitorSuccessThreshold(v["success_threshold"].([]interface{})),
 			TcpConfiguration:  expandNetworkConnectionMonitorTCPConfiguration(v["tcp_configuration"].([]interface{})),
-			TestFrequencySec:  utils.Int64(int64(v["test_frequency_in_seconds"].(int))),
+			TestFrequencySec:  pointer.To(int64(v["test_frequency_in_seconds"].(int))),
 		}
 
 		if preferredIPVersion := v["preferred_ip_version"]; preferredIPVersion != "" {
@@ -759,7 +759,7 @@ func expandNetworkConnectionMonitorHTTPConfiguration(input []interface{}) *conne
 
 	props := &connectionmonitors.ConnectionMonitorHTTPConfiguration{
 		Method:         pointer.To(connectionmonitors.HTTPConfigurationMethod(v["method"].(string))),
-		PreferHTTPS:    utils.Bool(v["prefer_https"].(bool)),
+		PreferHTTPS:    pointer.To(v["prefer_https"].(bool)),
 		RequestHeaders: expandNetworkConnectionMonitorHTTPHeader(v["request_header"].(*pluginsdk.Set).List()),
 	}
 
@@ -768,7 +768,7 @@ func expandNetworkConnectionMonitorHTTPConfiguration(input []interface{}) *conne
 	}
 
 	if port := v["port"]; port != 0 {
-		props.Port = utils.Int64(int64(port.(int)))
+		props.Port = pointer.To(int64(port.(int)))
 	}
 
 	if ranges := v["valid_status_code_ranges"].(*pluginsdk.Set).List(); len(ranges) != 0 {
@@ -786,8 +786,8 @@ func expandNetworkConnectionMonitorTCPConfiguration(input []interface{}) *connec
 	v := input[0].(map[string]interface{})
 
 	result := &connectionmonitors.ConnectionMonitorTcpConfiguration{
-		Port:              utils.Int64(int64(v["port"].(int))),
-		DisableTraceRoute: utils.Bool(!v["trace_route_enabled"].(bool)),
+		Port:              pointer.To(int64(v["port"].(int))),
+		DisableTraceRoute: pointer.To(!v["trace_route_enabled"].(bool)),
 	}
 
 	if destinationPortBehavior := v["destination_port_behavior"].(string); destinationPortBehavior != "" {
@@ -805,7 +805,7 @@ func expandNetworkConnectionMonitorIcmpConfiguration(input []interface{}) *conne
 	v := input[0].(map[string]interface{})
 
 	return &connectionmonitors.ConnectionMonitorIcmpConfiguration{
-		DisableTraceRoute: utils.Bool(!v["trace_route_enabled"].(bool)),
+		DisableTraceRoute: pointer.To(!v["trace_route_enabled"].(bool)),
 	}
 }
 
@@ -817,8 +817,8 @@ func expandNetworkConnectionMonitorSuccessThreshold(input []interface{}) *connec
 	v := input[0].(map[string]interface{})
 
 	return &connectionmonitors.ConnectionMonitorSuccessThreshold{
-		ChecksFailedPercent: utils.Int64(int64(v["checks_failed_percent"].(int))),
-		RoundTripTimeMs:     utils.Float(v["round_trip_time_ms"].(float64)),
+		ChecksFailedPercent: pointer.To(int64(v["checks_failed_percent"].(int))),
+		RoundTripTimeMs:     pointer.To(v["round_trip_time_ms"].(float64)),
 	}
 }
 
@@ -852,7 +852,7 @@ func expandNetworkConnectionMonitorTestGroup(input []interface{}) *[]connectionm
 		result := connectionmonitors.ConnectionMonitorTestGroup{
 			Name:               v["name"].(string),
 			Destinations:       *utils.ExpandStringSlice(v["destination_endpoints"].(*pluginsdk.Set).List()),
-			Disable:            utils.Bool(!v["enabled"].(bool)),
+			Disable:            pointer.To(!v["enabled"].(bool)),
 			Sources:            *utils.ExpandStringSlice(v["source_endpoints"].(*pluginsdk.Set).List()),
 			TestConfigurations: *utils.ExpandStringSlice(v["test_configuration_names"].(*pluginsdk.Set).List()),
 		}

--- a/internal/services/network/network_connection_monitor_resource_test.go
+++ b/internal/services/network/network_connection_monitor_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/connectionmonitors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkConnectionMonitorResource struct{}
@@ -279,7 +279,7 @@ func (t NetworkConnectionMonitorResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading Network Connection Monitor (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkConnectionMonitorResource) baseConfig(data acceptance.TestData) string {

--- a/internal/services/network/network_ddos_protection_plan_resource_test.go
+++ b/internal/services/network/network_ddos_protection_plan_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/ddosprotectionplans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkDDoSProtectionPlanResource struct{}
@@ -114,7 +114,7 @@ func (t NetworkDDoSProtectionPlanResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkDDoSProtectionPlanResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -127,7 +127,7 @@ func (NetworkDDoSProtectionPlanResource) Destroy(ctx context.Context, client *cl
 		return nil, fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (NetworkDDoSProtectionPlanResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -4,8 +4,8 @@
 package network
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkinterfaces"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type networkInterfaceUpdateInformation struct {
@@ -93,21 +93,21 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 	applicationSecurityGroups := make([]networkinterfaces.ApplicationSecurityGroup, 0)
 	for _, id := range info.applicationSecurityGroupIDs {
 		applicationSecurityGroups = append(applicationSecurityGroups, networkinterfaces.ApplicationSecurityGroup{
-			Id: utils.String(id),
+			Id: pointer.To(id),
 		})
 	}
 
 	applicationGatewayBackendAddressPools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
 	for _, id := range info.applicationGatewayBackendAddressPoolIDs {
 		applicationGatewayBackendAddressPools = append(applicationGatewayBackendAddressPools, networkinterfaces.ApplicationGatewayBackendAddressPool{
-			Id: utils.String(id),
+			Id: pointer.To(id),
 		})
 	}
 
 	loadBalancerInboundNatRules := make([]networkinterfaces.InboundNatRule, 0)
 	for _, id := range info.loadBalancerInboundNatRuleIDs {
 		loadBalancerInboundNatRules = append(loadBalancerInboundNatRules, networkinterfaces.InboundNatRule{
-			Id: utils.String(id),
+			Id: pointer.To(id),
 		})
 	}
 
@@ -120,7 +120,7 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 		for id, name := range info.loadBalancerBackendAddressPoolIDs {
 			if config.Name != nil && *config.Name == name {
 				loadBalancerBackendAddressPools = append(loadBalancerBackendAddressPools, networkinterfaces.BackendAddressPool{
-					Id: utils.String(id),
+					Id: pointer.To(id),
 				})
 			}
 

--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkinterfaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -202,8 +202,8 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("retrieving %s: `model` was nil", id)
 	}
 
-	if location := model.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := model.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	if props := model.Properties; props != nil {

--- a/internal/services/network/network_manager_admin_rule_collection_resource.go
+++ b/internal/services/network/network_manager_admin_rule_collection_resource.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkgroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/adminrulecollections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerAdminRuleCollectionModel struct {
@@ -157,7 +157,7 @@ func (r ManagerAdminRuleCollectionResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				properties.Description = utils.String(model.Description)
+				properties.Description = pointer.To(model.Description)
 			}
 
 			if _, err := client.CreateOrUpdate(ctx, *id, *existing.Model); err != nil {
@@ -225,7 +225,7 @@ func (r ManagerAdminRuleCollectionResource) Delete() sdk.ResourceFunc {
 			}
 
 			err = client.DeleteThenPoll(ctx, *id, adminrulecollections.DeleteOperationOptions{
-				Force: utils.Bool(true),
+				Force: pointer.To(true),
 			})
 			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/network/network_manager_admin_rule_collection_resource_test.go
+++ b/internal/services/network/network_manager_admin_rule_collection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/adminrulecollections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkAdminRuleCollectionResource struct{}
@@ -92,11 +92,11 @@ func (r NetworkAdminRuleCollectionResource) Exists(ctx context.Context, clients 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NetworkAdminRuleCollectionResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_admin_rule_resource.go
+++ b/internal/services/network/network_manager_admin_rule_resource.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/adminrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerAdminRuleModel struct {
@@ -393,7 +393,7 @@ func (r ManagerAdminRuleResource) Delete() sdk.ResourceFunc {
 			}
 
 			err = client.DeleteThenPoll(ctx, *id, adminrules.DeleteOperationOptions{
-				Force: utils.Bool(true),
+				Force: pointer.To(true),
 			})
 			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/network/network_manager_admin_rule_resource_test.go
+++ b/internal/services/network/network_manager_admin_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/adminrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerAdminRuleResource struct{}
@@ -99,11 +99,11 @@ func (r ManagerAdminRuleResource) Exists(ctx context.Context, clients *clients.C
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerAdminRuleResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_connectivity_configuration_resource.go
+++ b/internal/services/network/network_manager_connectivity_configuration_resource.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/connectivityconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerConnectivityConfigurationModel struct {
@@ -249,7 +249,7 @@ func (r ManagerConnectivityConfigurationResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				properties.Description = utils.String(model.Description)
+				properties.Description = pointer.To(model.Description)
 			}
 
 			if metadata.ResourceData.HasChange("hub") {
@@ -328,7 +328,7 @@ func (r ManagerConnectivityConfigurationResource) Delete() sdk.ResourceFunc {
 			}
 
 			err = client.DeleteThenPoll(ctx, *id, connectivityconfigurations.DeleteOperationOptions{
-				Force: utils.Bool(true),
+				Force: pointer.To(true),
 			})
 			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
@@ -385,8 +385,8 @@ func expandHubModel(inputList []HubModel) *[]connectivityconfigurations.Hub {
 	for _, v := range inputList {
 		input := v
 		output := connectivityconfigurations.Hub{
-			ResourceId:   utils.String(input.ResourceId),
-			ResourceType: utils.String(input.ResourceType),
+			ResourceId:   pointer.To(input.ResourceId),
+			ResourceType: pointer.To(input.ResourceType),
 		}
 
 		outputList = append(outputList, output)

--- a/internal/services/network/network_manager_connectivity_configuration_resource_test.go
+++ b/internal/services/network/network_manager_connectivity_configuration_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/connectivityconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerConnectivityConfigurationResource struct{}
@@ -113,11 +113,11 @@ func (r ManagerConnectivityConfigurationResource) Exists(ctx context.Context, cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerConnectivityConfigurationResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_deployment_resource.go
+++ b/internal/services/network/network_manager_deployment_resource.go
@@ -107,7 +107,7 @@ func (r ManagerDeploymentResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			normalizedLocation := azure.NormalizeLocation(state.Location)
+			normalizedLocation := location.Normalize(state.Location)
 			id := parse.NewNetworkManagerDeploymentID(networkManagerId.SubscriptionId, networkManagerId.ResourceGroupName, networkManagerId.NetworkManagerName, normalizedLocation, state.ScopeAccess)
 
 			locks.ByID(id.ID())
@@ -382,7 +382,7 @@ func resourceManagerDeploymentWaitForFinished(ctx context.Context, client *netwo
 func resourceManagerDeploymentResultRefreshFunc(ctx context.Context, client *networkmanagers.NetworkManagersClient, id *parse.ManagerDeploymentId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		listParam := networkmanagers.NetworkManagerDeploymentStatusParameter{
-			Regions:         &[]string{azure.NormalizeLocation(id.Location)},
+			Regions:         &[]string{location.Normalize(id.Location)},
 			DeploymentTypes: &[]networkmanagers.ConfigurationType{networkmanagers.ConfigurationType(id.ScopeAccess)},
 		}
 

--- a/internal/services/network/network_manager_deployment_resource_test.go
+++ b/internal/services/network/network_manager_deployment_resource_test.go
@@ -8,15 +8,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagers"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerDeploymentResource struct{}
@@ -122,7 +122,7 @@ func (r ManagerDeploymentResource) Exists(ctx context.Context, clients *clients.
 
 	client := clients.Network.NetworkManagers
 	listParam := networkmanagers.NetworkManagerDeploymentStatusParameter{
-		Regions:         &[]string{azure.NormalizeLocation(id.Location)},
+		Regions:         &[]string{location.Normalize(id.Location)},
 		DeploymentTypes: &[]networkmanagers.ConfigurationType{networkmanagers.ConfigurationType(id.ScopeAccess)},
 	}
 	networkManagerId := networkmanagers.NewNetworkManagerID(id.SubscriptionId, id.ResourceGroup, id.NetworkManagerName)
@@ -130,7 +130,7 @@ func (r ManagerDeploymentResource) Exists(ctx context.Context, clients *clients.
 	resp, err := client.NetworkManagerDeploymentStatusList(ctx, networkManagerId, listParam)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -139,7 +139,7 @@ func (r ManagerDeploymentResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("unexpected null model %s", *id)
 	}
 
-	return utils.Bool(resp.Model.Value != nil && len(*resp.Model.Value) != 0 && *(*resp.Model.Value)[0].ConfigurationIds != nil && len(*(*resp.Model.Value)[0].ConfigurationIds) != 0), nil
+	return pointer.To(resp.Model.Value != nil && len(*resp.Model.Value) != 0 && *(*resp.Model.Value)[0].ConfigurationIds != nil && len(*(*resp.Model.Value)[0].ConfigurationIds) != 0), nil
 }
 
 func (r ManagerDeploymentResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_management_group_connection_resource_test.go
+++ b/internal/services/network/network_manager_management_group_connection_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagerconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerManagementGroupConnectionResource struct{}
@@ -96,11 +96,11 @@ func (r ManagerManagementGroupConnectionResource) Exists(ctx context.Context, cl
 	resp, err := client.ManagementGroupNetworkManagerConnectionsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerManagementGroupConnectionResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_network_group_resource.go
+++ b/internal/services/network/network_manager_network_group_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerNetworkGroupModel struct {
@@ -204,7 +203,7 @@ func (r ManagerNetworkGroupResource) Delete() sdk.ResourceFunc {
 			}
 
 			err = client.DeleteThenPoll(ctx, *id, networkgroups.DeleteOperationOptions{
-				Force: utils.Bool(true),
+				Force: pointer.To(true),
 			})
 			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/network/network_manager_network_group_resource_test.go
+++ b/internal/services/network/network_manager_network_group_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkgroups"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerNetworkGroupResource struct{}
@@ -92,11 +92,11 @@ func (r ManagerNetworkGroupResource) Exists(ctx context.Context, clients *client
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerNetworkGroupResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_resource.go
+++ b/internal/services/network/network_manager_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	managementGroupValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -179,10 +178,10 @@ func (r ManagerResource) Create() sdk.ResourceFunc {
 			}
 
 			input := networkmanagers.NetworkManager{
-				Location: utils.String(azure.NormalizeLocation(state.Location)),
-				Name:     utils.String(state.Name),
+				Location: pointer.To(location.Normalize(state.Location)),
+				Name:     pointer.To(state.Name),
 				Properties: &networkmanagers.NetworkManagerProperties{
-					Description:                 utils.String(state.Description),
+					Description:                 pointer.To(state.Description),
 					NetworkManagerScopes:        expandNetworkManagerScope(state.Scope),
 					NetworkManagerScopeAccesses: expandNetworkManagerScopeAccesses(state.ScopeAccesses),
 				},
@@ -277,7 +276,7 @@ func (r ManagerResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				existing.Model.Properties.Description = utils.String(state.Description)
+				existing.Model.Properties.Description = pointer.To(state.Description)
 			}
 
 			if metadata.ResourceData.HasChange("scope") {
@@ -312,7 +311,7 @@ func (r ManagerResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s..", *id)
 			err = client.DeleteThenPoll(ctx, *id, networkmanagers.DeleteOperationOptions{
-				Force: utils.Bool(true),
+				Force: pointer.To(true),
 			})
 			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerResource struct{}
@@ -245,12 +245,12 @@ func (r ManagerResource) Exists(ctx context.Context, clients *clients.Client, st
 	resp, err := clients.Network.NetworkManagers.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_scope_connection_resource_test.go
+++ b/internal/services/network/network_manager_scope_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/scopeconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerScopeConnectionResource struct{}
@@ -95,11 +95,11 @@ func (r ManagerScopeConnectionResource) Exists(ctx context.Context, clients *cli
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerScopeConnectionResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_security_admin_configuration_resource.go
+++ b/internal/services/network/network_manager_security_admin_configuration_resource.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/securityadminconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerSecurityAdminConfigurationModel struct {
@@ -165,7 +165,7 @@ func (r ManagerSecurityAdminConfigurationResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				properties.Description = utils.String(model.Description)
+				properties.Description = pointer.To(model.Description)
 			}
 
 			if _, err := client.CreateOrUpdate(ctx, *id, *existing.Model); err != nil {
@@ -233,7 +233,7 @@ func (r ManagerSecurityAdminConfigurationResource) Delete() sdk.ResourceFunc {
 			}
 
 			err = client.DeleteThenPoll(ctx, *id, securityadminconfigurations.DeleteOperationOptions{
-				Force: utils.Bool(true),
+				Force: pointer.To(true),
 			})
 			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/network/network_manager_security_admin_configuration_resource_test.go
+++ b/internal/services/network/network_manager_security_admin_configuration_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/securityadminconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerSecurityAdminConfigurationResource struct{}
@@ -99,11 +99,11 @@ func (r ManagerSecurityAdminConfigurationResource) Exists(ctx context.Context, c
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerSecurityAdminConfigurationResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_static_member_resource_test.go
+++ b/internal/services/network/network_manager_static_member_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/staticmembers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerStaticMemberResource struct{}
@@ -57,11 +57,11 @@ func (r ManagerStaticMemberResource) Exists(ctx context.Context, clients *client
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerStaticMemberResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_manager_subscription_connection_resource_test.go
+++ b/internal/services/network/network_manager_subscription_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagerconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagerSubscriptionConnectionResource struct{}
@@ -95,11 +95,11 @@ func (r ManagerSubscriptionConnectionResource) Exists(ctx context.Context, clien
 	resp, err := client.SubscriptionNetworkManagerConnectionsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagerSubscriptionConnectionResource) template(data acceptance.TestData) string {

--- a/internal/services/network/network_packet_capture_resource.go
+++ b/internal/services/network/network_packet_capture_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceNetworkPacketCapture() *pluginsdk.Resource {
@@ -265,10 +264,10 @@ func expandNetworkPacketCaptureStorageLocation(input []interface{}) packetcaptur
 	storageLocation := packetcaptures.PacketCaptureStorageLocation{}
 
 	if v := location["file_path"]; v != "" {
-		storageLocation.FilePath = utils.String(v.(string))
+		storageLocation.FilePath = pointer.To(v.(string))
 	}
 	if v := location["storage_account_id"]; v != "" {
-		storageLocation.StorageId = utils.String(v.(string))
+		storageLocation.StorageId = pointer.To(v.(string))
 	}
 
 	return storageLocation
@@ -301,11 +300,11 @@ func expandNetworkPacketCaptureFilters(input []interface{}) *[]packetcaptures.Pa
 		remotePort := inputFilter["remote_port"].(string)
 
 		filters = append(filters, packetcaptures.PacketCaptureFilter{
-			LocalIPAddress:  utils.String(localIPAddress),
-			LocalPort:       utils.String(localPort),
+			LocalIPAddress:  pointer.To(localIPAddress),
+			LocalPort:       pointer.To(localPort),
 			Protocol:        pointer.To(packetcaptures.PcProtocol(protocol)),
-			RemoteIPAddress: utils.String(remoteIPAddress),
-			RemotePort:      utils.String(remotePort),
+			RemoteIPAddress: pointer.To(remoteIPAddress),
+			RemotePort:      pointer.To(remotePort),
 		})
 	}
 

--- a/internal/services/network/network_packet_capture_resource_test.go
+++ b/internal/services/network/network_packet_capture_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/packetcaptures"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkPacketCaptureResource struct{}
@@ -123,7 +123,7 @@ func (t NetworkPacketCaptureResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("reading Network Packet Capture (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkPacketCaptureResource) base(data acceptance.TestData) string {

--- a/internal/services/network/network_security_rule_resource_test.go
+++ b/internal/services/network/network_security_rule_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/securityrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkSecurityRuleResource struct{}
@@ -122,7 +122,7 @@ func (t NetworkSecurityRuleResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkSecurityRuleResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -135,7 +135,7 @@ func (NetworkSecurityRuleResource) Destroy(ctx context.Context, client *clients.
 		return nil, fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (NetworkSecurityRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/network_watcher_data_source_test.go
+++ b/internal/services/network/network_watcher_data_source_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -27,7 +27,7 @@ func testAccDataSourceNetworkWatcher_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("name").HasValue(name),
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.env").HasValue("test"),
 			),

--- a/internal/services/network/network_watcher_resource_test.go
+++ b/internal/services/network/network_watcher_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkwatchers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkWatcherResource struct{}
@@ -196,7 +196,7 @@ func (t NetworkWatcherResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NetworkWatcherResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -209,7 +209,7 @@ func (NetworkWatcherResource) Destroy(ctx context.Context, client *clients.Clien
 		return nil, fmt.Errorf("deleting Network Watcher %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (NetworkWatcherResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/network/parse/network_manager_deployment.go
+++ b/internal/services/network/parse/network_manager_deployment.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/networkmanagers"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
 
 type ManagerDeploymentId struct {
@@ -19,12 +19,12 @@ type ManagerDeploymentId struct {
 	ScopeAccess        string
 }
 
-func NewNetworkManagerDeploymentID(subscriptionId string, resourceGroup string, networkManagerName string, location string, scopeAccess string) *ManagerDeploymentId {
+func NewNetworkManagerDeploymentID(subscriptionId string, resourceGroup string, networkManagerName string, deploymentLocation string, scopeAccess string) *ManagerDeploymentId {
 	return &ManagerDeploymentId{
 		SubscriptionId:     subscriptionId,
 		ResourceGroup:      resourceGroup,
 		NetworkManagerName: networkManagerName,
-		Location:           azure.NormalizeLocation(location),
+		Location:           location.Normalize(deploymentLocation),
 		ScopeAccess:        scopeAccess,
 	}
 }
@@ -44,7 +44,7 @@ func NetworkManagerDeploymentID(networkManagerDeploymentId string) (*ManagerDepl
 	if v[1] == "" {
 		return nil, fmt.Errorf("expected location in network manager deployment ID with format `{networkManagerId}/commit|{location}|{scopeAccess}`, but got %s in %s", v[1], networkManagerDeploymentId)
 	}
-	normalizedLocation := azure.NormalizeLocation(v[1])
+	normalizedLocation := location.Normalize(v[1])
 
 	if v[2] == "" {
 		return nil, fmt.Errorf("expected scopeAccess in network manager deployment ID with format `{networkManagerId}/commit|{location}|{scopeAccess} to be one of the [Connectivity, SecurityAdmin]`, but got %s in %s", v[2], networkManagerDeploymentId)

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -497,7 +497,7 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	applicationSecurityGroupAssociation := existing.Model.Properties.ApplicationSecurityGroups
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	privateDnsZoneGroup := d.Get("private_dns_zone_group").([]interface{})
 	privateServiceConnections := d.Get("private_service_connection").([]interface{})
 	ipConfigurations := d.Get("ip_configuration").([]interface{})

--- a/internal/services/network/public_ip_prefix_resource_test.go
+++ b/internal/services/network/public_ip_prefix_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PublicIpPrefixResource struct{}
@@ -44,7 +43,7 @@ func (PublicIpPrefixResource) Destroy(ctx context.Context, client *clients.Clien
 		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccPublicIpPrefix_basic(t *testing.T) {

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePublicIp() *pluginsdk.Resource {
@@ -356,14 +355,14 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("idle_timeout_in_minutes") {
-		payload.Properties.IdleTimeoutInMinutes = utils.Int64(int64(d.Get("idle_timeout_in_minutes").(int)))
+		payload.Properties.IdleTimeoutInMinutes = pointer.To(int64(d.Get("idle_timeout_in_minutes").(int)))
 	}
 
 	if d.HasChange("domain_name_label") {
 		if payload.Properties.DnsSettings == nil {
 			payload.Properties.DnsSettings = &publicipaddresses.PublicIPAddressDnsSettings{}
 		}
-		payload.Properties.DnsSettings.DomainNameLabel = utils.String(d.Get("domain_name_label").(string))
+		payload.Properties.DnsSettings.DomainNameLabel = pointer.To(d.Get("domain_name_label").(string))
 	}
 
 	if d.HasChange("domain_name_label_scope") {
@@ -377,7 +376,7 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 		if payload.Properties.DnsSettings == nil {
 			payload.Properties.DnsSettings = &publicipaddresses.PublicIPAddressDnsSettings{}
 		}
-		payload.Properties.DnsSettings.ReverseFqdn = utils.String(d.Get("reverse_fqdn").(string))
+		payload.Properties.DnsSettings.ReverseFqdn = pointer.To(d.Get("reverse_fqdn").(string))
 	}
 
 	if d.HasChanges("tags") {

--- a/internal/services/network/route_filter_resource.go
+++ b/internal/services/network/route_filter_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/routefilters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -114,7 +113,7 @@ func resourceRouteFilterCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	log.Printf("[INFO] preparing arguments for Route Filter create.")
 
 	id := routefilters.NewRouteFilterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
 	existing, err := client.Get(ctx, id, routefilters.DefaultGetOperationOptions())
@@ -253,7 +252,7 @@ func expandRouteFilterRules(d *pluginsdk.ResourceData) *[]routefilters.RouteFilt
 		data := configRaw.(map[string]interface{})
 
 		rule := routefilters.RouteFilterRule{
-			Name: utils.String(data["name"].(string)),
+			Name: pointer.To(data["name"].(string)),
 			Properties: &routefilters.RouteFilterRulePropertiesFormat{
 				Access:              routefilters.Access(data["access"].(string)),
 				RouteFilterRuleType: routefilters.RouteFilterRuleType(data["rule_type"].(string)),

--- a/internal/services/network/route_filter_resource_test.go
+++ b/internal/services/network/route_filter_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/routefilters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RouteFilterResource struct{}
@@ -153,7 +153,7 @@ func (t RouteFilterResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, fmt.Errorf("reading Route Filter (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (RouteFilterResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -166,7 +166,7 @@ func (RouteFilterResource) Destroy(ctx context.Context, client *clients.Client, 
 		return nil, fmt.Errorf("deleting Route Filter %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (RouteFilterResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/route_resource_test.go
+++ b/internal/services/network/route_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/routes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RouteResource struct{}
@@ -127,7 +127,7 @@ func (t RouteResource) Exists(ctx context.Context, clients *clients.Client, stat
 		return nil, fmt.Errorf("reading Route (%s): %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r RouteResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -140,7 +140,7 @@ func (r RouteResource) Destroy(ctx context.Context, client *clients.Client, stat
 		return nil, fmt.Errorf("deleting on routesClient: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (RouteResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/route_table_resource.go
+++ b/internal/services/network/route_table_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name route_table -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
@@ -277,9 +276,9 @@ func expandRouteTableRoutes(d *pluginsdk.ResourceData) *[]routetables.Route {
 		data := configRaw.(map[string]interface{})
 
 		route := routetables.Route{
-			Name: utils.String(data["name"].(string)),
+			Name: pointer.To(data["name"].(string)),
 			Properties: &routetables.RoutePropertiesFormat{
-				AddressPrefix: utils.String(data["address_prefix"].(string)),
+				AddressPrefix: pointer.To(data["address_prefix"].(string)),
 				NextHopType:   routetables.RouteNextHopType(data["next_hop_type"].(string)),
 			},
 		}

--- a/internal/services/network/route_table_resource_test.go
+++ b/internal/services/network/route_table_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/routetables"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RouteTableResource struct{}
@@ -236,7 +236,7 @@ func (r RouteTableResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, fmt.Errorf("reading Route Table (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (RouteTableResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -249,7 +249,7 @@ func (RouteTableResource) Destroy(ctx context.Context, client *clients.Client, s
 		return nil, fmt.Errorf("deleting Route Table %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (RouteTableResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/subnet_network_security_group_association_resource_test.go
+++ b/internal/services/network/subnet_network_security_group_association_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubnetNetworkSecurityGroupAssociationResource struct{}
@@ -115,7 +115,7 @@ func (SubnetNetworkSecurityGroupAssociationResource) Exists(ctx context.Context,
 		return nil, fmt.Errorf("properties was nil for %s", *id)
 	}
 
-	return utils.Bool(props.NetworkSecurityGroup.Id != nil), nil
+	return pointer.To(props.NetworkSecurityGroup.Id != nil), nil
 }
 
 func (SubnetNetworkSecurityGroupAssociationResource) destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -360,7 +360,7 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	properties.Delegations = expandSubnetDelegation(delegationsRaw)
 
 	subnet := subnets.Subnet{
-		Name:       utils.String(id.SubnetName),
+		Name:       pointer.To(id.SubnetName),
 		Properties: &properties,
 	}
 
@@ -440,7 +440,7 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			props.AddressPrefixes = nil
 		case 1:
 			// N->1: we shall insist on using the `AddressPrefix` and clear the `AddressPrefixes`.
-			props.AddressPrefix = utils.String(addressPrefixesRaw[0].(string))
+			props.AddressPrefix = pointer.To(addressPrefixesRaw[0].(string))
 			props.AddressPrefixes = nil
 		default:
 			// 1->N: we shall insist on using the `AddressPrefixes` and clear the `AddressPrefix`. If both are set, service be confused and (currently) will only
@@ -509,7 +509,7 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	subnet := subnets.Subnet{
-		Name:       utils.String(id.SubnetName),
+		Name:       pointer.To(id.SubnetName),
 		Properties: &props,
 	}
 

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/subnets"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubnetResource struct{}
@@ -529,7 +529,7 @@ func (t SubnetResource) Exists(ctx context.Context, clients *clients.Client, sta
 		return nil, fmt.Errorf("reading Subnet (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (SubnetResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -542,7 +542,7 @@ func (SubnetResource) Destroy(ctx context.Context, client *clients.Client, state
 		return nil, fmt.Errorf("deleting Subnet %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (SubnetResource) hasNoNatGateway(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/network/virtual_hub_routing_intent_resource_test.go
+++ b/internal/services/network/virtual_hub_routing_intent_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualHubRoutingIntentResource struct{}
@@ -88,11 +88,11 @@ func (r VirtualHubRoutingIntentResource) Exists(ctx context.Context, clients *cl
 	resp, err := client.RoutingIntentGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VirtualHubRoutingIntentResource) template(data acceptance.TestData) string {

--- a/internal/services/network/virtual_machine_packet_capture_resource.go
+++ b/internal/services/network/virtual_machine_packet_capture_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceVirtualMachinePacketCapture() *pluginsdk.Resource {
@@ -186,9 +185,9 @@ func resourceVirtualMachinePacketCaptureCreate(d *pluginsdk.ResourceData, meta i
 			Target:                  targetResourceId,
 			TargetType:              pointer.To(packetcaptures.PacketCaptureTargetTypeAzureVM),
 			StorageLocation:         storageLocation,
-			BytesToCapturePerPacket: utils.Int64(int64(bytesToCapturePerPacket)),
-			TimeLimitInSeconds:      utils.Int64(int64(timeLimitInSeconds)),
-			TotalBytesPerSession:    utils.Int64(int64(totalBytesPerSession)),
+			BytesToCapturePerPacket: pointer.To(int64(bytesToCapturePerPacket)),
+			TimeLimitInSeconds:      pointer.To(int64(timeLimitInSeconds)),
+			TotalBytesPerSession:    pointer.To(int64(totalBytesPerSession)),
 			Filters:                 expandVirtualMachinePacketCaptureFilters(d.Get("filter").([]interface{})),
 		},
 	}
@@ -307,11 +306,11 @@ func expandVirtualMachinePacketCaptureFilters(input []interface{}) *[]packetcapt
 		remotePort := inputFilter["remote_port"].(string)
 
 		filter := packetcaptures.PacketCaptureFilter{
-			LocalIPAddress:  utils.String(localIPAddress),
-			LocalPort:       utils.String(localPort),
+			LocalIPAddress:  pointer.To(localIPAddress),
+			LocalPort:       pointer.To(localPort),
 			Protocol:        pointer.To(packetcaptures.PcProtocol(protocol)),
-			RemoteIPAddress: utils.String(remoteIPAddress),
-			RemotePort:      utils.String(remotePort),
+			RemoteIPAddress: pointer.To(remoteIPAddress),
+			RemotePort:      pointer.To(remotePort),
 		}
 		filters = append(filters, filter)
 	}

--- a/internal/services/network/virtual_machine_packet_capture_resource_test.go
+++ b/internal/services/network/virtual_machine_packet_capture_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/packetcaptures"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachinePacketCaptureResource struct{}
@@ -104,7 +104,7 @@ func (t VirtualMachinePacketCaptureResource) Exists(ctx context.Context, clients
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualMachinePacketCaptureResource) template(data acceptance.TestData) string {

--- a/internal/services/network/virtual_machine_scale_set_packet_capture_resource.go
+++ b/internal/services/network/virtual_machine_scale_set_packet_capture_resource.go
@@ -316,10 +316,10 @@ func expandVirtualMachineScaleSetPacketCaptureStorageLocation(input []interface{
 	storageLocation := packetcaptures.PacketCaptureStorageLocation{}
 
 	if v := location["file_path"]; v != "" {
-		storageLocation.FilePath = utils.String(v.(string))
+		storageLocation.FilePath = pointer.To(v.(string))
 	}
 	if v := location["storage_account_id"]; v != "" {
-		storageLocation.StorageId = utils.String(v.(string))
+		storageLocation.StorageId = pointer.To(v.(string))
 	}
 
 	return storageLocation

--- a/internal/services/network/virtual_machine_scale_set_packet_capture_resource_test.go
+++ b/internal/services/network/virtual_machine_scale_set_packet_capture_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/packetcaptures"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualMachineScaleSetPacketCaptureResource struct{}
@@ -119,7 +119,7 @@ func (t VirtualMachineScaleSetPacketCaptureResource) Exists(ctx context.Context,
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VirtualMachineScaleSetPacketCaptureResource) template(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_data_source_test.go
+++ b/internal/services/network/virtual_network_data_source_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -25,7 +25,7 @@ func TestAccDataSourceVirtualNetwork_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").HasValue(name),
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("dns_servers.0").HasValue("10.0.0.4"),
 				check.That(data.ResourceName).Key("address_space.0").HasValue("10.0.0.0/16"),
 				check.That(data.ResourceName).Key("subnets.0").HasValue("subnet1"),

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VirtualNetworkPeeringResource struct{}
@@ -160,7 +159,7 @@ func (r VirtualNetworkPeeringResource) Destroy(ctx context.Context, client *clie
 		return nil, fmt.Errorf("deleting on virtual network peering: %+v", err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r VirtualNetworkPeeringResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -584,7 +584,7 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	if d.HasChange("flow_timeout_in_minutes") {
 		payload.Properties.FlowTimeoutInMinutes = nil
 		if v := d.Get("flow_timeout_in_minutes"); v.(int) != 0 {
-			payload.Properties.FlowTimeoutInMinutes = utils.Int64(int64(v.(int)))
+			payload.Properties.FlowTimeoutInMinutes = pointer.To(int64(v.(int)))
 		}
 	}
 

--- a/internal/services/network/vpn_gateway_connection_resource.go
+++ b/internal/services/network/vpn_gateway_connection_resource.go
@@ -528,10 +528,10 @@ func expandVpnGatewayConnectionVpnSiteLinkConnections(input []interface{}) *[]vi
 	for _, itemRaw := range input {
 		item := itemRaw.(map[string]interface{})
 		v := virtualwans.VpnSiteLinkConnection{
-			Name: utils.String(item["name"].(string)),
+			Name: pointer.To(item["name"].(string)),
 			Properties: &virtualwans.VpnSiteLinkConnectionProperties{
 				VpnSiteLink: &virtualwans.SubResource{
-					Id: utils.String(item["vpn_site_link_id"].(string)),
+					Id: pointer.To(item["vpn_site_link_id"].(string)),
 				},
 				RoutingWeight:                  pointer.To(int64(item["route_weight"].(int))),
 				VpnConnectionProtocolType:      pointer.To(virtualwans.VirtualNetworkGatewayConnectionProtocol(item["protocol"].(string))),
@@ -673,19 +673,19 @@ func expandVpnGatewayConnectionRoutingConfiguration(input []interface{}) *virtua
 
 	output := &virtualwans.RoutingConfiguration{
 		AssociatedRouteTable: &virtualwans.SubResource{
-			Id: utils.String(raw["associated_route_table"].(string)),
+			Id: pointer.To(raw["associated_route_table"].(string)),
 		},
 	}
 
 	if inboundRouteMapId := raw["inbound_route_map_id"].(string); inboundRouteMapId != "" {
 		output.InboundRouteMap = &virtualwans.SubResource{
-			Id: utils.String(inboundRouteMapId),
+			Id: pointer.To(inboundRouteMapId),
 		}
 	}
 
 	if outboundRouteMapId := raw["outbound_route_map_id"].(string); outboundRouteMapId != "" {
 		output.OutboundRouteMap = &virtualwans.SubResource{
-			Id: utils.String(outboundRouteMapId),
+			Id: pointer.To(outboundRouteMapId),
 		}
 	}
 
@@ -813,7 +813,7 @@ func expandVpnGatewayConnectionNatRuleIds(input []interface{}) *[]virtualwans.Su
 
 	for _, item := range input {
 		results = append(results, virtualwans.SubResource{
-			Id: utils.String(item.(string)),
+			Id: pointer.To(item.(string)),
 		})
 	}
 

--- a/internal/services/network/vpn_gateway_connection_resource_test.go
+++ b/internal/services/network/vpn_gateway_connection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VPNGatewayConnectionResource struct{}
@@ -264,7 +264,7 @@ func (t VPNGatewayConnectionResource) Exists(ctx context.Context, clients *clien
 		return nil, fmt.Errorf("reading VPN Gateway Connnection (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VPNGatewayConnectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/vpn_gateway_resource.go
+++ b/internal/services/network/vpn_gateway_resource.go
@@ -248,7 +248,7 @@ func resourceVPNGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error
 			EnableBgpRouteTranslationForNat: pointer.To(d.Get("bgp_route_translation_for_nat_enabled").(bool)),
 			BgpSettings:                     bgpSettings,
 			VirtualHub: &virtualwans.SubResource{
-				Id: utils.String(d.Get("virtual_hub_id").(string)),
+				Id: pointer.To(d.Get("virtual_hub_id").(string)),
 			},
 			VpnGatewayScaleUnit:         pointer.To(int64(d.Get("scale_unit").(int))),
 			IsRoutingPreferenceInternet: pointer.To(d.Get("routing_preference").(string) == "Internet"),
@@ -329,7 +329,7 @@ func resourceVPNGatewayUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		model.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 	if d.HasChange("bgp_route_translation_for_nat_enabled") {
-		model.Properties.EnableBgpRouteTranslationForNat = utils.Bool(d.Get("bgp_route_translation_for_nat_enabled").(bool))
+		model.Properties.EnableBgpRouteTranslationForNat = pointer.To(d.Get("bgp_route_translation_for_nat_enabled").(bool))
 	}
 
 	bgpSettingsRaw := d.Get("bgp_settings").([]interface{})

--- a/internal/services/network/vpn_gateway_resource_test.go
+++ b/internal/services/network/vpn_gateway_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VPNGatewayResource struct{}
@@ -181,7 +181,7 @@ func (t VPNGatewayResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VPNGatewayResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/vpn_server_configuration_data_source.go
+++ b/internal/services/network/vpn_server_configuration_data_source.go
@@ -324,9 +324,9 @@ func (d VPNServerConfigurationDataSource) Read() sdk.ResourceFunc {
 			}
 
 			if model := resp.Model; model != nil {
-				m.Location = pointer.ToString(model.Location)
+				m.Location = pointer.From(model.Location)
 				if tags := model.Tags; tags != nil {
-					m.Tags = pointer.ToMapOfStringStrings(tags)
+					m.Tags = pointer.From(tags)
 				}
 
 				if props := resp.Model.Properties; props != nil {
@@ -354,9 +354,9 @@ func dataSourceFlattenVpnServerConfigurationAADAuthentication(input *virtualwans
 
 	return []AzureActiveDirectoryAuthenticationModel{
 		{
-			Audience: pointer.ToString(input.AadAudience),
-			Issuer:   pointer.ToString(input.AadIssuer),
-			Tenant:   pointer.ToString(input.AadTenant),
+			Audience: pointer.From(input.AadAudience),
+			Issuer:   pointer.From(input.AadIssuer),
+			Tenant:   pointer.From(input.AadTenant),
 		},
 	}
 }
@@ -373,8 +373,8 @@ func dataSourceFlattenVpnServerConfigurationClientRootCertificates(input *[]virt
 			continue
 		}
 		output = append(output, ClientRootCertificateModel{
-			Name:           pointer.ToString(v.Name),
-			PublicCertData: pointer.ToString(v.PublicCertData),
+			Name:           pointer.From(v.Name),
+			PublicCertData: pointer.From(v.PublicCertData),
 		})
 	}
 
@@ -393,8 +393,8 @@ func dataSourceFlattenVpnServerConfigurationClientRevokedCertificates(input *[]v
 		}
 
 		output = append(output, ClientRevokedCertificateModel{
-			Name:       pointer.ToString(v.Name),
-			Thumbprint: pointer.ToString(v.Thumbprint),
+			Name:       pointer.From(v.Name),
+			Thumbprint: pointer.From(v.Thumbprint),
 		})
 	}
 	return output
@@ -433,8 +433,8 @@ func dataSourceFlattenVpnServerConfigurationRadius(input *virtualwans.VpnServerC
 				continue
 			}
 			clientRootCertificates = append(clientRootCertificates, RadiusClientRootCertificateModel{
-				Name:       pointer.ToString(v.Name),
-				Thumbprint: pointer.ToString(v.Thumbprint),
+				Name:       pointer.From(v.Name),
+				Thumbprint: pointer.From(v.Thumbprint),
 			})
 		}
 	}
@@ -447,8 +447,8 @@ func dataSourceFlattenVpnServerConfigurationRadius(input *virtualwans.VpnServerC
 			}
 
 			serverRootCertificates = append(serverRootCertificates, ClientRootCertificateModel{
-				Name:           pointer.ToString(v.Name),
-				PublicCertData: pointer.ToString(v.PublicCertData),
+				Name:           pointer.From(v.Name),
+				PublicCertData: pointer.From(v.PublicCertData),
 			})
 		}
 	}
@@ -458,8 +458,8 @@ func dataSourceFlattenVpnServerConfigurationRadius(input *virtualwans.VpnServerC
 		for _, v := range *input.RadiusServers {
 			servers = append(servers, ServerModel{
 				Address: v.RadiusServerAddress,
-				Secret:  pointer.ToString(v.RadiusServerSecret),
-				Score:   pointer.ToInt64(v.RadiusServerScore),
+				Secret:  pointer.From(v.RadiusServerSecret),
+				Score:   pointer.From(v.RadiusServerScore),
 			})
 		}
 	}

--- a/internal/services/network/vpn_server_configuration_policy_group_resource.go
+++ b/internal/services/network/vpn_server_configuration_policy_group_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceVPNServerConfigurationPolicyGroup() *pluginsdk.Resource {
@@ -129,7 +128,7 @@ func resourceVPNServerConfigurationPolicyGroupCreate(d *pluginsdk.ResourceData, 
 
 	payload := virtualwans.VpnServerConfigurationPolicyGroup{
 		Properties: &virtualwans.VpnServerConfigurationPolicyGroupProperties{
-			IsDefault:     utils.Bool(d.Get("is_default").(bool)),
+			IsDefault:     pointer.To(d.Get("is_default").(bool)),
 			PolicyMembers: expandVPNServerConfigurationPolicyGroupPolicyMembers(d.Get("policy").(*pluginsdk.Set).List()),
 			Priority:      pointer.To(int64(d.Get("priority").(int))),
 		},
@@ -257,9 +256,9 @@ func expandVPNServerConfigurationPolicyGroupPolicyMembers(input []interface{}) *
 		v := item.(map[string]interface{})
 
 		results = append(results, virtualwans.VpnServerConfigurationPolicyGroupMember{
-			Name:           utils.String(v["name"].(string)),
+			Name:           pointer.To(v["name"].(string)),
 			AttributeType:  pointer.To(virtualwans.VpnPolicyMemberAttributeType(v["type"].(string))),
-			AttributeValue: utils.String(v["value"].(string)),
+			AttributeValue: pointer.To(v["value"].(string)),
 		})
 	}
 

--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -14,13 +14,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualwans"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceVPNServerConfiguration() *pluginsdk.Resource {
@@ -357,17 +355,17 @@ func resourceVPNServerConfigurationCreate(d *pluginsdk.ResourceData, meta interf
 			props.RadiusServers = radius.servers
 		}
 
-		props.RadiusServerAddress = utils.String(radius.address)
-		props.RadiusServerSecret = utils.String(radius.secret)
+		props.RadiusServerAddress = pointer.To(radius.address)
+		props.RadiusServerSecret = pointer.To(radius.secret)
 
 		props.RadiusClientRootCertificates = radius.clientRootCertificates
 		props.RadiusServerRootCertificates = radius.serverRootCertificates
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 	parameters := virtualwans.VpnServerConfiguration{
-		Location:   utils.String(location),
+		Location:   pointer.To(location),
 		Properties: &props,
 		Tags:       tags.Expand(t),
 	}
@@ -551,8 +549,8 @@ func resourceVPNServerConfigurationUpdate(d *pluginsdk.ResourceData, meta interf
 				payload.Properties.RadiusServers = radius.servers
 			}
 
-			payload.Properties.RadiusServerAddress = utils.String(radius.address)
-			payload.Properties.RadiusServerSecret = utils.String(radius.secret)
+			payload.Properties.RadiusServerAddress = pointer.To(radius.address)
+			payload.Properties.RadiusServerSecret = pointer.To(radius.secret)
 
 			payload.Properties.RadiusClientRootCertificates = radius.clientRootCertificates
 			payload.Properties.RadiusServerRootCertificates = radius.serverRootCertificates
@@ -605,9 +603,9 @@ func expandVpnServerConfigurationAADAuthentication(input []interface{}) *virtual
 
 	v := input[0].(map[string]interface{})
 	return &virtualwans.AadAuthenticationParameters{
-		AadAudience: utils.String(v["audience"].(string)),
-		AadIssuer:   utils.String(v["issuer"].(string)),
-		AadTenant:   utils.String(v["tenant"].(string)),
+		AadAudience: pointer.To(v["audience"].(string)),
+		AadIssuer:   pointer.To(v["issuer"].(string)),
+		AadTenant:   pointer.To(v["tenant"].(string)),
 	}
 }
 
@@ -646,8 +644,8 @@ func expandVpnServerConfigurationClientRootCertificates(input []interface{}) *[]
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 		clientRootCertificates = append(clientRootCertificates, virtualwans.VpnServerConfigVpnClientRootCertificate{
-			Name:           utils.String(raw["name"].(string)),
-			PublicCertData: utils.String(raw["public_cert_data"].(string)),
+			Name:           pointer.To(raw["name"].(string)),
+			PublicCertData: pointer.To(raw["public_cert_data"].(string)),
 		})
 	}
 
@@ -687,8 +685,8 @@ func expandVpnServerConfigurationClientRevokedCertificates(input []interface{}) 
 	for _, v := range input {
 		raw := v.(map[string]interface{})
 		clientRevokedCertificates = append(clientRevokedCertificates, virtualwans.VpnServerConfigVpnClientRevokedCertificate{
-			Name:       utils.String(raw["name"].(string)),
-			Thumbprint: utils.String(raw["thumbprint"].(string)),
+			Name:       pointer.To(raw["name"].(string)),
+			Thumbprint: pointer.To(raw["thumbprint"].(string)),
 		})
 	}
 
@@ -781,8 +779,8 @@ func expandVpnServerConfigurationRadius(input []interface{}) *vpnServerConfigura
 	for _, raw := range clientRootCertsRaw {
 		v := raw.(map[string]interface{})
 		clientRootCertificates = append(clientRootCertificates, virtualwans.VpnServerConfigRadiusClientRootCertificate{
-			Name:       utils.String(v["name"].(string)),
-			Thumbprint: utils.String(v["thumbprint"].(string)),
+			Name:       pointer.To(v["name"].(string)),
+			Thumbprint: pointer.To(v["thumbprint"].(string)),
 		})
 	}
 
@@ -791,8 +789,8 @@ func expandVpnServerConfigurationRadius(input []interface{}) *vpnServerConfigura
 	for _, raw := range serverRootCertsRaw {
 		v := raw.(map[string]interface{})
 		serverRootCertificates = append(serverRootCertificates, virtualwans.VpnServerConfigRadiusServerRootCertificate{
-			Name:           utils.String(v["name"].(string)),
-			PublicCertData: utils.String(v["public_cert_data"].(string)),
+			Name:           pointer.To(v["name"].(string)),
+			PublicCertData: pointer.To(v["public_cert_data"].(string)),
 		})
 	}
 
@@ -806,8 +804,8 @@ func expandVpnServerConfigurationRadius(input []interface{}) *vpnServerConfigura
 			v := raw.(map[string]interface{})
 			radiusServers = append(radiusServers, virtualwans.RadiusServer{
 				RadiusServerAddress: v["address"].(string),
-				RadiusServerSecret:  utils.String(v["secret"].(string)),
-				RadiusServerScore:   utils.Int64(int64(v["score"].(int))),
+				RadiusServerSecret:  pointer.To(v["secret"].(string)),
+				RadiusServerScore:   pointer.To(int64(v["score"].(int))),
 			})
 		}
 	}

--- a/internal/services/network/vpn_site_resource.go
+++ b/internal/services/network/vpn_site_resource.go
@@ -206,7 +206,7 @@ func resourceVpnSiteCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &virtualwans.VpnSiteProperties{
 			VirtualWAN: &virtualwans.SubResource{
-				Id: utils.String(d.Get("virtual_wan_id").(string)),
+				Id: pointer.To(d.Get("virtual_wan_id").(string)),
 			},
 			DeviceProperties: expandVpnSiteDeviceProperties(d.Get("device_vendor").(string), d.Get("device_model").(string)),
 			AddressSpace:     expandVpnSiteAddressSpace(d.Get("address_cidrs").(*pluginsdk.Set).List()),
@@ -407,7 +407,7 @@ func expandVpnSiteLinks(input []interface{}) *[]virtualwans.VpnSiteLink {
 		}
 		e := e.(map[string]interface{})
 		link := virtualwans.VpnSiteLink{
-			Name: utils.String(e["name"].(string)),
+			Name: pointer.To(e["name"].(string)),
 			Properties: &virtualwans.VpnSiteLinkProperties{
 				LinkProperties: &virtualwans.VpnLinkProviderProperties{
 					LinkSpeedInMbps: pointer.To(int64(e["speed_in_mbps"].(int))),
@@ -505,8 +505,8 @@ func expandVpnSiteVpnLinkBgpSettings(input []interface{}) *virtualwans.VpnLinkBg
 	v := input[0].(map[string]interface{})
 
 	return &virtualwans.VpnLinkBgpSettings{
-		Asn:               utils.Int64(int64(v["asn"].(int))),
-		BgpPeeringAddress: utils.String(v["peering_address"].(string)),
+		Asn:               pointer.To(int64(v["asn"].(int))),
+		BgpPeeringAddress: pointer.To(v["peering_address"].(string)),
 	}
 }
 
@@ -553,9 +553,9 @@ func expandVpnSiteO365TrafficCategoryPolicy(input []interface{}) *virtualwans.O3
 	trafficCategory := input[0].(map[string]interface{})
 
 	return &virtualwans.O365BreakOutCategoryPolicies{
-		Allow:    utils.Bool(trafficCategory["allow_endpoint_enabled"].(bool)),
-		Default:  utils.Bool(trafficCategory["default_endpoint_enabled"].(bool)),
-		Optimize: utils.Bool(trafficCategory["optimize_endpoint_enabled"].(bool)),
+		Allow:    pointer.To(trafficCategory["allow_endpoint_enabled"].(bool)),
+		Default:  pointer.To(trafficCategory["default_endpoint_enabled"].(bool)),
+		Optimize: pointer.To(trafficCategory["optimize_endpoint_enabled"].(bool)),
 	}
 }
 

--- a/internal/services/network/vpn_site_resource_test.go
+++ b/internal/services/network/vpn_site_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/virtualwans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VPNSiteResource struct{}
@@ -125,7 +125,7 @@ func (t VPNSiteResource) Exists(ctx context.Context, clients *clients.Client, st
 		return nil, fmt.Errorf("reading VPN Site (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VPNSiteResource) basic(data acceptance.TestData) string {

--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -510,14 +510,14 @@ func resourceWebApplicationFirewallPolicyCreate(d *pluginsdk.ResourceData, meta 
 		return tf.ImportAsExistsError("azurerm_web_application_firewall_policy", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	customRules := d.Get("custom_rules").([]interface{})
 	policySettings := d.Get("policy_settings").([]interface{})
 	managedRules := d.Get("managed_rules").([]interface{})
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := webapplicationfirewallpolicies.WebApplicationFirewallPolicy{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &webapplicationfirewallpolicies.WebApplicationFirewallPolicyPropertiesFormat{
 			CustomRules:    expandWebApplicationFirewallPolicyWebApplicationFirewallCustomRule(customRules),
 			PolicySettings: expandWebApplicationFirewallPolicyPolicySettings(policySettings),
@@ -953,7 +953,7 @@ func expandWebApplicationFirewallPolicyMatchCondition(input []interface{}) []web
 		result := webapplicationfirewallpolicies.MatchCondition{
 			MatchValues:      pointer.From(utils.ExpandStringSlice(matchValues)),
 			MatchVariables:   expandWebApplicationFirewallPolicyMatchVariable(matchVariables),
-			NegationConditon: utils.Bool(negationCondition),
+			NegationConditon: pointer.To(negationCondition),
 			Operator:         webapplicationfirewallpolicies.WebApplicationFirewallOperator(operator),
 			Transforms:       &transforms,
 		}
@@ -971,7 +971,7 @@ func expandWebApplicationFirewallPolicyMatchVariable(input []interface{}) []weba
 		selector := v["selector"].(string)
 
 		result := webapplicationfirewallpolicies.MatchVariable{
-			Selector:     utils.String(selector),
+			Selector:     pointer.To(selector),
 			VariableName: webapplicationfirewallpolicies.WebApplicationFirewallMatchVariable(variableName),
 		}
 

--- a/internal/services/network/web_application_firewall_policy_resource_test.go
+++ b/internal/services/network/web_application_firewall_policy_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebApplicationFirewallResource struct{}
@@ -445,7 +445,7 @@ func (t WebApplicationFirewallResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (WebApplicationFirewallResource) basic(data acceptance.TestData) string {

--- a/internal/services/networkfunction/network_function_azure_traffic_collector_resource_test.go
+++ b/internal/services/networkfunction/network_function_azure_traffic_collector_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetworkFunctionAzureTrafficCollectorResource struct{}
@@ -92,11 +92,11 @@ func (r NetworkFunctionAzureTrafficCollectorResource) Exists(ctx context.Context
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NetworkFunctionAzureTrafficCollectorResource) template(data acceptance.TestData) string {

--- a/internal/services/newrelic/new_relic_monitor_resource_test.go
+++ b/internal/services/newrelic/new_relic_monitor_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2024-03-01/monitors"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NewRelicMonitorResource struct{}
@@ -116,11 +116,11 @@ func (r NewRelicMonitorResource) Exists(ctx context.Context, clients *clients.Cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NewRelicMonitorResource) template(data acceptance.TestData) string {

--- a/internal/services/newrelic/new_relic_tag_rule_resource_test.go
+++ b/internal/services/newrelic/new_relic_tag_rule_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2024-03-01/tagrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NewRelicTagRuleResource struct{}
@@ -108,11 +108,11 @@ func (r NewRelicTagRuleResource) Exists(ctx context.Context, clients *clients.Cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NewRelicTagRuleResource) template(data acceptance.TestData, email string) string {

--- a/internal/services/nginx/nginx_api_key_data_source.go
+++ b/internal/services/nginx/nginx_api_key_data_source.go
@@ -96,8 +96,8 @@ func (m APIKeyDataSource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil && model.Properties != nil {
 				props := model.Properties
-				state.EndDateTime = pointer.ToString(props.EndDateTime)
-				state.Hint = pointer.ToString(props.Hint)
+				state.EndDateTime = pointer.From(props.EndDateTime)
+				state.Hint = pointer.From(props.Hint)
 			}
 
 			meta.SetID(id)

--- a/internal/services/nginx/nginx_api_key_resource.go
+++ b/internal/services/nginx/nginx_api_key_resource.go
@@ -213,8 +213,8 @@ func (m APIKeyResource) Read() sdk.ResourceFunc {
 			output.SecretText = state.SecretText
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
-					output.EndDateTime = pointer.ToString(props.EndDateTime)
-					output.Hint = pointer.ToString(props.Hint)
+					output.EndDateTime = pointer.From(props.EndDateTime)
+					output.Hint = pointer.From(props.Hint)
 				}
 			}
 			return meta.Encode(&output)

--- a/internal/services/nginx/nginx_certificate_resource.go
+++ b/internal/services/nginx/nginx_certificate_resource.go
@@ -190,12 +190,12 @@ func (m CertificateResource) Read() sdk.ResourceFunc {
 			}
 			var output CertificateModel
 
-			output.Name = pointer.ToString(result.Model.Name)
+			output.Name = pointer.From(result.Model.Name)
 			output.NginxDeploymentId = nginxdeployment.NewNginxDeploymentID(id.SubscriptionId, id.ResourceGroupName, id.NginxDeploymentName).ID()
 			prop := result.Model.Properties
-			output.KeyVirtualPath = pointer.ToString(prop.KeyVirtualPath)
-			output.KeyVaultSecretId = pointer.ToString(prop.KeyVaultSecretId)
-			output.CertificateVirtualPath = pointer.ToString(prop.CertificateVirtualPath)
+			output.KeyVirtualPath = pointer.From(prop.KeyVirtualPath)
+			output.KeyVaultSecretId = pointer.From(prop.KeyVaultSecretId)
+			output.CertificateVirtualPath = pointer.From(prop.CertificateVirtualPath)
 			return meta.Encode(&output)
 		},
 	}

--- a/internal/services/nginx/nginx_certificate_resource_test.go
+++ b/internal/services/nginx/nginx_certificate_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2024-11-01-preview/nginxcertificate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CertificateResource struct{}
@@ -28,7 +28,7 @@ func (a CertificateResource) Exists(ctx context.Context, client *clients.Client,
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Certificate %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func TestAccCertificate_basic(t *testing.T) {

--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -252,10 +252,10 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 			output.NginxDeploymentId = deployID.ID()
 
 			if prop := result.Model.Properties; prop != nil {
-				output.RootFile = pointer.ToString(prop.RootFile)
+				output.RootFile = pointer.From(prop.RootFile)
 
 				if prop.Package != nil && prop.Package.Data != nil {
-					output.PackageData = pointer.ToString(prop.Package.Data)
+					output.PackageData = pointer.From(prop.Package.Data)
 				}
 
 				if files := prop.Files; files != nil {
@@ -263,8 +263,8 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 					for _, file := range *files {
 						if pointer.From(file.Content) != "" {
 							configs = append(configs, ConfigFile{
-								Content:     pointer.ToString(file.Content),
-								VirtualPath: pointer.ToString(file.VirtualPath),
+								Content:     pointer.From(file.Content),
+								VirtualPath: pointer.From(file.VirtualPath),
 							})
 						}
 					}
@@ -277,12 +277,12 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 					configs := []ProtectedFile{}
 					for _, file := range *files {
 						config := ProtectedFile{
-							VirtualPath: pointer.ToString(file.VirtualPath),
-							ContentHash: pointer.ToString(file.ContentHash),
+							VirtualPath: pointer.From(file.VirtualPath),
+							ContentHash: pointer.From(file.ContentHash),
 						}
 						// GET returns protected files without content, so fill in from state
 						for _, protectedFile := range output.ProtectedFile {
-							if protectedFile.VirtualPath == pointer.ToString(file.VirtualPath) {
+							if protectedFile.VirtualPath == pointer.From(file.VirtualPath) {
 								config.Content = protectedFile.Content
 								break
 							}

--- a/internal/services/nginx/nginx_deployment_data_source.go
+++ b/internal/services/nginx/nginx_deployment_data_source.go
@@ -307,9 +307,9 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 			}
 
 			if model := result.Model; model != nil {
-				output.Location = pointer.ToString(model.Location)
+				output.Location = pointer.From(model.Location)
 				if tags := model.Tags; tags != nil {
-					output.Tags = pointer.ToMapOfStringStrings(model.Tags)
+					output.Tags = pointer.From(model.Tags)
 				}
 				if model.Sku != nil {
 					output.Sku = model.Sku.Name
@@ -320,17 +320,17 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 				}
 				output.Identity = *flattenedIdentity
 				if props := model.Properties; props != nil {
-					output.IpAddress = pointer.ToString(props.IPAddress)
-					output.NginxVersion = pointer.ToString(props.NginxVersion)
-					output.DataplaneAPIEndpoint = pointer.ToString(props.DataplaneApiEndpoint)
-					output.DiagnoseSupportEnabled = pointer.ToBool(props.EnableDiagnosticsSupport)
+					output.IpAddress = pointer.From(props.IPAddress)
+					output.NginxVersion = pointer.From(props.NginxVersion)
+					output.DataplaneAPIEndpoint = pointer.From(props.DataplaneApiEndpoint)
+					output.DiagnoseSupportEnabled = pointer.From(props.EnableDiagnosticsSupport)
 
 					if !features.FivePointOh() {
 						if props.Logging != nil && props.Logging.StorageAccount != nil {
 							output.LoggingStorageAccount = []LoggingStorageAccount{
 								{
-									Name:          pointer.ToString(props.Logging.StorageAccount.AccountName),
-									ContainerName: pointer.ToString(props.Logging.StorageAccount.ContainerName),
+									Name:          pointer.From(props.Logging.StorageAccount.AccountName),
+									ContainerName: pointer.From(props.Logging.StorageAccount.ContainerName),
 								},
 							}
 						}
@@ -341,7 +341,7 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 							if publicIps := frontend.PublicIPAddresses; publicIps != nil && len(*publicIps) > 0 {
 								output.FrontendPublic = append(output.FrontendPublic, FrontendPublic{})
 								for _, ip := range *publicIps {
-									output.FrontendPublic[0].IpAddress = append(output.FrontendPublic[0].IpAddress, pointer.ToString(ip.Id))
+									output.FrontendPublic[0].IpAddress = append(output.FrontendPublic[0].IpAddress, pointer.From(ip.Id))
 								}
 							}
 
@@ -353,9 +353,9 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 									}
 
 									output.FrontendPrivate = append(output.FrontendPrivate, FrontendPrivate{
-										IpAddress:        pointer.ToString(ip.PrivateIPAddress),
+										IpAddress:        pointer.From(ip.PrivateIPAddress),
 										AllocationMethod: method,
-										SubnetId:         pointer.ToString(ip.SubnetId),
+										SubnetId:         pointer.From(ip.SubnetId),
 									})
 								}
 							}
@@ -363,14 +363,14 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 
 						if netIf := profile.NetworkInterfaceConfiguration; netIf != nil {
 							output.NetworkInterface = []NetworkInterface{
-								{SubnetId: pointer.ToString(netIf.SubnetId)},
+								{SubnetId: pointer.From(netIf.SubnetId)},
 							}
 						}
 					}
 
 					if scaling := props.ScalingProperties; scaling != nil {
 						if capacity := scaling.Capacity; capacity != nil {
-							output.Capacity = pointer.ToInt64(props.ScalingProperties.Capacity)
+							output.Capacity = pointer.From(props.ScalingProperties.Capacity)
 						}
 						if autoScaleProfiles := scaling.AutoScaleSettings; autoScaleProfiles != nil {
 							profiles := autoScaleProfiles.Profiles
@@ -385,7 +385,7 @@ func (m DeploymentDataSource) Read() sdk.ResourceFunc {
 					}
 
 					if userProfile := props.UserProfile; userProfile != nil && userProfile.PreferredEmail != nil {
-						output.Email = pointer.ToString(props.UserProfile.PreferredEmail)
+						output.Email = pointer.From(props.UserProfile.PreferredEmail)
 					}
 
 					if props.AutoUpgradeProfile != nil {

--- a/internal/services/nginx/nginx_deployment_resource_test.go
+++ b/internal/services/nginx/nginx_deployment_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2024-11-01-preview/nginxdeployment"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/nginx"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DeploymentResource struct{}
@@ -29,7 +29,7 @@ func (a DeploymentResource) Exists(ctx context.Context, client *clients.Client, 
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Deployment %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func TestAccNginxDeployment_basic(t *testing.T) {

--- a/internal/services/notificationhub/notification_hub_authorization_rule_resource_test.go
+++ b/internal/services/notificationhub/notification_hub_authorization_rule_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2023-09-01/hubs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NotificationHubAuthorizationRuleResource struct{}
@@ -188,7 +188,7 @@ func (NotificationHubAuthorizationRuleResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NotificationHubAuthorizationRuleResource) listen(data acceptance.TestData) string {

--- a/internal/services/notificationhub/notification_hub_namespace_resource_test.go
+++ b/internal/services/notificationhub/notification_hub_namespace_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2023-09-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NotificationHubNamespaceResource struct{}
@@ -144,7 +144,7 @@ func (NotificationHubNamespaceResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NotificationHubNamespaceResource) free(data acceptance.TestData) string {

--- a/internal/services/notificationhub/notification_hub_resource.go
+++ b/internal/services/notificationhub/notification_hub_resource.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var notificationHubResourceName = "azurerm_notification_hub"
@@ -353,11 +353,11 @@ func expandNotificationHubsAPNSCredentials(inputs []interface{}) *hubs.ApnsCrede
 
 	credentials := hubs.ApnsCredential{
 		Properties: hubs.ApnsCredentialProperties{
-			AppId:    utils.String(teamId),
-			AppName:  utils.String(bundleId),
+			AppId:    pointer.To(teamId),
+			AppName:  pointer.To(bundleId),
 			Endpoint: endpoint,
-			KeyId:    utils.String(keyId),
-			Token:    utils.String(token),
+			KeyId:    pointer.To(keyId),
+			Token:    pointer.To(token),
 		},
 	}
 	return &credentials

--- a/internal/services/notificationhub/notification_hub_resource_test.go
+++ b/internal/services/notificationhub/notification_hub_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2023-09-01/hubs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NotificationHubResource struct{}
@@ -106,7 +106,7 @@ func (NotificationHubResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (NotificationHubResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
