### PR TITLE
services `R*` - deprecated function clean up

### DIFF
--- a/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
+++ b/internal/services/recoveryservices/backup_container_storage_account_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectionContainerStorageAccountResource struct{}
@@ -43,7 +43,7 @@ func (t BackupProtectionContainerStorageAccountResource) Exists(ctx context.Cont
 		return nil, fmt.Errorf("reading site recovery protection container (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BackupProtectionContainerStorageAccountResource) basic(data acceptance.TestData) string {

--- a/internal/services/recoveryservices/backup_policy_file_share_resource_test.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectionpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectionPolicyFileShareResource struct{}
@@ -395,7 +395,7 @@ func (t BackupProtectionPolicyFileShareResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("reading Recovery Service Protection Policy (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BackupProtectionPolicyFileShareResource) template(data acceptance.TestData) string {

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceBackupProtectionPolicyVM() *pluginsdk.Resource {
@@ -145,7 +144,7 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 
 	policyType := protectionpolicies.IAASVMPolicyType(d.Get("policy_type").(string))
 	vmProtectionPolicyProperties := &protectionpolicies.AzureIaaSVMProtectionPolicy{
-		TimeZone:         utils.String(d.Get("timezone").(string)),
+		TimeZone:         pointer.To(d.Get("timezone").(string)),
 		PolicyType:       pointer.To(policyType),
 		SchedulePolicy:   schedulePolicy,
 		TieringPolicy:    expandBackupProtectionPolicyVMTieringPolicy(d.Get("tiering_policy").([]interface{})),
@@ -337,7 +336,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	if d.HasChange("timezone") {
-		properties.TimeZone = utils.String(d.Get("timezone").(string))
+		properties.TimeZone = pointer.To(d.Get("timezone").(string))
 	}
 
 	if d.HasChange("instant_restore_resource_group") {
@@ -535,10 +534,10 @@ func expandBackupProtectionPolicyVMResourceGroup(d *pluginsdk.ResourceData) *pro
 	if v, ok := d.Get("instant_restore_resource_group").([]interface{}); ok && len(v) > 0 {
 		rgRaw := v[0].(map[string]interface{})
 		output := &protectionpolicies.InstantRPAdditionalDetails{
-			AzureBackupRGNamePrefix: utils.String(rgRaw["prefix"].(string)),
+			AzureBackupRGNamePrefix: pointer.To(rgRaw["prefix"].(string)),
 		}
 		if suffix, ok := rgRaw["suffix"]; ok && suffix != "" {
-			output.AzureBackupRGNameSuffix = utils.String(suffix.(string))
+			output.AzureBackupRGNameSuffix = pointer.To(suffix.(string))
 		}
 		return output
 	}

--- a/internal/services/recoveryservices/backup_policy_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectionpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectionPolicyVMResource struct{}
@@ -626,7 +626,7 @@ func (t BackupProtectionPolicyVMResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading Recovery Service Protection Policy (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BackupProtectionPolicyVMResource) template(data acceptance.TestData) string {

--- a/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectionPolicyVMWorkloadModel struct {
@@ -578,11 +577,11 @@ func expandBackupProtectionPolicyVMWorkloadSettings(input []Settings) *protectio
 
 	settings := input[0]
 	result := &protectionpolicies.Settings{
-		IsCompression: utils.Bool(settings.CompressionEnabled),
+		IsCompression: pointer.To(settings.CompressionEnabled),
 	}
 
 	if settings.TimeZone != "" {
-		result.TimeZone = utils.String(settings.TimeZone)
+		result.TimeZone = pointer.To(settings.TimeZone)
 	}
 
 	return result
@@ -1013,9 +1012,9 @@ func expandBackupProtectionPolicyVMWorkloadRetentionDailyFormat(input []int64) *
 		}
 
 		if item == 0 {
-			day.IsLast = utils.Bool(true)
+			day.IsLast = pointer.To(true)
 		} else {
-			day.IsLast = utils.Bool(false)
+			day.IsLast = pointer.To(false)
 		}
 
 		days = append(days, day)

--- a/internal/services/recoveryservices/backup_policy_vm_workload_resource_test.go
+++ b/internal/services/recoveryservices/backup_policy_vm_workload_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectionpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectionPolicyVMWorkloadResource struct{}
@@ -66,7 +66,7 @@ func (t BackupProtectionPolicyVMWorkloadResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("reading Recovery Service Protection Policy (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r BackupProtectionPolicyVMWorkloadResource) basic(data acceptance.TestData) string {

--- a/internal/services/recoveryservices/backup_protected_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_protected_file_share_resource.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceBackupProtectedFileShare() *pluginsdk.Resource {
@@ -236,8 +235,8 @@ func resourceBackupProtectedFileShareCreateUpdate(d *pluginsdk.ResourceData, met
 		Properties: &protecteditems.AzureFileshareProtectedItem{
 			PolicyId:         &policyID,
 			WorkloadType:     pointer.To(protecteditems.DataSourceTypeAzureFileShare),
-			SourceResourceId: utils.String(storageAccountID),
-			FriendlyName:     utils.String(fileShareName),
+			SourceResourceId: pointer.To(storageAccountID),
+			FriendlyName:     pointer.To(fileShareName),
 		},
 	}
 

--- a/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_file_share_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type BackupProtectedFileShareResource struct{}
@@ -120,7 +120,7 @@ func (t BackupProtectedFileShareResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading Recovery Service Protected File Share (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (BackupProtectedFileShareResource) base(data acceptance.TestData) string {

--- a/internal/services/recoveryservices/recovery_services_vault_hyperv_host_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_hyperv_host_test.go
@@ -10,13 +10,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationrecoveryservicesproviders"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 const (
@@ -60,11 +60,11 @@ func (r HyperVHostTestResource) Exists(ctx context.Context, clients *clients.Cli
 
 	for _, item := range resp.Items {
 		if item.Properties != nil && item.Properties.FriendlyName != nil && *item.Properties.FriendlyName == HostName {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (HyperVHostTestResource) virtualMachineExists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceRecoveryServicesVault() *pluginsdk.Resource {
@@ -249,7 +248,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if vaults.SkuName(sku) == vaults.SkuNameRSZero {
-		vault.Sku.Tier = utils.String("Standard")
+		vault.Sku.Tier = pointer.To("Standard")
 	}
 
 	if _, ok := d.GetOk("encryption"); ok {
@@ -346,7 +345,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		settingsId := replicationvaultsetting.NewReplicationVaultSettingID(id.SubscriptionId, id.ResourceGroupName, id.VaultName, "default")
 		settingsInput := replicationvaultsetting.VaultSettingCreationInput{
 			Properties: replicationvaultsetting.VaultSettingCreationInputProperties{
-				VMwareToAzureProviderType: utils.String("Vmware"),
+				VMwareToAzureProviderType: pointer.To("Vmware"),
 			},
 		}
 		if err := settingsClient.CreateThenPoll(ctx, settingsId, settingsInput); err != nil {
@@ -438,7 +437,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 
 		if vaults.SkuName(sku) == vaults.SkuNameRSZero {
-			vault.Sku.Tier = utils.String("Standard")
+			vault.Sku.Tier = pointer.To("Standard")
 		}
 
 		err = client.CreateOrUpdateThenPoll(ctx, id, vault)
@@ -759,10 +758,10 @@ func expandEncryption(d *pluginsdk.ResourceData) (*vaults.VaultPropertiesEncrypt
 	}
 	encryption := &vaults.VaultPropertiesEncryption{
 		KeyVaultProperties: &vaults.CmkKeyVaultProperties{
-			KeyUri: utils.String(keyUri),
+			KeyUri: pointer.To(keyUri),
 		},
 		KekIdentity: &vaults.CmkKekIdentity{
-			UseSystemAssignedIdentity: utils.Bool(encryptionMap["use_system_assigned_identity"].(bool)),
+			UseSystemAssignedIdentity: pointer.To(encryptionMap["use_system_assigned_identity"].(bool)),
 		},
 		InfrastructureEncryption: &infraEncryptionState,
 	}
@@ -770,7 +769,7 @@ func expandEncryption(d *pluginsdk.ResourceData) (*vaults.VaultPropertiesEncrypt
 		if *encryption.KekIdentity.UseSystemAssignedIdentity {
 			return nil, errors.New("`use_system_assigned_identity` must be disabled when `user_assigned_identity_id` is set")
 		}
-		encryption.KekIdentity.UserAssignedIdentity = utils.String(v)
+		encryption.KekIdentity.UserAssignedIdentity = pointer.To(v)
 	}
 	return encryption, nil
 }

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-01-01/vaults"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RecoveryServicesVaultResource struct{}
@@ -423,7 +423,7 @@ func (t RecoveryServicesVaultResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("reading Recovery Service (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func TestAccRecoveryServicesVault_encryptionWithKeyVaultKey(t *testing.T) {

--- a/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationfabrics"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
@@ -61,7 +60,7 @@ func resourceSiteRecoveryFabricCreate(d *pluginsdk.ResourceData, meta interface{
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	name := d.Get("name").(string)
 
 	client := meta.(*clients.Client).RecoveryServices.FabricClient

--- a/internal/services/recoveryservices/site_recovery_fabric_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationfabrics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryFabricResource struct{}
@@ -78,5 +78,5 @@ func (t SiteRecoveryFabricResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("reading Recovery Service Vault (%s): model is nil", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_hyperv_network_mapping_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_network_mapping_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationnetworkmappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryHyperVNetworkMappingResource struct{}
@@ -81,5 +81,5 @@ func (t SiteRecoveryHyperVNetworkMappingResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("retrieving Recovery Service Network Mapping %q: `model` was nil", id)
 	}
 
-	return utils.Bool(resp.Model.Id != nil), nil
+	return pointer.To(resp.Model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_association_resource.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_association_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationfabrics"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 const TargetContainerIdAzure = "Microsoft Azure"
@@ -108,7 +108,7 @@ func (h HyperVReplicationPolicyAssociationResource) Create() sdk.ResourceFunc {
 			param := replicationprotectioncontainermappings.CreateProtectionContainerMappingInput{
 				Properties: &replicationprotectioncontainermappings.CreateProtectionContainerMappingInputProperties{
 					PolicyId:                    &plan.PolicyId,
-					TargetProtectionContainerId: utils.String(TargetContainerIdAzure),
+					TargetProtectionContainerId: pointer.To(TargetContainerIdAzure),
 					ProviderSpecificInput:       replicationprotectioncontainermappings.BaseReplicationProviderSpecificContainerMappingInputImpl{},
 				},
 			}

--- a/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_association_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_association_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotectioncontainermappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoverHyperVReplicationPolicyAssociationResource struct{}
@@ -66,5 +66,5 @@ func (t SiteRecoverHyperVReplicationPolicyAssociationResource) Exists(ctx contex
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryReplicationPolicyHyperVResource struct{}
@@ -92,5 +92,5 @@ func (t SiteRecoveryReplicationPolicyHyperVResource) Exists(ctx context.Context,
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_network_mapping_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_network_mapping_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationnetworkmappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryNetworkMappingResource struct{}
@@ -108,5 +108,5 @@ func (t SiteRecoveryNetworkMappingResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("retrieving Recovery Service Network Mapping %q: `model` was nil", id)
 	}
 
-	return utils.Bool(resp.Model.Id != nil), nil
+	return pointer.To(resp.Model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotectioncontainermappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryProtectionContainerMappingResource struct{}
@@ -272,5 +272,5 @@ func (t SiteRecoveryProtectionContainerMappingResource) Exists(ctx context.Conte
 		return nil, fmt.Errorf("reading site recovery protection container mapping (%s): model is nil", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_protection_container_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotectioncontainers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryProtectionContainerResource struct{}
@@ -85,5 +85,5 @@ func (t SiteRecoveryProtectionContainerResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("reading site recovery protection container (%s): model is nil", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -431,14 +431,14 @@ func resourceSiteRecoveryReplicatedItemCreate(d *pluginsdk.ResourceData, meta in
 
 	var targetAvailabilitySetID *string
 	if id, isSet := d.GetOk("target_availability_set_id"); isSet {
-		targetAvailabilitySetID = utils.String(id.(string))
+		targetAvailabilitySetID = pointer.To(id.(string))
 	} else {
 		targetAvailabilitySetID = nil
 	}
 
 	var targetAvailabilityZone *string
 	if zone, isSet := d.GetOk("target_zone"); isSet {
-		targetAvailabilityZone = utils.String(zone.(string))
+		targetAvailabilityZone = pointer.To(zone.(string))
 	} else {
 		targetAvailabilityZone = nil
 	}
@@ -584,7 +584,7 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 				TfoStaticIPAddress:              &testStaticIp,
 				TfoPublicIPAddressId:            &testPublicIpAddressID,
 				TfoSubnetName:                   &testSubNetName,
-				IsPrimary:                       utils.Bool(true), // currently we can only set one IPconfig for a nic, so we dont need to expose this to users.
+				IsPrimary:                       pointer.To(true), // currently we can only set one IPconfig for a nic, so we dont need to expose this to users.
 			},
 		}
 		vmNics = append(vmNics, replicationprotecteditems.VMNicInputDetails{
@@ -1068,16 +1068,16 @@ func expandDiskEncryption(diskEncryptionInfoList []interface{}) *replicationprot
 	dek := diskEncryptionInfoMap["disk_encryption_key"].([]interface{})[0].(map[string]interface{})
 	diskEncryptionInfo := &replicationprotecteditems.DiskEncryptionInfo{
 		DiskEncryptionKeyInfo: &replicationprotecteditems.DiskEncryptionKeyInfo{
-			SecretIdentifier:      utils.String(dek["secret_url"].(string)),
-			KeyVaultResourceArmId: utils.String(dek["vault_id"].(string)),
+			SecretIdentifier:      pointer.To(dek["secret_url"].(string)),
+			KeyVaultResourceArmId: pointer.To(dek["vault_id"].(string)),
 		},
 	}
 
 	if keyEncryptionKey := diskEncryptionInfoMap["key_encryption_key"].([]interface{}); len(keyEncryptionKey) > 0 {
 		kek := keyEncryptionKey[0].(map[string]interface{})
 		diskEncryptionInfo.KeyEncryptionKeyInfo = &replicationprotecteditems.KeyEncryptionKeyInfo{
-			KeyIdentifier:         utils.String(kek["key_url"].(string)),
-			KeyVaultResourceArmId: utils.String(kek["vault_id"].(string)),
+			KeyIdentifier:         pointer.To(kek["key_url"].(string)),
+			KeyVaultResourceArmId: pointer.To(kek["vault_id"].(string)),
 		}
 	}
 

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotecteditems"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryReplicatedVmResource struct{}
@@ -2543,5 +2543,5 @@ func (r SiteRecoveryReplicatedVmResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading site recovery replicated vm (%s): model is nil", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryReplicationPolicyResource struct{}
@@ -109,5 +109,5 @@ func (t SiteRecoveryReplicationPolicyResource) Exists(ctx context.Context, clien
 		return nil, fmt.Errorf("reading site recovery replication policy (%s): model is nil", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationrecoveryplans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryReplicationRecoveryPlan struct{}
@@ -723,5 +723,5 @@ func (r SiteRecoveryReplicationRecoveryPlan) Exists(ctx context.Context, clients
 		return nil, fmt.Errorf("reading site recovery replication plan (%s): model is nil. ", id.String())
 	}
 
-	return utils.Bool(model.Id != nil), nil
+	return pointer.To(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_services_vault_hyperv_site_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_services_vault_hyperv_site_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationfabrics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type HyperVSiteResource struct{}
@@ -71,5 +71,5 @@ func (t HyperVSiteResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, fmt.Errorf("reading Recovery Service Vault (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_vmware_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replicated_vm_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotecteditems"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryVMWareReplicatedVmResource struct {
@@ -83,7 +83,7 @@ func (r SiteRecoveryVMWareReplicatedVmResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func TestAccSiteVMWareRecoveryReplicatedVM_basic(t *testing.T) {

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-01-01/vaults"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 const SiteRecoveryReplicationPolicyVMWareAssociationTargetContainerId string = "Microsoft Azure"
@@ -116,7 +116,7 @@ func (s VMWareReplicationPolicyAssociationResource) Create() sdk.ResourceFunc {
 
 			parameters := replicationprotectioncontainermappings.CreateProtectionContainerMappingInput{
 				Properties: &replicationprotectioncontainermappings.CreateProtectionContainerMappingInputProperties{
-					TargetProtectionContainerId: utils.String(SiteRecoveryReplicationPolicyVMWareAssociationTargetContainerId),
+					TargetProtectionContainerId: pointer.To(SiteRecoveryReplicationPolicyVMWareAssociationTargetContainerId),
 					PolicyId:                    &model.RecoveryReplicationPolicyId,
 					ProviderSpecificInput:       replicationprotectioncontainermappings.BaseReplicationProviderSpecificContainerMappingInputImpl{},
 				},

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotectioncontainermappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryVMWareReplicationPolicyAssociationResource struct{}
@@ -73,5 +73,5 @@ func (t SiteRecoveryVMWareReplicationPolicyAssociationResource) Exists(ctx conte
 		return nil, fmt.Errorf("reading %s: %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-01-01/vaults"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 const EnableMultiVMSyncEnabled string = "True"
@@ -121,8 +121,8 @@ func (r VMWareReplicationPolicyResource) Create() sdk.ResourceFunc {
 					ProviderSpecificInput: &replicationpolicies.InMageRcmPolicyCreationInput{
 						RecoveryPointHistoryInMinutes:     &recoveryPoint,
 						AppConsistentFrequencyInMinutes:   &appConsistency,
-						CrashConsistentFrequencyInMinutes: utils.Int64(10),
-						EnableMultiVMSync:                 utils.String(EnableMultiVMSyncEnabled),
+						CrashConsistentFrequencyInMinutes: pointer.To(int64(10)),
+						EnableMultiVMSync:                 pointer.To(EnableMultiVMSyncEnabled),
 					},
 				},
 			}
@@ -210,8 +210,8 @@ func (r VMWareReplicationPolicyResource) Update() sdk.ResourceFunc {
 					ReplicationProviderSettings: &replicationpolicies.InMageRcmPolicyCreationInput{
 						RecoveryPointHistoryInMinutes:     &recoveryPoint,
 						AppConsistentFrequencyInMinutes:   &appConsistency,
-						EnableMultiVMSync:                 utils.String(EnableMultiVMSyncEnabled),
-						CrashConsistentFrequencyInMinutes: utils.Int64(10),
+						EnableMultiVMSync:                 pointer.To(EnableMultiVMSyncEnabled),
+						CrashConsistentFrequencyInMinutes: pointer.To(int64(10)),
 					},
 				},
 			}

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SiteRecoveryVMWareReplicationPolicyResource struct{}
@@ -103,5 +103,5 @@ func (t SiteRecoveryVMWareReplicationPolicyResource) Exists(ctx context.Context,
 		return nil, fmt.Errorf("reading %s: %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redhatopenshift/2023-09-04/openshiftclusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type OpenShiftClusterResource struct{}
@@ -200,7 +200,7 @@ func (t OpenShiftClusterResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("reading Red Hat Openshift Cluster (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r OpenShiftClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -25,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceRedisEnterpriseCluster() *pluginsdk.Resource {
@@ -286,7 +286,7 @@ func expandRedisEnterpriseClusterSku(v string) redisenterprise.Sku {
 
 	return redisenterprise.Sku{
 		Name:     redisenterprise.SkuName(redisSku.Name),
-		Capacity: utils.Int64(capacity),
+		Capacity: pointer.To(capacity),
 	}
 }
 

--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource_test.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2024-10-01/redisenterprise"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RedisEnterpriseClusterResource struct{}
@@ -99,11 +99,11 @@ func (r RedisEnterpriseClusterResource) Exists(ctx context.Context, client *clie
 	resp, err := client.RedisEnterprise.Client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r RedisEnterpriseClusterResource) template(data acceptance.TestData) string {

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2024-10-01/databases"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2024-10-01/redisenterprise"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceRedisEnterpriseDatabase() *pluginsdk.Resource {
@@ -278,7 +278,7 @@ func resourceRedisEnterpriseDatabaseCreate(d *pluginsdk.ResourceData, meta inter
 			Modules:          module,
 			// Persistence:      expandArmDatabasePersistence(d.Get("persistence").([]interface{})),
 			GeoReplication: linkedDatabase,
-			Port:           utils.Int64(int64(d.Get("port").(int))),
+			Port:           pointer.To(int64(d.Get("port").(int))),
 		},
 	}
 
@@ -429,7 +429,7 @@ func resourceRedisEnterpriseDatabaseUpdate(d *pluginsdk.ResourceData, meta inter
 			Modules:          module,
 			// Persistence:      expandArmDatabasePersistence(d.Get("persistence").([]interface{})),
 			GeoReplication: linkedDatabase,
-			Port:           utils.Int64(int64(d.Get("port").(int))),
+			Port:           pointer.To(int64(d.Get("port").(int))),
 		},
 	}
 
@@ -504,7 +504,7 @@ func expandArmDatabaseModuleArray(input []interface{}, isGeoEnabled bool) (*[]da
 		}
 		results = append(results, databases.Module{
 			Name: moduleName,
-			Args: utils.String(v["args"].(string)),
+			Args: pointer.To(v["args"].(string)),
 		})
 	}
 	return &results, nil
@@ -517,9 +517,9 @@ func expandArmDatabaseModuleArray(input []interface{}, isGeoEnabled bool) (*[]da
 // 	}
 // 	v := input[0].(map[string]interface{})
 // 	return &redisenterprise.Persistence{
-// 		AofEnabled:   utils.Bool(v["aof_enabled"].(bool)),
+// 		AofEnabled:   pointer.To(v["aof_enabled"].(bool)),
 // 		AofFrequency: redisenterprise.AofFrequency(v["aof_frequency"].(string)),
-// 		RdbEnabled:   utils.Bool(v["rdb_enabled"].(bool)),
+// 		RdbEnabled:   pointer.To(v["rdb_enabled"].(bool)),
 // 		RdbFrequency: redisenterprise.RdbFrequency(v["rdb_frequency"].(string)),
 // 	}
 // }
@@ -571,13 +571,13 @@ func expandArmGeoLinkedDatabase(inputId []interface{}, parentDBId string, inputG
 			isParentDbIncluded = true
 		}
 		idList = append(idList, databases.LinkedDatabase{
-			Id: utils.String(id.(string)),
+			Id: pointer.To(id.(string)),
 		})
 	}
 	if isParentDbIncluded {
 		return &databases.DatabasePropertiesGeoReplication{
 			LinkedDatabases: &idList,
-			GroupNickname:   utils.String(inputGeoName),
+			GroupNickname:   pointer.To(inputGeoName),
 		}, nil
 	}
 

--- a/internal/services/redisenterprise/redis_enterprise_database_resource_test.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2024-10-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RedisEnterpriseDatabaseResource struct{}
@@ -147,13 +147,13 @@ func (r RedisEnterpriseDatabaseResource) Exists(ctx context.Context, client *cli
 	resp, err := client.RedisEnterprise.DatabaseClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r RedisEnterpriseDatabaseResource) template(data acceptance.TestData) string {

--- a/internal/services/relay/relay_hybrid_connection_authorization_rule_resource.go
+++ b/internal/services/relay/relay_hybrid_connection_authorization_rule_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/hybridconnections"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceRelayHybridConnectionAuthorizationRule() *pluginsdk.Resource {
@@ -86,7 +86,7 @@ func resourceRelayHybridConnectionAuthorizationRuleCreateUpdate(d *pluginsdk.Res
 	}
 
 	parameters := hybridconnections.AuthorizationRule{
-		Name: utils.String(resourceId.AuthorizationRuleName),
+		Name: pointer.To(resourceId.AuthorizationRuleName),
 		Properties: &hybridconnections.AuthorizationRuleProperties{
 			Rights: expandHybridConnectionAuthorizationRuleRights(d),
 		},

--- a/internal/services/relay/relay_hybrid_connection_authorization_rule_resource_test.go
+++ b/internal/services/relay/relay_hybrid_connection_authorization_rule_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/hybridconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RelayHybridConnectionAuthorizationRuleResource struct{}
@@ -61,12 +61,12 @@ func (t RelayHybridConnectionAuthorizationRuleResource) Exists(ctx context.Conte
 	resp, err := clients.Relay.HybridConnectionsClient.GetAuthorizationRule(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (RelayHybridConnectionAuthorizationRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/relay/relay_hybrid_connection_resource_test.go
+++ b/internal/services/relay/relay_hybrid_connection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/hybridconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RelayHybridConnectionResource struct{}
@@ -99,7 +99,7 @@ func (t RelayHybridConnectionResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (RelayHybridConnectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/relay/relay_namespace_authorization_rule_resource.go
+++ b/internal/services/relay/relay_namespace_authorization_rule_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceRelayNamespaceAuthorizationRule() *pluginsdk.Resource {
@@ -80,7 +80,7 @@ func resourceRelayNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceDa
 	}
 
 	parameters := namespaces.AuthorizationRule{
-		Name: utils.String(resourceId.AuthorizationRuleName),
+		Name: pointer.To(resourceId.AuthorizationRuleName),
 		Properties: &namespaces.AuthorizationRuleProperties{
 			Rights: expandAuthorizationRuleRights(d),
 		},

--- a/internal/services/relay/relay_namespace_authorization_rule_ressource_test.go
+++ b/internal/services/relay/relay_namespace_authorization_rule_ressource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RelayNamespaceAuthorizationRuleResource struct{}
@@ -61,12 +61,12 @@ func (t RelayNamespaceAuthorizationRuleResource) Exists(ctx context.Context, cli
 	resp, err := clients.Relay.NamespacesClient.GetAuthorizationRule(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (RelayNamespaceAuthorizationRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/relay/relay_namespace_resource.go
+++ b/internal/services/relay/relay_namespace_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -118,7 +117,7 @@ func resourceRelayNamespaceCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 
 	skuTier := namespaces.SkuTier(d.Get("sku_name").(string))
 	parameters := namespaces.RelayNamespace{
-		Location: azure.NormalizeLocation(d.Get("location").(string)),
+		Location: location.Normalize(d.Get("location").(string)),
 		Sku: &namespaces.Sku{
 			Name: namespaces.SkuName(d.Get("sku_name").(string)),
 			Tier: &skuTier,

--- a/internal/services/relay/relay_namespace_resource_test.go
+++ b/internal/services/relay/relay_namespace_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type RelayNamespaceResource struct{}
@@ -89,13 +89,13 @@ func (t RelayNamespaceResource) Exists(ctx context.Context, clients *clients.Cli
 	resp, err := clients.Relay.NamespacesClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (RelayNamespaceResource) basic(data acceptance.TestData) string {

--- a/internal/services/resource/management_group_template_deployment_resource.go
+++ b/internal/services/resource/management_group_template_deployment_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -134,7 +135,7 @@ func managementGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, 
 	}
 
 	deployment := resources.ScopedDeployment{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &resources.DeploymentProperties{
 			DebugSetting: expandTemplateDeploymentDebugSetting(d.Get("debug_level").(string)),
 			Mode:         resources.DeploymentModeIncremental,
@@ -152,7 +153,7 @@ func managementGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, 
 
 	if templateSpecVersionID, ok := d.GetOk("template_spec_version_id"); ok {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(templateSpecVersionID.(string)),
+			ID: pointer.To(templateSpecVersionID.(string)),
 		}
 	}
 
@@ -245,7 +246,7 @@ func managementGroupTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, 
 
 	if d.HasChange("template_spec_version_id") {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(d.Get("template_spec_version_id").(string)),
+			ID: pointer.To(d.Get("template_spec_version_id").(string)),
 		}
 
 		if d.Get("template_spec_version_id").(string) != "" {

--- a/internal/services/resource/management_group_template_deployment_resource_test.go
+++ b/internal/services/resource/management_group_template_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagementGroupTemplateDeploymentResource struct{}
@@ -154,5 +154,5 @@ func (t ManagementGroupTemplateDeploymentResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("reading Subscription Template Deployment (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }

--- a/internal/services/resource/management_lock_resource.go
+++ b/internal/services/resource/management_lock_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceManagementLock() *pluginsdk.Resource {
@@ -92,7 +92,7 @@ func resourceManagementLockCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	payload := managementlocks.ManagementLockObject{
 		Properties: managementlocks.ManagementLockProperties{
 			Level: managementlocks.LockLevel(d.Get("lock_level").(string)),
-			Notes: utils.String(d.Get("notes").(string)),
+			Notes: pointer.To(d.Get("notes").(string)),
 		},
 	}
 

--- a/internal/services/resource/management_lock_resource_test.go
+++ b/internal/services/resource/management_lock_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagementLockResource struct{}
@@ -175,7 +175,7 @@ func (t ManagementLockResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ManagementLockResource) resourceGroupReadOnlyBasic(data acceptance.TestData) string {

--- a/internal/services/resource/resource_deployment_script_azure_cli_resource_test.go
+++ b/internal/services/resource/resource_deployment_script_azure_cli_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceDeploymentScriptAzureCLIResource struct{}
@@ -92,11 +92,11 @@ func (r ResourceDeploymentScriptAzureCLIResource) Exists(ctx context.Context, cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ResourceDeploymentScriptAzureCLIResource) template(data acceptance.TestData) string {

--- a/internal/services/resource/resource_deployment_script_azure_power_shell_resource_test.go
+++ b/internal/services/resource/resource_deployment_script_azure_power_shell_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceDeploymentScriptAzurePowerShellResource struct{}
@@ -106,11 +106,11 @@ func (r ResourceDeploymentScriptAzurePowerShellResource) Exists(ctx context.Cont
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ResourceDeploymentScriptAzurePowerShellResource) template(data acceptance.TestData) string {

--- a/internal/services/resource/resource_group_data_source_test.go
+++ b/internal/services/resource/resource_group_data_source_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -23,7 +23,7 @@ func TestAccDataSourceAzureRMResourceGroup_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").HasValue(fmt.Sprintf("acctestRg-%d", data.RandomInteger)),
-				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.env").HasValue("test"),
 				check.That(data.ResourceName).Key("managed_by").HasValue("test"),

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -172,7 +173,7 @@ func resourceGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, me
 
 	if templateSpecVersionID, ok := d.GetOk("template_spec_version_id"); ok {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(templateSpecVersionID.(string)),
+			ID: pointer.To(templateSpecVersionID.(string)),
 		}
 	}
 
@@ -266,7 +267,7 @@ func resourceGroupTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, me
 
 	if d.HasChange("template_spec_version_id") {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(d.Get("template_spec_version_id").(string)),
+			ID: pointer.To(d.Get("template_spec_version_id").(string)),
 		}
 
 		if d.Get("template_spec_version_id").(string) != "" {

--- a/internal/services/resource/resource_group_template_deployment_resource_test.go
+++ b/internal/services/resource/resource_group_template_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceGroupTemplateDeploymentResource struct{}
@@ -325,7 +325,7 @@ func (t ResourceGroupTemplateDeploymentResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("reading Management Lock (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (ResourceGroupTemplateDeploymentResource) emptyConfig(data acceptance.TestData, deploymentMode string) string {

--- a/internal/services/resource/resource_management_private_link_association_resource_test.go
+++ b/internal/services/resource/resource_management_private_link_association_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/privatelinkassociation"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceManagementPrivateLinkAssociationTestResource struct {
@@ -83,7 +83,7 @@ func (r ResourceManagementPrivateLinkAssociationTestResource) Exists(ctx context
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ResourceManagementPrivateLinkAssociationTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/resource/resource_management_private_link_resource_test.go
+++ b/internal/services/resource/resource_management_private_link_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ResourceManagementPrivateLinkTestResource struct{}
@@ -59,7 +59,7 @@ func (r ResourceManagementPrivateLinkTestResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ResourceManagementPrivateLinkTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/resource/resource_provider_registration_resource_test.go
+++ b/internal/services/resource/resource_provider_registration_resource_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceproviders/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 // NOTE: this can be moved up a level when all the others are
@@ -107,7 +106,7 @@ func (ResourceProviderRegistrationResource) Exists(ctx context.Context, client *
 	resp, err := client.Resource.ResourceProvidersClient.Get(ctx, *id, providers.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)

--- a/internal/services/resource/subscription_template_deployment_resource.go
+++ b/internal/services/resource/subscription_template_deployment_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -121,7 +122,7 @@ func subscriptionTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, met
 	}
 
 	deployment := resources.Deployment{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &resources.DeploymentProperties{
 			DebugSetting: expandTemplateDeploymentDebugSetting(d.Get("debug_level").(string)),
 			Mode:         resources.DeploymentModeIncremental,
@@ -139,7 +140,7 @@ func subscriptionTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, met
 
 	if templateSpecVersionID, ok := d.GetOk("template_spec_version_id"); ok {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(templateSpecVersionID.(string)),
+			ID: pointer.To(templateSpecVersionID.(string)),
 		}
 	}
 
@@ -230,7 +231,7 @@ func subscriptionTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, met
 
 	if d.HasChange("template_spec_version_id") {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(d.Get("template_spec_version_id").(string)),
+			ID: pointer.To(d.Get("template_spec_version_id").(string)),
 		}
 
 		if d.Get("template_spec_version_id").(string) != "" {

--- a/internal/services/resource/subscription_template_deployment_resource_test.go
+++ b/internal/services/resource/subscription_template_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubscriptionTemplateDeploymentResource struct{}
@@ -149,7 +149,7 @@ func (t SubscriptionTemplateDeploymentResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("reading Subscription Template Deployment (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (SubscriptionTemplateDeploymentResource) emptyConfig(data acceptance.TestData) string {

--- a/internal/services/resource/template_deployment_common.go
+++ b/internal/services/resource/template_deployment_common.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type templateDeploymentDebugLevel string
@@ -40,12 +40,12 @@ var templateDeploymentDebugLevels = []string{
 func expandTemplateDeploymentDebugSetting(debugLevel string) *resources.DebugSetting {
 	if debugLevel == "" {
 		return &resources.DebugSetting{
-			DetailLevel: utils.String(string(debugLevelNone)),
+			DetailLevel: pointer.To(string(debugLevelNone)),
 		}
 	}
 
 	return &resources.DebugSetting{
-		DetailLevel: utils.String(debugLevel),
+		DetailLevel: pointer.To(debugLevel),
 	}
 }
 

--- a/internal/services/resource/tenant_template_deployment_resource.go
+++ b/internal/services/resource/tenant_template_deployment_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -120,7 +121,7 @@ func tenantTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	deployment := resources.ScopedDeployment{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: &resources.DeploymentProperties{
 			DebugSetting: expandTemplateDeploymentDebugSetting(d.Get("debug_level").(string)),
 			Mode:         resources.DeploymentModeIncremental,
@@ -138,7 +139,7 @@ func tenantTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, meta inte
 
 	if templateSpecVersionID, ok := d.GetOk("template_spec_version_id"); ok {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(templateSpecVersionID.(string)),
+			ID: pointer.To(templateSpecVersionID.(string)),
 		}
 	}
 
@@ -231,7 +232,7 @@ func tenantTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, meta inte
 
 	if d.HasChange("template_spec_version_id") {
 		deployment.Properties.TemplateLink = &resources.TemplateLink{
-			ID: utils.String(d.Get("template_spec_version_id").(string)),
+			ID: pointer.To(d.Get("template_spec_version_id").(string)),
 		}
 
 		if d.Get("template_spec_version_id").(string) != "" {

--- a/internal/services/resource/tenant_template_deployment_resource_test.go
+++ b/internal/services/resource/tenant_template_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type TenantTemplateDeploymentResource struct{}
@@ -55,7 +55,7 @@ func (t TenantTemplateDeploymentResource) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("reading Tenant Template Deployment (%s): %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (TenantTemplateDeploymentResource) emptyConfig(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
