### PR TITLE
services `S*` part 1 - deprecated function clean up

### DIFF
--- a/internal/services/search/search_service_resource_test.go
+++ b/internal/services/search/search_service_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/search/2025-05-01/services"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SearchServiceResource struct{}
@@ -630,7 +630,7 @@ func (r SearchServiceResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("%s was not found: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (SearchServiceResource) template(data acceptance.TestData) string {

--- a/internal/services/securitycenter/advanced_threat_protection_resource.go
+++ b/internal/services/securitycenter/advanced_threat_protection_resource.go
@@ -82,7 +82,7 @@ func resourceAdvancedThreatProtectionCreateUpdate(d *pluginsdk.ResourceData, met
 
 	setting := security.AdvancedThreatProtectionSetting{
 		AdvancedThreatProtectionProperties: &security.AdvancedThreatProtectionProperties{
-			IsEnabled: utils.Bool(d.Get("enabled").(bool)),
+			IsEnabled: pointer.To(d.Get("enabled").(bool)),
 		},
 	}
 
@@ -169,7 +169,7 @@ func resourceAdvancedThreatProtectionDelete(d *pluginsdk.ResourceData, meta inte
 	// there is no delete.. so lets just do best effort and set it to false?
 	setting := security.AdvancedThreatProtectionSetting{
 		AdvancedThreatProtectionProperties: &security.AdvancedThreatProtectionProperties{
-			IsEnabled: utils.Bool(false),
+			IsEnabled: pointer.To(false),
 		},
 	}
 

--- a/internal/services/securitycenter/advanced_threat_protection_resource_test.go
+++ b/internal/services/securitycenter/advanced_threat_protection_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AdvancedThreatProtectionResource struct{}
@@ -106,7 +106,7 @@ func (AdvancedThreatProtectionResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("reading Advanced Threat Protection (%s): %+v", id.TargetResourceID, err)
 	}
 
-	return utils.Bool(resp.AdvancedThreatProtectionProperties != nil), nil
+	return pointer.To(resp.AdvancedThreatProtectionProperties != nil), nil
 }
 
 // nolint unused

--- a/internal/services/securitycenter/iot_security_device_group_resource.go
+++ b/internal/services/securitycenter/iot_security_device_group_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -254,7 +255,7 @@ func expandIotSecurityDeviceGroupAllowRule(input []interface{}) *[]security.Basi
 	if connectionFromIPNotAllowed := v["connection_from_ips_not_allowed"].(*pluginsdk.Set).List(); len(connectionFromIPNotAllowed) > 0 {
 		result = append(result, security.ConnectionFromIPNotAllowed{
 			AllowlistValues: utils.ExpandStringSlice(connectionFromIPNotAllowed),
-			IsEnabled:       utils.Bool(true),
+			IsEnabled:       pointer.To(true),
 		})
 	}
 
@@ -262,7 +263,7 @@ func expandIotSecurityDeviceGroupAllowRule(input []interface{}) *[]security.Basi
 	if connectionToIPsNotAllowed := v["connection_to_ips_not_allowed"].(*pluginsdk.Set).List(); len(connectionToIPsNotAllowed) > 0 {
 		connectionToIPListNotAllowed = &security.ConnectionToIPNotAllowed{
 			AllowlistValues: utils.ExpandStringSlice(connectionToIPsNotAllowed),
-			IsEnabled:       utils.Bool(true),
+			IsEnabled:       pointer.To(true),
 		}
 	}
 	if connectionToIPListNotAllowed != nil {
@@ -273,7 +274,7 @@ func expandIotSecurityDeviceGroupAllowRule(input []interface{}) *[]security.Basi
 	if LocalUsersNotAllowed := v["local_users_not_allowed"].(*pluginsdk.Set).List(); len(LocalUsersNotAllowed) > 0 {
 		localUserListNotAllowed = &security.LocalUserNotAllowed{
 			AllowlistValues: utils.ExpandStringSlice(LocalUsersNotAllowed),
-			IsEnabled:       utils.Bool(true),
+			IsEnabled:       pointer.To(true),
 		}
 	}
 	if localUserListNotAllowed != nil {
@@ -284,7 +285,7 @@ func expandIotSecurityDeviceGroupAllowRule(input []interface{}) *[]security.Basi
 	if processesNotAllowed := v["processes_not_allowed"].(*pluginsdk.Set).List(); len(processesNotAllowed) > 0 {
 		processListNotAllowed = &security.ProcessNotAllowed{
 			AllowlistValues: utils.ExpandStringSlice(processesNotAllowed),
-			IsEnabled:       utils.Bool(true),
+			IsEnabled:       pointer.To(true),
 		}
 	}
 	if processListNotAllowed != nil {
@@ -318,115 +319,115 @@ func expandIotSecurityDeviceGroupTimeWindowRule(input []interface{}) (*[]securit
 		switch t {
 		case security.RuleTypeActiveConnectionsNotInAllowedRange:
 			result = append(result, security.ActiveConnectionsNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeAmqpC2DMessagesNotInAllowedRange:
 			result = append(result, security.AmqpC2DMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeMqttC2DMessagesNotInAllowedRange:
 			result = append(result, security.MqttC2DMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeHTTPC2DMessagesNotInAllowedRange:
 			result = append(result, security.HTTPC2DMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeAmqpC2DRejectedMessagesNotInAllowedRange:
 			result = append(result, security.AmqpC2DRejectedMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeMqttC2DRejectedMessagesNotInAllowedRange:
 			result = append(result, security.MqttC2DRejectedMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeHTTPC2DRejectedMessagesNotInAllowedRange:
 			result = append(result, security.HTTPC2DRejectedMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeAmqpD2CMessagesNotInAllowedRange:
 			result = append(result, security.AmqpD2CMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeMqttD2CMessagesNotInAllowedRange:
 			result = append(result, security.MqttD2CMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeHTTPD2CMessagesNotInAllowedRange:
 			result = append(result, security.HTTPD2CMessagesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeDirectMethodInvokesNotInAllowedRange:
 			result = append(result, security.DirectMethodInvokesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeFailedLocalLoginsNotInAllowedRange:
 			result = append(result, security.FailedLocalLoginsNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeFileUploadsNotInAllowedRange:
 			result = append(result, security.FileUploadsNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeQueuePurgesNotInAllowedRange:
 			result = append(result, security.QueuePurgesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeTwinUpdatesNotInAllowedRange:
 			result = append(result, security.TwinUpdatesNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		case security.RuleTypeUnauthorizedOperationsNotInAllowedRange:
 			result = append(result, security.UnauthorizedOperationsNotInAllowedRange{
-				TimeWindowSize: utils.String(duration),
-				MinThreshold:   utils.Int32(min),
-				MaxThreshold:   utils.Int32(max),
-				IsEnabled:      utils.Bool(true),
+				TimeWindowSize: pointer.To(duration),
+				MinThreshold:   pointer.To(min),
+				MaxThreshold:   pointer.To(max),
+				IsEnabled:      pointer.To(true),
 			})
 		}
 	}

--- a/internal/services/securitycenter/iot_security_device_group_resource_test.go
+++ b/internal/services/securitycenter/iot_security_device_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type DeviceSecurityGroupResource struct{}
@@ -103,7 +103,7 @@ func (DeviceSecurityGroupResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("reading Iot Security Device Group %q: %+v", id.ID(), err)
 	}
 
-	return utils.Bool(resp.DeviceSecurityGroupProperties != nil), nil
+	return pointer.To(resp.DeviceSecurityGroupProperties != nil), nil
 }
 
 func (r DeviceSecurityGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/securitycenter/iot_security_solution_resource.go
+++ b/internal/services/securitycenter/iot_security_solution_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
@@ -306,9 +307,9 @@ func resourceIotSecuritySolutionCreateUpdate(d *pluginsdk.ResourceData, meta int
 		unmaskedIPLoggingStatus = security.UnmaskedIPLoggingStatusEnabled
 	}
 	solution := security.IoTSecuritySolutionModel{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		IoTSecuritySolutionProperties: &security.IoTSecuritySolutionProperties{
-			DisplayName:                  utils.String(d.Get("display_name").(string)),
+			DisplayName:                  pointer.To(d.Get("display_name").(string)),
 			Status:                       status,
 			Export:                       expandIotSecuritySolutionExport(d.Get("events_to_export").(*pluginsdk.Set).List()),
 			IotHubs:                      utils.ExpandStringSlice(d.Get("iothub_ids").(*pluginsdk.Set).List()),
@@ -328,7 +329,7 @@ func resourceIotSecuritySolutionCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	logAnalyticsWorkspaceId := d.Get("log_analytics_workspace_id").(string)
 	if logAnalyticsWorkspaceId != "" {
-		solution.Workspace = utils.String(logAnalyticsWorkspaceId)
+		solution.Workspace = pointer.To(logAnalyticsWorkspaceId)
 	}
 
 	query := d.Get("query_for_resources").(string)
@@ -336,7 +337,7 @@ func resourceIotSecuritySolutionCreateUpdate(d *pluginsdk.ResourceData, meta int
 	if query != "" || len(querySubscriptions) > 0 {
 		if query != "" && len(querySubscriptions) > 0 {
 			solution.UserDefinedResources = &security.UserDefinedResourcesProperties{
-				Query:              utils.String(query),
+				Query:              pointer.To(query),
 				QuerySubscriptions: utils.ExpandStringSlice(querySubscriptions),
 			}
 		} else {
@@ -461,7 +462,7 @@ func expandIotSecuritySolutionAdditionalWorkspace(input []interface{}) *[]securi
 		}
 
 		results = append(results, security.AdditionalWorkspacesProperties{
-			Workspace: utils.String(v["workspace_id"].(string)),
+			Workspace: pointer.To(v["workspace_id"].(string)),
 			Type:      security.Sentinel,
 			DataTypes: &dataTypes,
 		})

--- a/internal/services/securitycenter/iot_security_solution_resource_test.go
+++ b/internal/services/securitycenter/iot_security_solution_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type IotSecuritySolutionResource struct{}
@@ -125,7 +125,7 @@ func (IotSecuritySolutionResource) Exists(ctx context.Context, clients *clients.
 		return nil, fmt.Errorf("reading Security Center Iot Security Solution %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r IotSecuritySolutionResource) basic(data acceptance.TestData) string {

--- a/internal/services/securitycenter/security_center_assessment_policy_resource.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource.go
@@ -306,7 +306,7 @@ func resourceArmSecurityCenterAssessmentPolicyUpdate(d *pluginsdk.ResourceData, 
 	}
 
 	if d.HasChange("remediation_description") {
-		existing.Model.Properties.RemediationDescription = utils.String(d.Get("remediation_description").(string))
+		existing.Model.Properties.RemediationDescription = pointer.To(d.Get("remediation_description").(string))
 	}
 
 	if d.HasChange("user_impact") {

--- a/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterAssessmentPolicyResource struct{}
@@ -82,7 +81,7 @@ func (r SecurityCenterAssessmentPolicyResource) Exists(ctx context.Context, clie
 	resp, err := assessmentMetadataClient.GetInSubscription(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving %q: %+v", *id, err)

--- a/internal/services/securitycenter/security_center_assessment_resource.go
+++ b/internal/services/securitycenter/security_center_assessment_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -197,8 +198,8 @@ func expandSecurityCenterAssessmentStatus(input []interface{}) *security.Assessm
 	v := input[0].(map[string]interface{})
 	return &security.AssessmentStatus{
 		Code:        security.AssessmentStatusCode(v["code"].(string)),
-		Cause:       utils.String(v["cause"].(string)),
-		Description: utils.String(v["description"].(string)),
+		Cause:       pointer.To(v["cause"].(string)),
+		Description: pointer.To(v["description"].(string)),
 	}
 }
 

--- a/internal/services/securitycenter/security_center_assessment_resource_test.go
+++ b/internal/services/securitycenter/security_center_assessment_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -102,13 +103,13 @@ func (r SecurityCenterAssessmentResource) Exists(ctx context.Context, client *cl
 	resp, err := assessmentClient.Get(ctx, id.TargetResourceID, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving Azure Security Center Assessment %q: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.AssessmentProperties != nil), nil
+	return pointer.To(resp.AssessmentProperties != nil), nil
 }
 
 func (r SecurityCenterAssessmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/securitycenter/security_center_auto_provisioning_resource_test.go
+++ b/internal/services/securitycenter/security_center_auto_provisioning_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterAutoProvisionResource struct{}
@@ -55,7 +55,7 @@ func (SecurityCenterAutoProvisionResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("retrieving auto-provisioning setting for %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.AutoProvisioningSettingProperties != nil), nil
+	return pointer.To(resp.AutoProvisioningSettingProperties != nil), nil
 }
 
 func (SecurityCenterAutoProvisionResource) setting(setting string) string {

--- a/internal/services/securitycenter/security_center_automation_resource.go
+++ b/internal/services/securitycenter/security_center_automation_resource.go
@@ -59,7 +59,7 @@ func resourceSecurityCenterAutomation() *pluginsdk.Resource {
 				Type:      pluginsdk.TypeString,
 				Required:  true,
 				ForceNew:  true,
-				StateFunc: azure.NormalizeLocation,
+				StateFunc: location.StateFunc,
 			},
 
 			"resource_group_name": commonschema.ResourceGroupName(),
@@ -238,7 +238,7 @@ func resourceSecurityCenterAutomationCreateUpdate(d *pluginsdk.ResourceData, met
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	enabled := d.Get("enabled").(bool)
 
 	// Build automation struct

--- a/internal/services/securitycenter/security_center_contact_resource.go
+++ b/internal/services/securitycenter/security_center_contact_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/azuresdkhacks"
@@ -95,8 +96,8 @@ func resourceSecurityCenterContactCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 	contact := security.Contact{
 		ContactProperties: &security.ContactProperties{
-			Email: utils.String(d.Get("email").(string)),
-			Phone: utils.String(d.Get("phone").(string)),
+			Email: pointer.To(d.Get("email").(string)),
+			Phone: pointer.To(d.Get("phone").(string)),
 		},
 	}
 

--- a/internal/services/securitycenter/security_center_contact_resource_test.go
+++ b/internal/services/securitycenter/security_center_contact_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterContactResource struct{}
@@ -133,7 +133,7 @@ func (SecurityCenterContactResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.ContactProperties != nil), nil
+	return pointer.To(resp.ContactProperties != nil), nil
 }
 
 func (SecurityCenterContactResource) template(name, email, phone string, notifications, adminAlerts bool) string {

--- a/internal/services/securitycenter/security_center_server_vulnerability_assessment_virtual_machine_resource_test.go
+++ b/internal/services/securitycenter/security_center_server_vulnerability_assessment_virtual_machine_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServerVulnerabilityAssessmentVirtualMachineResource struct{}
@@ -59,7 +59,7 @@ func (ServerVulnerabilityAssessmentVirtualMachineResource) Exists(ctx context.Co
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (ServerVulnerabilityAssessmentVirtualMachineResource) basicCfg(data acceptance.TestData) string {

--- a/internal/services/securitycenter/security_center_server_vulnerability_assessments_setting_resource.go
+++ b/internal/services/securitycenter/security_center_server_vulnerability_assessments_setting_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-05-01/servervulnerabilityassessmentssettings"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSecurityCenterServerVulnerabilityAssessmentsSetting() *pluginsdk.Resource {
@@ -72,8 +72,8 @@ func resourceSecurityCenterServerVulnerabilityAssessmentsSettingCreateOrUpdate(d
 	}
 
 	setting := servervulnerabilityassessmentssettings.AzureServersSetting{
-		Type: utils.String("AzureServersSetting"),
-		Name: utils.String("AzureServersSetting"),
+		Type: pointer.To("AzureServersSetting"),
+		Name: pointer.To("AzureServersSetting"),
 		Properties: &servervulnerabilityassessmentssettings.ServerVulnerabilityAssessmentsAzureSettingProperties{
 			SelectedProvider: servervulnerabilityassessmentssettings.ServerVulnerabilityAssessmentsAzureSettingSelectedProvider(d.Get("vulnerability_assessment_provider").(string)),
 		},

--- a/internal/services/securitycenter/security_center_server_vulnerability_assessments_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_server_vulnerability_assessments_setting_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-05-01/servervulnerabilityassessmentssettings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterServerVulnerabilityAssessmentsSettingResource struct{}
@@ -47,19 +47,19 @@ func (SecurityCenterServerVulnerabilityAssessmentsSettingResource) Exists(ctx co
 	}
 
 	if resp.Model == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	if azureServersSetting, ok := resp.Model.(servervulnerabilityassessmentssettings.AzureServersSetting); ok {
 		if azureServersSetting.Properties == nil {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		if azureServersSetting.Properties.SelectedProvider != "" {
-			return utils.Bool(true), nil
+			return pointer.To(true), nil
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (SecurityCenterServerVulnerabilityAssessmentsSettingResource) basicCfg(providerName string) string {

--- a/internal/services/securitycenter/security_center_setting_resource_test.go
+++ b/internal/services/securitycenter/security_center_setting_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2022-05-01/settings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterSettingResource struct{}
@@ -115,23 +115,23 @@ func (SecurityCenterSettingResource) Exists(ctx context.Context, clients *client
 	}
 
 	if resp.Model == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	if alertSyncSettings, ok := resp.Model.(settings.AlertSyncSettings); ok {
 		if alertSyncSettings.Properties == nil {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
-		return utils.Bool(alertSyncSettings.Properties.Enabled), nil
+		return pointer.To(alertSyncSettings.Properties.Enabled), nil
 	}
 	if dataExportSettings, ok := resp.Model.(settings.DataExportSettings); ok {
 		if dataExportSettings.Properties == nil {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
-		return utils.Bool(dataExportSettings.Properties.Enabled), nil
+		return pointer.To(dataExportSettings.Properties.Enabled), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (SecurityCenterSettingResource) Destroy(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -157,21 +157,21 @@ func (SecurityCenterSettingResource) Destroy(ctx context.Context, clients *clien
 	}
 
 	if resp.Model == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	if alertSyncSettings, ok := resp.Model.(settings.AlertSyncSettings); ok {
 		if alertSyncSettings.Properties == nil || !alertSyncSettings.Properties.Enabled {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 	}
 	if dataExportSettings, ok := resp.Model.(settings.DataExportSettings); ok {
 		if dataExportSettings.Properties == nil || !dataExportSettings.Properties.Enabled {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (SecurityCenterSettingResource) cfg(settingName string, enabled bool) string {

--- a/internal/services/securitycenter/security_center_storage_defender_resource_test.go
+++ b/internal/services/securitycenter/security_center_storage_defender_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterStorageDefenderResource struct{}
@@ -30,7 +30,7 @@ func (SecurityCenterStorageDefenderResource) Exists(ctx context.Context, clients
 	}
 
 	if resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.IsEnabled == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	return resp.Model.Properties.IsEnabled, nil

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterSubscriptionPricingResource struct{}
@@ -244,7 +244,7 @@ func (SecurityCenterSubscriptionPricingResource) Exists(ctx context.Context, cli
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model.Properties != nil && resp.Model.Properties.PricingTier != pricings_v2023_01_01.PricingTierFree), nil
+	return pointer.To(resp.Model.Properties != nil && resp.Model.Properties.PricingTier != pricings_v2023_01_01.PricingTierFree), nil
 }
 
 func (SecurityCenterSubscriptionPricingResource) tier(tier string, resource_type string) string {

--- a/internal/services/securitycenter/security_center_workspace_resource.go
+++ b/internal/services/securitycenter/security_center_workspace_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -91,8 +92,8 @@ func resourceSecurityCenterWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta
 
 	contact := security.WorkspaceSetting{
 		WorkspaceSettingProperties: &security.WorkspaceSettingProperties{
-			Scope:       utils.String(d.Get("scope").(string)),
-			WorkspaceID: utils.String(logAnalyticsWorkspaceId.ID()),
+			Scope:       pointer.To(d.Get("scope").(string)),
+			WorkspaceID: pointer.To(logAnalyticsWorkspaceId.ID()),
 		},
 	}
 
@@ -167,7 +168,7 @@ func resourceSecurityCenterWorkspaceRead(d *pluginsdk.ResourceData, meta interfa
 			}
 			workspaceId = id.ID()
 		}
-		d.Set("workspace_id", utils.String(workspaceId))
+		d.Set("workspace_id", pointer.To(workspaceId))
 	}
 
 	return nil

--- a/internal/services/securitycenter/security_center_workspace_resource_test.go
+++ b/internal/services/securitycenter/security_center_workspace_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityCenterWorkspaceResource struct{}
@@ -92,7 +92,7 @@ func (SecurityCenterWorkspaceResource) Exists(ctx context.Context, clients *clie
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.WorkspaceSettingProperties != nil), nil
+	return pointer.To(resp.WorkspaceSettingProperties != nil), nil
 }
 
 func (SecurityCenterWorkspaceResource) basicCfg(data acceptance.TestData, scope string) string {

--- a/internal/services/sentinel/sentinel_alert_rule.go
+++ b/internal/services/sentinel/sentinel_alert_rule.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -279,16 +280,16 @@ func expandAlertRuleAlertDetailsOverride(input []interface{}) *alertrules.AlertD
 	output := &alertrules.AlertDetailsOverride{}
 
 	if v := b["description_format"]; v != "" {
-		output.AlertDescriptionFormat = utils.String(v.(string))
+		output.AlertDescriptionFormat = pointer.To(v.(string))
 	}
 	if v := b["display_name_format"]; v != "" {
-		output.AlertDisplayNameFormat = utils.String(v.(string))
+		output.AlertDisplayNameFormat = pointer.To(v.(string))
 	}
 	if v := b["severity_column_name"]; v != "" {
-		output.AlertSeverityColumnName = utils.String(v.(string))
+		output.AlertSeverityColumnName = pointer.To(v.(string))
 	}
 	if v := b["tactics_column_name"]; v != "" {
-		output.AlertTacticsColumnName = utils.String(v.(string))
+		output.AlertTacticsColumnName = pointer.To(v.(string))
 	}
 	if v := b["dynamic_property"]; v != nil && len(v.([]interface{})) > 0 {
 		output.AlertDynamicProperties = expandAlertRuleAlertDynamicProperties(v.([]interface{}))
@@ -349,7 +350,7 @@ func expandAlertRuleAlertDynamicProperties(input []interface{}) *[]alertrules.Al
 		property := alertrules.AlertProperty(b["name"].(string))
 		output = append(output, alertrules.AlertPropertyMapping{
 			AlertProperty: &property,
-			Value:         utils.String(b["value"].(string)),
+			Value:         pointer.To(b["value"].(string)),
 		})
 	}
 
@@ -423,8 +424,8 @@ func expandAlertRuleFieldMapping(input []interface{}) *[]alertrules.FieldMapping
 	for _, e := range input {
 		b := e.(map[string]interface{})
 		result = append(result, alertrules.FieldMapping{
-			Identifier: utils.String(b["identifier"].(string)),
-			ColumnName: utils.String(b["column_name"].(string)),
+			Identifier: pointer.To(b["identifier"].(string)),
+			ColumnName: pointer.To(b["column_name"].(string)),
 		})
 	}
 
@@ -466,7 +467,7 @@ func expandAlertRuleSentinelEntityMapping(input []interface{}) *[]alertrules.Sen
 	for _, e := range input {
 		b := e.(map[string]interface{})
 		result = append(result, alertrules.SentinelEntityMapping{
-			ColumnName: utils.String(b["column_name"].(string)),
+			ColumnName: pointer.To(b["column_name"].(string)),
 		})
 	}
 

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	securityinsight "github.com/jackofallops/kermit/sdk/securityinsights/2022-10-01-preview/securityinsights"
 )
 
@@ -227,7 +227,7 @@ func (r AlertRuleAnomalyBuiltInResource) Create() sdk.ResourceFunc {
 					IsDefaultSettings:        builtinRule.IsDefaultSettings,
 					AnomalySettingsVersion:   builtinRule.AnomalySettingsVersion,
 					SettingsDefinitionID:     builtinRule.SettingsDefinitionID,
-					Enabled:                  utils.Bool(metaModel.Enabled),
+					Enabled:                  pointer.To(metaModel.Enabled),
 					SettingsStatus:           securityinsight.SettingsStatus(metaModel.Mode),
 					CustomizableObservations: builtinRule.CustomizableObservations,
 				},
@@ -373,7 +373,7 @@ func (r AlertRuleAnomalyBuiltInResource) Update() sdk.ResourceFunc {
 					IsDefaultSettings:        existing.IsDefaultSettings,
 					AnomalySettingsVersion:   existing.AnomalySettingsVersion,
 					SettingsDefinitionID:     existing.SettingsDefinitionID,
-					Enabled:                  utils.Bool(metaModel.Enabled),
+					Enabled:                  pointer.To(metaModel.Enabled),
 					SettingsStatus:           securityinsight.SettingsStatus(metaModel.Mode),
 					CustomizableObservations: existing.CustomizableObservations,
 				},
@@ -437,7 +437,7 @@ func (r AlertRuleAnomalyBuiltInResource) Delete() sdk.ResourceFunc {
 					IsDefaultSettings:        existing.IsDefaultSettings,
 					AnomalySettingsVersion:   existing.AnomalySettingsVersion,
 					SettingsDefinitionID:     existing.SettingsDefinitionID,
-					Enabled:                  utils.Bool(false),
+					Enabled:                  pointer.To(false),
 					SettingsStatus:           securityinsight.SettingsStatus(metaModel.Mode),
 					CustomizableObservations: existing.CustomizableObservations,
 				},

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleAnomalyBuiltInResource struct{}
@@ -39,7 +39,7 @@ func (r SentinelAlertRuleAnomalyBuiltInResource) Exists(ctx context.Context, cli
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Sentinel Alert Rule Anomaly Built In %q (Workspace %q / Resource Group %q): %+v", id.SecurityMLAnalyticsSettingName, id.WorkspaceName, id.ResourceGroup, err)
 	}
-	return utils.Bool(resp != nil && resp.Enabled != nil && *resp.Enabled == true), nil
+	return pointer.To(resp != nil && resp.Enabled != nil && *resp.Enabled == true), nil
 }
 
 func TestAccSentinelAlertRuleAnomalyBuiltIn_basic(t *testing.T) {

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	securityinsight "github.com/jackofallops/kermit/sdk/securityinsights/2022-10-01-preview/securityinsights"
 )
 
@@ -372,16 +372,16 @@ func (r AlertRuleAnomalyDuplicateResource) Create() sdk.ResourceFunc {
 				Kind: securityinsight.KindBasicSecurityMLAnalyticsSettingKindAnomaly,
 				AnomalySecurityMLAnalyticsSettingsProperties: &securityinsight.AnomalySecurityMLAnalyticsSettingsProperties{
 					Description:            builtInAnomalyRule.Description,
-					DisplayName:            utils.String(metaModel.DisplayName),
+					DisplayName:            pointer.To(metaModel.DisplayName),
 					RequiredDataConnectors: builtInAnomalyRule.RequiredDataConnectors,
 					Tactics:                builtInAnomalyRule.Tactics,
 					Techniques:             builtInAnomalyRule.Techniques,
 					AnomalyVersion:         builtInAnomalyRule.AnomalyVersion,
 					Frequency:              builtInAnomalyRule.Frequency,
-					IsDefaultSettings:      utils.Bool(false), // for duplicate one, it's not default settings.
+					IsDefaultSettings:      pointer.To(false), // for duplicate one, it's not default settings.
 					AnomalySettingsVersion: builtInAnomalyRule.AnomalySettingsVersion,
 					SettingsDefinitionID:   builtInAnomalyRule.SettingsDefinitionID,
-					Enabled:                utils.Bool(metaModel.Enabled),
+					Enabled:                pointer.To(metaModel.Enabled),
 					SettingsStatus:         securityinsight.SettingsStatusFlighting,
 				},
 			}
@@ -540,7 +540,7 @@ func (r AlertRuleAnomalyDuplicateResource) Update() sdk.ResourceFunc {
 					IsDefaultSettings:      existing.IsDefaultSettings,
 					AnomalySettingsVersion: existing.AnomalySettingsVersion,
 					SettingsDefinitionID:   existing.SettingsDefinitionID,
-					Enabled:                utils.Bool(metaModel.Enabled),
+					Enabled:                pointer.To(metaModel.Enabled),
 					SettingsStatus:         securityinsight.SettingsStatus(metaModel.Mode),
 				},
 			}

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleAnomalyDuplicateResource struct{}
@@ -40,7 +40,7 @@ func (r SentinelAlertRuleAnomalyDuplicateResource) Exists(ctx context.Context, c
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Sentinel Alert Rule Anomaly Built In %q (Workspace %q / Resource Group %q): %+v", id.SecurityMLAnalyticsSettingName, id.WorkspaceName, id.ResourceGroup, err)
 	}
-	return utils.Bool(resp != nil), nil
+	return pointer.To(resp != nil), nil
 }
 
 func TestAccSentinelAlertRuleAnomalyDuplicate_basic(t *testing.T) {

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleFusionResource struct{}
@@ -94,7 +94,7 @@ func (r SentinelAlertRuleFusionResource) Exists(ctx context.Context, client *cli
 	resp, err := alertRuleClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving Sentinel Alert Rule Fusion (%q): %+v", state.String(), err)
@@ -105,10 +105,10 @@ func (r SentinelAlertRuleFusionResource) Exists(ctx context.Context, client *cli
 		if !ok {
 			return nil, fmt.Errorf("the Alert Rule %q is not a Fusion Alert Rule", id)
 		}
-		return utils.Bool(rule.Id != nil), nil
+		return pointer.To(rule.Id != nil), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r SentinelAlertRuleFusionResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleMLBehaviorAnalyticsResource struct{}
@@ -103,7 +103,7 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) Exists(ctx context.Context
 	resp, err := alertRuleClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("retrieving Sentinel Alert Rule MLBehaviorAnalytics (%q): %+v", state.String(), err)
@@ -114,10 +114,10 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) Exists(ctx context.Context
 		if !ok {
 			return nil, fmt.Errorf("the Alert Rule %q is not a Fusion Alert Rule", id)
 		}
-		return utils.Bool(rule.Id != nil), nil
+		return pointer.To(rule.Id != nil), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r SentinelAlertRuleMLBehaviorAnalyticsResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -158,14 +159,14 @@ func resourceSentinelAlertRuleMsSecurityIncidentCreateUpdate(d *pluginsdk.Resour
 		Properties: &alertrules.MicrosoftSecurityIncidentCreationAlertRuleProperties{
 			ProductFilter:    alertrules.MicrosoftSecurityProductName(d.Get("product_filter").(string)),
 			DisplayName:      d.Get("display_name").(string),
-			Description:      utils.String(d.Get("description").(string)),
+			Description:      pointer.To(d.Get("description").(string)),
 			Enabled:          d.Get("enabled").(bool),
 			SeveritiesFilter: expandAlertRuleMsSecurityIncidentSeverityFilter(d.Get("severity_filter").(*pluginsdk.Set).List()),
 		},
 	}
 
 	if v, ok := d.GetOk("alert_rule_template_guid"); ok {
-		param.Properties.AlertRuleTemplateName = utils.String(v.(string))
+		param.Properties.AlertRuleTemplateName = pointer.To(v.(string))
 	}
 
 	if dnf, ok := d.GetOk("display_name_filter"); ok {

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleMsSecurityIncidentResource struct{}
@@ -152,10 +152,10 @@ func (t SentinelAlertRuleMsSecurityIncidentResource) Exists(ctx context.Context,
 		if !ok {
 			return nil, fmt.Errorf("the Alert Rule %q is not a Fusion Alert Rule", id)
 		}
-		return utils.Bool(rule.Id != nil), nil
+		return pointer.To(rule.Id != nil), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r SentinelAlertRuleMsSecurityIncidentResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -347,7 +348,7 @@ func resourceSentinelAlertRuleNrtCreateUpdate(d *pluginsdk.ResourceData, meta in
 
 	param := alertrules.NrtAlertRule{
 		Properties: &alertrules.NrtAlertRuleProperties{
-			Description:           utils.String(d.Get("description").(string)),
+			Description:           pointer.To(d.Get("description").(string)),
 			DisplayName:           d.Get("display_name").(string),
 			Techniques:            expandAlertRuleTechnicals(d.Get("techniques").(*pluginsdk.Set).List()),
 			Tactics:               expandAlertRuleTactics(d.Get("tactics").(*pluginsdk.Set).List()),
@@ -361,10 +362,10 @@ func resourceSentinelAlertRuleNrtCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("alert_rule_template_guid"); ok {
-		param.Properties.AlertRuleTemplateName = utils.String(v.(string))
+		param.Properties.AlertRuleTemplateName = pointer.To(v.(string))
 	}
 	if v, ok := d.GetOk("alert_rule_template_version"); ok {
-		param.Properties.TemplateVersion = utils.String(v.(string))
+		param.Properties.TemplateVersion = pointer.To(v.(string))
 	}
 	if v, ok := d.GetOk("event_grouping"); ok {
 		param.Properties.EventGroupingSettings = expandAlertRuleEventGroupingSetting(v.([]interface{}))

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleNrtResource struct{}
@@ -145,10 +145,10 @@ func (t SentinelAlertRuleNrtResource) Exists(ctx context.Context, clients *clien
 		if !ok {
 			return nil, fmt.Errorf("the Alert Rule %q is not a Fusion Alert Rule", id)
 		}
-		return utils.Bool(rule.Id != nil), nil
+		return pointer.To(rule.Id != nil), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r SentinelAlertRuleNrtResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource.go
@@ -402,7 +402,7 @@ func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, m
 
 	param := alertrules.ScheduledAlertRule{
 		Properties: &alertrules.ScheduledAlertRuleProperties{
-			Description:           utils.String(d.Get("description").(string)),
+			Description:           pointer.To(d.Get("description").(string)),
 			DisplayName:           d.Get("display_name").(string),
 			Tactics:               expandAlertRuleTactics(d.Get("tactics").(*pluginsdk.Set).List()),
 			Techniques:            expandAlertRuleTechnicals(d.Get("techniques").(*pluginsdk.Set).List()),
@@ -420,10 +420,10 @@ func resourceSentinelAlertRuleScheduledCreateUpdate(d *pluginsdk.ResourceData, m
 	}
 
 	if v, ok := d.GetOk("alert_rule_template_guid"); ok {
-		param.Properties.AlertRuleTemplateName = utils.String(v.(string))
+		param.Properties.AlertRuleTemplateName = pointer.To(v.(string))
 	}
 	if v, ok := d.GetOk("alert_rule_template_version"); ok {
-		param.Properties.TemplateVersion = utils.String(v.(string))
+		param.Properties.TemplateVersion = pointer.To(v.(string))
 	}
 	if v, ok := d.GetOk("event_grouping"); ok {
 		param.Properties.EventGroupingSettings = expandAlertRuleEventGroupingSetting(v.([]interface{}))

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleScheduledResource struct{}
@@ -189,10 +189,10 @@ func (t SentinelAlertRuleScheduledResource) Exists(ctx context.Context, clients 
 		if !ok {
 			return nil, fmt.Errorf("the Alert Rule %q is not a Fusion Alert Rule", id)
 		}
-		return utils.Bool(rule.Id != nil), nil
+		return pointer.To(rule.Id != nil), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r SentinelAlertRuleScheduledResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_alert_rule_threat_intelligence_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_threat_intelligence_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2023-12-01-preview/alertrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAlertRuleThreatIntelligenceResource struct{}
@@ -103,7 +103,7 @@ func (r SentinelAlertRuleThreatIntelligenceResource) Exists(ctx context.Context,
 	resp, err := alertRuleClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("reading Sentinel Threat Intelligence Alert Rule %q: %v", id, err)
 	}
@@ -113,10 +113,10 @@ func (r SentinelAlertRuleThreatIntelligenceResource) Exists(ctx context.Context,
 		if !ok {
 			return nil, fmt.Errorf("the Alert Rule %q is not a Fusion Alert Rule", id)
 		}
-		return utils.Bool(rule.Id != nil), nil
+		return pointer.To(rule.Id != nil), nil
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r SentinelAlertRuleThreatIntelligenceResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_automation_rule_resource.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource.go
@@ -473,7 +473,7 @@ func expandAutomationRuleActionIncident(input []interface{}) ([]automationrules.
 		var ownerPtr *automationrules.IncidentOwnerInfo
 		if ownerIdStr := b["owner_id"].(string); ownerIdStr != "" {
 			ownerPtr = &automationrules.IncidentOwnerInfo{
-				ObjectId: utils.String(ownerIdStr),
+				ObjectId: pointer.To(ownerIdStr),
 			}
 		}
 

--- a/internal/services/sentinel/sentinel_automation_rule_resource_test.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2024-09-01/automationrules"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SentinelAutomationRuleResource struct {
@@ -180,12 +180,12 @@ func (r SentinelAutomationRuleResource) Exists(ctx context.Context, clients *cli
 
 	if resp, err := client.Get(ctx, *id); err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelAutomationRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_aws_cloud_trail_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_aws_cloud_trail_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -88,7 +89,7 @@ func resourceSentinelDataConnectorAwsCloudTrailCreateUpdate(d *pluginsdk.Resourc
 	param := securityinsight.AwsCloudTrailDataConnector{
 		Name: &name,
 		AwsCloudTrailDataConnectorProperties: &securityinsight.AwsCloudTrailDataConnectorProperties{
-			AwsRoleArn: utils.String(d.Get("aws_role_arn").(string)),
+			AwsRoleArn: pointer.To(d.Get("aws_role_arn").(string)),
 			DataTypes: &securityinsight.AwsCloudTrailDataConnectorDataTypes{
 				Logs: &securityinsight.AwsCloudTrailDataConnectorDataTypesLogs{
 					State: securityinsight.DataTypeStateEnabled,

--- a/internal/services/sentinel/sentinel_data_connector_aws_s3_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_aws_s3_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
@@ -122,9 +123,9 @@ func (r DataConnectorAwsS3Resource) Create() sdk.ResourceFunc {
 			params := securityinsight.AwsS3DataConnector{
 				Name: &plan.Name,
 				AwsS3DataConnectorProperties: &securityinsight.AwsS3DataConnectorProperties{
-					DestinationTable: utils.String(plan.DestinationTable),
+					DestinationTable: pointer.To(plan.DestinationTable),
 					SqsUrls:          &plan.SqsUrls,
-					RoleArn:          utils.String(plan.AwsRoleArm),
+					RoleArn:          pointer.To(plan.AwsRoleArm),
 					DataTypes: &securityinsight.AwsS3DataConnectorDataTypes{
 						Logs: &securityinsight.AwsS3DataConnectorDataTypesLogs{
 							State: securityinsight.DataTypeStateEnabled,

--- a/internal/services/sentinel/sentinel_data_connector_azure_active_directory_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_active_directory_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorAzureActiveDirectoryResource) Exists(ctx context.Co
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorAzureActiveDirectoryResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorAzureAdvancedThreatProtectionResource) Exists(ctx c
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorAzureAdvancedThreatProtectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_azure_security_center_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_security_center_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorAzureSecurityCenterResource) Exists(ctx context.Con
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorAzureSecurityCenterResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_dynamics_365_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_dynamics_365_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorDynamics365Resource) Exists(ctx context.Context, cl
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorDynamics365Resource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_iot_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_iot_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorIOTResource) Exists(ctx context.Context, clients *c
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorIOTResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -116,12 +117,12 @@ func (r SentinelDataConnectorMicrosoftCloudAppSecurityResource) Exists(ctx conte
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorMicrosoftCloudAppSecurityResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorMicrosoftDefenderAdvancedThreatProtectionResource) 
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorMicrosoftDefenderAdvancedThreatProtectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -210,13 +211,13 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) IDValidationFunc() plu
 func expandSentinelDataConnectorMicrosoftThreatIntelligenceMicrosoftEmergingThreatFeed(input DataConnectorMicrosoftThreatIntelligenceModel) *securityinsight.MSTIDataConnectorDataTypesMicrosoftEmergingThreatFeed {
 	if input.MicrosoftEmergingThreatFeedLookBackDate == "" {
 		return &securityinsight.MSTIDataConnectorDataTypesMicrosoftEmergingThreatFeed{
-			LookbackPeriod: utils.String(""),
+			LookbackPeriod: pointer.To(""),
 			State:          securityinsight.DataTypeStateDisabled,
 		}
 	}
 
 	return &securityinsight.MSTIDataConnectorDataTypesMicrosoftEmergingThreatFeed{
-		LookbackPeriod: utils.String(input.MicrosoftEmergingThreatFeedLookBackDate),
+		LookbackPeriod: pointer.To(input.MicrosoftEmergingThreatFeedLookBackDate),
 		State:          securityinsight.DataTypeStateEnabled,
 	}
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -109,10 +110,10 @@ func (r SentinelDataConnectorMicrosoftThreatIntelligence) Exists(ctx context.Con
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorMicrosoftThreatProtectionResource) Exists(ctx conte
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorMicrosoftThreatProtectionResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_office_365_project_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_project_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorOffice365ProjectResource) Exists(ctx context.Contex
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorOffice365ProjectResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_office_365_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -123,12 +124,12 @@ func (r SentinelDataConnectorOffice365Resource) Exists(ctx context.Context, clie
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Sentinel Data Connector Office 365 %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorOffice365Resource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_office_atp_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_atp_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorOfficeATPResource) Exists(ctx context.Context, clie
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorOfficeATPResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_office_irm_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_irm_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorOfficeIRMResource) Exists(ctx context.Context, clie
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorOfficeIRMResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_office_power_bi_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_power_bi_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorOfficePowerBIResource) Exists(ctx context.Context, 
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorOfficePowerBIResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -73,12 +74,12 @@ func (r SentinelDataConnectorThreatIntelligenceResource) Exists(ctx context.Cont
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SentinelDataConnectorThreatIntelligenceResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -151,12 +152,12 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) Exists(ctx context.Context
 
 	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r DataConnectorThreatIntelligenceTAXIIResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboarding_resource_test.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboarding_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/sentinelonboardingstates"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SecurityInsightsSentinelOnboardingStateResource struct{}
@@ -91,11 +91,11 @@ func (r SecurityInsightsSentinelOnboardingStateResource) Exists(ctx context.Cont
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SecurityInsightsSentinelOnboardingStateResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_metadata_resource.go
+++ b/internal/services/sentinel/sentinel_metadata_resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	sentinelmetadata "github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/metadata"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MetadataModel struct {
@@ -670,10 +670,10 @@ func expandMetadataSourceModel(input []MetadataSourceModel) *sentinelmetadata.Me
 		Kind: sentinelmetadata.SourceKind(v.Kind),
 	}
 	if v.Name != "" {
-		output.Name = utils.String(v.Name)
+		output.Name = pointer.To(v.Name)
 	}
 	if v.Id != "" {
-		output.SourceId = utils.String(v.Id)
+		output.SourceId = pointer.To(v.Id)
 	}
 	return &output
 }
@@ -701,13 +701,13 @@ func expandMetadataAuthorModel(input []MetadataAuthorModel) *sentinelmetadata.Me
 	v := input[0]
 	output := sentinelmetadata.MetadataAuthor{}
 	if v.Name != "" {
-		output.Name = utils.String(v.Name)
+		output.Name = pointer.To(v.Name)
 	}
 	if v.Email != "" {
-		output.Email = utils.String(v.Email)
+		output.Email = pointer.To(v.Email)
 	}
 	if v.Link != "" {
-		output.Link = utils.String(v.Link)
+		output.Link = pointer.To(v.Link)
 	}
 	return &output
 }
@@ -738,13 +738,13 @@ func expandMetadataSupportModel(input []MetadataSupportModel) *sentinelmetadata.
 		Tier: sentinelmetadata.SupportTier(v.Tier),
 	}
 	if v.Name != "" {
-		output.Name = utils.String(v.Name)
+		output.Name = pointer.To(v.Name)
 	}
 	if v.Email != "" {
-		output.Email = utils.String(v.Email)
+		output.Email = pointer.To(v.Email)
 	}
 	if v.Link != "" {
-		output.Link = utils.String(v.Link)
+		output.Link = pointer.To(v.Link)
 	}
 	return &output
 }
@@ -802,14 +802,14 @@ func expandMetadataDependencies(input interface{}) (dependencies *sentinelmetada
 		dependencies = &sentinelmetadata.MetadataDependencies{}
 		// "name" is not returned in response, so it's not supported for now.
 		if v, ok := j["contentId"]; ok {
-			dependencies.ContentId = utils.String(v.(string))
+			dependencies.ContentId = pointer.To(v.(string))
 		}
 		if v, ok := j["kind"]; ok {
 			kind := sentinelmetadata.Kind(v.(string))
 			dependencies.Kind = &kind
 		}
 		if v, ok := j["version"]; ok {
-			dependencies.Version = utils.String(v.(string))
+			dependencies.Version = pointer.To(v.(string))
 		}
 		if v, ok := j["operator"]; ok {
 			op := sentinelmetadata.Operator(v.(string))

--- a/internal/services/sentinel/sentinel_metadata_resource_test.go
+++ b/internal/services/sentinel/sentinel_metadata_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	sentinelmetadata "github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/metadata"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type MetadataResource struct{}
@@ -30,7 +30,7 @@ func (r MetadataResource) Exists(ctx context.Context, clients *clients.Client, s
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func TestAccMetadata_basic(t *testing.T) {

--- a/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource.go
+++ b/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource.go
@@ -929,7 +929,7 @@ func expandThreatIntelligenceKillChainPhaseModel(inputList []killChainPhaseModel
 	for _, v := range inputList {
 		input := v
 		output := securityinsight.ThreatIntelligenceKillChainPhase{
-			KillChainName: utils.String(killChainName),
+			KillChainName: pointer.To(killChainName),
 		}
 
 		if input.PhaseName != "" {

--- a/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource_test.go
+++ b/internal/services/sentinel/sentinel_threat_intelligence_indicator_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -136,12 +137,12 @@ func (r SecurityInsightsIndicatorResource) Exists(ctx context.Context, clients *
 	resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.IndicatorName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Value != nil), nil
+	return pointer.To(resp.Value != nil), nil
 }
 
 func (r SecurityInsightsIndicatorResource) template(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/watchlistitems"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WatchlistItemResource struct{}
@@ -89,12 +89,12 @@ func (r WatchlistItemResource) Exists(ctx context.Context, clients *clients.Clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r WatchlistItemResource) basic(data acceptance.TestData) string {

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/watchlists"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WatchlistResource struct{}
@@ -75,12 +75,12 @@ func (r WatchlistResource) Exists(ctx context.Context, clients *clients.Client, 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r WatchlistResource) basic(data acceptance.TestData) string {

--- a/internal/services/servicebus/servicebus_namespace_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_authorization_rule_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespacesauthorizationrule"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceBusNamespaceAuthorizationRule() *pluginsdk.Resource {
@@ -94,7 +94,7 @@ func resourceServiceBusNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.Resou
 	}
 
 	parameters := namespacesauthorizationrule.SBAuthorizationRule{
-		Name: utils.String(id.AuthorizationRuleName),
+		Name: pointer.To(id.AuthorizationRuleName),
 		Properties: &namespacesauthorizationrule.SBAuthorizationRuleProperties{
 			Rights: *expandAuthorizationRuleRights(d),
 		},

--- a/internal/services/servicebus/servicebus_namespace_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_authorization_rule_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespacesauthorizationrule"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusNamespaceAuthorizationRuleResource struct{}
@@ -116,7 +116,7 @@ func (t ServiceBusNamespaceAuthorizationRuleResource) Exists(ctx context.Context
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusNamespaceAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/disasterrecoveryconfigs"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusNamespaceDisasterRecoveryConfigResource struct{}
@@ -123,7 +123,7 @@ func resourceServiceBusNamespaceDisasterRecoveryConfigCreate(d *pluginsdk.Resour
 
 	parameters := disasterrecoveryconfigs.ArmDisasterRecovery{
 		Properties: &disasterrecoveryconfigs.ArmDisasterRecoveryProperties{
-			PartnerNamespace: utils.String(partnerNamespaceId),
+			PartnerNamespace: pointer.To(partnerNamespaceId),
 		},
 	}
 
@@ -163,7 +163,7 @@ func resourceServiceBusNamespaceDisasterRecoveryConfigUpdate(d *pluginsdk.Resour
 
 	parameters := disasterrecoveryconfigs.ArmDisasterRecovery{
 		Properties: &disasterrecoveryconfigs.ArmDisasterRecoveryProperties{
-			PartnerNamespace: utils.String(d.Get("partner_namespace_id").(string)),
+			PartnerNamespace: pointer.To(d.Get("partner_namespace_id").(string)),
 		},
 	}
 

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/disasterrecoveryconfigs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusNamespaceDisasterRecoveryConfigResource struct{}
@@ -61,7 +61,7 @@ func (t ServiceBusNamespaceDisasterRecoveryConfigResource) Exists(ctx context.Co
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusNamespaceDisasterRecoveryConfigResource) basic(data acceptance.TestData) string {

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespacesauthorizationrule"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -290,7 +289,7 @@ func resourceServiceBusNamespaceCreate(d *pluginsdk.ResourceData, meta interface
 
 	log.Printf("[INFO] preparing arguments for ServiceBus Namespace create")
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	sku := d.Get("sku").(string)
 	t := d.Get("tags").(map[string]interface{})
 

--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusNamespaceResource struct{}
@@ -310,7 +310,7 @@ func (t ServiceBusNamespaceResource) Exists(ctx context.Context, clients *client
 		return nil, fmt.Errorf("reading Service Bus NameSpace (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusNamespaceResource) basic(data acceptance.TestData) string {

--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/queues"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceBusQueueAuthorizationRule() *pluginsdk.Resource {
@@ -90,7 +90,7 @@ func resourceServiceBusQueueAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	parameters := queuesauthorizationrule.SBAuthorizationRule{
-		Name: utils.String(id.AuthorizationRuleName),
+		Name: pointer.To(id.AuthorizationRuleName),
 		Properties: &queuesauthorizationrule.SBAuthorizationRuleProperties{
 			Rights: *expandQueueAuthorizationRuleRights(d),
 		},

--- a/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_authorization_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/queuesauthorizationrule"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusQueueAuthorizationRuleResource struct{}
@@ -148,7 +148,7 @@ func (t ServiceBusQueueAuthorizationRuleResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusQueueAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceBusQueue() *pluginsdk.Resource {
@@ -255,16 +254,16 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	userConfig["enableBatchOps"] = enableBatchedOperations
 
 	parameters := queues.SBQueue{
-		Name: utils.String(id.QueueName),
+		Name: pointer.To(id.QueueName),
 		Properties: &queues.SBQueueProperties{
-			DeadLetteringOnMessageExpiration: utils.Bool(deadLetteringOnMesExp),
-			EnableBatchedOperations:          utils.Bool(enableBatchedOperations),
-			EnableExpress:                    utils.Bool(enableExpress),
-			EnablePartitioning:               utils.Bool(enablePartitioning),
-			MaxDeliveryCount:                 utils.Int64(int64(maxDeliveryCount)),
-			MaxSizeInMegabytes:               utils.Int64(int64(maxSizeInMB)),
-			RequiresDuplicateDetection:       utils.Bool(requireDuplicateDetection),
-			RequiresSession:                  utils.Bool(requireSession),
+			DeadLetteringOnMessageExpiration: pointer.To(deadLetteringOnMesExp),
+			EnableBatchedOperations:          pointer.To(enableBatchedOperations),
+			EnableExpress:                    pointer.To(enableExpress),
+			EnablePartitioning:               pointer.To(enablePartitioning),
+			MaxDeliveryCount:                 pointer.To(int64(maxDeliveryCount)),
+			MaxSizeInMegabytes:               pointer.To(int64(maxSizeInMB)),
+			RequiresDuplicateDetection:       pointer.To(requireDuplicateDetection),
+			RequiresSession:                  pointer.To(requireSession),
 			Status:                           &status,
 		},
 	}
@@ -324,7 +323,7 @@ func resourceServiceBusQueueCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		if sku != namespaces.SkuNamePremium {
 			return fmt.Errorf("%s does not support input on `max_message_size_in_kilobytes` in %s SKU and should be removed", id, sku)
 		}
-		parameters.Properties.MaxMessageSizeInKilobytes = utils.Int64(int64(v.(int)))
+		parameters.Properties.MaxMessageSizeInKilobytes = pointer.To(int64(v.(int)))
 	}
 
 	if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {

--- a/internal/services/servicebus/servicebus_queue_resource_test.go
+++ b/internal/services/servicebus/servicebus_queue_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/queues"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusQueueResource struct{}
@@ -364,7 +364,7 @@ func (t ServiceBusQueueResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusQueueResource) basic(data acceptance.TestData) string {

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topics"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceBusSubscription() *pluginsdk.Resource {
@@ -218,13 +218,13 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 	status := subscriptions.EntityStatus(d.Get("status").(string))
 	parameters := subscriptions.SBSubscription{
 		Properties: &subscriptions.SBSubscriptionProperties{
-			DeadLetteringOnMessageExpiration:          utils.Bool(d.Get("dead_lettering_on_message_expiration").(bool)),
-			DeadLetteringOnFilterEvaluationExceptions: utils.Bool(d.Get("dead_lettering_on_filter_evaluation_error").(bool)),
-			EnableBatchedOperations:                   utils.Bool(enableBatchedOperations),
-			MaxDeliveryCount:                          utils.Int64(int64(d.Get("max_delivery_count").(int))),
-			RequiresSession:                           utils.Bool(d.Get("requires_session").(bool)),
+			DeadLetteringOnMessageExpiration:          pointer.To(d.Get("dead_lettering_on_message_expiration").(bool)),
+			DeadLetteringOnFilterEvaluationExceptions: pointer.To(d.Get("dead_lettering_on_filter_evaluation_error").(bool)),
+			EnableBatchedOperations:                   pointer.To(enableBatchedOperations),
+			MaxDeliveryCount:                          pointer.To(int64(d.Get("max_delivery_count").(int))),
+			RequiresSession:                           pointer.To(d.Get("requires_session").(bool)),
 			Status:                                    &status,
-			IsClientAffine:                            utils.Bool(isClintScopedEnabled),
+			IsClientAffine:                            pointer.To(isClintScopedEnabled),
 			ClientAffineProperties:                    &subscriptions.SBClientAffineProperties{},
 		},
 	}
@@ -297,7 +297,7 @@ func resourceServiceBusSubscriptionRead(d *pluginsdk.ResourceData, meta interfac
 			d.Set("requires_session", props.RequiresSession)
 			d.Set("forward_to", props.ForwardTo)
 			d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
-			d.Set("status", utils.String(string(*props.Status)))
+			d.Set("status", pointer.To(string(*props.Status)))
 			d.Set("client_scoped_subscription_enabled", props.IsClientAffine)
 			d.Set("batched_operations_enabled", props.EnableBatchedOperations)
 

--- a/internal/services/servicebus/servicebus_subscription_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusSubscriptionResource struct{}
@@ -241,7 +241,7 @@ func (t ServiceBusSubscriptionResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 const testAccServiceBusSubscription_tfTemplate = `

--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceBusSubscriptionRule() *pluginsdk.Resource {
@@ -357,35 +356,35 @@ func expandAzureRmServiceBusCorrelationFilter(d *pluginsdk.ResourceData) (*rules
 	correlationFilter := rules.CorrelationFilter{}
 
 	if correlationID != "" {
-		correlationFilter.CorrelationId = utils.String(correlationID)
+		correlationFilter.CorrelationId = pointer.To(correlationID)
 	}
 
 	if messageID != "" {
-		correlationFilter.MessageId = utils.String(messageID)
+		correlationFilter.MessageId = pointer.To(messageID)
 	}
 
 	if to != "" {
-		correlationFilter.To = utils.String(to)
+		correlationFilter.To = pointer.To(to)
 	}
 
 	if replyTo != "" {
-		correlationFilter.ReplyTo = utils.String(replyTo)
+		correlationFilter.ReplyTo = pointer.To(replyTo)
 	}
 
 	if label != "" {
-		correlationFilter.Label = utils.String(label)
+		correlationFilter.Label = pointer.To(label)
 	}
 
 	if sessionID != "" {
-		correlationFilter.SessionId = utils.String(sessionID)
+		correlationFilter.SessionId = pointer.To(sessionID)
 	}
 
 	if replyToSessionID != "" {
-		correlationFilter.ReplyToSessionId = utils.String(replyToSessionID)
+		correlationFilter.ReplyToSessionId = pointer.To(replyToSessionID)
 	}
 
 	if contentType != "" {
-		correlationFilter.ContentType = utils.String(contentType)
+		correlationFilter.ContentType = pointer.To(contentType)
 	}
 
 	if len(*properties) > 0 {
@@ -454,7 +453,7 @@ func flattenProperties(input *map[string]string) map[string]*string {
 
 	if input != nil {
 		for k, v := range *input {
-			output[k] = utils.String(v)
+			output[k] = pointer.To(v)
 		}
 	}
 

--- a/internal/services/servicebus/servicebus_subscription_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/subscriptions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusSubscriptionRuleResource struct{}
@@ -179,7 +179,7 @@ func (t ServiceBusSubscriptionRuleResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ServiceBusSubscriptionRuleResource) basicSqlFilter(data acceptance.TestData) string {

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/namespaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topics"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/servicebus/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceBusTopicAuthorizationRule() *pluginsdk.Resource {
@@ -93,7 +93,7 @@ func resourceServiceBusTopicAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	parameters := topicsauthorizationrule.SBAuthorizationRule{
-		Name: utils.String(id.AuthorizationRuleName),
+		Name: pointer.To(id.AuthorizationRuleName),
 		Properties: &topicsauthorizationrule.SBAuthorizationRuleProperties{
 			Rights: *expandTopicAuthorizationRuleRights(d),
 		},

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topicsauthorizationrule"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusTopicAuthorizationRuleResource struct{}
@@ -150,7 +150,7 @@ func (t ServiceBusTopicAuthorizationRuleResource) Exists(ctx context.Context, cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusTopicAuthorizationRuleResource) base(data acceptance.TestData, listen, send, manage bool) string {

--- a/internal/services/servicebus/servicebus_topic_resource_test.go
+++ b/internal/services/servicebus/servicebus_topic_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2024-01-01/topics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceBusTopicResource struct{}
@@ -265,7 +265,7 @@ func (t ServiceBusTopicResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (ServiceBusTopicResource) basic(data acceptance.TestData) string {

--- a/internal/services/servicebus/transition.go
+++ b/internal/services/servicebus/transition.go
@@ -3,7 +3,7 @@
 
 package servicebus
 
-import "github.com/hashicorp/terraform-provider-azurerm/utils"
+import "github.com/hashicorp/go-azure-helpers/lang/pointer"
 
 func expandTags(input map[string]interface{}) *map[string]string {
 	output := make(map[string]string)
@@ -18,7 +18,7 @@ func flattenTags(input *map[string]string) map[string]*string {
 
 	if input != nil {
 		for k, v := range *input {
-			output[k] = utils.String(v)
+			output[k] = pointer.To(v)
 		}
 	}
 

--- a/internal/services/serviceconnector/app_service_connection_resource.go
+++ b/internal/services/serviceconnector/app_service_connection_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var _ sdk.ResourceWithUpdate = AppServiceConnectorResource{}
@@ -164,8 +163,8 @@ func (r AppServiceConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			props := servicelinker.LinkerResource{
-				Id:         utils.String(id.ID()),
-				Name:       utils.String(model.Name),
+				Id:         pointer.To(id.ID()),
+				Name:       pointer.To(model.Name),
 				Properties: serviceConnectorProperties,
 			}
 

--- a/internal/services/serviceconnector/app_service_connection_resource_test.go
+++ b/internal/services/serviceconnector/app_service_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2024-04-01/servicelinker"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceConnectorAppServiceResource struct{}
@@ -28,11 +28,11 @@ func (r ServiceConnectorAppServiceResource) Exists(ctx context.Context, client *
 	resp, err := client.ServiceConnector.ServiceLinkerClient.LinkerGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccServiceConnectorAppServiceCosmosdb_basic(t *testing.T) {

--- a/internal/services/serviceconnector/function_app_connection_resource.go
+++ b/internal/services/serviceconnector/function_app_connection_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FunctionAppConnectorResource struct{}
@@ -161,8 +160,8 @@ func (r FunctionAppConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			props := servicelinker.LinkerResource{
-				Id:         utils.String(id.ID()),
-				Name:       utils.String(model.Name),
+				Id:         pointer.To(id.ID()),
+				Name:       pointer.To(model.Name),
 				Properties: serviceConnectorProperties,
 			}
 

--- a/internal/services/serviceconnector/function_app_connection_resource_test.go
+++ b/internal/services/serviceconnector/function_app_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2024-04-01/servicelinker"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type FunctionAppConnectorResource struct{}
@@ -28,11 +28,11 @@ func (r FunctionAppConnectorResource) Exists(ctx context.Context, client *client
 	resp, err := client.ServiceConnector.ServiceLinkerClient.LinkerGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccServiceConnectorFunctionAppCosmosdb_basic(t *testing.T) {

--- a/internal/services/serviceconnector/helper.go
+++ b/internal/services/serviceconnector/helper.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AuthInfoModel struct {
@@ -304,7 +303,7 @@ func expandSecretStore(input []SecretStoreModel) *servicelinker.SecretStore {
 
 	keyVaultId := v.KeyVaultId
 	return &servicelinker.SecretStore{
-		KeyVaultId: utils.String(keyVaultId),
+		KeyVaultId: pointer.To(keyVaultId),
 	}
 }
 

--- a/internal/services/serviceconnector/spring_cloud_connection_resource.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudConnectorResource struct{}
@@ -164,8 +163,8 @@ func (r SpringCloudConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			props := servicelinker.LinkerResource{
-				Id:         utils.String(id.ID()),
-				Name:       utils.String(model.Name),
+				Id:         pointer.To(id.ID()),
+				Name:       pointer.To(model.Name),
 				Properties: serviceConnectorProperties,
 			}
 

--- a/internal/services/serviceconnector/spring_cloud_connection_resource_test.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2024-04-01/servicelinker"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceConnectorSpringCloudResource struct{}
@@ -28,11 +28,11 @@ func (r ServiceConnectorSpringCloudResource) Exists(ctx context.Context, client 
 	resp, err := client.ServiceConnector.ServiceLinkerClient.LinkerGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccServiceConnectorSpringCloudCosmosdb_basic(t *testing.T) {

--- a/internal/services/servicefabric/service_fabric_cluster_resource.go
+++ b/internal/services/servicefabric/service_fabric_cluster_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceServiceFabricCluster() *pluginsdk.Resource {
@@ -624,7 +624,7 @@ func resourceServiceFabricClusterCreateUpdate(d *pluginsdk.ResourceData, meta in
 			ReliabilityLevel:                   &reliabilityLevel,
 			UpgradeDescription:                 upgradePolicy,
 			UpgradeMode:                        &upgradeMode,
-			VmImage:                            utils.String(vmImage),
+			VmImage:                            pointer.To(vmImage),
 		},
 	}
 
@@ -659,7 +659,7 @@ func resourceServiceFabricClusterCreateUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	if clusterCodeVersion != "" {
-		clusterModel.Properties.ClusterCodeVersion = utils.String(clusterCodeVersion)
+		clusterModel.Properties.ClusterCodeVersion = pointer.To(clusterCodeVersion)
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, clusterModel); err != nil {
@@ -838,9 +838,9 @@ func expandServiceFabricClusterAzureActiveDirectory(input []interface{}) *cluste
 	clientApplication := v["client_application_id"].(string)
 
 	config := cluster.AzureActiveDirectory{
-		TenantId:           utils.String(tenantId),
-		ClusterApplication: utils.String(clusterApplication),
-		ClientApplication:  utils.String(clientApplication),
+		TenantId:           pointer.To(tenantId),
+		ClusterApplication: pointer.To(clusterApplication),
+		ClientApplication:  pointer.To(clientApplication),
 	}
 	return &config
 }
@@ -897,7 +897,7 @@ func expandServiceFabricClusterCertificate(input []interface{}) *cluster.Certifi
 	}
 
 	if thumb, ok := v["thumbprint_secondary"]; ok {
-		result.ThumbprintSecondary = utils.String(thumb.(string))
+		result.ThumbprintSecondary = pointer.To(thumb.(string))
 	}
 
 	return &result
@@ -1025,7 +1025,7 @@ func expandServiceFabricClusterReverseProxyCertificate(input []interface{}) *clu
 	}
 
 	if thumb, ok := v["thumbprint_secondary"]; ok {
-		result.ThumbprintSecondary = utils.String(thumb.(string))
+		result.ThumbprintSecondary = pointer.To(thumb.(string))
 	}
 
 	return &result
@@ -1182,8 +1182,8 @@ func expandServiceFabricClusterUpgradePolicyHealthPolicy(input []interface{}) cl
 	}
 
 	v := input[0].(map[string]interface{})
-	healthPolicy.MaxPercentUnhealthyApplications = utils.Int64(int64(v["max_unhealthy_applications_percent"].(int)))
-	healthPolicy.MaxPercentUnhealthyNodes = utils.Int64(int64(v["max_unhealthy_nodes_percent"].(int)))
+	healthPolicy.MaxPercentUnhealthyApplications = pointer.To(int64(v["max_unhealthy_applications_percent"].(int)))
+	healthPolicy.MaxPercentUnhealthyNodes = pointer.To(int64(v["max_unhealthy_nodes_percent"].(int)))
 
 	return healthPolicy
 }
@@ -1196,7 +1196,7 @@ func expandServiceFabricClusterUpgradePolicy(input []interface{}) *cluster.Clust
 	policy := &cluster.ClusterUpgradePolicy{}
 	v := input[0].(map[string]interface{})
 
-	policy.ForceRestart = utils.Bool(v["force_restart_enabled"].(bool))
+	policy.ForceRestart = pointer.To(v["force_restart_enabled"].(bool))
 	policy.HealthCheckStableDuration = v["health_check_stable_duration"].(string)
 	policy.UpgradeDomainTimeout = v["upgrade_domain_timeout"].(string)
 	policy.UpgradeReplicaSetCheckTimeout = v["upgrade_replica_set_check_timeout"].(string)
@@ -1336,11 +1336,11 @@ func expandServiceFabricClusterNodeTypes(input []interface{}) []cluster.NodeType
 		}
 
 		if isStateless, ok := node["is_stateless"]; ok {
-			result.IsStateless = utils.Bool(isStateless.(bool))
+			result.IsStateless = pointer.To(isStateless.(bool))
 		}
 
 		if multipleAvailabilityZones, ok := node["multiple_availability_zones"]; ok {
-			result.MultipleAvailabilityZones = utils.Bool(multipleAvailabilityZones.(bool))
+			result.MultipleAvailabilityZones = pointer.To(multipleAvailabilityZones.(bool))
 		}
 
 		if props, ok := node["placement_properties"]; ok {
@@ -1362,7 +1362,7 @@ func expandServiceFabricClusterNodeTypes(input []interface{}) []cluster.NodeType
 		}
 
 		if v := int64(node["reverse_proxy_endpoint_port"].(int)); v != 0 {
-			result.ReverseProxyEndpointPort = utils.Int64(v)
+			result.ReverseProxyEndpointPort = pointer.To(v)
 		}
 
 		applicationPortsRaw := node["application_ports"].([]interface{})

--- a/internal/services/servicefabric/service_fabric_cluster_resource_test.go
+++ b/internal/services/servicefabric/service_fabric_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicefabric/2021-06-01/cluster"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ServiceFabricClusterResource struct{}
@@ -779,11 +779,11 @@ func (r ServiceFabricClusterResource) Exists(ctx context.Context, client *client
 	resp, err := client.ServiceFabric.ClustersClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.ID(), err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ServiceFabricClusterResource) basic(data acceptance.TestData, count int) string {

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomFabricSetting struct {
@@ -257,7 +256,7 @@ func (k ClusterResource) Create() sdk.ResourceFunc {
 			managedClusterId := managedcluster.NewManagedClusterID(subscriptionId, model.ResourceGroup, model.Name)
 			cluster := managedcluster.ManagedCluster{
 				Location:   model.Location,
-				Name:       utils.String(model.Name),
+				Name:       pointer.To(model.Name),
 				Properties: expandClusterProperties(&model),
 				Sku:        managedcluster.Sku{Name: model.Sku},
 			}
@@ -399,7 +398,7 @@ func (k ClusterResource) Update() sdk.ResourceFunc {
 
 			cluster := managedcluster.ManagedCluster{
 				Location:   model.Location,
-				Name:       utils.String(model.Name),
+				Name:       pointer.To(model.Name),
 				Properties: expandClusterProperties(&model),
 				Sku: managedcluster.Sku{
 					Name: model.Sku,
@@ -753,7 +752,7 @@ func expandClusterProperties(model *ClusterResourceModel) *managedcluster.Manage
 	}
 	out.AddonFeatures = &addons
 
-	out.AdminPassword = utils.String(model.Password)
+	out.AdminPassword = pointer.To(model.Password)
 	out.AdminUserName = model.Username
 
 	out.DnsName = model.Name
@@ -769,9 +768,9 @@ func expandClusterProperties(model *ClusterResourceModel) *managedcluster.Manage
 		if adAuth := auth[0].ADAuth; len(adAuth) > 0 {
 			if adAuth[0].ClientApp != "" && adAuth[0].ClusterApp != "" && adAuth[0].TenantId != "" {
 				out.AzureActiveDirectory = &managedcluster.AzureActiveDirectory{
-					ClientApplication:  utils.String(adAuth[0].ClientApp),
-					ClusterApplication: utils.String(adAuth[0].ClusterApp),
-					TenantId:           utils.String(adAuth[0].TenantId),
+					ClientApplication:  pointer.To(adAuth[0].ClientApp),
+					ClusterApplication: pointer.To(adAuth[0].ClusterApp),
+					TenantId:           pointer.To(adAuth[0].TenantId),
 				}
 			}
 		}
@@ -779,9 +778,9 @@ func expandClusterProperties(model *ClusterResourceModel) *managedcluster.Manage
 			clients := make([]managedcluster.ClientCertificate, len(certs))
 			for idx, cert := range certs {
 				clients[idx] = managedcluster.ClientCertificate{
-					CommonName: utils.String(cert.CommonName),
+					CommonName: pointer.To(cert.CommonName),
 					IsAdmin:    cert.CertificateType == CertTypeAdmin,
-					Thumbprint: utils.String(cert.Thumbprint),
+					Thumbprint: pointer.To(cert.Thumbprint),
 				}
 			}
 			out.Clients = &clients
@@ -824,7 +823,7 @@ func expandClusterProperties(model *ClusterResourceModel) *managedcluster.Manage
 				BackendPort:      rule.BackendPort,
 				FrontendPort:     rule.FrontendPort,
 				ProbeProtocol:    rule.ProbeProtocol,
-				ProbeRequestPath: utils.String(rule.ProbeRequestPath),
+				ProbeRequestPath: pointer.To(rule.ProbeRequestPath),
 				Protocol:         rule.Protocol,
 			}
 

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource_test.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2024-04-01/managedcluster"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ClusterResource struct{}
@@ -137,11 +137,11 @@ func (r ClusterResource) Exists(ctx context.Context, clients *clients.Client, st
 	resp, err := clients.ServiceFabricManaged.ManagedClusterClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("while checking for cluster's %q existence: %+v", id.String(), err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ClusterResource) basic(data acceptance.TestData, nodeTypeData string) string {

--- a/internal/services/signalr/signalr_service_custom_certificate_resource.go
+++ b/internal/services/signalr/signalr_service_custom_certificate_resource.go
@@ -17,7 +17,6 @@ import (
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomCertSignalrServiceResourceModel struct {
@@ -124,7 +123,7 @@ func (r CustomCertSignalrServiceResource) Create() sdk.ResourceFunc {
 				if customCertSignalrService.CertificateVersion != "" && certVersion != customCertSignalrService.CertificateVersion {
 					return fmt.Errorf("certificate version in cert id is different from `certificate_version`")
 				}
-				customCert.Properties.KeyVaultSecretVersion = utils.String(certVersion)
+				customCert.Properties.KeyVaultSecretVersion = pointer.To(certVersion)
 			}
 
 			if err := client.CustomCertificatesCreateOrUpdateThenPoll(ctx, id, customCert); err != nil {

--- a/internal/services/signalr/signalr_service_custom_certificate_resource_test.go
+++ b/internal/services/signalr/signalr_service_custom_certificate_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomCertSignalrServiceResource struct{}
@@ -169,10 +169,10 @@ func (r CustomCertSignalrServiceResource) Exists(ctx context.Context, client *cl
 	resp, err := client.SignalR.SignalRClient.CustomCertificatesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }

--- a/internal/services/signalr/signalr_service_custom_domain_resource.go
+++ b/internal/services/signalr/signalr_service_custom_domain_resource.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomDomainSignalrServiceModel struct {
@@ -109,7 +109,7 @@ func (r CustomDomainSignalrServiceResource) Create() sdk.ResourceFunc {
 				Properties: signalr.CustomDomainProperties{
 					DomainName: customDomainSignalrServiceModel.DomainName,
 					CustomCertificate: signalr.ResourceReference{
-						Id: utils.String(customDomainSignalrServiceModel.SignalrCustomCertificateId),
+						Id: pointer.To(customDomainSignalrServiceModel.SignalrCustomCertificateId),
 					},
 				},
 			}

--- a/internal/services/signalr/signalr_service_custom_domain_resource_test.go
+++ b/internal/services/signalr/signalr_service_custom_domain_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SignalrServiceCustomDomainResource struct{}
@@ -55,11 +55,11 @@ func (r SignalrServiceCustomDomainResource) Exists(ctx context.Context, client *
 	resp, err := client.SignalR.SignalRClient.CustomDomainsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SignalrServiceCustomDomainResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/signalr_service_network_acl_resource_test.go
+++ b/internal/services/signalr/signalr_service_network_acl_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SignalRServiceNetworkACLResource struct{}
@@ -136,7 +136,7 @@ func (r SignalRServiceNetworkACLResource) Exists(ctx context.Context, clients *c
 		}
 	}
 
-	return utils.Bool(!isDefaultConfiguration), nil
+	return pointer.To(!isDefaultConfiguration), nil
 }
 
 func (r SignalRServiceNetworkACLResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -65,7 +65,7 @@ func resourceArmSignalRServiceCreate(d *pluginsdk.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 
 	id := signalr.NewSignalRID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
@@ -148,14 +148,14 @@ func resourceArmSignalRServiceCreate(d *pluginsdk.ResourceData, meta interface{}
 			Upstream:                 expandUpstreamSettings(upstreamSettings),
 			LiveTraceConfiguration:   expandSignalRLiveTraceConfig(d.Get("live_trace").([]interface{})),
 			ResourceLogConfiguration: resourceLogsData,
-			PublicNetworkAccess:      utils.String(publicNetworkAcc),
-			DisableAadAuth:           utils.Bool(!d.Get("aad_auth_enabled").(bool)),
-			DisableLocalAuth:         utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			PublicNetworkAccess:      pointer.To(publicNetworkAcc),
+			DisableAadAuth:           pointer.To(!d.Get("aad_auth_enabled").(bool)),
+			DisableLocalAuth:         pointer.To(!d.Get("local_auth_enabled").(bool)),
 			Tls: &signalr.SignalRTlsSettings{
-				ClientCertEnabled: utils.Bool(tlsClientCertEnabled),
+				ClientCertEnabled: pointer.To(tlsClientCertEnabled),
 			},
 			Serverless: &signalr.ServerlessSettings{
-				ConnectionTimeoutInSeconds: utils.Int64(int64(d.Get("serverless_connection_timeout_in_seconds").(int))),
+				ConnectionTimeoutInSeconds: pointer.To(int64(d.Get("serverless_connection_timeout_in_seconds").(int))),
 			},
 		},
 		Sku:  expandSignalRServiceSku(sku),
@@ -372,7 +372,7 @@ func resourceArmSignalRServiceUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		if d.HasChange("serverless_connection_timeout_in_seconds") {
 			resourceType.Properties.Serverless = &signalr.ServerlessSettings{
-				ConnectionTimeoutInSeconds: utils.Int64(int64(d.Get("serverless_connection_timeout_in_seconds").(int))),
+				ConnectionTimeoutInSeconds: pointer.To(int64(d.Get("serverless_connection_timeout_in_seconds").(int))),
 			}
 		}
 
@@ -392,21 +392,21 @@ func resourceArmSignalRServiceUpdate(d *pluginsdk.ResourceData, meta interface{}
 			if currentSku == "Free_F1" && publicNetworkAcc == "Disabled" {
 				return fmt.Errorf("SKU Free_F1 does not support disabling public network access")
 			}
-			resourceType.Properties.PublicNetworkAccess = utils.String(publicNetworkAcc)
+			resourceType.Properties.PublicNetworkAccess = pointer.To(publicNetworkAcc)
 		}
 
 		if d.HasChange("local_auth_enabled") {
-			resourceType.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_auth_enabled").(bool))
+			resourceType.Properties.DisableLocalAuth = pointer.To(!d.Get("local_auth_enabled").(bool))
 		}
 
 		if d.HasChange("aad_auth_enabled") {
-			resourceType.Properties.DisableAadAuth = utils.Bool(!d.Get("aad_auth_enabled").(bool))
+			resourceType.Properties.DisableAadAuth = pointer.To(!d.Get("aad_auth_enabled").(bool))
 		}
 
 		if d.HasChange("tls_client_cert_enabled") {
 			tlsClientCertEnabled := d.Get("tls_client_cert_enabled").(bool)
 			resourceType.Properties.Tls = &signalr.SignalRTlsSettings{
-				ClientCertEnabled: utils.Bool(tlsClientCertEnabled),
+				ClientCertEnabled: pointer.To(tlsClientCertEnabled),
 			}
 			if currentSku == "Free_F1" && tlsClientCertEnabled {
 				return fmt.Errorf("SKU Free_F1 does not support enabling tls client cert")
@@ -545,9 +545,9 @@ func expandUpstreamSettings(input []interface{}) *signalr.ServerlessUpstreamSett
 			Type: &authTypeNone,
 		}
 		upstreamTemplate := signalr.UpstreamTemplate{
-			HubPattern:      utils.String(strings.Join(*utils.ExpandStringSlice(setting["hub_pattern"].([]interface{})), ",")),
-			EventPattern:    utils.String(strings.Join(*utils.ExpandStringSlice(setting["event_pattern"].([]interface{})), ",")),
-			CategoryPattern: utils.String(strings.Join(*utils.ExpandStringSlice(setting["category_pattern"].([]interface{})), ",")),
+			HubPattern:      pointer.To(strings.Join(*utils.ExpandStringSlice(setting["hub_pattern"].([]interface{})), ",")),
+			EventPattern:    pointer.To(strings.Join(*utils.ExpandStringSlice(setting["event_pattern"].([]interface{})), ",")),
+			CategoryPattern: pointer.To(strings.Join(*utils.ExpandStringSlice(setting["category_pattern"].([]interface{})), ",")),
 			UrlTemplate:     setting["url_template"].(string),
 			Auth:            &auth,
 		}
@@ -556,7 +556,7 @@ func expandUpstreamSettings(input []interface{}) *signalr.ServerlessUpstreamSett
 			upstreamTemplate.Auth = &signalr.UpstreamAuthSettings{
 				Type: &authTypeManagedIdentity,
 				ManagedIdentity: &signalr.ManagedIdentitySettings{
-					Resource: utils.String(setting["user_assigned_identity_id"].(string)),
+					Resource: pointer.To(setting["user_assigned_identity_id"].(string)),
 				},
 			}
 		}
@@ -655,7 +655,7 @@ func expandSignalRServiceSku(input []interface{}) *signalr.ResourceSku {
 	v := input[0].(map[string]interface{})
 	return &signalr.ResourceSku{
 		Name:     v["name"].(string),
-		Capacity: utils.Int64(int64(v["capacity"].(int))),
+		Capacity: pointer.To(int64(v["capacity"].(int))),
 	}
 }
 
@@ -695,8 +695,8 @@ func expandSignalRLiveTraceConfig(input []interface{}) *signalr.LiveTraceConfigu
 		messageLogEnabled = "true"
 	}
 	resourceCategories = append(resourceCategories, signalr.LiveTraceCategory{
-		Name:    utils.String("MessagingLogs"),
-		Enabled: utils.String(messageLogEnabled),
+		Name:    pointer.To("MessagingLogs"),
+		Enabled: pointer.To(messageLogEnabled),
 	})
 
 	connectivityLogEnabled := "false"
@@ -704,8 +704,8 @@ func expandSignalRLiveTraceConfig(input []interface{}) *signalr.LiveTraceConfigu
 		connectivityLogEnabled = "true"
 	}
 	resourceCategories = append(resourceCategories, signalr.LiveTraceCategory{
-		Name:    utils.String("ConnectivityLogs"),
-		Enabled: utils.String(connectivityLogEnabled),
+		Name:    pointer.To("ConnectivityLogs"),
+		Enabled: pointer.To(connectivityLogEnabled),
 	})
 
 	httpLogEnabled := "false"
@@ -713,8 +713,8 @@ func expandSignalRLiveTraceConfig(input []interface{}) *signalr.LiveTraceConfigu
 		httpLogEnabled = "true"
 	}
 	resourceCategories = append(resourceCategories, signalr.LiveTraceCategory{
-		Name:    utils.String("HttpRequestLogs"),
-		Enabled: utils.String(httpLogEnabled),
+		Name:    pointer.To("HttpRequestLogs"),
+		Enabled: pointer.To(httpLogEnabled),
 	})
 
 	return &signalr.LiveTraceConfiguration{
@@ -780,8 +780,8 @@ func expandSignalRResourceLogConfig(connectivityLogEnabled bool, messagingLogEna
 		messagingLog = "true"
 	}
 	resourceLogCategories = append(resourceLogCategories, signalr.ResourceLogCategory{
-		Name:    utils.String("MessagingLogs"),
-		Enabled: utils.String(messagingLog),
+		Name:    pointer.To("MessagingLogs"),
+		Enabled: pointer.To(messagingLog),
 	})
 
 	connectivityLog := "false"
@@ -789,8 +789,8 @@ func expandSignalRResourceLogConfig(connectivityLogEnabled bool, messagingLogEna
 		connectivityLog = "true"
 	}
 	resourceLogCategories = append(resourceLogCategories, signalr.ResourceLogCategory{
-		Name:    utils.String("ConnectivityLogs"),
-		Enabled: utils.String(connectivityLog),
+		Name:    pointer.To("ConnectivityLogs"),
+		Enabled: pointer.To(connectivityLog),
 	})
 
 	httpLog := "false"
@@ -798,8 +798,8 @@ func expandSignalRResourceLogConfig(connectivityLogEnabled bool, messagingLogEna
 		httpLog = "true"
 	}
 	resourceLogCategories = append(resourceLogCategories, signalr.ResourceLogCategory{
-		Name:    utils.String("HttpRequestLogs"),
-		Enabled: utils.String(httpLog),
+		Name:    pointer.To("HttpRequestLogs"),
+		Enabled: pointer.To(httpLog),
 	})
 
 	return &signalr.ResourceLogConfiguration{

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SignalRServiceResource struct{}
@@ -577,11 +577,11 @@ func (r SignalRServiceResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.SignalR.SignalRClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SignalRServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/signalr_shared_private_link_resource_resource.go
+++ b/internal/services/signalr/signalr_shared_private_link_resource_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSignalRSharedPrivateLinkResource() *pluginsdk.Resource {
@@ -115,7 +115,7 @@ func resourceSignalRSharedPrivateLinkCreateUpdate(d *pluginsdk.ResourceData, met
 
 	requestMessage := d.Get("request_message").(string)
 	if requestMessage != "" {
-		parameters.Properties.RequestMessage = utils.String(requestMessage)
+		parameters.Properties.RequestMessage = pointer.To(requestMessage)
 	}
 
 	if err := client.SharedPrivateLinkResourcesCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {

--- a/internal/services/signalr/signalr_shared_private_link_resource_resource_test.go
+++ b/internal/services/signalr/signalr_shared_private_link_resource_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2024-03-01/signalr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SignalrSharedPrivateLinkResource struct{}
@@ -70,11 +70,11 @@ func (r SignalrSharedPrivateLinkResource) Exists(ctx context.Context, clients *c
 	resp, err := clients.SignalR.SignalRClient.SharedPrivateLinkResourcesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SignalrSharedPrivateLinkResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/web_pubsub_custom_certificate_resource.go
+++ b/internal/services/signalr/web_pubsub_custom_certificate_resource.go
@@ -18,7 +18,6 @@ import (
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomCertWebPubsubModel struct {
@@ -121,7 +120,7 @@ func (r CustomCertWebPubsubResource) Create() sdk.ResourceFunc {
 				},
 			}
 			if keyVaultCertificateId.Version != "" {
-				customCertObj.Properties.KeyVaultSecretVersion = utils.String(keyVaultCertificateId.Version)
+				customCertObj.Properties.KeyVaultSecretVersion = pointer.To(keyVaultCertificateId.Version)
 			}
 
 			if err := client.CustomCertificatesCreateOrUpdateThenPoll(ctx, id, customCertObj); err != nil {

--- a/internal/services/signalr/web_pubsub_custom_certificate_resource_test.go
+++ b/internal/services/signalr/web_pubsub_custom_certificate_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomCertWebPubsubResource struct{}
@@ -183,9 +183,9 @@ func (r CustomCertWebPubsubResource) Exists(ctx context.Context, client *clients
 	resp, err := client.SignalR.WebPubSubClient.WebPubSub.CustomCertificatesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/signalr/web_pubsub_custom_domain_resource.go
+++ b/internal/services/signalr/web_pubsub_custom_domain_resource.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CustomDomainWebPubsubModel struct {
@@ -109,7 +109,7 @@ func (r CustomDomainWebPubsubResource) Create() sdk.ResourceFunc {
 				Properties: webpubsub.CustomDomainProperties{
 					DomainName: customDomainWebPubsubModel.DomainName,
 					CustomCertificate: webpubsub.ResourceReference{
-						Id: utils.String(customDomainWebPubsubModel.WebPubsubCustomCertificateId),
+						Id: pointer.To(customDomainWebPubsubModel.WebPubsubCustomCertificateId),
 					},
 				},
 			}

--- a/internal/services/signalr/web_pubsub_custom_domain_resource_test.go
+++ b/internal/services/signalr/web_pubsub_custom_domain_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebPubsubCustomDomainResource struct{}
@@ -55,11 +55,11 @@ func (r WebPubsubCustomDomainResource) Exists(ctx context.Context, client *clien
 	resp, err := client.SignalR.WebPubSubClient.WebPubSub.CustomDomainsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WebPubsubCustomDomainResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/web_pubsub_hub_resource.go
+++ b/internal/services/signalr/web_pubsub_hub_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
@@ -274,7 +275,7 @@ func expandEventHandler(input []interface{}) *[]webpubsub.EventHandler {
 		}
 
 		if v, ok := block["user_event_pattern"]; ok {
-			eventHandlerSettings.UserEventPattern = utils.String(v.(string))
+			eventHandlerSettings.UserEventPattern = pointer.To(v.(string))
 		}
 
 		if v, ok := block["system_events"]; ok {
@@ -350,7 +351,7 @@ func expandEventListener(input []interface{}) (*[]webpubsub.EventListener, error
 		}
 		filter := webpubsub.EventNameFilter{
 			SystemEvents:     &systemEvents,
-			UserEventPattern: utils.String(userEventPattern),
+			UserEventPattern: pointer.To(userEventPattern),
 		}
 
 		endpointName := block["eventhub_namespace_name"].(string)

--- a/internal/services/signalr/web_pubsub_hub_resource_test.go
+++ b/internal/services/signalr/web_pubsub_hub_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebPubsubHubResource struct{}
@@ -203,11 +203,11 @@ func (r WebPubsubHubResource) Exists(ctx context.Context, clients *clients.Clien
 	resp, err := clients.SignalR.WebPubSubClient.WebPubSub.HubsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WebPubsubHubResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/web_pubsub_network_acl_resource_test.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebPubsubNetworkACLResource struct{}
@@ -146,7 +146,7 @@ func (r WebPubsubNetworkACLResource) Exists(ctx context.Context, clients *client
 		}
 	}
 
-	return utils.Bool(!isDefaultConfiguration), nil
+	return pointer.To(!isDefaultConfiguration), nil
 }
 
 func (r WebPubsubNetworkACLResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/web_pubsub_resource.go
+++ b/internal/services/signalr/web_pubsub_resource.go
@@ -26,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceWebPubSub() *pluginsdk.Resource {
@@ -239,11 +238,11 @@ func resourceWebPubSubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		Identity: identity,
 		Properties: &webpubsub.WebPubSubProperties{
 			LiveTraceConfiguration: expandLiveTraceConfig(liveTraceConfig),
-			PublicNetworkAccess:    utils.String(publicNetworkAcc),
-			DisableAadAuth:         utils.Bool(!d.Get("aad_auth_enabled").(bool)),
-			DisableLocalAuth:       utils.Bool(!d.Get("local_auth_enabled").(bool)),
+			PublicNetworkAccess:    pointer.To(publicNetworkAcc),
+			DisableAadAuth:         pointer.To(!d.Get("aad_auth_enabled").(bool)),
+			DisableLocalAuth:       pointer.To(!d.Get("local_auth_enabled").(bool)),
 			Tls: &webpubsub.WebPubSubTlsSettings{
-				ClientCertEnabled: utils.Bool(d.Get("tls_client_cert_enabled").(bool)),
+				ClientCertEnabled: pointer.To(d.Get("tls_client_cert_enabled").(bool)),
 			},
 		},
 		Sku: &webpubsub.ResourceSku{
@@ -420,8 +419,8 @@ func expandLiveTraceConfig(input []interface{}) *webpubsub.LiveTraceConfiguratio
 		messageLogEnabled = "true"
 	}
 	resourceCategories = append(resourceCategories, webpubsub.LiveTraceCategory{
-		Name:    utils.String("MessagingLogs"),
-		Enabled: utils.String(messageLogEnabled),
+		Name:    pointer.To("MessagingLogs"),
+		Enabled: pointer.To(messageLogEnabled),
 	})
 
 	connectivityLogEnabled := "false"
@@ -429,8 +428,8 @@ func expandLiveTraceConfig(input []interface{}) *webpubsub.LiveTraceConfiguratio
 		connectivityLogEnabled = "true"
 	}
 	resourceCategories = append(resourceCategories, webpubsub.LiveTraceCategory{
-		Name:    utils.String("ConnectivityLogs"),
-		Enabled: utils.String(connectivityLogEnabled),
+		Name:    pointer.To("ConnectivityLogs"),
+		Enabled: pointer.To(connectivityLogEnabled),
 	})
 
 	httpLogEnabled := "false"
@@ -438,8 +437,8 @@ func expandLiveTraceConfig(input []interface{}) *webpubsub.LiveTraceConfiguratio
 		httpLogEnabled = "true"
 	}
 	resourceCategories = append(resourceCategories, webpubsub.LiveTraceCategory{
-		Name:    utils.String("HttpRequestLogs"),
-		Enabled: utils.String(httpLogEnabled),
+		Name:    pointer.To("HttpRequestLogs"),
+		Enabled: pointer.To(httpLogEnabled),
 	})
 
 	return &webpubsub.LiveTraceConfiguration{

--- a/internal/services/signalr/web_pubsub_resource_test.go
+++ b/internal/services/signalr/web_pubsub_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebPubsubResource struct{}
@@ -287,11 +287,11 @@ func (r WebPubsubResource) Exists(ctx context.Context, client *clients.Client, s
 	resp, err := client.SignalR.WebPubSubClient.WebPubSub.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WebPubsubResource) basic(data acceptance.TestData) string {

--- a/internal/services/signalr/web_pubsub_shared_private_link_resource_resource.go
+++ b/internal/services/signalr/web_pubsub_shared_private_link_resource_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceWebPubSubSharedPrivateLinkService() *pluginsdk.Resource {
@@ -112,7 +111,7 @@ func resourceWebPubsubSharedPrivateLinkServiceCreateUpdate(d *pluginsdk.Resource
 
 	requestMessage := d.Get("request_message").(string)
 	if requestMessage != "" {
-		parameters.Properties.RequestMessage = utils.String(requestMessage)
+		parameters.Properties.RequestMessage = pointer.To(requestMessage)
 	}
 
 	if err := client.SharedPrivateLinkResourcesCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {

--- a/internal/services/signalr/web_pubsub_shared_private_link_resource_resource_test.go
+++ b/internal/services/signalr/web_pubsub_shared_private_link_resource_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WebPubsubSharedPrivateLinkResource struct{}
@@ -57,12 +57,12 @@ func (r WebPubsubSharedPrivateLinkResource) Exists(ctx context.Context, clients 
 	resp, err := clients.SignalR.WebPubSubClient.WebPubSub.SharedPrivateLinkResourcesGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r WebPubsubSharedPrivateLinkResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
