### PR TITLE
services `O*`/`P*` - deprecated function clean up

### DIFF
--- a/internal/services/oracle/oracle_autonomous_database_resource.go
+++ b/internal/services/oracle/oracle_autonomous_database_resource.go
@@ -441,7 +441,7 @@ func (AutonomousDatabaseRegularResource) Read() sdk.ResourceFunc {
 				state.LicenseModel = string(pointer.From(props.LicenseModel))
 				state.Location = result.Model.Location
 				state.MtlsConnectionRequired = pointer.From(props.IsMtlsConnectionRequired)
-				state.Name = pointer.ToString(result.Model.Name)
+				state.Name = pointer.From(result.Model.Name)
 				state.NationalCharacterSet = pointer.From(props.NcharacterSet)
 				state.SubnetId = pointer.From(props.SubnetId)
 				state.Tags = pointer.From(result.Model.Tags)

--- a/internal/services/oracle/oracle_exadata_infrastructure_resource.go
+++ b/internal/services/oracle/oracle_exadata_infrastructure_resource.go
@@ -339,7 +339,7 @@ func (ExadataInfraResource) Read() sdk.ResourceFunc {
 				state.Tags = pointer.From(model.Tags)
 				if props := model.Properties; props != nil {
 					state.CustomerContacts = FlattenCustomerContacts(result.Model.Properties.CustomerContacts)
-					state.Name = pointer.ToString(result.Model.Name)
+					state.Name = pointer.From(result.Model.Name)
 					state.Location = result.Model.Location
 					state.Zones = result.Model.Zones
 					state.ResourceGroupName = id.ResourceGroupName

--- a/internal/services/orbital/orbital_contact_profile_resource.go
+++ b/internal/services/orbital/orbital_contact_profile_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContactProfileResource struct{}
@@ -157,9 +156,9 @@ func (r ContactProfileResource) Create() sdk.ResourceFunc {
 			}
 
 			contactProfile := contactprofile.ContactProfile{
-				Id:         utils.String(id.ID()),
+				Id:         pointer.To(id.ID()),
 				Location:   model.Location,
-				Name:       utils.String(model.Name),
+				Name:       pointer.To(model.Name),
 				Properties: contactProfilesProperties,
 				Tags:       pointer.To(model.Tags),
 			}

--- a/internal/services/orbital/orbital_contact_profile_resource_test.go
+++ b/internal/services/orbital/orbital_contact_profile_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContactProfileResource struct{}
@@ -132,11 +132,11 @@ func (r ContactProfileResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.Orbital.ContactProfileClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retreiving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ContactProfileResource) basic(data acceptance.TestData) string {

--- a/internal/services/orbital/orbital_contact_resource.go
+++ b/internal/services/orbital/orbital_contact_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var _ sdk.ResourceWithDeprecationAndNoReplacement = ContactResource{}
@@ -132,8 +132,8 @@ func (r ContactResource) Create() sdk.ResourceFunc {
 			}
 
 			contact := contact.Contact{
-				Id:         utils.String(id.ID()),
-				Name:       utils.String(model.Name),
+				Id:         pointer.To(id.ID()),
+				Name:       pointer.To(model.Name),
 				Properties: contactProperties,
 			}
 			if _, err = client.Create(ctx, id, contact); err != nil {

--- a/internal/services/orbital/orbital_contact_resource_test.go
+++ b/internal/services/orbital/orbital_contact_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ContactResource struct{}
@@ -50,11 +50,11 @@ func (r ContactResource) Exists(ctx context.Context, client *clients.Client, sta
 	resp, err := client.Orbital.ContactClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ContactResource) basic(data acceptance.TestData) string {

--- a/internal/services/orbital/orbital_spacecraft_resource.go
+++ b/internal/services/orbital/orbital_spacecraft_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpacecraftResource struct{}
@@ -120,16 +120,16 @@ func (r SpacecraftResource) Create() sdk.ResourceFunc {
 			}
 			spacecraftProperties := spacecraft.SpacecraftsProperties{
 				Links:     links,
-				NoradId:   utils.String(model.NoradId),
+				NoradId:   pointer.To(model.NoradId),
 				TleLine1:  model.TwoLineElements[0],
 				TleLine2:  model.TwoLineElements[1],
 				TitleLine: model.TitleLine,
 			}
 
 			spacecraft := spacecraft.Spacecraft{
-				Id:         utils.String(id.ID()),
+				Id:         pointer.To(id.ID()),
 				Location:   model.Location,
-				Name:       utils.String(model.Name),
+				Name:       pointer.To(model.Name),
 				Properties: spacecraftProperties,
 				Tags:       &model.Tags,
 			}
@@ -237,7 +237,7 @@ func (r SpacecraftResource) Update() sdk.ResourceFunc {
 					Location: state.Location,
 					Properties: spacecraft.SpacecraftsProperties{
 						Links:     spacecraftLinks,
-						NoradId:   utils.String(state.NoradId),
+						NoradId:   pointer.To(state.NoradId),
 						TitleLine: state.TitleLine,
 						TleLine1:  state.TwoLineElements[0],
 						TleLine2:  state.TwoLineElements[1],

--- a/internal/services/orbital/orbital_spacecraft_resource_test.go
+++ b/internal/services/orbital/orbital_spacecraft_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpacecraftResource struct{}
@@ -89,11 +89,11 @@ func (r SpacecraftResource) Exists(ctx context.Context, client *clients.Client, 
 	resp, err := client.Orbital.SpacecraftClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpacecraftResource) basic(data acceptance.TestData) string {

--- a/internal/services/policy/assignment_resource_base.go
+++ b/internal/services/policy/assignment_resource_base.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/policy/validate"
@@ -45,19 +44,19 @@ func (br assignmentBaseResource) createFunc(resourceName, scopeFieldName string)
 
 			assignment := policyassignments.PolicyAssignment{
 				Properties: &policyassignments.PolicyAssignmentProperties{
-					PolicyDefinitionId: utils.String(metadata.ResourceData.Get("policy_definition_id").(string)),
-					DisplayName:        utils.String(metadata.ResourceData.Get("display_name").(string)),
-					Scope:              utils.String(id.Scope),
+					PolicyDefinitionId: pointer.To(metadata.ResourceData.Get("policy_definition_id").(string)),
+					DisplayName:        pointer.To(metadata.ResourceData.Get("display_name").(string)),
+					Scope:              pointer.To(id.Scope),
 					EnforcementMode:    convertEnforcementMode(metadata.ResourceData.Get("enforce").(bool)),
 				},
 			}
 
 			if v := metadata.ResourceData.Get("description").(string); v != "" {
-				assignment.Properties.Description = utils.String(v)
+				assignment.Properties.Description = pointer.To(v)
 			}
 
 			if v := metadata.ResourceData.Get("location").(string); v != "" {
-				assignment.Location = utils.String(azure.NormalizeLocation(v))
+				assignment.Location = pointer.To(location.Normalize(v))
 			}
 
 			if v, ok := metadata.ResourceData.GetOk("identity"); ok {
@@ -252,19 +251,19 @@ func (br assignmentBaseResource) updateFunc() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("description") {
-				update.Properties.Description = utils.String(metadata.ResourceData.Get("description").(string))
+				update.Properties.Description = pointer.To(metadata.ResourceData.Get("description").(string))
 			}
 			if metadata.ResourceData.HasChange("display_name") {
-				update.Properties.DisplayName = utils.String(metadata.ResourceData.Get("display_name").(string))
+				update.Properties.DisplayName = pointer.To(metadata.ResourceData.Get("display_name").(string))
 			}
 			if metadata.ResourceData.HasChange("enforce") {
 				update.Properties.EnforcementMode = convertEnforcementMode(metadata.ResourceData.Get("enforce").(bool))
 			}
 			if metadata.ResourceData.HasChange("location") {
-				update.Location = utils.String(metadata.ResourceData.Get("location").(string))
+				update.Location = pointer.To(metadata.ResourceData.Get("location").(string))
 			}
 			if metadata.ResourceData.HasChange("policy_definition_id") {
-				update.Properties.PolicyDefinitionId = utils.String(metadata.ResourceData.Get("policy_definition_id").(string))
+				update.Properties.PolicyDefinitionId = pointer.To(metadata.ResourceData.Get("policy_definition_id").(string))
 			}
 
 			if metadata.ResourceData.HasChange("identity") {
@@ -548,7 +547,7 @@ func (br assignmentBaseResource) expandNonComplianceMessages(input []interface{}
 				Message: m["content"].(string),
 			}
 			if id := m["policy_definition_reference_id"].(string); id != "" {
-				ncm.PolicyDefinitionReferenceId = utils.String(id)
+				ncm.PolicyDefinitionReferenceId = pointer.To(id)
 			}
 			output = append(output, ncm)
 		}

--- a/internal/services/policy/management_group_policy_assignment_resource_test.go
+++ b/internal/services/policy/management_group_policy_assignment_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	assignments "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagementGroupAssignmentTestResource struct{}
@@ -311,13 +311,13 @@ func (r ManagementGroupAssignmentTestResource) Exists(ctx context.Context, clien
 	assignment, err := client.Policy.AssignmentsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(assignment.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ManagementGroupAssignmentTestResource) withBuiltInPolicyBasic(data acceptance.TestData) string {

--- a/internal/services/policy/management_group_policy_exemption_resource.go
+++ b/internal/services/policy/management_group_policy_exemption_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -132,18 +133,18 @@ func resourceArmManagementGroupPolicyExemptionCreateUpdate(d *pluginsdk.Resource
 
 	exemption := policy.Exemption{
 		ExemptionProperties: &policy.ExemptionProperties{
-			PolicyAssignmentID:           utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyAssignmentID:           pointer.To(d.Get("policy_assignment_id").(string)),
 			PolicyDefinitionReferenceIds: utils.ExpandStringSlice(d.Get("policy_definition_reference_ids").([]interface{})),
 			ExemptionCategory:            policy.ExemptionCategory(d.Get("exemption_category").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("display_name"); ok {
-		exemption.DisplayName = utils.String(v.(string))
+		exemption.DisplayName = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
-		exemption.Description = utils.String(v.(string))
+		exemption.Description = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("expires_on"); ok {

--- a/internal/services/policy/management_group_policy_exemption_resource_test.go
+++ b/internal/services/policy/management_group_policy_exemption_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -95,11 +96,11 @@ func (r ManagementGroupPolicyExemptionResource) Exists(ctx context.Context, clie
 	resp, err := client.Policy.ExemptionsClient.Get(ctx, managementGroupId.ID(), id.Name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.ID(), err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ManagementGroupPolicyExemptionResource) basic(data acceptance.TestData) string {

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	mgmtGrpParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/parse"
@@ -109,9 +110,9 @@ func resourceArmPolicyDefinitionCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	properties := policy.DefinitionProperties{
 		PolicyType:  policy.Type(policyType),
-		Mode:        utils.String(mode),
-		DisplayName: utils.String(displayName),
-		Description: utils.String(description),
+		Mode:        pointer.To(mode),
+		DisplayName: pointer.To(displayName),
+		Description: pointer.To(description),
 	}
 
 	if policyRuleString := d.Get("policy_rule").(string); policyRuleString != "" {
@@ -139,7 +140,7 @@ func resourceArmPolicyDefinitionCreateUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	definition := policy.Definition{
-		Name:                 utils.String(name),
+		Name:                 pointer.To(name),
 		DefinitionProperties: &properties,
 	}
 

--- a/internal/services/policy/policy_definition_resource_test.go
+++ b/internal/services/policy/policy_definition_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -193,12 +194,12 @@ func (r PolicyDefinitionResource) Exists(ctx context.Context, client *clients.Cl
 	}
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Policy Definition %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.DefinitionProperties != nil), nil
+	return pointer.To(resp.DefinitionProperties != nil), nil
 }
 
 func (r PolicyDefinitionResource) basic(data acceptance.TestData) string {

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePolicyVirtualMachineConfigurationAssignment() *pluginsdk.Resource {
@@ -150,8 +149,8 @@ func resourcePolicyVirtualMachineConfigurationAssignmentCreateUpdate(d *pluginsd
 	}
 	guestConfiguration := expandGuestConfigurationAssignment(d.Get("configuration").([]interface{}), id.GuestConfigurationAssignmentName)
 	assignment := guestconfigurationassignments.GuestConfigurationAssignment{
-		Name:     *utils.String(id.GuestConfigurationAssignmentName),
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Name:     *pointer.To(id.GuestConfigurationAssignmentName),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &guestconfigurationassignments.GuestConfigurationAssignmentProperties{
 			GuestConfiguration: guestConfiguration,
 		},
@@ -239,8 +238,8 @@ func expandGuestConfigurationAssignment(input []interface{}, name string) *guest
 	v := input[0].(map[string]interface{})
 
 	result := guestconfigurationassignments.GuestConfigurationNavigation{
-		Name:                   utils.String(name),
-		Version:                utils.String(v["version"].(string)),
+		Name:                   pointer.To(name),
+		Version:                pointer.To(v["version"].(string)),
 		ConfigurationParameter: expandGuestConfigurationAssignmentConfigurationParameters(v["parameter"].(*pluginsdk.Set).List()),
 	}
 
@@ -249,11 +248,11 @@ func expandGuestConfigurationAssignment(input []interface{}, name string) *guest
 	}
 
 	if v, ok := v["content_hash"]; ok {
-		result.ContentHash = utils.String(v.(string))
+		result.ContentHash = pointer.To(v.(string))
 	}
 
 	if v, ok := v["content_uri"]; ok {
-		result.ContentUri = utils.String(v.(string))
+		result.ContentUri = pointer.To(v.(string))
 	}
 
 	return &result
@@ -264,8 +263,8 @@ func expandGuestConfigurationAssignmentConfigurationParameters(input []interface
 	for _, item := range input {
 		v := item.(map[string]interface{})
 		results = append(results, guestconfigurationassignments.ConfigurationParameter{
-			Name:  utils.String(v["name"].(string)),
-			Value: utils.String(v["value"].(string)),
+			Name:  pointer.To(v["name"].(string)),
+			Value: pointer.To(v["value"].(string)),
 		})
 	}
 	return &results

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PolicyVirtualMachineConfigurationAssignmentResource struct{}
@@ -81,7 +80,7 @@ func (r PolicyVirtualMachineConfigurationAssignmentResource) Exists(ctx context.
 	resp, err := client.Policy.GuestConfigurationAssignmentsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/policy/resource_group_policy_assignment_resource_test.go
+++ b/internal/services/policy/resource_group_policy_assignment_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	assignments "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceGroupAssignmentTestResource struct{}
@@ -253,13 +253,13 @@ func (r ResourceGroupAssignmentTestResource) Exists(ctx context.Context, client 
 	assignment, err := client.Policy.AssignmentsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(assignment.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ResourceGroupAssignmentTestResource) withBuiltInPolicyBasic(data acceptance.TestData) string {

--- a/internal/services/policy/resource_group_policy_exemption_resource.go
+++ b/internal/services/policy/resource_group_policy_exemption_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -133,18 +134,18 @@ func resourceArmResourceGroupPolicyExemptionCreateUpdate(d *pluginsdk.ResourceDa
 
 	exemption := policy.Exemption{
 		ExemptionProperties: &policy.ExemptionProperties{
-			PolicyAssignmentID:           utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyAssignmentID:           pointer.To(d.Get("policy_assignment_id").(string)),
 			PolicyDefinitionReferenceIds: utils.ExpandStringSlice(d.Get("policy_definition_reference_ids").([]interface{})),
 			ExemptionCategory:            policy.ExemptionCategory(d.Get("exemption_category").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("display_name"); ok {
-		exemption.DisplayName = utils.String(v.(string))
+		exemption.DisplayName = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
-		exemption.Description = utils.String(v.(string))
+		exemption.Description = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("expires_on"); ok {

--- a/internal/services/policy/resource_group_policy_exemption_resource_test.go
+++ b/internal/services/policy/resource_group_policy_exemption_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -92,11 +93,11 @@ func (r ResourceGroupPolicyExemptionResource) Exists(ctx context.Context, client
 	resp, err := client.Policy.ExemptionsClient.Get(ctx, resourceGroupId.ID(), id.PolicyExemptionName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.ID(), err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ResourceGroupPolicyExemptionResource) basic(data acceptance.TestData) string {

--- a/internal/services/policy/resource_policy_assignment_resource_test.go
+++ b/internal/services/policy/resource_policy_assignment_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	assignments "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceAssignmentTestResource struct{}
@@ -282,13 +282,13 @@ func (r ResourceAssignmentTestResource) Exists(ctx context.Context, client *clie
 	assignment, err := client.Policy.AssignmentsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(assignment.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ResourceAssignmentTestResource) withBuiltInPolicyBasic(data acceptance.TestData) string {

--- a/internal/services/policy/resource_policy_exemption_resource.go
+++ b/internal/services/policy/resource_policy_exemption_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -127,18 +128,18 @@ func resourceArmResourcePolicyExemptionCreateUpdate(d *pluginsdk.ResourceData, m
 
 	exemption := policy.Exemption{
 		ExemptionProperties: &policy.ExemptionProperties{
-			PolicyAssignmentID:           utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyAssignmentID:           pointer.To(d.Get("policy_assignment_id").(string)),
 			PolicyDefinitionReferenceIds: utils.ExpandStringSlice(d.Get("policy_definition_reference_ids").([]interface{})),
 			ExemptionCategory:            policy.ExemptionCategory(d.Get("exemption_category").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("display_name"); ok {
-		exemption.DisplayName = utils.String(v.(string))
+		exemption.DisplayName = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
-		exemption.Description = utils.String(v.(string))
+		exemption.Description = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("expires_on"); ok {

--- a/internal/services/policy/resource_policy_exemption_resource_test.go
+++ b/internal/services/policy/resource_policy_exemption_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -89,11 +90,11 @@ func (r ResourcePolicyExemptionResource) Exists(ctx context.Context, client *cli
 	resp, err := client.Policy.ExemptionsClient.Get(ctx, id.ResourceId, id.Name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.ID(), err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ResourcePolicyExemptionResource) basic(data acceptance.TestData) string {

--- a/internal/services/policy/resource_policy_remediation_resource.go
+++ b/internal/services/policy/resource_policy_remediation_resource.go
@@ -276,21 +276,21 @@ func readRemediationProperties(d *pluginsdk.ResourceData) (prop *remediations.Re
 		Filters: &remediations.RemediationFilters{
 			Locations: utils.ExpandStringSlice(d.Get("location_filters").([]interface{})),
 		},
-		PolicyAssignmentId:          utils.String(d.Get("policy_assignment_id").(string)),
-		PolicyDefinitionReferenceId: utils.String(d.Get("policy_definition_reference_id").(string)),
+		PolicyAssignmentId:          pointer.To(d.Get("policy_assignment_id").(string)),
+		PolicyDefinitionReferenceId: pointer.To(d.Get("policy_definition_reference_id").(string)),
 	}
 	mode := remediations.ResourceDiscoveryMode(d.Get("resource_discovery_mode").(string))
 	prop.ResourceDiscoveryMode = &mode
 	if v := d.Get("failure_percentage").(float64); v != 0 {
 		prop.FailureThreshold = &remediations.RemediationPropertiesFailureThreshold{
-			Percentage: utils.Float(v),
+			Percentage: pointer.To(v),
 		}
 	}
 	if v := d.Get("parallel_deployments").(int); v != 0 {
-		prop.ParallelDeployments = utils.Int64(int64(v))
+		prop.ParallelDeployments = pointer.To(int64(v))
 	}
 	if v := d.Get("resource_count").(int); v != 0 {
-		prop.ResourceCount = utils.Int64(int64(v))
+		prop.ResourceCount = pointer.To(int64(v))
 	}
 	return
 }

--- a/internal/services/policy/subscription_policy_assignment_resource_test.go
+++ b/internal/services/policy/subscription_policy_assignment_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	assignments "github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubscriptionAssignmentTestResource struct{}
@@ -286,13 +286,13 @@ func (r SubscriptionAssignmentTestResource) Exists(ctx context.Context, client *
 	assignment, err := client.Policy.AssignmentsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(assignment.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // subscription assignment for allowed location policy should contain all locations, or it will block some network resource create

--- a/internal/services/policy/subscription_policy_exemption_resource.go
+++ b/internal/services/policy/subscription_policy_exemption_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2021-06-01-preview/policy" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
@@ -131,18 +132,18 @@ func resourceArmSubscriptionPolicyExemptionCreateUpdate(d *pluginsdk.ResourceDat
 
 	exemption := policy.Exemption{
 		ExemptionProperties: &policy.ExemptionProperties{
-			PolicyAssignmentID:           utils.String(d.Get("policy_assignment_id").(string)),
+			PolicyAssignmentID:           pointer.To(d.Get("policy_assignment_id").(string)),
 			PolicyDefinitionReferenceIds: utils.ExpandStringSlice(d.Get("policy_definition_reference_ids").([]interface{})),
 			ExemptionCategory:            policy.ExemptionCategory(d.Get("exemption_category").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("display_name"); ok {
-		exemption.DisplayName = utils.String(v.(string))
+		exemption.DisplayName = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("description"); ok {
-		exemption.Description = utils.String(v.(string))
+		exemption.Description = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("expires_on"); ok {

--- a/internal/services/policy/subscription_policy_exemption_resource_test.go
+++ b/internal/services/policy/subscription_policy_exemption_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -92,11 +93,11 @@ func (r SubscriptionPolicyExemptionResource) Exists(ctx context.Context, client 
 	resp, err := client.Policy.ExemptionsClient.Get(ctx, subscriptionId.ID(), id.PolicyExemptionName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.ID(), err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SubscriptionPolicyExemptionResource) basic(data acceptance.TestData) string {

--- a/internal/services/portal/portal_dashboard_resource.go
+++ b/internal/services/portal/portal_dashboard_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/portal/validate"
@@ -132,7 +131,7 @@ func resourcePortalDashboardRead(d *pluginsdk.ResourceData, meta interface{}) er
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		if props := model.Properties; props != nil {
 			v, err := json.Marshal(props)

--- a/internal/services/portal/portal_dashboard_resource_test.go
+++ b/internal/services/portal/portal_dashboard_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PortalDashboardResource struct{}
@@ -71,7 +71,7 @@ func (PortalDashboardResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PortalDashboardResource) basic(data acceptance.TestData) string {

--- a/internal/services/portal/portal_tenant_configuration_resource.go
+++ b/internal/services/portal/portal_tenant_configuration_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/tenantconfiguration"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePortalTenantConfiguration() *pluginsdk.Resource {
@@ -70,7 +70,7 @@ func resourcePortalTenantConfigurationCreateUpdate(d *pluginsdk.ResourceData, me
 
 	parameters := tenantconfiguration.Configuration{
 		Properties: &tenantconfiguration.ConfigurationProperties{
-			EnforcePrivateMarkdownStorage: utils.Bool(d.Get("private_markdown_storage_enforced").(bool)),
+			EnforcePrivateMarkdownStorage: pointer.To(d.Get("private_markdown_storage_enforced").(bool)),
 		},
 	}
 

--- a/internal/services/portal/portal_tenant_configuration_resource_test.go
+++ b/internal/services/portal/portal_tenant_configuration_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/portal/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PortalTenantConfigurationResource struct{}
@@ -91,7 +91,7 @@ func (r PortalTenantConfigurationResource) Exists(ctx context.Context, client *c
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PortalTenantConfigurationResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -107,7 +107,7 @@ func (r PortalTenantConfigurationResource) Destroy(ctx context.Context, client *
 		}
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r PortalTenantConfigurationResource) basic(enforcePrivateMarkdownStorage bool) string {

--- a/internal/services/postgres/postgresql_active_directory_administrator_resource_test.go
+++ b/internal/services/postgres/postgresql_active_directory_administrator_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serveradministrators"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgreSqlAdministratorResource struct{}
@@ -96,7 +96,7 @@ func (r PostgreSqlAdministratorResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("reading Postgresql AAD Administrator (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PostgreSqlAdministratorResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -109,7 +109,7 @@ func (r PostgreSqlAdministratorResource) Destroy(ctx context.Context, client *cl
 		return nil, fmt.Errorf("deleting Postgresql AAD Administrator (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (PostgreSqlAdministratorResource) basic(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_configuration_resource.go
+++ b/internal/services/postgres/postgresql_configuration_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePostgreSQLConfiguration() *pluginsdk.Resource {
@@ -76,7 +76,7 @@ func resourcePostgreSQLConfigurationCreate(d *pluginsdk.ResourceData, meta inter
 
 	properties := configurations.Configuration{
 		Properties: &configurations.ConfigurationProperties{
-			Value: utils.String(d.Get("value").(string)),
+			Value: pointer.To(d.Get("value").(string)),
 		},
 	}
 

--- a/internal/services/postgres/postgresql_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_configuration_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgreSQLConfigurationResource struct{}
@@ -202,7 +202,7 @@ func (t PostgreSQLConfigurationResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PostgreSQLConfigurationResource) backslashQuote(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_database_resource.go
+++ b/internal/services/postgres/postgresql_database_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePostgreSQLDatabase() *pluginsdk.Resource {
@@ -97,8 +97,8 @@ func resourcePostgreSQLDatabaseCreate(d *pluginsdk.ResourceData, meta interface{
 
 	properties := databases.Database{
 		Properties: &databases.DatabaseProperties{
-			Charset:   utils.String(d.Get("charset").(string)),
-			Collation: utils.String(d.Get("collation").(string)),
+			Charset:   pointer.To(d.Get("charset").(string)),
+			Collation: pointer.To(d.Get("collation").(string)),
 		},
 	}
 

--- a/internal/services/postgres/postgresql_database_resource_test.go
+++ b/internal/services/postgres/postgresql_database_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgreSQLDatabaseResource struct{}
@@ -126,7 +126,7 @@ func (t PostgreSQLDatabaseResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PostgreSQLDatabaseResource) basic(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_firewall_rule_resource_test.go
+++ b/internal/services/postgres/postgresql_firewall_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgreSQLFirewallRuleResource struct{}
@@ -70,7 +70,7 @@ func (t PostgreSQLFirewallRuleResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("reading Postgresql Firewall Rule (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PostgreSQLFirewallRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/administrators"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgresqlFlexibleServerAdministratorResource struct{}
@@ -74,7 +74,7 @@ func (r PostgresqlFlexibleServerAdministratorResource) Exists(ctx context.Contex
 		return nil, fmt.Errorf("reading Postgresql AAD Administrator (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PostgresqlFlexibleServerAdministratorResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -87,7 +87,7 @@ func (r PostgresqlFlexibleServerAdministratorResource) Destroy(ctx context.Conte
 		return nil, fmt.Errorf("deleting Postgresql AAD Administrator (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (PostgresqlFlexibleServerAdministratorResource) basic(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_flexible_server_database_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_database_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePostgresqlFlexibleServerDatabase() *pluginsdk.Resource {
@@ -101,8 +101,8 @@ func resourcePostgresqlFlexibleServerDatabaseCreate(d *pluginsdk.ResourceData, m
 
 	properties := databases.Database{
 		Properties: &databases.DatabaseProperties{
-			Charset:   utils.String(d.Get("charset").(string)),
-			Collation: utils.String(d.Get("collation").(string)),
+			Charset:   pointer.To(d.Get("charset").(string)),
+			Collation: pointer.To(d.Get("collation").(string)),
 		},
 	}
 

--- a/internal/services/postgres/postgresql_flexible_server_database_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_database_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgresqlFlexibleServerDatabaseResource struct{}
@@ -89,7 +89,7 @@ func (PostgresqlFlexibleServerDatabaseResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PostgresqlFlexibleServerDatabaseResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2024-08-01/firewallrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgresqlFlexibleServerFirewallRuleResource struct{}
@@ -85,7 +85,7 @@ func (PostgresqlFlexibleServerFirewallRuleResource) Exists(ctx context.Context, 
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PostgresqlFlexibleServerFirewallRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -584,7 +584,7 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 	if storage.StorageSizeGB == nil || *storage.StorageSizeGB == 0 {
 		// set the default value for storage_mb...
 		storageMb = 32768
-		storage.StorageSizeGB = pointer.FromInt64(int64(32))
+		storage.StorageSizeGB = pointer.To(int64(32))
 		log.Printf("[DEBUG]: Default 'storage_mb' Set -> %d\n", storageMb)
 	} else {
 		storageMb = int(*storage.StorageSizeGB) * 1024
@@ -1118,7 +1118,7 @@ func expandArmServerStorage(d *pluginsdk.ResourceData) *servers.Storage {
 	storage.AutoGrow = &autoGrow
 
 	if v, ok := d.GetOk("storage_mb"); ok {
-		storage.StorageSizeGB = pointer.FromInt64(int64(v.(int) / 1024))
+		storage.StorageSizeGB = pointer.To(int64(v.(int) / 1024))
 	}
 
 	if v, ok := d.GetOk("storage_tier"); ok {

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgresqlFlexibleServerVirtualEndpointResource struct{}
@@ -146,7 +145,7 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Destroy(ctx context.Con
 		return nil, fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (PostgresqlFlexibleServerVirtualEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_server_data_source.go
+++ b/internal/services/postgres/postgresql_server_data_source.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -88,7 +88,7 @@ func dataSourcePostgreSqlServerRead(d *pluginsdk.ResourceData, meta interface{})
 	d.SetId(id.ID())
 
 	if model := resp.Model; model != nil {
-		d.Set("location", azure.NormalizeLocation(model.Location))
+		d.Set("location", location.Normalize(model.Location))
 
 		if err := d.Set("identity", identity.FlattenSystemAssigned(model.Identity)); err != nil {
 			return fmt.Errorf("setting `identity`: %+v", err)

--- a/internal/services/postgres/postgresql_server_key_resource.go
+++ b/internal/services/postgres/postgresql_server_key_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2020-01-01/serverkeys"
@@ -20,7 +21,6 @@ import (
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePostgreSQLServerKey() *pluginsdk.Resource {
@@ -79,7 +79,7 @@ func getPostgreSQLServerKeyName(ctx context.Context, keyVaultsClient *client.Cli
 	if err != nil {
 		return nil, err
 	}
-	return utils.String(fmt.Sprintf("%s_%s_%s", keyVaultID.VaultName, keyVaultKeyID.Name, keyVaultKeyID.Version)), nil
+	return pointer.To(fmt.Sprintf("%s_%s_%s", keyVaultID.VaultName, keyVaultKeyID.Name, keyVaultKeyID.Version)), nil
 }
 
 func resourcePostgreSQLServerKeyCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -131,7 +131,7 @@ func resourcePostgreSQLServerKeyCreateUpdate(d *pluginsdk.ResourceData, meta int
 	param := serverkeys.ServerKey{
 		Properties: &serverkeys.ServerKeyProperties{
 			ServerKeyType: serverkeys.ServerKeyTypeAzureKeyVault,
-			Uri:           utils.String(d.Get("key_vault_key_id").(string)),
+			Uri:           pointer.To(d.Get("key_vault_key_id").(string)),
 		},
 	}
 

--- a/internal/services/postgres/postgresql_server_key_resource_test.go
+++ b/internal/services/postgres/postgresql_server_key_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2020-01-01/serverkeys"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgreSQLServerKeyResource struct{}
@@ -113,7 +113,7 @@ func (t PostgreSQLServerKeyResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading Postgresql Server Key (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PostgreSQLServerKeyResource) template(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -689,7 +689,7 @@ func resourcePostgreSQLServerUpdate(d *pluginsdk.ResourceData, meta interface{})
 	oldCreateMode, newCreateMode := d.GetChange("create_mode")
 	replicaUpdatedToDefault := servers.CreateMode(oldCreateMode.(string)) == servers.CreateModeReplica && servers.CreateMode(newCreateMode.(string)) == servers.CreateModeDefault
 	if replicaUpdatedToDefault {
-		properties.Properties.ReplicationRole = utils.String("None")
+		properties.Properties.ReplicationRole = pointer.To("None")
 	}
 
 	// Update Admin Password in the separate call when Replication is stopped: https://github.com/Azure/azure-rest-api-specs/issues/16898
@@ -910,8 +910,8 @@ func expandServerSkuName(skuName string) (*servers.Sku, error) {
 	return &servers.Sku{
 		Name:     skuName,
 		Tier:     &tier,
-		Capacity: utils.Int64(int64(capacity)),
-		Family:   utils.String(parts[1]),
+		Capacity: pointer.To(int64(capacity)),
+		Family:   pointer.To(parts[1]),
 	}, nil
 }
 
@@ -928,7 +928,7 @@ func expandPostgreSQLStorageProfile(d *pluginsdk.ResourceData) *servers.StorageP
 	}
 
 	if v, ok := d.GetOk("backup_retention_days"); ok {
-		storage.BackupRetentionDays = utils.Int64(int64(v.(int)))
+		storage.BackupRetentionDays = pointer.To(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("geo_redundant_backup_enabled"); ok {
@@ -941,7 +941,7 @@ func expandPostgreSQLStorageProfile(d *pluginsdk.ResourceData) *servers.StorageP
 	}
 
 	if v, ok := d.GetOk("storage_mb"); ok {
-		storage.StorageMB = utils.Int64(int64(v.(int)))
+		storage.StorageMB = pointer.To(int64(v.(int)))
 	}
 
 	return &storage
@@ -973,19 +973,19 @@ func expandSecurityAlertPolicy(i interface{}) *serversecurityalertpolicies.Serve
 	}
 
 	if v, ok := block["email_account_admins"]; ok {
-		props.EmailAccountAdmins = utils.Bool(v.(bool))
+		props.EmailAccountAdmins = pointer.To(v.(bool))
 	}
 
 	if v, ok := block["retention_days"]; ok {
-		props.RetentionDays = utils.Int64(int64(v.(int)))
+		props.RetentionDays = pointer.To(int64(v.(int)))
 	}
 
 	if v, ok := block["storage_account_access_key"]; ok && v.(string) != "" {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := block["storage_endpoint"]; ok && v.(string) != "" {
-		props.StorageEndpoint = utils.String(v.(string))
+		props.StorageEndpoint = pointer.To(v.(string))
 	}
 
 	return &serversecurityalertpolicies.ServerSecurityAlertPolicy{

--- a/internal/services/postgres/postgresql_virtual_network_rule_resource.go
+++ b/internal/services/postgres/postgresql_virtual_network_rule_resource.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePostgreSQLVirtualNetworkRule() *pluginsdk.Resource {
@@ -97,7 +97,7 @@ func resourcePostgreSQLVirtualNetworkRuleCreateUpdate(d *pluginsdk.ResourceData,
 	parameters := virtualnetworkrules.VirtualNetworkRule{
 		Properties: &virtualnetworkrules.VirtualNetworkRuleProperties{
 			VirtualNetworkSubnetId:           d.Get("subnet_id").(string),
-			IgnoreMissingVnetServiceEndpoint: utils.Bool(d.Get("ignore_missing_vnet_service_endpoint").(bool)),
+			IgnoreMissingVnetServiceEndpoint: pointer.To(d.Get("ignore_missing_vnet_service_endpoint").(bool)),
 		},
 	}
 

--- a/internal/services/postgres/postgresql_virtual_network_rule_resource_test.go
+++ b/internal/services/postgres/postgresql_virtual_network_rule_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/virtualnetworkrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PostgreSQLVirtualNetworkRuleResource struct{}
@@ -147,7 +147,7 @@ func (r PostgreSQLVirtualNetworkRuleResource) Exists(ctx context.Context, client
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PostgreSQLVirtualNetworkRuleResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -160,7 +160,7 @@ func (r PostgreSQLVirtualNetworkRuleResource) Destroy(ctx context.Context, clien
 		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (PostgreSQLVirtualNetworkRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/powerbi/powerbi_embedded_resource.go
+++ b/internal/services/powerbi/powerbi_embedded_resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/powerbi/validate"
@@ -115,7 +114,7 @@ func resourcePowerBIEmbeddedCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	mode := capacities.Mode(d.Get("mode").(string))
 
 	parameters := capacities.DedicatedCapacity{
-		Location: azure.NormalizeLocation(d.Get("location").(string)),
+		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &capacities.DedicatedCapacityProperties{
 			Administration: &capacities.DedicatedCapacityAdministrators{
 				Members: utils.ExpandStringSlice(administrators),

--- a/internal/services/powerbi/powerbi_embedded_resource_test.go
+++ b/internal/services/powerbi/powerbi_embedded_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PowerBIEmbeddedResource struct{}
@@ -122,7 +122,7 @@ func (PowerBIEmbeddedResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("retrieving %s: %v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PowerBIEmbeddedResource) template(data acceptance.TestData) string {

--- a/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourcePrivateDnsAaaaRecord() *pluginsdk.Resource {
@@ -106,17 +106,17 @@ func resourcePrivateDnsAaaaRecordCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	parameters := privatedns.RecordSet{
-		Name: utils.String(id.RelativeRecordSetName),
+		Name: pointer.To(id.RelativeRecordSetName),
 		Properties: &privatedns.RecordSetProperties{
 			Metadata:    tags.Expand(d.Get("tags").(map[string]interface{})),
-			Ttl:         utils.Int64(int64(d.Get("ttl").(int))),
+			Ttl:         pointer.To(int64(d.Get("ttl").(int))),
 			AaaaRecords: expandAzureRmPrivateDnsAaaaRecords(d),
 		},
 	}
 
 	options := privatedns.RecordSetsCreateOrUpdateOperationOptions{
-		IfMatch:     utils.String(""),
-		IfNoneMatch: utils.String(""),
+		IfMatch:     pointer.To(""),
+		IfNoneMatch: pointer.To(""),
 	}
 	if _, err := client.RecordSetsCreateOrUpdate(ctx, id, parameters, options); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
@@ -175,7 +175,7 @@ func resourcePrivateDnsAaaaRecordDelete(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	options := privatedns.RecordSetsDeleteOperationOptions{IfMatch: utils.String("")}
+	options := privatedns.RecordSetsDeleteOperationOptions{IfMatch: pointer.To("")}
 
 	if _, err := dnsClient.RecordSetsDelete(ctx, *id, options); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name private_dns_zone_virtual_network_link -service-package-name privatedns -properties "name,private_dns_zone_name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
@@ -113,13 +112,13 @@ func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	parameters := virtualnetworklinks.VirtualNetworkLink{
-		Location: utils.String("global"),
+		Location: pointer.To("global"),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Properties: &virtualnetworklinks.VirtualNetworkLinkProperties{
 			VirtualNetwork: &virtualnetworklinks.SubResource{
-				Id: utils.String(d.Get("virtual_network_id").(string)),
+				Id: pointer.To(d.Get("virtual_network_id").(string)),
 			},
-			RegistrationEnabled: utils.Bool(d.Get("registration_enabled").(bool)),
+			RegistrationEnabled: pointer.To(d.Get("registration_enabled").(bool)),
 		},
 	}
 
@@ -128,8 +127,8 @@ func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	options := virtualnetworklinks.CreateOrUpdateOperationOptions{
-		IfMatch:     utils.String(""),
-		IfNoneMatch: utils.String(""),
+		IfMatch:     pointer.To(""),
+		IfNoneMatch: pointer.To(""),
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, options); err != nil {
@@ -190,7 +189,7 @@ func resourcePrivateDnsZoneVirtualNetworkLinkDelete(d *pluginsdk.ResourceData, m
 		return err
 	}
 
-	options := virtualnetworklinks.DeleteOperationOptions{IfMatch: utils.String("")}
+	options := virtualnetworklinks.DeleteOperationOptions{IfMatch: pointer.To("")}
 
 	if err = client.DeleteThenPoll(ctx, *id, options); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2024-06-01/virtualnetworklinks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PrivateDnsZoneVirtualNetworkLinkResource struct{}
@@ -151,7 +151,7 @@ func (t PrivateDnsZoneVirtualNetworkLinkResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("reading Private DNS Zone Virtual Network Link (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (PrivateDnsZoneVirtualNetworkLinkResource) basic(data acceptance.TestData) string {

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PrivateDNSResolverDnsForwardingRulesetResource struct{}
@@ -92,11 +92,11 @@ func (r PrivateDNSResolverDnsForwardingRulesetResource) Exists(ctx context.Conte
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PrivateDNSResolverDnsForwardingRulesetResource) template(data acceptance.TestData) string {

--- a/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/forwardingrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PrivateDNSResolverForwardingRuleResource struct{}
@@ -92,11 +92,11 @@ func (r PrivateDNSResolverForwardingRuleResource) Exists(ctx context.Context, cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PrivateDNSResolverForwardingRuleResource) template(data acceptance.TestData) string {

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DNSResolverInboundEndpointResource struct{}
@@ -106,11 +106,11 @@ func (r DNSResolverInboundEndpointResource) Exists(ctx context.Context, clients 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r DNSResolverInboundEndpointResource) template(data acceptance.TestData) string {

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DNSResolverOutboundEndpointResource struct{}
@@ -92,11 +92,11 @@ func (r DNSResolverOutboundEndpointResource) Exists(ctx context.Context, clients
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r DNSResolverOutboundEndpointResource) template(data acceptance.TestData) string {

--- a/internal/services/privatednsresolver/private_dns_resolver_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PrivateDNSResolverDnsResolverResource struct{}
@@ -92,11 +92,11 @@ func (r PrivateDNSResolverDnsResolverResource) Exists(ctx context.Context, clien
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PrivateDNSResolverDnsResolverResource) template(data acceptance.TestData) string {

--- a/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/virtualnetworklinks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type PrivateDNSResolverVirtualNetworkLinkResource struct{}
@@ -92,11 +92,11 @@ func (r PrivateDNSResolverVirtualNetworkLinkResource) Exists(ctx context.Context
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r PrivateDNSResolverVirtualNetworkLinkResource) template(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
