### PR TITLE
services `S*` part 2 - deprecated function clean up

### DIFF
--- a/internal/services/springcloud/spring_cloud_accelerator_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_accelerator_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -54,11 +55,11 @@ func (r SpringCloudAcceleratorResource) Exists(ctx context.Context, client *clie
 	resp, err := client.AppPlatform.ApplicationAcceleratorClient.Get(ctx, id.ResourceGroup, id.SpringName, id.ApplicationAcceleratorName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudAcceleratorResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_active_deployment_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_active_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudActiveDeploymentResource struct{}
@@ -91,7 +91,7 @@ func (r SpringCloudActiveDeploymentResource) Exists(ctx context.Context, clients
 		}
 	}
 
-	return utils.Bool(len(deployments) != 0), nil
+	return pointer.To(len(deployments) != 0), nil
 }
 
 func (r SpringCloudActiveDeploymentResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_api_portal_custom_domain_resource.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_custom_domain_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -94,7 +95,7 @@ func resourceSpringCloudAPIPortalCustomDomainCreateUpdate(d *pluginsdk.ResourceD
 
 	apiPortalCustomDomainResource := appplatform.APIPortalCustomDomainResource{
 		Properties: &appplatform.APIPortalCustomDomainProperties{
-			Thumbprint: utils.String(d.Get("thumbprint").(string)),
+			Thumbprint: pointer.To(d.Get("thumbprint").(string)),
 		},
 	}
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, id.DomainName, apiPortalCustomDomainResource)

--- a/internal/services/springcloud/spring_cloud_api_portal_custom_domain_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_api_portal_custom_domain_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -54,11 +55,11 @@ func (r SpringCloudAPIPortalCustomDomainResource) Exists(ctx context.Context, cl
 	resp, err := client.AppPlatform.APIPortalCustomDomainClient.Get(ctx, id.ResourceGroup, id.SpringName, id.ApiPortalName, id.DomainName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudAPIPortalCustomDomainResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_app_cosmosdb_association_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_cosmosdb_association_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -173,7 +174,7 @@ func resourceSpringCloudAppCosmosDBAssociationCreateUpdate(d *pluginsdk.Resource
 	sqlDatabaseName := d.Get("cosmosdb_sql_database_name")
 
 	bindingParameters := map[string]*string{
-		springCloudAppCosmosDbAssociationKeyAPIType: utils.String(apiType),
+		springCloudAppCosmosDbAssociationKeyAPIType: pointer.To(apiType),
 	}
 
 	switch apiType {
@@ -181,23 +182,23 @@ func resourceSpringCloudAppCosmosDBAssociationCreateUpdate(d *pluginsdk.Resource
 		if cassandraKeyspaceName == "" {
 			return fmt.Errorf("`cosmosdb_cassandra_keyspace_name` should be set if `api_type` is `%s`", apiType)
 		}
-		bindingParameters[springCloudAppCosmosDbAssociationKeyKeySpace] = utils.String(cassandraKeyspaceName.(string))
+		bindingParameters[springCloudAppCosmosDbAssociationKeyKeySpace] = pointer.To(cassandraKeyspaceName.(string))
 	case springCloudAppCosmosDbAssociationAPITypeGremlin:
 		if gremlinDatabaseName == "" || gremlinGraphName == "" {
 			return fmt.Errorf("`cosmosdb_gremlin_database_name` and `cosmosdb_gremlin_graph_name` should be set if `api_type` is `%s`", apiType)
 		}
-		bindingParameters[springCloudAppCosmosDbAssociationKeyDatabaseName] = utils.String(gremlinDatabaseName.(string))
-		bindingParameters[springCloudAppCosmosDbAssociationKeyCollectionName] = utils.String(gremlinGraphName.(string))
+		bindingParameters[springCloudAppCosmosDbAssociationKeyDatabaseName] = pointer.To(gremlinDatabaseName.(string))
+		bindingParameters[springCloudAppCosmosDbAssociationKeyCollectionName] = pointer.To(gremlinGraphName.(string))
 	case springCloudAppCosmosDbAssociationAPITypeMongo:
 		if mongoDatabaseName == "" {
 			return fmt.Errorf("`cosmosdb_mongo_database_name` should be set if `api_type` is `%s`", apiType)
 		}
-		bindingParameters[springCloudAppCosmosDbAssociationKeyDatabaseName] = utils.String(mongoDatabaseName.(string))
+		bindingParameters[springCloudAppCosmosDbAssociationKeyDatabaseName] = pointer.To(mongoDatabaseName.(string))
 	case springCloudAppCosmosDbAssociationAPITypeSql:
 		if sqlDatabaseName == "" {
 			return fmt.Errorf("`cosmosdb_sql_database_name` should be set if `api_type` is `%s`", apiType)
 		}
-		bindingParameters[springCloudAppCosmosDbAssociationKeyDatabaseName] = utils.String(sqlDatabaseName.(string))
+		bindingParameters[springCloudAppCosmosDbAssociationKeyDatabaseName] = pointer.To(sqlDatabaseName.(string))
 	case springCloudAppCosmosDbAssociationAPITypeTable:
 		if cassandraKeyspaceName != "" || gremlinDatabaseName != "" || gremlinGraphName != "" || mongoDatabaseName != "" || sqlDatabaseName != "" {
 			return fmt.Errorf("`cosmosdb_cassandra_keyspace_name`, `cosmosdb_gremlin_database_name`, `cosmosdb_gremlin_graph_name`, `cosmosdb_mongo_database_name`, `cosmosdb_sql_database_name` should not be set if `api_type` is `%s`", apiType)
@@ -207,8 +208,8 @@ func resourceSpringCloudAppCosmosDBAssociationCreateUpdate(d *pluginsdk.Resource
 	bindingResource := appplatform.BindingResource{
 		Properties: &appplatform.BindingResourceProperties{
 			BindingParameters: bindingParameters,
-			Key:               utils.String(d.Get("cosmosdb_access_key").(string)),
-			ResourceID:        utils.String(d.Get("cosmosdb_account_id").(string)),
+			Key:               pointer.To(d.Get("cosmosdb_access_key").(string)),
+			ResourceID:        pointer.To(d.Get("cosmosdb_account_id").(string)),
 		},
 	}
 

--- a/internal/services/springcloud/spring_cloud_app_cosmosdb_association_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_app_cosmosdb_association_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudAppCosmosDbAssociationResource struct{}
@@ -289,7 +289,7 @@ func (t SpringCloudAppCosmosDbAssociationResource) Exists(ctx context.Context, c
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudAppCosmosDbAssociationResource) cassandra_basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_app_dynamics_application_performance_monitoring_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_app_dynamics_application_performance_monitoring_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudAppDynamicsApplicationPerformanceMonitoringResource struct{}
@@ -97,11 +97,11 @@ func (r SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) Exists(c
 	resp, err := client.AppPlatform.AppPlatformClient.ApmsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SpringCloudAppDynamicsApplicationPerformanceMonitoringResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_app_mysql_association_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_mysql_association_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/servers"
 	flexibleServers "github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/servers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -127,11 +128,11 @@ func resourceSpringCloudAppMysqlAssociationCreateUpdate(d *pluginsdk.ResourceDat
 	bindingResource := appplatform.BindingResource{
 		Properties: &appplatform.BindingResourceProperties{
 			BindingParameters: map[string]*string{
-				springCloudAppMysqlAssociationKeyDatabase: utils.String(d.Get("database_name").(string)),
-				springCloudAppMysqlAssociationKeyUsername: utils.String(d.Get("username").(string)),
+				springCloudAppMysqlAssociationKeyDatabase: pointer.To(d.Get("database_name").(string)),
+				springCloudAppMysqlAssociationKeyUsername: pointer.To(d.Get("username").(string)),
 			},
-			Key:        utils.String(d.Get("password").(string)),
-			ResourceID: utils.String(d.Get("mysql_server_id").(string)),
+			Key:        pointer.To(d.Get("password").(string)),
+			ResourceID: pointer.To(d.Get("mysql_server_id").(string)),
 		},
 	}
 

--- a/internal/services/springcloud/spring_cloud_app_mysql_association_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_app_mysql_association_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudAppMysqlAssociationResource struct{}
@@ -81,7 +81,7 @@ func (r SpringCloudAppMysqlAssociationResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudAppMysqlAssociationResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_app_redis_association_resource.go
+++ b/internal/services/springcloud/spring_cloud_app_redis_association_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2024-03-01/redis"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -114,10 +115,10 @@ func resourceSpringCloudAppRedisAssociationCreateUpdate(d *pluginsdk.ResourceDat
 	bindingResource := appplatform.BindingResource{
 		Properties: &appplatform.BindingResourceProperties{
 			BindingParameters: map[string]*string{
-				springCloudAppRedisAssociationKeySSL: utils.String(fmt.Sprintf("%t", d.Get("ssl_enabled").(bool))),
+				springCloudAppRedisAssociationKeySSL: pointer.To(fmt.Sprintf("%t", d.Get("ssl_enabled").(bool))),
 			},
-			Key:        utils.String(d.Get("redis_access_key").(string)),
-			ResourceID: utils.String(d.Get("redis_cache_id").(string)),
+			Key:        pointer.To(d.Get("redis_access_key").(string)),
+			ResourceID: pointer.To(d.Get("redis_cache_id").(string)),
 		},
 	}
 

--- a/internal/services/springcloud/spring_cloud_app_redis_association_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_app_redis_association_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudAppRedisAssociationResource struct{}
@@ -103,7 +103,7 @@ func (t SpringCloudAppRedisAssociationResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudAppRedisAssociationResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_app_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_app_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	parse "github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudAppResource struct{}
@@ -245,7 +245,7 @@ func (r SpringCloudAppResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("reading Spring Cloud App %q (Spring Cloud Service %q / Resource Group %q): %+v", id.AppName, id.SpringName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (SpringCloudAppResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_application_insights_application_performance_monitoring_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_application_insights_application_performance_monitoring_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource struct{}
@@ -97,11 +97,11 @@ func (r SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) 
 	resp, err := client.AppPlatform.AppPlatformClient.ApmsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudApplicationInsightsApplicationPerformanceMonitoringResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_application_live_view_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_application_live_view_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -54,11 +55,11 @@ func (r SpringCloudApplicationLiveViewResource) Exists(ctx context.Context, clie
 	resp, err := client.AppPlatform.ApplicationLiveViewsClient.Get(ctx, id.ResourceGroup, id.SpringName, id.ApplicationLiveViewName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudApplicationLiveViewResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_build_deployment_resource.go
+++ b/internal/services/springcloud/spring_cloud_build_deployment_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	appplatform2 "github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -175,11 +176,11 @@ func resourceSpringCloudBuildDeploymentCreateUpdate(d *pluginsdk.ResourceData, m
 		Sku: &appplatform.Sku{
 			Name:     service.Sku.Name,
 			Tier:     service.Sku.Tier,
-			Capacity: utils.Int32(int32(d.Get("instance_count").(int))),
+			Capacity: pointer.To(int32(d.Get("instance_count").(int))),
 		},
 		Properties: &appplatform.DeploymentResourceProperties{
 			Source: appplatform.BuildResultUserSourceInfo{
-				BuildResultID: utils.String(d.Get("build_result_id").(string)),
+				BuildResultID: pointer.To(d.Get("build_result_id").(string)),
 			},
 			DeploymentSettings: &appplatform.DeploymentSettings{
 				AddonConfigs:         addonConfig,
@@ -290,8 +291,8 @@ func expandSpringCloudBuildDeploymentResourceRequests(input []interface{}) *appp
 	}
 
 	result := appplatform.ResourceRequests{
-		CPU:    utils.String(cpuResult),
-		Memory: utils.String(memResult),
+		CPU:    pointer.To(cpuResult),
+		Memory: pointer.To(memResult),
 	}
 
 	return &result

--- a/internal/services/springcloud/spring_cloud_build_deployment_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_build_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudBuildDeploymentResource struct{}
@@ -125,7 +125,7 @@ func (r SpringCloudBuildDeploymentResource) Exists(ctx context.Context, clients 
 		return nil, fmt.Errorf("reading Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudBuildDeploymentResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_build_pack_binding_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_build_pack_binding_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -96,11 +97,11 @@ func (r SpringCloudBuildPackBindingResource) Exists(ctx context.Context, client 
 	resp, err := client.AppPlatform.BuildPackBindingClient.Get(ctx, id.ResourceGroup, id.SpringName, id.BuildServiceName, id.BuilderName, id.BuildPackBindingName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudBuildPackBindingResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_builder_resource.go
+++ b/internal/services/springcloud/spring_cloud_builder_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -212,7 +213,7 @@ func expandBuildServiceBuilderBuildPacksGroupPropertiesArray(input []interface{}
 	for _, item := range input {
 		v := item.(map[string]interface{})
 		results = append(results, appplatform.BuildpacksGroupProperties{
-			Name:       utils.String(v["name"].(string)),
+			Name:       pointer.To(v["name"].(string)),
 			Buildpacks: expandBuildServiceBuilderBuildPackPropertiesArray(v["build_pack_ids"].([]interface{})),
 		})
 	}
@@ -225,8 +226,8 @@ func expandBuildServiceBuilderStackProperties(input []interface{}) *appplatform.
 	}
 	v := input[0].(map[string]interface{})
 	return &appplatform.StackProperties{
-		ID:      utils.String(v["id"].(string)),
-		Version: utils.String(v["version"].(string)),
+		ID:      pointer.To(v["id"].(string)),
+		Version: pointer.To(v["version"].(string)),
 	}
 }
 
@@ -234,7 +235,7 @@ func expandBuildServiceBuilderBuildPackPropertiesArray(input []interface{}) *[]a
 	results := make([]appplatform.BuildpackProperties, 0)
 	for _, item := range input {
 		results = append(results, appplatform.BuildpackProperties{
-			ID: utils.String(item.(string)),
+			ID: pointer.To(item.(string)),
 		})
 	}
 	return &results

--- a/internal/services/springcloud/spring_cloud_builder_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_builder_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -54,11 +55,11 @@ func (r SpringCloudBuildServiceBuilderResource) Exists(ctx context.Context, clie
 	resp, err := client.AppPlatform.BuildServiceBuilderClient.Get(ctx, id.ResourceGroup, id.SpringName, id.BuildServiceName, id.BuilderName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudBuildServiceBuilderResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_certificate_resource.go
+++ b/internal/services/springcloud/spring_cloud_certificate_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -124,14 +125,14 @@ func resourceSpringCloudCertificateCreate(d *pluginsdk.ResourceData, meta interf
 			return err
 		}
 		cert.Properties = &appplatform.KeyVaultCertificateProperties{
-			VaultURI:          utils.String(strings.TrimSuffix(keyVaultCertificateId.KeyVaultBaseUrl, "/")),
+			VaultURI:          pointer.To(strings.TrimSuffix(keyVaultCertificateId.KeyVaultBaseUrl, "/")),
 			KeyVaultCertName:  &keyVaultCertificateId.Name,
-			ExcludePrivateKey: utils.Bool(d.Get("exclude_private_key").(bool)),
+			ExcludePrivateKey: pointer.To(d.Get("exclude_private_key").(bool)),
 		}
 	}
 	if value, ok := d.GetOk("certificate_content"); ok {
 		cert.Properties = &appplatform.ContentCertificateProperties{
-			Content: utils.String(value.(string)),
+			Content: pointer.To(value.(string)),
 		}
 	}
 

--- a/internal/services/springcloud/spring_cloud_certificate_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_certificate_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudCertificateResource struct{}
@@ -76,7 +76,7 @@ func (t SpringCloudCertificateResource) Exists(ctx context.Context, clients *cli
 		return nil, fmt.Errorf("reading Spring Cloud Certificate %q (Spring Cloud Service %q / Resource Group %q): %+v", id.CertificateName, id.SpringName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudCertificateResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_container_deployment_resource.go
+++ b/internal/services/springcloud/spring_cloud_container_deployment_resource.go
@@ -208,16 +208,16 @@ func resourceSpringCloudContainerDeploymentCreateUpdate(d *pluginsdk.ResourceDat
 		Sku: &appplatform.Sku{
 			Name:     service.Sku.Name,
 			Tier:     service.Sku.Tier,
-			Capacity: utils.Int32(int32(d.Get("instance_count").(int))),
+			Capacity: pointer.To(int32(d.Get("instance_count").(int))),
 		},
 		Properties: &appplatform.DeploymentResourceProperties{
 			Source: appplatform.CustomContainerUserSourceInfo{
 				CustomContainer: &appplatform.CustomContainer{
-					Server:            utils.String(d.Get("server").(string)),
-					ContainerImage:    utils.String(d.Get("image").(string)),
+					Server:            pointer.To(d.Get("server").(string)),
+					ContainerImage:    pointer.To(d.Get("image").(string)),
 					Command:           utils.ExpandStringSlice(d.Get("commands").([]interface{})),
 					Args:              utils.ExpandStringSlice(d.Get("arguments").([]interface{})),
-					LanguageFramework: utils.String(d.Get("language_framework").(string)),
+					LanguageFramework: pointer.To(d.Get("language_framework").(string)),
 				},
 			},
 			DeploymentSettings: &appplatform.DeploymentSettings{
@@ -335,8 +335,8 @@ func expandSpringCloudContainerDeploymentResourceRequests(input []interface{}) *
 	}
 
 	result := appplatform.ResourceRequests{
-		CPU:    utils.String(cpuResult),
-		Memory: utils.String(memResult),
+		CPU:    pointer.To(cpuResult),
+		Memory: pointer.To(memResult),
 	}
 
 	return &result

--- a/internal/services/springcloud/spring_cloud_container_deployment_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_container_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudContainerDeploymentResource struct{}
@@ -125,7 +125,7 @@ func (r SpringCloudContainerDeploymentResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("reading Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudContainerDeploymentResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_custom_domain_resource.go
+++ b/internal/services/springcloud/spring_cloud_custom_domain_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -106,8 +107,8 @@ func resourceSpringCloudCustomDomainCreateUpdate(d *pluginsdk.ResourceData, meta
 
 	domain := appplatform.CustomDomainResource{
 		Properties: &appplatform.CustomDomainProperties{
-			Thumbprint: utils.String(d.Get("thumbprint").(string)),
-			CertName:   utils.String(d.Get("certificate_name").(string)),
+			Thumbprint: pointer.To(d.Get("thumbprint").(string)),
+			CertName:   pointer.To(d.Get("certificate_name").(string)),
 		},
 	}
 

--- a/internal/services/springcloud/spring_cloud_custom_domain_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_custom_domain_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudCustomDomainResource struct{}
@@ -124,7 +124,7 @@ func (r SpringCloudCustomDomainResource) Exists(ctx context.Context, clients *cl
 		return nil, fmt.Errorf("reading Spring Cloud Custom Domain %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DomainName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudCustomDomainResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_customized_accelerator_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_customized_accelerator_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudCustomizedAcceleratorResource struct{}
@@ -111,11 +111,11 @@ func (r SpringCloudCustomizedAcceleratorResource) Exists(ctx context.Context, cl
 	resp, err := client.AppPlatform.AppPlatformClient.CustomizedAcceleratorsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudCustomizedAcceleratorResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_dev_tool_portal_resource.go
+++ b/internal/services/springcloud/spring_cloud_dev_tool_portal_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -160,7 +161,7 @@ func (s SpringCloudDevToolPortalResource) Create() sdk.ResourceFunc {
 
 			DevToolPortalResource := appplatform.DevToolPortalResource{
 				Properties: &appplatform.DevToolPortalProperties{
-					Public:        utils.Bool(model.PublicNetworkAccessEnabled),
+					Public:        pointer.To(model.PublicNetworkAccessEnabled),
 					SsoProperties: expandSpringCloudDevToolPortalSsoProperties(model.Sso),
 					Features:      expandSpringCloudDevToolPortalFeatures(model.ApplicationAcceleratorEnabled, model.ApplicationLiveViewEnabled),
 				},
@@ -202,7 +203,7 @@ func (s SpringCloudDevToolPortalResource) Update() sdk.ResourceFunc {
 
 			DevToolPortalResource := appplatform.DevToolPortalResource{
 				Properties: &appplatform.DevToolPortalProperties{
-					Public:        utils.Bool(model.PublicNetworkAccessEnabled),
+					Public:        pointer.To(model.PublicNetworkAccessEnabled),
 					SsoProperties: expandSpringCloudDevToolPortalSsoProperties(model.Sso),
 					Features:      expandSpringCloudDevToolPortalFeatures(model.ApplicationAcceleratorEnabled, model.ApplicationLiveViewEnabled),
 				},
@@ -327,9 +328,9 @@ func expandSpringCloudDevToolPortalSsoProperties(input []SsoModel) *appplatform.
 
 	return &appplatform.DevToolPortalSsoProperties{
 		Scopes:       &sso.Scope,
-		ClientID:     utils.String(sso.ClientId),
-		ClientSecret: utils.String(sso.ClientSecret),
-		MetadataURL:  utils.String(sso.MetadataUrl),
+		ClientID:     pointer.To(sso.ClientId),
+		ClientSecret: pointer.To(sso.ClientSecret),
+		MetadataURL:  pointer.To(sso.MetadataUrl),
 	}
 }
 

--- a/internal/services/springcloud/spring_cloud_dev_tool_portal_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_dev_tool_portal_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -101,11 +102,11 @@ func (r SpringCloudDevToolPortalResource) Exists(ctx context.Context, client *cl
 	resp, err := client.AppPlatform.DevToolPortalClient.Get(ctx, id.ResourceGroup, id.SpringName, id.DevToolPortalName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudDevToolPortalResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_dynatrace_application_performance_monitoring_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_dynatrace_application_performance_monitoring_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/appplatform/2024-01-01-preview/appplatform"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudDynatraceApplicationPerformanceMonitoringResource struct{}
@@ -97,11 +97,11 @@ func (r SpringCloudDynatraceApplicationPerformanceMonitoringResource) Exists(ctx
 	resp, err := client.AppPlatform.AppPlatformClient.ApmsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SpringCloudDynatraceApplicationPerformanceMonitoringResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_gateway_custom_domain_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_custom_domain_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -96,7 +97,7 @@ func resourceSpringCloudGatewayCustomDomainCreateUpdate(d *pluginsdk.ResourceDat
 
 	gatewayCustomDomainResource := appplatform.GatewayCustomDomainResource{
 		Properties: &appplatform.GatewayCustomDomainProperties{
-			Thumbprint: utils.String(d.Get("thumbprint").(string)),
+			Thumbprint: pointer.To(d.Get("thumbprint").(string)),
 		},
 	}
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.GatewayName, id.DomainName, gatewayCustomDomainResource)

--- a/internal/services/springcloud/spring_cloud_gateway_custom_domain_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_gateway_custom_domain_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -54,11 +55,11 @@ func (r SpringCloudGatewayCustomDomainResource) Exists(ctx context.Context, clie
 	resp, err := client.AppPlatform.GatewayCustomDomainClient.Get(ctx, id.ResourceGroup, id.SpringName, id.GatewayName, id.DomainName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudGatewayCustomDomainResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -211,10 +212,10 @@ func resourceSpringCloudGatewayRouteConfigCreateUpdate(d *pluginsdk.ResourceData
 
 	gatewayRouteConfigResource := appplatform.GatewayRouteConfigResource{
 		Properties: &appplatform.GatewayRouteConfigProperties{
-			AppResourceID: utils.String(d.Get("spring_cloud_app_id").(string)),
+			AppResourceID: pointer.To(d.Get("spring_cloud_app_id").(string)),
 			Protocol:      appplatform.GatewayRouteConfigProtocol(d.Get("protocol").(string)),
 			Routes:        expandGatewayRouteConfigGatewayAPIRouteArray(d.Get("route").(*pluginsdk.Set).List()),
-			SsoEnabled:    utils.Bool(d.Get("sso_validation_enabled").(bool)),
+			SsoEnabled:    pointer.To(d.Get("sso_validation_enabled").(bool)),
 			OpenAPI:       expandGatewayRouteConfigOpenApi(d.Get("open_api").([]interface{})),
 		},
 	}
@@ -320,14 +321,14 @@ func expandGatewayRouteConfigGatewayAPIRouteArray(input []interface{}) *[]apppla
 	for _, item := range input {
 		v := item.(map[string]interface{})
 		results = append(results, appplatform.GatewayAPIRoute{
-			Title:       utils.String(v["title"].(string)),
-			Description: utils.String(v["description"].(string)),
-			URI:         utils.String(v["uri"].(string)),
-			SsoEnabled:  utils.Bool(v["sso_validation_enabled"].(bool)),
-			TokenRelay:  utils.Bool(v["token_relay"].(bool)),
+			Title:       pointer.To(v["title"].(string)),
+			Description: pointer.To(v["description"].(string)),
+			URI:         pointer.To(v["uri"].(string)),
+			SsoEnabled:  pointer.To(v["sso_validation_enabled"].(bool)),
+			TokenRelay:  pointer.To(v["token_relay"].(bool)),
 			Predicates:  utils.ExpandStringSlice(v["predicates"].(*pluginsdk.Set).List()),
 			Filters:     utils.ExpandStringSlice(v["filters"].(*pluginsdk.Set).List()),
-			Order:       utils.Int32(int32(v["order"].(int))),
+			Order:       pointer.To(int32(v["order"].(int))),
 			Tags:        utils.ExpandStringSlice(v["classification_tags"].(*pluginsdk.Set).List()),
 		})
 	}
@@ -387,7 +388,7 @@ func expandGatewayRouteConfigOpenApi(input []interface{}) *appplatform.GatewayRo
 
 	config := input[0].(map[string]interface{})
 	return &appplatform.GatewayRouteConfigOpenAPIProperties{
-		URI: utils.String(config["uri"].(string)),
+		URI: pointer.To(config["uri"].(string)),
 	}
 }
 

--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -117,11 +118,11 @@ func (r SpringCloudGatewayRouteConfigResource) Exists(ctx context.Context, clien
 	resp, err := client.AppPlatform.GatewayRouteConfigClient.Get(ctx, id.ResourceGroup, id.SpringName, id.GatewayName, id.RouteConfigName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SpringCloudGatewayRouteConfigResource) template(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_java_deployment_resource.go
+++ b/internal/services/springcloud/spring_cloud_java_deployment_resource.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -87,13 +88,13 @@ func resourceSpringCloudJavaDeploymentCreate(d *pluginsdk.ResourceData, meta int
 		Sku: &appplatform.Sku{
 			Name:     service.Sku.Name,
 			Tier:     service.Sku.Tier,
-			Capacity: utils.Int32(int32(d.Get("instance_count").(int))),
+			Capacity: pointer.To(int32(d.Get("instance_count").(int))),
 		},
 		Properties: &appplatform.DeploymentResourceProperties{
 			Source: appplatform.JarUploadedUserSourceInfo{
-				RuntimeVersion: utils.String(d.Get("runtime_version").(string)),
-				JvmOptions:     utils.String(d.Get("jvm_options").(string)),
-				RelativePath:   utils.String("<default>"),
+				RuntimeVersion: pointer.To(d.Get("runtime_version").(string)),
+				JvmOptions:     pointer.To(d.Get("jvm_options").(string)),
+				RelativePath:   pointer.To("<default>"),
 				Type:           appplatform.TypeBasicUserSourceInfoTypeJar,
 			},
 			DeploymentSettings: &appplatform.DeploymentSettings{
@@ -136,12 +137,12 @@ func resourceSpringCloudJavaDeploymentUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if d.HasChange("instance_count") {
-		existing.Sku.Capacity = utils.Int32(int32(d.Get("instance_count").(int)))
+		existing.Sku.Capacity = pointer.To(int32(d.Get("instance_count").(int)))
 	}
 
 	if d.HasChange("cpu") {
 		if existing.Properties.DeploymentSettings.ResourceRequests != nil {
-			existing.Properties.DeploymentSettings.ResourceRequests.CPU = utils.String(strconv.Itoa(d.Get("cpu").(int)))
+			existing.Properties.DeploymentSettings.ResourceRequests.CPU = pointer.To(strconv.Itoa(d.Get("cpu").(int)))
 		}
 	}
 
@@ -151,14 +152,14 @@ func resourceSpringCloudJavaDeploymentUpdate(d *pluginsdk.ResourceData, meta int
 
 	if d.HasChange("jvm_options") {
 		if source, ok := existing.Properties.Source.AsJarUploadedUserSourceInfo(); ok {
-			source.JvmOptions = utils.String(d.Get("jvm_options").(string))
+			source.JvmOptions = pointer.To(d.Get("jvm_options").(string))
 			existing.Properties.Source = source
 		}
 	}
 
 	if d.HasChange("memory_in_gb") {
 		if existing.Properties.DeploymentSettings.ResourceRequests != nil {
-			existing.Properties.DeploymentSettings.ResourceRequests.Memory = utils.String(fmt.Sprintf("%dGi", d.Get("memory_in_gb").(int)))
+			existing.Properties.DeploymentSettings.ResourceRequests.Memory = pointer.To(fmt.Sprintf("%dGi", d.Get("memory_in_gb").(int)))
 		}
 	}
 
@@ -172,7 +173,7 @@ func resourceSpringCloudJavaDeploymentUpdate(d *pluginsdk.ResourceData, meta int
 
 	if d.HasChange("runtime_version") {
 		if source, ok := existing.Properties.Source.AsJarUploadedUserSourceInfo(); ok {
-			source.RuntimeVersion = utils.String(d.Get("runtime_version").(string))
+			source.RuntimeVersion = pointer.To(d.Get("runtime_version").(string))
 			existing.Properties.Source = source
 		}
 	}
@@ -255,7 +256,7 @@ func expandSpringCloudDeploymentEnvironmentVariables(envMap map[string]interface
 	output := make(map[string]*string, len(envMap))
 
 	for k, v := range envMap {
-		output[k] = utils.String(v.(string))
+		output[k] = pointer.To(v.(string))
 	}
 
 	return output
@@ -290,8 +291,8 @@ func expandSpringCloudDeploymentResourceRequests(input []interface{}) *appplatfo
 	}
 
 	result := appplatform.ResourceRequests{
-		CPU:    utils.String(cpuResult),
-		Memory: utils.String(memResult),
+		CPU:    pointer.To(cpuResult),
+		Memory: pointer.To(memResult),
 	}
 
 	return &result

--- a/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_java_deployment_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudJavaDeploymentResource struct{}
@@ -132,7 +132,7 @@ func (r SpringCloudJavaDeploymentResource) Exists(ctx context.Context, clients *
 		return nil, fmt.Errorf("reading Spring Cloud Deployment %q (Spring Cloud Service %q / App %q / Resource Group %q): %+v", id.DeploymentName, id.SpringName, id.AppName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (r SpringCloudJavaDeploymentResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -455,31 +455,31 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 		return tf.ImportAsExistsError("azurerm_spring_cloud_service", id.ID())
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	resource := appplatform.ServiceResource{
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Properties: &appplatform.ClusterResourceProperties{
 			NetworkProfile:      expandSpringCloudNetwork(d.Get("network").([]interface{})),
-			ZoneRedundant:       utils.Bool(d.Get("zone_redundant").(bool)),
+			ZoneRedundant:       pointer.To(d.Get("zone_redundant").(bool)),
 			MarketplaceResource: expandSpringCloudMarketplaceResource(d.Get("marketplace").([]interface{})),
 		},
 		Sku: &appplatform.Sku{
-			Name: utils.String(d.Get("sku_name").(string)),
+			Name: pointer.To(d.Get("sku_name").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if enabled := d.Get("log_stream_public_endpoint_enabled").(bool); enabled {
 		resource.Properties.VnetAddons = &appplatform.ServiceVNetAddons{
-			LogStreamPublicEndpoint: utils.Bool(enabled),
+			LogStreamPublicEndpoint: pointer.To(enabled),
 		}
 	}
 
 	// we set sku_tier only when managed_environment_id is set
 	// otherwise we break the existing flows where sku_name is set to E0/Basic etc.,
 	if v, ok := d.GetOk("managed_environment_id"); ok {
-		resource.Properties.ManagedEnvironmentID = utils.String(v.(string))
-		resource.Sku.Tier = utils.String(d.Get("sku_tier").(string))
+		resource.Properties.ManagedEnvironmentID = pointer.To(v.(string))
+		resource.Sku.Tier = pointer.To(d.Get("sku_tier").(string))
 	}
 
 	gitProperty, err := expandSpringCloudConfigServerGitProperty(d.Get("config_server_git_setting").([]interface{}))
@@ -556,7 +556,7 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 		agentPoolResource := appplatform.BuildServiceAgentPoolResource{
 			Properties: &appplatform.BuildServiceAgentPoolProperties{
 				PoolSize: &appplatform.BuildServiceAgentPoolSizeProperties{
-					Name: utils.String(size),
+					Name: pointer.To(size),
 				},
 			},
 		}
@@ -592,7 +592,7 @@ func resourceSpringCloudServiceUpdate(d *pluginsdk.ResourceData, meta interface{
 	if d.HasChange("tags") {
 		model := appplatform.ServiceResource{
 			Sku: &appplatform.Sku{
-				Name: utils.String(d.Get("sku_name").(string)),
+				Name: pointer.To(d.Get("sku_name").(string)),
 			},
 			Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 		}
@@ -684,7 +684,7 @@ func resourceSpringCloudServiceUpdate(d *pluginsdk.ResourceData, meta interface{
 		agentPoolResource := appplatform.BuildServiceAgentPoolResource{
 			Properties: &appplatform.BuildServiceAgentPoolProperties{
 				PoolSize: &appplatform.BuildServiceAgentPoolSizeProperties{
-					Name: utils.String(size),
+					Name: pointer.To(size),
 				},
 			},
 		}
@@ -824,13 +824,13 @@ func resourceSpringCloudServiceRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		if vnetAddons := props.VnetAddons; vnetAddons != nil {
-			if err := d.Set("log_stream_public_endpoint_enabled", utils.Bool(*vnetAddons.LogStreamPublicEndpoint)); err != nil {
+			if err := d.Set("log_stream_public_endpoint_enabled", pointer.To(*vnetAddons.LogStreamPublicEndpoint)); err != nil {
 				return fmt.Errorf("setting `log_stream_public_endpoint_enabled`: %+v", err)
 			}
 		}
 
 		if managedEnvironmentID := props.ManagedEnvironmentID; managedEnvironmentID != nil {
-			if err := d.Set("managed_environment_id", utils.String(*props.ManagedEnvironmentID)); err != nil {
+			if err := d.Set("managed_environment_id", pointer.To(*props.ManagedEnvironmentID)); err != nil {
 				return fmt.Errorf("setting `managed_environment_id`: %+v", err)
 			}
 		}
@@ -936,21 +936,21 @@ func expandSpringCloudNetwork(input []interface{}) *appplatform.NetworkProfile {
 	v := input[0].(map[string]interface{})
 	cidrRanges := utils.ExpandStringSlice(v["cidr_ranges"].([]interface{}))
 	network := &appplatform.NetworkProfile{
-		ServiceRuntimeSubnetID: utils.String(v["service_runtime_subnet_id"].(string)),
-		AppSubnetID:            utils.String(v["app_subnet_id"].(string)),
-		ServiceCidr:            utils.String(strings.Join(*cidrRanges, ",")),
-		OutboundType:           utils.String(v["outbound_type"].(string)),
+		ServiceRuntimeSubnetID: pointer.To(v["service_runtime_subnet_id"].(string)),
+		AppSubnetID:            pointer.To(v["app_subnet_id"].(string)),
+		ServiceCidr:            pointer.To(strings.Join(*cidrRanges, ",")),
+		OutboundType:           pointer.To(v["outbound_type"].(string)),
 	}
 	if readTimeoutInSeconds := v["read_timeout_seconds"].(int); readTimeoutInSeconds != 0 {
 		network.IngressConfig = &appplatform.IngressConfig{
-			ReadTimeoutInSeconds: utils.Int32(int32(readTimeoutInSeconds)),
+			ReadTimeoutInSeconds: pointer.To(int32(readTimeoutInSeconds)),
 		}
 	}
 	if serviceRuntimeNetworkResourceGroup := v["service_runtime_network_resource_group"].(string); serviceRuntimeNetworkResourceGroup != "" {
-		network.ServiceRuntimeNetworkResourceGroup = utils.String(serviceRuntimeNetworkResourceGroup)
+		network.ServiceRuntimeNetworkResourceGroup = pointer.To(serviceRuntimeNetworkResourceGroup)
 	}
 	if appNetworkResourceGroup := v["app_network_resource_group"].(string); appNetworkResourceGroup != "" {
-		network.AppNetworkResourceGroup = utils.String(appNetworkResourceGroup)
+		network.AppNetworkResourceGroup = pointer.To(appNetworkResourceGroup)
 	}
 	return network
 }
@@ -966,11 +966,11 @@ func expandSpringCloudConfigServerGitProperty(input []interface{}) (*appplatform
 	}
 
 	result := appplatform.ConfigServerGitProperty{
-		URI: utils.String(v["uri"].(string)),
+		URI: pointer.To(v["uri"].(string)),
 	}
 
 	if label := v["label"].(string); label != "" {
-		result.Label = utils.String(label)
+		result.Label = pointer.To(label)
 	}
 	if searchPaths := v["search_paths"].([]interface{}); len(searchPaths) > 0 {
 		result.SearchPaths = utils.ExpandStringSlice(searchPaths)
@@ -983,19 +983,19 @@ func expandSpringCloudConfigServerGitProperty(input []interface{}) (*appplatform
 	}
 	if len(httpBasicAuth) > 0 {
 		v := httpBasicAuth[0].(map[string]interface{})
-		result.Username = utils.String(v["username"].(string))
-		result.Password = utils.String(v["password"].(string))
+		result.Username = pointer.To(v["username"].(string))
+		result.Password = pointer.To(v["password"].(string))
 	}
 	if len(sshAuth) > 0 {
 		v := sshAuth[0].(map[string]interface{})
-		result.PrivateKey = utils.String(v["private_key"].(string))
-		result.StrictHostKeyChecking = utils.Bool(v["strict_host_key_checking_enabled"].(bool))
+		result.PrivateKey = pointer.To(v["private_key"].(string))
+		result.StrictHostKeyChecking = pointer.To(v["strict_host_key_checking_enabled"].(bool))
 
 		if hostKey := v["host_key"].(string); hostKey != "" {
-			result.HostKey = utils.String(hostKey)
+			result.HostKey = pointer.To(hostKey)
 		}
 		if hostKeyAlgorithm := v["host_key_algorithm"].(string); hostKeyAlgorithm != "" {
-			result.HostKeyAlgorithm = utils.String(hostKeyAlgorithm)
+			result.HostKeyAlgorithm = pointer.To(hostKeyAlgorithm)
 		}
 	}
 
@@ -1016,12 +1016,12 @@ func expandSpringCloudGitPatternRepository(input []interface{}) (*[]appplatform.
 		v := item.(map[string]interface{})
 
 		result := appplatform.GitPatternRepository{
-			Name: utils.String(v["name"].(string)),
-			URI:  utils.String(v["uri"].(string)),
+			Name: pointer.To(v["name"].(string)),
+			URI:  pointer.To(v["uri"].(string)),
 		}
 
 		if label := v["label"].(string); len(label) > 0 {
-			result.Label = utils.String(label)
+			result.Label = pointer.To(label)
 		}
 		if pattern := v["pattern"].([]interface{}); len(pattern) > 0 {
 			result.Pattern = utils.ExpandStringSlice(pattern)
@@ -1037,19 +1037,19 @@ func expandSpringCloudGitPatternRepository(input []interface{}) (*[]appplatform.
 		}
 		if len(httpBasicAuth) > 0 {
 			v := httpBasicAuth[0].(map[string]interface{})
-			result.Username = utils.String(v["username"].(string))
-			result.Password = utils.String(v["password"].(string))
+			result.Username = pointer.To(v["username"].(string))
+			result.Password = pointer.To(v["password"].(string))
 		}
 		if len(sshAuth) > 0 {
 			v := sshAuth[0].(map[string]interface{})
-			result.PrivateKey = utils.String(v["private_key"].(string))
-			result.StrictHostKeyChecking = utils.Bool(v["strict_host_key_checking_enabled"].(bool))
+			result.PrivateKey = pointer.To(v["private_key"].(string))
+			result.StrictHostKeyChecking = pointer.To(v["strict_host_key_checking_enabled"].(bool))
 
 			if hostKey := v["host_key"].(string); hostKey != "" {
-				result.HostKey = utils.String(hostKey)
+				result.HostKey = pointer.To(hostKey)
 			}
 			if hostKeyAlgorithm := v["host_key_algorithm"].(string); hostKeyAlgorithm != "" {
-				result.HostKeyAlgorithm = utils.String(hostKeyAlgorithm)
+				result.HostKeyAlgorithm = pointer.To(hostKeyAlgorithm)
 			}
 		}
 
@@ -1061,15 +1061,15 @@ func expandSpringCloudGitPatternRepository(input []interface{}) (*[]appplatform.
 func expandSpringCloudTrace(input []interface{}) *appplatform.MonitoringSettingProperties {
 	if len(input) == 0 || input[0] == nil {
 		return &appplatform.MonitoringSettingProperties{
-			TraceEnabled: utils.Bool(false),
+			TraceEnabled: pointer.To(false),
 		}
 	}
 
 	v := input[0].(map[string]interface{})
 	return &appplatform.MonitoringSettingProperties{
-		TraceEnabled:                  utils.Bool(true),
-		AppInsightsInstrumentationKey: utils.String(v["connection_string"].(string)),
-		AppInsightsSamplingRate:       utils.Float(v["sample_rate"].(float64)),
+		TraceEnabled:                  pointer.To(true),
+		AppInsightsInstrumentationKey: pointer.To(v["connection_string"].(string)),
+		AppInsightsSamplingRate:       pointer.To(v["sample_rate"].(float64)),
 	}
 }
 
@@ -1081,12 +1081,12 @@ func expandSpringCloudContainerRegistries(input []interface{}) []appplatform.Con
 	for _, item := range input {
 		v := item.(map[string]interface{})
 		out = append(out, appplatform.ContainerRegistryResource{
-			Name: utils.String(v["name"].(string)),
+			Name: pointer.To(v["name"].(string)),
 			Properties: &appplatform.ContainerRegistryProperties{
 				Credentials: &appplatform.ContainerRegistryBasicCredentials{
-					Username: utils.String(v["username"].(string)),
-					Password: utils.String(v["password"].(string)),
-					Server:   utils.String(v["server"].(string)),
+					Username: pointer.To(v["username"].(string)),
+					Password: pointer.To(v["password"].(string)),
+					Server:   pointer.To(v["server"].(string)),
 				},
 			},
 		})
@@ -1101,7 +1101,7 @@ func expandSpringCloudBuildService(input []interface{}, springId parse.SpringClo
 	v := input[0].(map[string]interface{})
 	out := appplatform.BuildServiceProperties{}
 	if value := v["container_registry_name"].(string); value != "" {
-		out.ContainerRegistry = utils.String(parse.NewSpringCloudContainerRegistryID(springId.SubscriptionId, springId.ResourceGroup, springId.SpringName, value).ID())
+		out.ContainerRegistry = pointer.To(parse.NewSpringCloudContainerRegistryID(springId.SubscriptionId, springId.ResourceGroup, springId.SpringName, value).ID())
 	}
 	return out
 }
@@ -1112,9 +1112,9 @@ func expandSpringCloudMarketplaceResource(input []interface{}) *appplatform.Mark
 	}
 	v := input[0].(map[string]interface{})
 	return &appplatform.MarketplaceResource{
-		Plan:      utils.String(v["plan"].(string)),
-		Publisher: utils.String(v["publisher"].(string)),
-		Product:   utils.String(v["product"].(string)),
+		Plan:      pointer.To(v["plan"].(string)),
+		Publisher: pointer.To(v["publisher"].(string)),
+		Product:   pointer.To(v["product"].(string)),
 	}
 }
 

--- a/internal/services/springcloud/spring_cloud_service_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_service_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudServiceResource struct{}
@@ -269,7 +269,7 @@ func (t SpringCloudServiceResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("unable to read Spring Cloud Service %q (Resource Group %q): %+v", id.SpringName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (SpringCloudServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/springcloud/spring_cloud_storage_resource.go
+++ b/internal/services/springcloud/spring_cloud_storage_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
@@ -104,8 +105,8 @@ func resourceSpringCloudStorageCreateUpdate(d *pluginsdk.ResourceData, meta inte
 
 	storageResource := appplatform.StorageResource{
 		Properties: &appplatform.StorageAccount{
-			AccountName: utils.String(d.Get("storage_account_name").(string)),
-			AccountKey:  utils.String(d.Get("storage_account_key").(string)),
+			AccountName: pointer.To(d.Get("storage_account_name").(string)),
+			AccountKey:  pointer.To(d.Get("storage_account_key").(string)),
 			StorageType: appplatform.StorageTypeStorageAccount,
 		},
 	}

--- a/internal/services/springcloud/spring_cloud_storage_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_storage_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SpringCloudStorageResource struct{}
@@ -59,7 +59,7 @@ func (r SpringCloudStorageResource) Exists(ctx context.Context, clients *clients
 		return nil, fmt.Errorf("unable to read %q: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Properties != nil), nil
+	return pointer.To(resp.Properties != nil), nil
 }
 
 func (SpringCloudStorageResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_account_customer_managed_key_resource.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account_customer_managed_key -service-package-name storage -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id"
@@ -203,27 +202,27 @@ func resourceStorageAccountCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceD
 			Encryption: &storageaccounts.Encryption{
 				Services: &storageaccounts.EncryptionServices{
 					Blob: &storageaccounts.EncryptionService{
-						Enabled: utils.Bool(true),
+						Enabled: pointer.To(true),
 					},
 					File: &storageaccounts.EncryptionService{
-						Enabled: utils.Bool(true),
+						Enabled: pointer.To(true),
 					},
 				},
 				Identity: &storageaccounts.EncryptionIdentity{
-					UserAssignedIdentity: utils.String(userAssignedIdentity),
+					UserAssignedIdentity: pointer.To(userAssignedIdentity),
 				},
 				KeySource: pointer.To(storageaccounts.KeySourceMicrosoftPointKeyvault),
 				Keyvaultproperties: &storageaccounts.KeyVaultProperties{
-					Keyname:     utils.String(keyName),
-					Keyversion:  utils.String(keyVersion),
-					Keyvaulturi: utils.String(keyVaultURI),
+					Keyname:     pointer.To(keyName),
+					Keyversion:  pointer.To(keyVersion),
+					Keyvaulturi: pointer.To(keyVaultURI),
 				},
 			},
 		},
 	}
 
 	if federatedIdentityClientID != "" {
-		payload.Properties.Encryption.Identity.FederatedIdentityClientId = utils.String(federatedIdentityClientID)
+		payload.Properties.Encryption.Identity.FederatedIdentityClientId = pointer.To(federatedIdentityClientID)
 	}
 	if _, err = storageClient.Update(ctx, *id, payload); err != nil {
 		return fmt.Errorf("updating Customer Managed Key for %s: %+v", id, err)
@@ -335,10 +334,10 @@ func resourceStorageAccountCustomerManagedKeyDelete(d *pluginsdk.ResourceData, m
 			Encryption: &storageaccounts.Encryption{
 				Services: &storageaccounts.EncryptionServices{
 					Blob: &storageaccounts.EncryptionService{
-						Enabled: utils.Bool(true),
+						Enabled: pointer.To(true),
 					},
 					File: &storageaccounts.EncryptionService{
-						Enabled: utils.Bool(true),
+						Enabled: pointer.To(true),
 					},
 				},
 				KeySource: pointer.To(storageaccounts.KeySourceMicrosoftPointStorage),

--- a/internal/services/storage/storage_account_customer_managed_key_resource_test.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/storageaccounts"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageAccountCustomerManagedKeyResource struct{}
@@ -210,7 +210,7 @@ func (r StorageAccountCustomerManagedKeyResource) Exists(ctx context.Context, cl
 	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *accountId, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 
 		return nil, fmt.Errorf("Bad: Get on storageServiceClient: %+v", err)
@@ -220,7 +220,7 @@ func (r StorageAccountCustomerManagedKeyResource) Exists(ctx context.Context, cl
 		if props := model.Properties; props != nil {
 			if encryption := props.Encryption; encryption != nil {
 				if encryption.KeySource != nil && *encryption.KeySource == storageaccounts.KeySourceMicrosoftPointKeyvault {
-					return utils.Bool(true), nil
+					return pointer.To(true), nil
 				}
 
 				return nil, fmt.Errorf("%q should be %q", *encryption.KeySource, string(storageaccounts.KeySourceMicrosoftPointKeyvault))
@@ -228,7 +228,7 @@ func (r StorageAccountCustomerManagedKeyResource) Exists(ctx context.Context, cl
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r StorageAccountCustomerManagedKeyResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_account_local_user_resource.go
+++ b/internal/services/storage/storage_account_local_user_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_account_local_user -service-package-name storage -properties "name" -compare-values "subscription_id:storage_account_id,resource_group_name:storage_account_id,storage_account_name:storage_account_id" -test-name "passwordOnly"
@@ -265,7 +264,7 @@ func (r LocalUserResource) Create() sdk.ResourceFunc {
 			}
 
 			if plan.HomeDirectory != "" {
-				params.Properties.HomeDirectory = utils.String(plan.HomeDirectory)
+				params.Properties.HomeDirectory = pointer.To(plan.HomeDirectory)
 			}
 
 			if _, err = client.CreateOrUpdate(ctx, id, params); err != nil {

--- a/internal/services/storage/storage_account_local_user_resource_test.go
+++ b/internal/services/storage/storage_account_local_user_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/localusers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageAccountLocalUserResource struct{}
@@ -193,12 +193,12 @@ func (r StorageAccountLocalUserResource) Exists(ctx context.Context, clients *cl
 
 	if resp, err := client.Get(ctx, *id); err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageAccountLocalUserResource) passwordOnly(data acceptance.TestData) string {

--- a/internal/services/storage/storage_account_network_rules_resource_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageAccountNetworkRulesResource struct{}
@@ -192,7 +191,7 @@ func (r StorageAccountNetworkRulesResource) Exists(ctx context.Context, client *
 	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *id, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
@@ -211,7 +210,7 @@ func (r StorageAccountNetworkRulesResource) Exists(ctx context.Context, client *
 		}
 	}
 
-	return utils.Bool(false), nil
+	return pointer.To(false), nil
 }
 
 func (r StorageAccountNetworkRulesResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2536,9 +2536,9 @@ func expandAccountCustomerManagedKey(ctx context.Context, keyVaultClient *keyVau
 			keyVersion = pointer.To(keyId.KeyVersion)
 			keyVaultURI = pointer.To(keyId.BaseUri())
 		} else if keyId, err := managedHsmParse.ManagedHSMDataPlaneVersionlessKeyID(managedHSMKeyId.(string), nil); err == nil {
-			keyName = utils.String(keyId.KeyName)
-			keyVersion = utils.String("")
-			keyVaultURI = utils.String(keyId.BaseUri())
+			keyName = pointer.To(keyId.KeyName)
+			keyVersion = pointer.To("")
+			keyVaultURI = pointer.To(keyId.BaseUri())
 		} else {
 			return nil, fmt.Errorf("parsing %q as HSM key ID", managedHSMKeyId.(string))
 		}
@@ -2562,7 +2562,7 @@ func expandAccountCustomerManagedKey(ctx context.Context, keyVaultClient *keyVau
 			},
 		},
 		Identity: &storageaccounts.EncryptionIdentity{
-			UserAssignedIdentity: utils.String(v["user_assigned_identity_id"].(string)),
+			UserAssignedIdentity: pointer.To(v["user_assigned_identity_id"].(string)),
 		},
 		KeySource: pointer.To(storageaccounts.KeySourceMicrosoftPointKeyvault),
 		Keyvaultproperties: &storageaccounts.KeyVaultProperties{
@@ -2602,7 +2602,7 @@ func expandAccountImmutabilityPolicy(input []interface{}) *storageaccounts.Immut
 
 	v := input[0].(map[string]interface{})
 	return &storageaccounts.ImmutableStorageAccount{
-		Enabled: utils.Bool(true),
+		Enabled: pointer.To(true),
 		ImmutabilityPolicy: &storageaccounts.AccountImmutabilityPolicyProperties{
 			AllowProtectedAppendWrites:            pointer.To(v["allow_protected_append_writes"].(bool)),
 			ImmutabilityPeriodSinceCreationInDays: pointer.To(int64(v["period_since_creation_in_days"].(int))),
@@ -2636,16 +2636,16 @@ func expandAccountActiveDirectoryProperties(input []interface{}) *storageaccount
 		DomainName: m["domain_name"].(string),
 	}
 	if v := m["storage_sid"]; v != "" {
-		output.AzureStorageSid = utils.String(v.(string))
+		output.AzureStorageSid = pointer.To(v.(string))
 	}
 	if v := m["domain_sid"]; v != "" {
-		output.DomainSid = utils.String(v.(string))
+		output.DomainSid = pointer.To(v.(string))
 	}
 	if v := m["forest_name"]; v != "" {
-		output.ForestName = utils.String(v.(string))
+		output.ForestName = pointer.To(v.(string))
 	}
 	if v := m["netbios_domain_name"]; v != "" {
-		output.NetBiosDomainName = utils.String(v.(string))
+		output.NetBiosDomainName = pointer.To(v.(string))
 	}
 	return output
 }
@@ -2757,7 +2757,7 @@ func expandAccountBlobServiceProperties(kind storageaccounts.Kind, input []inter
 			CorsRules: &[]blobservice.CorsRule{},
 		},
 		DeleteRetentionPolicy: &blobservice.DeleteRetentionPolicy{
-			Enabled: utils.Bool(false),
+			Enabled: pointer.To(false),
 		},
 	}
 

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/storageaccounts"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageAccountResource struct{}
@@ -2010,11 +2010,11 @@ func (r StorageAccountResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.Storage.ResourceManager.StorageAccounts.GetProperties(ctx, *id, storageaccounts.DefaultGetPropertiesOperationOptions())
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageAccountResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -2025,7 +2025,7 @@ func (r StorageAccountResource) Destroy(ctx context.Context, client *clients.Cli
 	if _, err := client.Storage.ResourceManager.StorageAccounts.Delete(ctx, *id); err != nil {
 		return nil, fmt.Errorf("deleting %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageAccountResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -307,9 +308,9 @@ func expandBlobInventoryPolicyFilter(input []interface{}, objectType string) (*b
 		PrefixMatch:         utils.ExpandStringSlice(v["prefix_match"].(*pluginsdk.Set).List()),
 		ExcludePrefix:       utils.ExpandStringSlice(v["exclude_prefixes"].(*pluginsdk.Set).List()),
 		BlobTypes:           utils.ExpandStringSlice(v["blob_types"].(*pluginsdk.Set).List()),
-		IncludeBlobVersions: utils.Bool(v["include_blob_versions"].(bool)),
-		IncludeDeleted:      utils.Bool(v["include_deleted"].(bool)),
-		IncludeSnapshots:    utils.Bool(v["include_snapshots"].(bool)),
+		IncludeBlobVersions: pointer.To(v["include_blob_versions"].(bool)),
+		IncludeDeleted:      pointer.To(v["include_deleted"].(bool)),
+		IncludeSnapshots:    pointer.To(v["include_snapshots"].(bool)),
 	}
 
 	// If the objectType is Container, the following values must be nil when passed to the API

--- a/internal/services/storage/storage_blob_resource_test.go
+++ b/internal/services/storage/storage_blob_resource_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/blobs"
 )
 
@@ -557,11 +556,11 @@ func (r StorageBlobResource) Exists(ctx context.Context, client *clients.Client,
 	resp, err := blobsClient.GetProperties(ctx, id.ContainerName, id.BlobName, input)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Blob %q (Container %q / Account %q): %+v", id.BlobName, id.ContainerName, id.AccountId.AccountName, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageBlobResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -586,7 +585,7 @@ func (r StorageBlobResource) Destroy(ctx context.Context, client *clients.Client
 	if _, err = blobsClient.Delete(ctx, id.ContainerName, id.BlobName, input); err != nil {
 		return nil, fmt.Errorf("deleting Blob %q (Container %q / Account %q): %+v", id.BlobName, id.ContainerName, id.AccountId.AccountName, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageBlobResource) blobMatchesFile(kind blobs.BlobType, filePath string) func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/storage/storage_container_immutability_policy_resource_test.go
+++ b/internal/services/storage/storage_container_immutability_policy_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/blobcontainers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageContainerImmutabilityPolicyResource struct{}
@@ -125,7 +125,7 @@ func (r StorageContainerImmutabilityPolicyResource) Exists(ctx context.Context, 
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.Model != nil && resp.Model.Properties.State != nil && !strings.EqualFold(string(*resp.Model.Properties.State), "Deleted")), nil
+	return pointer.To(resp.Model != nil && resp.Model.Properties.State != nil && !strings.EqualFold(string(*resp.Model.Properties.State), "Deleted")), nil
 }
 
 func (r StorageContainerImmutabilityPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/datalakestore/filesystems"
 )
 
@@ -184,12 +184,12 @@ func (r StorageDataLakeGen2FileSystemResource) Exists(ctx context.Context, clien
 	resp, err := filesystemsClient.GetProperties(ctx, id.FileSystemName)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving File System %q (Account %q): %+v", id.FileSystemName, id.AccountId.AccountName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageDataLakeGen2FileSystemResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -215,7 +215,7 @@ func (r StorageDataLakeGen2FileSystemResource) Destroy(ctx context.Context, clie
 		return nil, fmt.Errorf("deleting File System %q (Account %q): %+v", id.FileSystemName, id.AccountId.AccountName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageDataLakeGen2FileSystemResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_data_lake_gen2_path_resource_test.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/datalakestore/paths"
 )
 
@@ -153,12 +153,12 @@ func (r StorageDataLakeGen2PathResource) Exists(ctx context.Context, client *cli
 	resp, err := pathsClient.GetProperties(ctx, id.FileSystemName, id.Path, paths.GetPropertiesInput{Action: paths.GetPropertiesActionGetStatus})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Path %q (File System %q / Account %q): %+v", id.Path, id.FileSystemName, id.AccountId.AccountName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageDataLakeGen2PathResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	// nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/managementpolicies"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStorageManagementPolicy() *pluginsdk.Resource {
@@ -507,16 +507,16 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.TierToCool = &managementpolicies.DateAfterModification{}
 				if sinceModOK {
-					baseBlob.TierToCool.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
+					baseBlob.TierToCool.DaysAfterModificationGreaterThan = pointer.To(float64(sinceMod.(int)))
 				}
 				if sinceAccessOK {
-					baseBlob.TierToCool.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
+					baseBlob.TierToCool.DaysAfterLastAccessTimeGreaterThan = pointer.To(float64(sinceAccess.(int)))
 				}
 				if sinceCreateOK {
-					baseBlob.TierToCool.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
+					baseBlob.TierToCool.DaysAfterCreationGreaterThan = pointer.To(float64(sinceCreate.(int)))
 				}
 				if autoTierToHotOK {
-					baseBlob.EnableAutoTierToHotFromCool = utils.Bool(autoTierToHotOK)
+					baseBlob.EnableAutoTierToHotFromCool = pointer.To(autoTierToHotOK)
 				}
 			}
 
@@ -544,16 +544,16 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.TierToArchive = &managementpolicies.DateAfterModification{}
 				if sinceModOK {
-					baseBlob.TierToArchive.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
+					baseBlob.TierToArchive.DaysAfterModificationGreaterThan = pointer.To(float64(sinceMod.(int)))
 				}
 				if sinceAccessOK {
-					baseBlob.TierToArchive.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
+					baseBlob.TierToArchive.DaysAfterLastAccessTimeGreaterThan = pointer.To(float64(sinceAccess.(int)))
 				}
 				if sinceCreateOK {
-					baseBlob.TierToArchive.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
+					baseBlob.TierToArchive.DaysAfterCreationGreaterThan = pointer.To(float64(sinceCreate.(int)))
 				}
 				if v := d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_archive_after_days_since_last_tier_change_greater_than", ruleIndex)); v != -1 {
-					baseBlob.TierToArchive.DaysAfterLastTierChangeGreaterThan = utils.Float(float64(v.(int)))
+					baseBlob.TierToArchive.DaysAfterLastTierChangeGreaterThan = pointer.To(float64(v.(int)))
 				}
 			}
 
@@ -580,13 +580,13 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.Delete = &managementpolicies.DateAfterModification{}
 				if sinceModOK {
-					baseBlob.Delete.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
+					baseBlob.Delete.DaysAfterModificationGreaterThan = pointer.To(float64(sinceMod.(int)))
 				}
 				if sinceAccessOK {
-					baseBlob.Delete.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
+					baseBlob.Delete.DaysAfterLastAccessTimeGreaterThan = pointer.To(float64(sinceAccess.(int)))
 				}
 				if sinceCreateOK {
-					baseBlob.Delete.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
+					baseBlob.Delete.DaysAfterCreationGreaterThan = pointer.To(float64(sinceCreate.(int)))
 				}
 			}
 
@@ -614,13 +614,13 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 			if sinceModOK || sinceAccessOK || sinceCreateOK {
 				baseBlob.TierToCold = &managementpolicies.DateAfterModification{}
 				if sinceModOK {
-					baseBlob.TierToCold.DaysAfterModificationGreaterThan = utils.Float(float64(sinceMod.(int)))
+					baseBlob.TierToCold.DaysAfterModificationGreaterThan = pointer.To(float64(sinceMod.(int)))
 				}
 				if sinceAccessOK {
-					baseBlob.TierToCold.DaysAfterLastAccessTimeGreaterThan = utils.Float(float64(sinceAccess.(int)))
+					baseBlob.TierToCold.DaysAfterLastAccessTimeGreaterThan = pointer.To(float64(sinceAccess.(int)))
 				}
 				if sinceCreateOK {
-					baseBlob.TierToCold.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
+					baseBlob.TierToCold.DaysAfterCreationGreaterThan = pointer.To(float64(sinceCreate.(int)))
 				}
 			}
 
@@ -639,7 +639,7 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 					DaysAfterCreationGreaterThan: float64(v.(int)),
 				}
 				if vv := d.Get(fmt.Sprintf("rule.%d.actions.0.snapshot.0.tier_to_archive_after_days_since_last_tier_change_greater_than", ruleIndex)); vv != -1 {
-					snapshot.TierToArchive.DaysAfterLastTierChangeGreaterThan = utils.Float(float64(vv.(int)))
+					snapshot.TierToArchive.DaysAfterLastTierChangeGreaterThan = pointer.To(float64(vv.(int)))
 				}
 			}
 			if v := d.Get(fmt.Sprintf("rule.%d.actions.0.snapshot.0.change_tier_to_cool_after_days_since_creation", ruleIndex)); v != -1 {
@@ -667,7 +667,7 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 					DaysAfterCreationGreaterThan: float64(v.(int)),
 				}
 				if vv := d.Get(fmt.Sprintf("rule.%d.actions.0.version.0.tier_to_archive_after_days_since_last_tier_change_greater_than", ruleIndex)); vv != -1 {
-					version.TierToArchive.DaysAfterLastTierChangeGreaterThan = utils.Float(float64(vv.(int)))
+					version.TierToArchive.DaysAfterLastTierChangeGreaterThan = pointer.To(float64(vv.(int)))
 				}
 			}
 			if v := d.Get(fmt.Sprintf("rule.%d.actions.0.version.0.change_tier_to_cool_after_days_since_creation", ruleIndex)); v != -1 {

--- a/internal/services/storage/storage_management_policy_resource_test.go
+++ b/internal/services/storage/storage_management_policy_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageManagementPolicyResource struct{}
@@ -435,11 +435,11 @@ func (r StorageManagementPolicyResource) Exists(ctx context.Context, client *cli
 	resp, err := client.Storage.ResourceManager.ManagementPolicies.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Management Policy for %s: %+v", id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageManagementPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_object_replication_resource.go
+++ b/internal/services/storage/storage_object_replication_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-05-01/objectreplicationpolicies"
@@ -308,12 +309,12 @@ func expandArmObjectReplicationRuleArray(input []interface{}) *[]objectreplicati
 			SourceContainer:      v["source_container_name"].(string),
 			DestinationContainer: v["destination_container_name"].(string),
 			Filters: &objectreplicationpolicies.ObjectReplicationPolicyFilter{
-				MinCreationTime: utils.String(expandArmObjectReplicationMinCreationTime(v["copy_blobs_created_after"].(string))),
+				MinCreationTime: pointer.To(expandArmObjectReplicationMinCreationTime(v["copy_blobs_created_after"].(string))),
 			},
 		}
 
 		if r, ok := v["name"].(string); ok && r != "" {
-			result.RuleId = utils.String(r)
+			result.RuleId = pointer.To(r)
 		}
 
 		if f, ok := v["filter_out_blobs_with_prefix"]; ok {

--- a/internal/services/storage/storage_object_replication_resource_test.go
+++ b/internal/services/storage/storage_object_replication_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageObjectReplicationResource struct{}
@@ -163,7 +163,7 @@ func (r StorageObjectReplicationResource) Exists(ctx context.Context, client *cl
 	dstResp, err := client.Storage.ResourceManager.ObjectReplicationPolicies.Get(ctx, id.Dst)
 	if err != nil {
 		if response.WasNotFound(dstResp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
@@ -171,12 +171,12 @@ func (r StorageObjectReplicationResource) Exists(ctx context.Context, client *cl
 	srcResp, err := client.Storage.ResourceManager.ObjectReplicationPolicies.Get(ctx, id.Src)
 	if err != nil {
 		if response.WasNotFound(srcResp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageObjectReplicationResource) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_directory_resource_deprecated_test.go
+++ b/internal/services/storage/storage_share_directory_resource_deprecated_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/directories"
 )
 
@@ -203,11 +203,11 @@ func (r StorageShareDirectoryResourceDeprecated) Exists(ctx context.Context, cli
 	resp, err := dirClient.Get(ctx, id.ShareName, id.DirectoryPath)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Storage Share %q (File Share %q in %s): %+v", id.DirectoryPath, id.ShareName, account.StorageAccountId, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageShareDirectoryResourceDeprecated) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_directory_resource_test.go
+++ b/internal/services/storage/storage_share_directory_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/directories"
 )
 
@@ -170,11 +170,11 @@ func (r StorageShareDirectoryResource) Exists(ctx context.Context, client *clien
 	resp, err := dirClient.Get(ctx, id.ShareName, id.DirectoryPath)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Storage Share %q (File Share %q in %s): %+v", id.DirectoryPath, id.ShareName, account.StorageAccountId, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageShareDirectoryResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/accounts"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/files"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/shares"
@@ -191,9 +191,9 @@ func resourceStorageShareFileCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	input := files.CreateInput{
 		MetaData:           ExpandMetaData(d.Get("metadata").(map[string]interface{})),
-		ContentType:        utils.String(d.Get("content_type").(string)),
-		ContentEncoding:    utils.String(d.Get("content_encoding").(string)),
-		ContentDisposition: utils.String(d.Get("content_disposition").(string)),
+		ContentType:        pointer.To(d.Get("content_type").(string)),
+		ContentEncoding:    pointer.To(d.Get("content_encoding").(string)),
+		ContentDisposition: pointer.To(d.Get("content_disposition").(string)),
 	}
 
 	if v, ok := d.GetOk("content_md5"); ok {
@@ -272,9 +272,9 @@ func resourceStorageShareFileUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	if d.HasChange("content_type") || d.HasChange("content_encoding") || d.HasChange("content_disposition") {
 		input := files.SetPropertiesInput{
-			ContentType:        utils.String(d.Get("content_type").(string)),
-			ContentEncoding:    utils.String(d.Get("content_encoding").(string)),
-			ContentDisposition: utils.String(d.Get("content_disposition").(string)),
+			ContentType:        pointer.To(d.Get("content_type").(string)),
+			ContentEncoding:    pointer.To(d.Get("content_encoding").(string)),
+			ContentDisposition: pointer.To(d.Get("content_disposition").(string)),
 			ContentLength:      int64(d.Get("content_length").(int)),
 			MetaData:           ExpandMetaData(d.Get("metadata").(map[string]interface{})),
 		}

--- a/internal/services/storage/storage_share_file_resource_deprecated_test.go
+++ b/internal/services/storage/storage_share_file_resource_deprecated_test.go
@@ -10,13 +10,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/files"
 )
 
@@ -249,7 +249,7 @@ func (StorageShareFileResourceDeprecated) Exists(ctx context.Context, clients *c
 		return nil, fmt.Errorf("retrieving Account %q for File %q (Share %q): %s", id.AccountId.AccountName, id.FileName, id.ShareName, err)
 	}
 	if account == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	client, err := clients.Storage.FileShareFilesDataPlaneClient(ctx, *account, clients.Storage.DataPlaneOperationSupportingAnyAuthMethod())
@@ -264,7 +264,7 @@ func (StorageShareFileResourceDeprecated) Exists(ctx context.Context, clients *c
 		}
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (StorageShareFileResourceDeprecated) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_share_file_resource_test.go
+++ b/internal/services/storage/storage_share_file_resource_test.go
@@ -10,12 +10,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/files"
 )
 
@@ -208,7 +208,7 @@ func (StorageShareFileResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, fmt.Errorf("retrieving Account %q for File %q (Share %q): %s", id.AccountId.AccountName, id.FileName, id.ShareName, err)
 	}
 	if account == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
 	client, err := clients.Storage.FileShareFilesDataPlaneClient(ctx, *account, clients.Storage.DataPlaneOperationSupportingAnyAuthMethod())
@@ -223,7 +223,7 @@ func (StorageShareFileResource) Exists(ctx context.Context, clients *clients.Cli
 		}
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (StorageShareFileResource) template(data acceptance.TestData) string {

--- a/internal/services/storage/storage_sync_cloud_endpoint_resource.go
+++ b/internal/services/storage/storage_sync_cloud_endpoint_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/cloudendpointresource"
@@ -19,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_sync_cloud_endpoint -service-package-name storage -properties "name" -compare-values "subscription_id:storage_sync_group_id,resource_group_name:storage_sync_group_id,storage_sync_service_name:storage_sync_group_id,sync_group_name:storage_sync_group_id"
@@ -105,8 +105,8 @@ func resourceStorageSyncCloudEndpointCreate(d *pluginsdk.ResourceData, meta inte
 
 	parameters := cloudendpointresource.CloudEndpointCreateParameters{
 		Properties: &cloudendpointresource.CloudEndpointCreateParametersProperties{
-			StorageAccountResourceId: utils.String(d.Get("storage_account_id").(string)),
-			AzureFileShareName:       utils.String(d.Get("file_share_name").(string)),
+			StorageAccountResourceId: pointer.To(d.Get("storage_account_id").(string)),
+			AzureFileShareName:       pointer.To(d.Get("file_share_name").(string)),
 		},
 	}
 

--- a/internal/services/storage/storage_sync_cloud_endpoint_resource_test.go
+++ b/internal/services/storage/storage_sync_cloud_endpoint_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/cloudendpointresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageSyncCloudEndpointResource struct{}
@@ -74,7 +74,7 @@ func (r StorageSyncCloudEndpointResource) Exists(ctx context.Context, client *cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageSyncCloudEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_sync_group_resource_test.go
+++ b/internal/services/storage/storage_sync_group_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/syncgroupresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageSyncGroupResource struct{}
@@ -58,7 +58,7 @@ func (r StorageSyncGroupResource) Exists(ctx context.Context, client *clients.Cl
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageSyncGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_sync_resource_test.go
+++ b/internal/services/storage/storage_sync_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageSyncResource struct{}
@@ -102,7 +102,7 @@ func (r StorageSyncResource) Exists(ctx context.Context, client *clients.Client,
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageSyncResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_sync_server_endpoint_resource_test.go
+++ b/internal/services/storage/storage_sync_server_endpoint_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/serverendpointresource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageSyncServerEndpointTestResource struct{}
@@ -75,7 +75,7 @@ func (r StorageSyncServerEndpointTestResource) Exists(ctx context.Context, clien
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageSyncServerEndpointTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_table_entity_resource_test.go
+++ b/internal/services/storage/storage_table_entity_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/table/entities"
 )
 
@@ -157,11 +157,11 @@ func (r StorageTableEntityResource) Exists(ctx context.Context, client *clients.
 	resp, err := entitiesClient.Get(ctx, id.TableName, input)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Entity (Partition Key %q / Row Key %q) (Table %q in %s): %+v", id.PartitionKey, id.RowKey, id.TableName, account.StorageAccountId, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageTableEntityResource) basic(data acceptance.TestData) string {

--- a/internal/services/storage/storage_table_resource_test.go
+++ b/internal/services/storage/storage_table_resource_test.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/giovanni/storage/2023-11-03/table/tables"
 )
 
@@ -129,7 +129,7 @@ func (r StorageTableResource) Destroy(ctx context.Context, client *clients.Clien
 	if err := tablesClient.Delete(ctx, id.TableName); err != nil {
 		return nil, fmt.Errorf("deleting Table %q (Account %q): %+v", id.TableName, id.AccountId.AccountName, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StorageTableResource) basic(data acceptance.TestData) string {

--- a/internal/services/storagecache/hpc_cache_blob_nfs_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_blob_nfs_target_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceHPCCacheBlobNFSTarget() *pluginsdk.Resource {
@@ -161,11 +160,11 @@ func resourceHPCCacheBlobNFSTargetCreateUpdate(d *pluginsdk.ResourceData, meta i
 	}
 
 	if v, ok := d.GetOk("verification_timer_in_seconds"); ok {
-		param.Properties.BlobNfs.VerificationTimer = utils.Int64(int64(v.(int)))
+		param.Properties.BlobNfs.VerificationTimer = pointer.To(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("write_back_timer_in_seconds"); ok {
-		param.Properties.BlobNfs.WriteBackTimer = utils.Int64(int64(v.(int)))
+		param.Properties.BlobNfs.WriteBackTimer = pointer.To(int64(v.(int)))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {

--- a/internal/services/storagecache/hpc_cache_nfs_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_nfs_target_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceHPCCacheNFSTarget() *pluginsdk.Resource {
@@ -169,11 +168,11 @@ func resourceHPCCacheNFSTargetCreateOrUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("verification_timer_in_seconds"); ok {
-		param.Properties.Nfs3.VerificationTimer = utils.Int64(int64(v.(int)))
+		param.Properties.Nfs3.VerificationTimer = pointer.To(int64(v.(int)))
 	}
 
 	if v, ok := d.GetOk("write_back_timer_in_seconds"); ok {
-		param.Properties.Nfs3.WriteBackTimer = utils.Int64(int64(v.(int)))
+		param.Properties.Nfs3.WriteBackTimer = pointer.To(int64(v.(int)))
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, param); err != nil {

--- a/internal/services/storagecache/hpc_cache_resource.go
+++ b/internal/services/storagecache/hpc_cache_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-05-01/caches"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
@@ -81,7 +80,7 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	location := d.Get("location").(string)
+	loc := d.Get("location").(string)
 	cacheSize := d.Get("cache_size_in_gb").(int)
 	subnet := d.Get("subnet_id").(string)
 	skuName := d.Get("sku_name").(string)
@@ -132,9 +131,9 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	cache := caches.Cache{
 		Name:     pointer.To(name),
-		Location: pointer.To(location),
+		Location: pointer.To(loc),
 		Properties: &caches.CacheProperties{
-			CacheSizeGB:     utils.Int64(int64(cacheSize)),
+			CacheSizeGB:     pointer.To(int64(cacheSize)),
 			Subnet:          pointer.To(subnet),
 			NetworkSettings: expandStorageCacheNetworkSettings(d),
 			SecuritySettings: &caches.CacheSecuritySettings{
@@ -173,7 +172,7 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 		if err != nil {
 			return fmt.Errorf("validating Key Vault Key %q for HPC Cache: %+v", keyVaultKeyId, err)
 		}
-		if azure.NormalizeLocation(keyVaultDetails.location) != azure.NormalizeLocation(location) {
+		if location.Normalize(keyVaultDetails.location) != location.Normalize(loc) {
 			return fmt.Errorf("validating Key Vault %q (Resource Group %q) for HPC Cache: Key Vault must be in the same region as HPC Cache", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
 		}
 		if !keyVaultDetails.softDeleteEnabled {
@@ -286,7 +285,7 @@ func resourceHPCCacheRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 
 		if props := m.Properties; props != nil {
-			d.Set("location", azure.NormalizeLocation(pointer.From(m.Location)))
+			d.Set("location", location.Normalize(pointer.From(m.Location)))
 			d.Set("cache_size_in_gb", props.CacheSizeGB)
 			d.Set("subnet_id", props.Subnet)
 			d.Set("mount_addresses", utils.FlattenStringSlice(props.MountAddresses))
@@ -456,7 +455,7 @@ func flattenStorageCacheNfsAccessRules(input []caches.NfsAccessRule) ([]interfac
 
 func expandStorageCacheNetworkSettings(d *pluginsdk.ResourceData) *caches.CacheNetworkSettings {
 	out := &caches.CacheNetworkSettings{
-		Mtu:       utils.Int64(int64(d.Get("mtu").(int))),
+		Mtu:       pointer.To(int64(d.Get("mtu").(int))),
 		NtpServer: pointer.To(d.Get("ntp_server").(string)),
 	}
 

--- a/internal/services/storagecache/managed_lustre_file_system_resource_test.go
+++ b/internal/services/storagecache/managed_lustre_file_system_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2024-07-01/amlfilesystems"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagedLustreFileSystemResource struct{}
@@ -112,11 +112,11 @@ func (r ManagedLustreFileSystemResource) Exists(ctx context.Context, clients *cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ManagedLustreFileSystemResource) template(data acceptance.TestData) string {

--- a/internal/services/storagemover/storage_mover_agent_resource_test.go
+++ b/internal/services/storagemover/storage_mover_agent_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/agents"
 	"github.com/hashicorp/go-uuid"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverAgentTestResource struct{}
@@ -95,11 +95,11 @@ func (r StorageMoverAgentTestResource) Exists(ctx context.Context, clients *clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageMoverAgentTestResource) template(data acceptance.TestData) string {

--- a/internal/services/storagemover/storage_mover_job_definition_resource_test.go
+++ b/internal/services/storagemover/storage_mover_job_definition_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/jobdefinitions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverJobDefinitionTestResource struct{}
@@ -92,11 +92,11 @@ func (r StorageMoverJobDefinitionTestResource) Exists(ctx context.Context, clien
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageMoverJobDefinitionTestResource) template(data acceptance.TestData) string {

--- a/internal/services/storagemover/storage_mover_project_resource_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/projects"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverProjectTestResource struct{}
@@ -92,11 +92,11 @@ func (r StorageMoverProjectTestResource) Exists(ctx context.Context, clients *cl
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageMoverProjectTestResource) template(data acceptance.TestData) string {

--- a/internal/services/storagemover/storage_mover_resource_test.go
+++ b/internal/services/storagemover/storage_mover_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverTestResource struct{}
@@ -92,11 +92,11 @@ func (r StorageMoverTestResource) Exists(ctx context.Context, clients *clients.C
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageMoverTestResource) template(data acceptance.TestData) string {

--- a/internal/services/storagemover/storage_mover_source_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_source_endpoint_resource.go
@@ -9,13 +9,13 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverSourceEndpointModel struct {
@@ -135,7 +135,7 @@ func (r StorageMoverSourceEndpointResource) Create() sdk.ResourceFunc {
 
 			if model.Description != "" {
 				if v, ok := properties.Properties.(endpoints.NfsMountEndpointProperties); ok {
-					v.Description = utils.String(model.Description)
+					v.Description = pointer.To(model.Description)
 					properties.Properties = v
 				}
 			}
@@ -178,7 +178,7 @@ func (r StorageMoverSourceEndpointResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("description") {
 				if v, ok := properties.Properties.(endpoints.NfsMountEndpointProperties); ok {
-					v.Description = utils.String(model.Description)
+					v.Description = pointer.To(model.Description)
 					properties.Properties = v
 				}
 			}

--- a/internal/services/storagemover/storage_mover_source_endpoint_resource_test.go
+++ b/internal/services/storagemover/storage_mover_source_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverSourceEndpointTestResource struct{}
@@ -92,11 +92,11 @@ func (r StorageMoverSourceEndpointTestResource) Exists(ctx context.Context, clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageMoverSourceEndpointTestResource) template(data acceptance.TestData) string {

--- a/internal/services/storagemover/storage_mover_target_endpoint_resource.go
+++ b/internal/services/storagemover/storage_mover_target_endpoint_resource.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverTargetEndpointModel struct {
@@ -123,7 +123,7 @@ func (r StorageMoverTargetEndpointResource) Create() sdk.ResourceFunc {
 
 			if model.Description != "" {
 				if v, ok := properties.Properties.(endpoints.AzureStorageBlobContainerEndpointProperties); ok {
-					v.Description = utils.String(model.Description)
+					v.Description = pointer.To(model.Description)
 					properties.Properties = v
 				}
 			}
@@ -166,7 +166,7 @@ func (r StorageMoverTargetEndpointResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("description") {
 				if v, ok := properties.Properties.(endpoints.AzureStorageBlobContainerEndpointProperties); ok {
-					v.Description = utils.String(model.Description)
+					v.Description = pointer.To(model.Description)
 					properties.Properties = v
 				}
 			}

--- a/internal/services/storagemover/storage_mover_target_endpoint_resource_test.go
+++ b/internal/services/storagemover/storage_mover_target_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StorageMoverTargetEndpointTestResource struct{}
@@ -92,11 +92,11 @@ func (r StorageMoverTargetEndpointTestResource) Exists(ctx context.Context, clie
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r StorageMoverTargetEndpointTestResource) template(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_cluster_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_cluster_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsClusterResource struct{}
@@ -101,11 +101,11 @@ func (r StreamAnalyticsClusterResource) Exists(ctx context.Context, client *clie
 	resp, err := client.StreamAnalytics.ClustersClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStreamAnalyticsFunctionUDA() *pluginsdk.Resource {
@@ -150,7 +150,7 @@ func resourceStreamAnalyticsFunctionUDACreate(d *pluginsdk.ResourceData, meta in
 			Properties: &functions.FunctionConfiguration{
 				Binding: &functions.JavaScriptFunctionBinding{
 					Properties: &functions.JavaScriptFunctionBindingProperties{
-						Script: utils.String(d.Get("script").(string)),
+						Script: pointer.To(d.Get("script").(string)),
 					},
 				},
 				Inputs: expandStreamAnalyticsFunctionUDAInputs(d.Get("input").([]interface{})),
@@ -237,7 +237,7 @@ func resourceStreamAnalyticsFunctionUDAUpdate(d *pluginsdk.ResourceData, meta in
 			Properties: &functions.FunctionConfiguration{
 				Binding: &functions.JavaScriptFunctionBinding{
 					Properties: &functions.JavaScriptFunctionBindingProperties{
-						Script: utils.String(d.Get("script").(string)),
+						Script: pointer.To(d.Get("script").(string)),
 					},
 				},
 				Inputs: expandStreamAnalyticsFunctionUDAInputs(d.Get("input").([]interface{})),
@@ -280,8 +280,8 @@ func expandStreamAnalyticsFunctionUDAInputs(input []interface{}) *[]functions.Fu
 		v := raw.(map[string]interface{})
 		variableType := v["type"].(string)
 		outputs = append(outputs, functions.FunctionInput{
-			DataType:                 utils.String(variableType),
-			IsConfigurationParameter: utils.Bool(v["configuration_parameter"].(bool)),
+			DataType:                 pointer.To(variableType),
+			IsConfigurationParameter: pointer.To(v["configuration_parameter"].(bool)),
 		})
 	}
 
@@ -320,7 +320,7 @@ func expandStreamAnalyticsFunctionUDAOutput(input []interface{}) *functions.Func
 
 	dataType := output["type"].(string)
 	return &functions.FunctionOutput{
-		DataType: utils.String(dataType),
+		DataType: pointer.To(dataType),
 	}
 }
 

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_uda_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsFunctionJavaScriptUDAResource struct{}
@@ -131,12 +131,12 @@ func (r StreamAnalyticsFunctionJavaScriptUDAResource) Exists(ctx context.Context
 	resp, err := client.StreamAnalytics.FunctionsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s : %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsFunctionJavaScriptUDAResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStreamAnalyticsFunctionUDF() *pluginsdk.Resource {
@@ -151,7 +151,7 @@ func resourceStreamAnalyticsFunctionUDFCreateUpdate(d *pluginsdk.ResourceData, m
 			Properties: &functions.FunctionConfiguration{
 				Binding: &functions.JavaScriptFunctionBinding{
 					Properties: &functions.JavaScriptFunctionBindingProperties{
-						Script: utils.String(d.Get("script").(string)),
+						Script: pointer.To(d.Get("script").(string)),
 					},
 				},
 				Inputs: inputs,
@@ -256,8 +256,8 @@ func expandStreamAnalyticsFunctionInputs(input []interface{}) *[]functions.Funct
 		v := raw.(map[string]interface{})
 		variableType := v["type"].(string)
 		outputs = append(outputs, functions.FunctionInput{
-			DataType:                 utils.String(variableType),
-			IsConfigurationParameter: utils.Bool(v["configuration_parameter"].(bool)),
+			DataType:                 pointer.To(variableType),
+			IsConfigurationParameter: pointer.To(v["configuration_parameter"].(bool)),
 		})
 	}
 
@@ -296,7 +296,7 @@ func expandStreamAnalyticsFunctionOutput(input []interface{}) *functions.Functio
 
 	dataType := output["type"].(string)
 	return &functions.FunctionOutput{
-		DataType: utils.String(dataType),
+		DataType: pointer.To(dataType),
 	}
 }
 

--- a/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_function_javascript_udf_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsFunctionJavaScriptUDFResource struct{}
@@ -102,12 +102,12 @@ func (r StreamAnalyticsFunctionJavaScriptUDFResource) Exists(ctx context.Context
 	resp, err := client.StreamAnalytics.FunctionsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s : %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsFunctionJavaScriptUDFResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_job_schedule_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_schedule_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/streamingjobs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsJobScheduleResource struct{}
@@ -97,7 +97,7 @@ func (r StreamAnalyticsJobScheduleResource) Exists(ctx context.Context, client *
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil && resp.Model.Properties.OutputStartTime != nil), nil
+	return pointer.To(resp.Model != nil && resp.Model.Properties.OutputStartTime != nil), nil
 }
 
 func (r StreamAnalyticsJobScheduleResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_managed_private_endpoint_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_managed_private_endpoint_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/privateendpoints"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ManagedPrivateEndpointResource struct{}
@@ -108,7 +108,7 @@ func (r ManagedPrivateEndpointResource) Create() sdk.ResourceFunc {
 					ManualPrivateLinkServiceConnections: &[]privateendpoints.PrivateLinkServiceConnection{
 						{
 							Properties: &privateendpoints.PrivateLinkServiceConnectionProperties{
-								PrivateLinkServiceId: utils.String(model.TargetResourceId),
+								PrivateLinkServiceId: pointer.To(model.TargetResourceId),
 								GroupIds:             &[]string{model.SubResourceName},
 							},
 						},

--- a/internal/services/streamanalytics/stream_analytics_managed_private_endpoint_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_managed_private_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/privateendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsManagedPrivateEndpointResource struct{}
@@ -58,11 +58,11 @@ func (r StreamAnalyticsManagedPrivateEndpointResource) Exists(ctx context.Contex
 	resp, err := client.StreamAnalytics.EndpointsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsManagedPrivateEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStreamAnalyticsOutputBlob() *pluginsdk.Resource {
@@ -193,7 +192,7 @@ func resourceStreamAnalyticsOutputBlobCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if batchMinRows, ok := d.GetOk("batch_min_rows"); ok {
-		props.Properties.SizeWindow = utils.Int64(int64(batchMinRows.(int)))
+		props.Properties.SizeWindow = pointer.To(int64(batchMinRows.(int)))
 	}
 
 	// timeWindow and sizeWindow must be set for Parquet serialization

--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputBlobResource struct{}
@@ -162,11 +162,11 @@ func (r StreamAnalyticsOutputBlobResource) Exists(ctx context.Context, client *c
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputBlobResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type OutputCosmosDBResource struct{}
@@ -144,17 +143,17 @@ func (r OutputCosmosDBResource) Create() sdk.ResourceFunc {
 			}
 
 			documentDbOutputProps := &outputs.DocumentDbOutputDataSourceProperties{
-				AccountId:             utils.String(databaseId.DatabaseAccountName),
-				AccountKey:            utils.String(model.AccountKey),
-				Database:              utils.String(databaseId.Name),
-				CollectionNamePattern: utils.String(model.ContainerName),
-				DocumentId:            utils.String(model.DocumentID),
-				PartitionKey:          utils.String(model.PartitionKey),
+				AccountId:             pointer.To(databaseId.DatabaseAccountName),
+				AccountKey:            pointer.To(model.AccountKey),
+				Database:              pointer.To(databaseId.Name),
+				CollectionNamePattern: pointer.To(model.ContainerName),
+				DocumentId:            pointer.To(model.DocumentID),
+				PartitionKey:          pointer.To(model.PartitionKey),
 				AuthenticationMode:    pointer.To(outputs.AuthenticationMode(model.AuthenticationMode)),
 			}
 
 			props := outputs.Output{
-				Name: utils.String(model.Name),
+				Name: pointer.To(model.Name),
 				Properties: &outputs.OutputProperties{
 					Datasource: &outputs.DocumentDbOutputDataSource{
 						Properties: documentDbOutputProps,

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputCosmosDBResource struct{}
@@ -94,11 +94,11 @@ func (r StreamAnalyticsOutputCosmosDBResource) Exists(ctx context.Context, clien
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputCosmosDBResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_eventhub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_eventhub_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputEventhubResource struct{}
@@ -181,11 +181,11 @@ func (r StreamAnalyticsOutputEventhubResource) Exists(ctx context.Context, clien
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputEventhubResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_function_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_function_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type OutputFunctionResource struct{}
@@ -128,15 +127,15 @@ func (r OutputFunctionResource) Create() sdk.ResourceFunc {
 			}
 
 			props := outputs.Output{
-				Name: utils.String(model.Name),
+				Name: pointer.To(model.Name),
 				Properties: &outputs.OutputProperties{
 					Datasource: &outputs.AzureFunctionOutputDataSource{
 						Properties: &outputs.AzureFunctionOutputDataSourceProperties{
-							FunctionAppName: utils.String(model.FunctionApp),
-							FunctionName:    utils.String(model.FunctionName),
-							ApiKey:          utils.String(model.ApiKey),
-							MaxBatchSize:    utils.Float(float64(model.BatchMaxInBytes)),
-							MaxBatchCount:   utils.Float(float64(model.BatchMaxCount)),
+							FunctionAppName: pointer.To(model.FunctionApp),
+							FunctionName:    pointer.To(model.FunctionName),
+							ApiKey:          pointer.To(model.ApiKey),
+							MaxBatchSize:    pointer.To(float64(model.BatchMaxInBytes)),
+							MaxBatchCount:   pointer.To(float64(model.BatchMaxCount)),
 						},
 					},
 				},
@@ -220,15 +219,15 @@ func (r OutputFunctionResource) Update() sdk.ResourceFunc {
 			}
 
 			props := outputs.Output{
-				Name: utils.String(state.Name),
+				Name: pointer.To(state.Name),
 				Properties: &outputs.OutputProperties{
 					Datasource: &outputs.AzureFunctionOutputDataSource{
 						Properties: &outputs.AzureFunctionOutputDataSourceProperties{
-							FunctionAppName: utils.String(state.FunctionApp),
-							FunctionName:    utils.String(state.FunctionName),
-							ApiKey:          utils.String(state.ApiKey),
-							MaxBatchSize:    utils.Float(float64(state.BatchMaxInBytes)),
-							MaxBatchCount:   utils.Float(float64(state.BatchMaxCount)),
+							FunctionAppName: pointer.To(state.FunctionApp),
+							FunctionName:    pointer.To(state.FunctionName),
+							ApiKey:          pointer.To(state.ApiKey),
+							MaxBatchSize:    pointer.To(float64(state.BatchMaxInBytes)),
+							MaxBatchCount:   pointer.To(float64(state.BatchMaxCount)),
 						},
 					},
 				},

--- a/internal/services/streamanalytics/stream_analytics_output_function_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_function_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputFunctionResource struct{}
@@ -95,11 +95,11 @@ func (r StreamAnalyticsOutputFunctionResource) Exists(ctx context.Context, clien
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputFunctionResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_mssql_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_mssql_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputSqlResource struct{}
@@ -130,11 +130,11 @@ func (r StreamAnalyticsOutputSqlResource) Exists(ctx context.Context, client *cl
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputSqlResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_powerbi_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_powerbi_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputPowerBIResource struct{}
@@ -28,11 +28,11 @@ func (r StreamAnalyticsOutputPowerBIResource) Exists(ctx context.Context, client
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func TestAccStreamAnalyticsOutputPowerBI_basic(t *testing.T) {

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_queue_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_queue_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputServiceBusQueueResource struct{}
@@ -197,11 +197,11 @@ func (r StreamAnalyticsOutputServiceBusQueueResource) Exists(ctx context.Context
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputServiceBusQueueResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputServiceBusTopicResource struct{}
@@ -177,11 +177,11 @@ func (r StreamAnalyticsOutputServiceBusTopicResource) Exists(ctx context.Context
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving (%s): %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputServiceBusTopicResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -16,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStreamAnalyticsOutputSynapse() *pluginsdk.Resource {
@@ -123,15 +123,15 @@ func resourceStreamAnalyticsOutputSynapseCreateUpdate(d *pluginsdk.ResourceData,
 	}
 
 	props := outputs.Output{
-		Name: utils.String(id.OutputName),
+		Name: pointer.To(id.OutputName),
 		Properties: &outputs.OutputProperties{
 			Datasource: &outputs.AzureSynapseOutputDataSource{
 				Properties: &outputs.AzureSynapseDataSourceProperties{
-					Server:   utils.String(d.Get("server").(string)),
-					Database: utils.String(d.Get("database").(string)),
-					User:     utils.String(d.Get("user").(string)),
-					Password: utils.String(d.Get("password").(string)),
-					Table:    utils.String(d.Get("table").(string)),
+					Server:   pointer.To(d.Get("server").(string)),
+					Database: pointer.To(d.Get("database").(string)),
+					User:     pointer.To(d.Get("user").(string)),
+					Password: pointer.To(d.Get("password").(string)),
+					Table:    pointer.To(d.Get("table").(string)),
 				},
 			},
 		},

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputSynapseResource struct{}
@@ -94,11 +94,11 @@ func (r StreamAnalyticsOutputSynapseResource) Exists(ctx context.Context, client
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputSynapseResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_output_table_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_table_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type OutputTableResource struct{}
@@ -144,12 +144,12 @@ func (r OutputTableResource) Create() sdk.ResourceFunc {
 			}
 
 			tableOutputProps := &outputs.AzureTableOutputDataSourceProperties{
-				AccountName:  utils.String(model.StorageAccount),
-				AccountKey:   utils.String(model.StorageAccountKey),
-				Table:        utils.String(model.Table),
-				PartitionKey: utils.String(model.PartitionKey),
-				RowKey:       utils.String(model.RowKey),
-				BatchSize:    utils.Int64(model.BatchSize),
+				AccountName:  pointer.To(model.StorageAccount),
+				AccountKey:   pointer.To(model.StorageAccountKey),
+				Table:        pointer.To(model.Table),
+				PartitionKey: pointer.To(model.PartitionKey),
+				RowKey:       pointer.To(model.RowKey),
+				BatchSize:    pointer.To(model.BatchSize),
 			}
 
 			if v := model.ColumnsToRemove; len(v) > 0 {
@@ -157,7 +157,7 @@ func (r OutputTableResource) Create() sdk.ResourceFunc {
 			}
 
 			props := outputs.Output{
-				Name: utils.String(model.Name),
+				Name: pointer.To(model.Name),
 				Properties: &outputs.OutputProperties{
 					Datasource: &outputs.AzureTableOutputDataSource{
 						Properties: tableOutputProps,
@@ -275,12 +275,12 @@ func (r OutputTableResource) Update() sdk.ResourceFunc {
 			}
 
 			props := &outputs.AzureTableOutputDataSourceProperties{
-				AccountName:  utils.String(state.StorageAccount),
-				AccountKey:   utils.String(state.StorageAccountKey),
-				Table:        utils.String(state.Table),
-				PartitionKey: utils.String(state.PartitionKey),
-				RowKey:       utils.String(state.RowKey),
-				BatchSize:    utils.Int64(state.BatchSize),
+				AccountName:  pointer.To(state.StorageAccount),
+				AccountKey:   pointer.To(state.StorageAccountKey),
+				Table:        pointer.To(state.Table),
+				PartitionKey: pointer.To(state.PartitionKey),
+				RowKey:       pointer.To(state.RowKey),
+				BatchSize:    pointer.To(state.BatchSize),
 			}
 
 			if metadata.ResourceData.HasChange("columns_to_remove") {
@@ -288,7 +288,7 @@ func (r OutputTableResource) Update() sdk.ResourceFunc {
 			}
 
 			output := outputs.Output{
-				Name: utils.String(state.Name),
+				Name: pointer.To(state.Name),
 				Properties: &outputs.OutputProperties{
 					Datasource: &outputs.AzureTableOutputDataSource{
 						Properties: props,

--- a/internal/services/streamanalytics/stream_analytics_output_table_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_table_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsOutputTableResource struct{}
@@ -116,11 +116,11 @@ func (r StreamAnalyticsOutputTableResource) Exists(ctx context.Context, client *
 	resp, err := client.StreamAnalytics.OutputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsOutputTableResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsReferenceInputBlobResource struct{}
@@ -124,11 +124,11 @@ func (r StreamAnalyticsReferenceInputBlobResource) Exists(ctx context.Context, c
 	resp, err := client.StreamAnalytics.InputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsReferenceInputBlobResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsReferenceInputMsSqlResource struct{}
@@ -94,11 +94,11 @@ func (r StreamAnalyticsReferenceInputMsSqlResource) Exists(ctx context.Context, 
 	resp, err := client.StreamAnalytics.InputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsReferenceInputMsSqlResource) basic(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStreamAnalyticsStreamInputBlob() *pluginsdk.Resource {
@@ -149,20 +148,20 @@ func resourceStreamAnalyticsStreamInputBlobCreateUpdate(d *pluginsdk.ResourceDat
 	}
 
 	props := inputs.Input{
-		Name: utils.String(id.InputName),
+		Name: pointer.To(id.InputName),
 		Properties: &inputs.StreamInputProperties{
 			// Type: streamanalytics.TypeBasicInputPropertiesTypeStream,
 			Datasource: &inputs.BlobStreamInputDataSource{
 				// Type: streamanalytics.TypeBasicStreamInputDataSourceTypeMicrosoftStorageBlob,
 				Properties: &inputs.BlobStreamInputDataSourceProperties{
-					Container:   utils.String(containerName),
-					DateFormat:  utils.String(dateFormat),
-					PathPattern: utils.String(pathPattern),
-					TimeFormat:  utils.String(timeFormat),
+					Container:   pointer.To(containerName),
+					DateFormat:  pointer.To(dateFormat),
+					PathPattern: pointer.To(pathPattern),
+					TimeFormat:  pointer.To(timeFormat),
 					StorageAccounts: &[]inputs.StorageAccount{
 						{
-							AccountName: utils.String(storageAccountName),
-							AccountKey:  utils.String(storageAccountKey),
+							AccountName: pointer.To(storageAccountName),
+							AccountKey:  pointer.To(storageAccountKey),
 						},
 					},
 					AuthenticationMode: pointer.To(inputs.AuthenticationMode(d.Get("authentication_mode").(string))),

--- a/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsStreamInputBlobResource struct{}
@@ -124,11 +124,11 @@ func (r StreamAnalyticsStreamInputBlobResource) Exists(ctx context.Context, clie
 	resp, err := client.StreamAnalytics.InputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsStreamInputBlobResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsStreamInputEventHubResource struct{}
@@ -170,11 +170,11 @@ func (r StreamAnalyticsStreamInputEventHubResource) Exists(ctx context.Context, 
 	resp, err := client.StreamAnalytics.InputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsStreamInputEventHubResource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_v2_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_v2_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsStreamInputEventHubV2Resource struct{}
@@ -170,11 +170,11 @@ func (r StreamAnalyticsStreamInputEventHubV2Resource) Exists(ctx context.Context
 	resp, err := client.StreamAnalytics.InputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsStreamInputEventHubV2Resource) avro(data acceptance.TestData) string {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceStreamAnalyticsStreamInputIoTHub() *pluginsdk.Resource {
@@ -133,15 +133,15 @@ func resourceStreamAnalyticsStreamInputIoTHubCreateUpdate(d *pluginsdk.ResourceD
 	}
 
 	props := inputs.Input{
-		Name: utils.String(id.InputName),
+		Name: pointer.To(id.InputName),
 		Properties: &inputs.StreamInputProperties{
 			Datasource: &inputs.IoTHubStreamInputDataSource{
 				Properties: &inputs.IoTHubStreamInputDataSourceProperties{
-					ConsumerGroupName:      utils.String(consumerGroupName),
-					SharedAccessPolicyKey:  utils.String(sharedAccessPolicyKey),
-					SharedAccessPolicyName: utils.String(sharedAccessPolicyName),
-					Endpoint:               utils.String(endpoint),
-					IotHubNamespace:        utils.String(iotHubNamespace),
+					ConsumerGroupName:      pointer.To(consumerGroupName),
+					SharedAccessPolicyKey:  pointer.To(sharedAccessPolicyKey),
+					SharedAccessPolicyName: pointer.To(sharedAccessPolicyName),
+					Endpoint:               pointer.To(endpoint),
+					IotHubNamespace:        pointer.To(iotHubNamespace),
 				},
 			},
 			Serialization: serialization,

--- a/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type StreamAnalyticsStreamInputIoTHubResource struct{}
@@ -109,11 +109,11 @@ func (r StreamAnalyticsStreamInputIoTHubResource) Exists(ctx context.Context, cl
 	resp, err := client.StreamAnalytics.InputsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StreamAnalyticsStreamInputIoTHubResource) avro(data acceptance.TestData) string {

--- a/internal/services/subscription/subscription_resource.go
+++ b/internal/services/subscription/subscription_resource.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 var SubscriptionResourceName = "azurerm_subscription"
@@ -183,7 +182,7 @@ func resourceSubscriptionCreate(d *pluginsdk.ResourceData, meta interface{}) err
 			return fmt.Errorf("an Alias for Subscription %q already exists with name %q - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information", subscriptionId, *exists, "azurerm_subscription")
 		}
 
-		req.Properties.SubscriptionId = utils.String(subscriptionId)
+		req.Properties.SubscriptionId = pointer.To(subscriptionId)
 		existingSub, err := client.Get(ctx, subscriptionResourceId)
 		if err != nil {
 			return fmt.Errorf("retrieving existing %s: %+v", subscriptionResourceId, err)
@@ -209,8 +208,8 @@ func resourceSubscriptionCreate(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 	} else {
 		// If we're not assuming control of an existing Subscription, we need to know where to create it.
-		req.Properties.DisplayName = utils.String(d.Get("subscription_name").(string))
-		req.Properties.BillingScope = utils.String(d.Get("billing_scope_id").(string))
+		req.Properties.DisplayName = pointer.To(d.Get("subscription_name").(string))
+		req.Properties.BillingScope = pointer.To(d.Get("billing_scope_id").(string))
 	}
 
 	if err := aliasClient.AliasCreateThenPoll(ctx, id, req); err != nil {
@@ -276,7 +275,7 @@ func resourceSubscriptionUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		defer locks.UnlockByID(subscriptionId.ID())
 
 		displayName := subscriptionAlias.SubscriptionName{
-			SubscriptionName: utils.String(d.Get("subscription_name").(string)),
+			SubscriptionName: pointer.To(d.Get("subscription_name").(string)),
 		}
 		if _, err := aliasClient.SubscriptionRename(ctx, subscriptionId, displayName); err != nil {
 			return fmt.Errorf("could not update Display Name of Subscription %q: %+v", subscriptionId, err)

--- a/internal/services/subscription/subscription_resource_test.go
+++ b/internal/services/subscription/subscription_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SubscriptionResource struct{}
@@ -105,12 +105,12 @@ func (SubscriptionResource) Exists(ctx context.Context, client *clients.Client, 
 	resp, err := client.Subscription.AliasClient.AliasGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Subscription Alias %q: %+v", id.AliasName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 // TODO - Need Env vars in CI for Billing Account and Enrollment Account - Testing disabled for now

--- a/internal/services/synapse/synapse_firewall_rule_resource.go
+++ b/internal/services/synapse/synapse_firewall_rule_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
@@ -94,8 +95,8 @@ func resourceSynapseFirewallRuleCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	parameters := synapse.IPFirewallRuleInfo{
 		IPFirewallRuleProperties: &synapse.IPFirewallRuleProperties{
-			StartIPAddress: utils.String(d.Get("start_ip_address").(string)),
-			EndIPAddress:   utils.String(d.Get("end_ip_address").(string)),
+			StartIPAddress: pointer.To(d.Get("start_ip_address").(string)),
+			EndIPAddress:   pointer.To(d.Get("end_ip_address").(string)),
 		},
 	}
 

--- a/internal/services/synapse/synapse_firewall_rule_resource_test.go
+++ b/internal/services/synapse/synapse_firewall_rule_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -79,12 +80,12 @@ func (r SynapseFirewallRuleResource) Exists(ctx context.Context, client *clients
 	resp, err := client.Synapse.FirewallRulesClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Firewall Rule %q (Workspace %q / Resource Group %q): %+v", id.Name, id.WorkspaceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseFirewallRuleResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_integration_runtime_azure_resource.go
+++ b/internal/services/synapse/synapse_integration_runtime_azure_resource.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/migration"
@@ -135,17 +135,17 @@ func resourceSynapseIntegrationRuntimeAzureCreateUpdate(d *pluginsdk.ResourceDat
 	}
 
 	integrationRuntime := synapse.IntegrationRuntimeResource{
-		Name: utils.String(id.Name),
+		Name: pointer.To(id.Name),
 		Properties: synapse.ManagedIntegrationRuntime{
-			Description: utils.String(d.Get("description").(string)),
+			Description: pointer.To(d.Get("description").(string)),
 			Type:        synapse.TypeBasicIntegrationRuntimeTypeManaged,
 			ManagedIntegrationRuntimeTypeProperties: &synapse.ManagedIntegrationRuntimeTypeProperties{
 				ComputeProperties: &synapse.IntegrationRuntimeComputeProperties{
-					Location: utils.String(azure.NormalizeLocation(d.Get("location").(string))),
+					Location: pointer.To(location.Normalize(d.Get("location").(string))),
 					DataFlowProperties: &synapse.IntegrationRuntimeDataFlowProperties{
 						ComputeType: synapse.DataFlowComputeType(d.Get("compute_type").(string)),
-						CoreCount:   utils.Int32(int32(d.Get("core_count").(int))),
-						TimeToLive:  utils.Int32(int32(d.Get("time_to_live_min").(int))),
+						CoreCount:   pointer.To(int32(d.Get("core_count").(int))),
+						TimeToLive:  pointer.To(int32(d.Get("time_to_live_min").(int))),
 					},
 				},
 			},

--- a/internal/services/synapse/synapse_integration_runtime_azure_resource_test.go
+++ b/internal/services/synapse/synapse_integration_runtime_azure_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SynapseIntegrationRuntimeAzureResource struct{}
@@ -115,7 +115,7 @@ func (r SynapseIntegrationRuntimeAzureResource) Exists(ctx context.Context, clie
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseIntegrationRuntimeAzureResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_integration_runtime_self_hosted_resource.go
+++ b/internal/services/synapse/synapse_integration_runtime_self_hosted_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/migration"
@@ -105,9 +106,9 @@ func resourceSynapseIntegrationRuntimeSelfHostedCreateUpdate(d *pluginsdk.Resour
 	}
 
 	integrationRuntime := synapse.IntegrationRuntimeResource{
-		Name: utils.String(id.Name),
+		Name: pointer.To(id.Name),
 		Properties: synapse.SelfHostedIntegrationRuntime{
-			Description: utils.String(d.Get("description").(string)),
+			Description: pointer.To(d.Get("description").(string)),
 			Type:        synapse.TypeBasicIntegrationRuntimeTypeSelfHosted,
 		},
 	}

--- a/internal/services/synapse/synapse_integration_runtime_self_hosted_resource_test.go
+++ b/internal/services/synapse/synapse_integration_runtime_self_hosted_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SynapseIntegrationRuntimeSelfHostedResource struct{}
@@ -57,7 +57,7 @@ func (r SynapseIntegrationRuntimeSelfHostedResource) Exists(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseIntegrationRuntimeSelfHostedResource) template(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_linked_service_resource.go
+++ b/internal/services/synapse/synapse_linked_service_resource.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/migration"
@@ -486,8 +487,8 @@ func expandSynapseLinkedServiceIntegrationRuntimeV2(input []interface{}) *artifa
 
 	v := input[0].(map[string]interface{})
 	return &artifacts.IntegrationRuntimeReference{
-		ReferenceName: utils.String(v["name"].(string)),
-		Type:          utils.String("IntegrationRuntimeReference"),
+		ReferenceName: pointer.To(v["name"].(string)),
+		Type:          pointer.To("IntegrationRuntimeReference"),
 		Parameters:    v["parameters"].(map[string]interface{}),
 	}
 }

--- a/internal/services/synapse/synapse_linked_service_resource_test.go
+++ b/internal/services/synapse/synapse_linked_service_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type LinkedServiceResource struct{}
@@ -143,7 +143,7 @@ func (t LinkedServiceResource) Exists(ctx context.Context, clients *clients.Clie
 		return nil, fmt.Errorf("reading %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r LinkedServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_managed_private_endpoint_resource.go
+++ b/internal/services/synapse/synapse_managed_private_endpoint_resource.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -114,8 +115,8 @@ func resourceSynapseManagedPrivateEndpointCreate(d *pluginsdk.ResourceData, meta
 
 	managedPrivateEndpoint := managedvirtualnetwork.ManagedPrivateEndpoint{
 		Properties: &managedvirtualnetwork.ManagedPrivateEndpointProperties{
-			PrivateLinkResourceID: utils.String(d.Get("target_resource_id").(string)),
-			GroupID:               utils.String(d.Get("subresource_name").(string)),
+			PrivateLinkResourceID: pointer.To(d.Get("target_resource_id").(string)),
+			GroupID:               pointer.To(d.Get("subresource_name").(string)),
 		},
 	}
 	if _, err := client.Create(ctx, id.ManagedVirtualNetworkName, id.Name, managedPrivateEndpoint); err != nil {

--- a/internal/services/synapse/synapse_managed_private_endpoint_resource_test.go
+++ b/internal/services/synapse/synapse_managed_private_endpoint_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -66,12 +67,12 @@ func (r SynapseManagedPrivateEndpointResource) Exists(ctx context.Context, clien
 	resp, err := managedPrivateEndpointsClient.Get(ctx, id.ManagedVirtualNetworkName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Managed Private Endpoints (Workspace %q / Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseManagedPrivateEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_private_link_hub_resource.go
+++ b/internal/services/synapse/synapse_private_link_hub_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -77,7 +78,7 @@ func resourceSynapsePrivateLinkHubCreate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	privateLinkHubInfo := synapse.PrivateLinkHub{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 

--- a/internal/services/synapse/synapse_private_link_hub_resource_test.go
+++ b/internal/services/synapse/synapse_private_link_hub_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -79,12 +80,12 @@ func (r SynapsePrivateLinkHubResource) Exists(ctx context.Context, client *clien
 	resp, err := client.Synapse.PrivateLinkHubsClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapsePrivateLinkHubResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_role_assignment_resource.go
+++ b/internal/services/synapse/synapse_role_assignment_resource.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	frsUUID "github.com/gofrs/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -174,7 +175,7 @@ func resourceSynapseRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interfa
 	roleAssignment := accesscontrol.RoleAssignmentRequest{
 		RoleID:      roleId,
 		PrincipalID: &principalID,
-		Scope:       utils.String(scope),
+		Scope:       pointer.To(scope),
 	}
 
 	if v, ok := d.GetOk("principal_type"); ok {

--- a/internal/services/synapse/synapse_role_assignment_resource_test.go
+++ b/internal/services/synapse/synapse_role_assignment_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -87,12 +88,12 @@ func (r SynapseRoleAssignmentResource) Exists(ctx context.Context, client *clien
 	resp, err := roleAssignmentsClient.GetRoleAssignmentByID(ctx, id.DataPlaneAssignmentId)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse RoleAssignment (Resource Group %q): %+v", workspaceName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseRoleAssignmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -285,28 +286,28 @@ func resourceSynapseSparkPoolCreate(d *pluginsdk.ResourceData, meta interface{})
 		BigDataPoolResourceProperties: &synapse.BigDataPoolResourceProperties{
 			AutoPause:                 expandArmSparkPoolAutoPauseProperties(d.Get("auto_pause").([]interface{})),
 			AutoScale:                 autoScale,
-			CacheSize:                 utils.Int32(int32(d.Get("cache_size").(int))),
-			IsComputeIsolationEnabled: utils.Bool(d.Get("compute_isolation_enabled").(bool)),
+			CacheSize:                 pointer.To(int32(d.Get("cache_size").(int))),
+			IsComputeIsolationEnabled: pointer.To(d.Get("compute_isolation_enabled").(bool)),
 			DynamicExecutorAllocation: &synapse.DynamicExecutorAllocation{
-				Enabled:      utils.Bool(d.Get("dynamic_executor_allocation_enabled").(bool)),
-				MinExecutors: utils.Int32(int32(d.Get("min_executors").(int))),
-				MaxExecutors: utils.Int32(int32(d.Get("max_executors").(int))),
+				Enabled:      pointer.To(d.Get("dynamic_executor_allocation_enabled").(bool)),
+				MinExecutors: pointer.To(int32(d.Get("min_executors").(int))),
+				MaxExecutors: pointer.To(int32(d.Get("max_executors").(int))),
 			},
-			DefaultSparkLogFolder:       utils.String(d.Get("spark_log_folder").(string)),
+			DefaultSparkLogFolder:       pointer.To(d.Get("spark_log_folder").(string)),
 			NodeSize:                    synapse.NodeSize(d.Get("node_size").(string)),
 			NodeSizeFamily:              synapse.NodeSizeFamily(d.Get("node_size_family").(string)),
-			SessionLevelPackagesEnabled: utils.Bool(d.Get("session_level_packages_enabled").(bool)),
+			SessionLevelPackagesEnabled: pointer.To(d.Get("session_level_packages_enabled").(bool)),
 			SparkConfigProperties:       expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{})),
-			SparkEventsFolder:           utils.String(d.Get("spark_events_folder").(string)),
-			SparkVersion:                utils.String(d.Get("spark_version").(string)),
+			SparkEventsFolder:           pointer.To(d.Get("spark_events_folder").(string)),
+			SparkVersion:                pointer.To(d.Get("spark_version").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 	if !*autoScale.Enabled {
-		bigDataPoolInfo.NodeCount = utils.Int32(int32(d.Get("node_count").(int)))
+		bigDataPoolInfo.NodeCount = pointer.To(int32(d.Get("node_count").(int)))
 	}
 
-	force := utils.Bool(false)
+	force := pointer.To(false)
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName, bigDataPoolInfo, force)
 	if err != nil {
 		return fmt.Errorf("creating %s: %v", id, err)
@@ -406,29 +407,29 @@ func resourceSynapseSparkPoolUpdate(d *pluginsdk.ResourceData, meta interface{})
 		BigDataPoolResourceProperties: &synapse.BigDataPoolResourceProperties{
 			AutoPause:                 expandArmSparkPoolAutoPauseProperties(d.Get("auto_pause").([]interface{})),
 			AutoScale:                 autoScale,
-			CacheSize:                 utils.Int32(int32(d.Get("cache_size").(int))),
-			IsComputeIsolationEnabled: utils.Bool(d.Get("compute_isolation_enabled").(bool)),
+			CacheSize:                 pointer.To(int32(d.Get("cache_size").(int))),
+			IsComputeIsolationEnabled: pointer.To(d.Get("compute_isolation_enabled").(bool)),
 			DynamicExecutorAllocation: &synapse.DynamicExecutorAllocation{
-				Enabled:      utils.Bool(d.Get("dynamic_executor_allocation_enabled").(bool)),
-				MinExecutors: utils.Int32(int32(d.Get("min_executors").(int))),
-				MaxExecutors: utils.Int32(int32(d.Get("max_executors").(int))),
+				Enabled:      pointer.To(d.Get("dynamic_executor_allocation_enabled").(bool)),
+				MinExecutors: pointer.To(int32(d.Get("min_executors").(int))),
+				MaxExecutors: pointer.To(int32(d.Get("max_executors").(int))),
 			},
-			DefaultSparkLogFolder:       utils.String(d.Get("spark_log_folder").(string)),
+			DefaultSparkLogFolder:       pointer.To(d.Get("spark_log_folder").(string)),
 			LibraryRequirements:         expandArmSparkPoolLibraryRequirements(d.Get("library_requirement").([]interface{})),
 			NodeSize:                    synapse.NodeSize(d.Get("node_size").(string)),
 			NodeSizeFamily:              synapse.NodeSizeFamily(d.Get("node_size_family").(string)),
-			SessionLevelPackagesEnabled: utils.Bool(d.Get("session_level_packages_enabled").(bool)),
+			SessionLevelPackagesEnabled: pointer.To(d.Get("session_level_packages_enabled").(bool)),
 			SparkConfigProperties:       expandSparkPoolSparkConfig(d.Get("spark_config").([]interface{})),
-			SparkEventsFolder:           utils.String(d.Get("spark_events_folder").(string)),
-			SparkVersion:                utils.String(d.Get("spark_version").(string)),
+			SparkEventsFolder:           pointer.To(d.Get("spark_events_folder").(string)),
+			SparkVersion:                pointer.To(d.Get("spark_version").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 	if !*autoScale.Enabled {
-		bigDataPoolInfo.NodeCount = utils.Int32(int32(d.Get("node_count").(int)))
+		bigDataPoolInfo.NodeCount = pointer.To(int32(d.Get("node_count").(int)))
 	}
 
-	force := utils.Bool(false)
+	force := pointer.To(false)
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName, bigDataPoolInfo, force)
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
@@ -466,27 +467,27 @@ func resourceSynapseSparkPoolDelete(d *pluginsdk.ResourceData, meta interface{})
 func expandArmSparkPoolAutoPauseProperties(input []interface{}) *synapse.AutoPauseProperties {
 	if len(input) == 0 {
 		return &synapse.AutoPauseProperties{
-			Enabled: utils.Bool(false),
+			Enabled: pointer.To(false),
 		}
 	}
 	v := input[0].(map[string]interface{})
 	return &synapse.AutoPauseProperties{
-		DelayInMinutes: utils.Int32(int32(v["delay_in_minutes"].(int))),
-		Enabled:        utils.Bool(true),
+		DelayInMinutes: pointer.To(int32(v["delay_in_minutes"].(int))),
+		Enabled:        pointer.To(true),
 	}
 }
 
 func expandArmSparkPoolAutoScaleProperties(input []interface{}) *synapse.AutoScaleProperties {
 	if len(input) == 0 || input[0] == nil {
 		return &synapse.AutoScaleProperties{
-			Enabled: utils.Bool(false),
+			Enabled: pointer.To(false),
 		}
 	}
 	v := input[0].(map[string]interface{})
 	return &synapse.AutoScaleProperties{
-		MinNodeCount: utils.Int32(int32(v["min_node_count"].(int))),
-		Enabled:      utils.Bool(true),
-		MaxNodeCount: utils.Int32(int32(v["max_node_count"].(int))),
+		MinNodeCount: pointer.To(int32(v["min_node_count"].(int))),
+		Enabled:      pointer.To(true),
+		MaxNodeCount: pointer.To(int32(v["max_node_count"].(int))),
 	}
 }
 
@@ -496,8 +497,8 @@ func expandArmSparkPoolLibraryRequirements(input []interface{}) *synapse.Library
 	}
 	v := input[0].(map[string]interface{})
 	return &synapse.LibraryRequirements{
-		Content:  utils.String(v["content"].(string)),
-		Filename: utils.String(v["filename"].(string)),
+		Content:  pointer.To(v["content"].(string)),
+		Filename: pointer.To(v["filename"].(string)),
 	}
 }
 
@@ -507,8 +508,8 @@ func expandSparkPoolSparkConfig(input []interface{}) *synapse.SparkConfigPropert
 	}
 	value := input[0].(map[string]interface{})
 	return &synapse.SparkConfigProperties{
-		Content:  utils.String(value["content"].(string)),
-		Filename: utils.String(value["filename"].(string)),
+		Content:  pointer.To(value["content"].(string)),
+		Filename: pointer.To(value["filename"].(string)),
 	}
 }
 

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -143,12 +144,12 @@ func (r SynapseSparkPoolResource) Exists(ctx context.Context, client *clients.Cl
 	resp, err := client.Synapse.SparkPoolClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.BigDataPoolName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Spark Pool %q (Workspace %q / Resource Group %q): %+v", id.BigDataPoolName, id.WorkspaceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseSparkPoolResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
@@ -112,15 +113,15 @@ func resourceSynapseSqlPoolExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resou
 	params := synapse.ExtendedSQLPoolBlobAuditingPolicy{
 		ExtendedSQLPoolBlobAuditingPolicyProperties: &synapse.ExtendedSQLPoolBlobAuditingPolicyProperties{
 			State:                       synapse.BlobAuditingPolicyStateEnabled,
-			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
-			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
-			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
+			StorageEndpoint:             pointer.To(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse:  pointer.To(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:               pointer.To(int32(d.Get("retention_in_days").(int))),
+			IsAzureMonitorTargetEnabled: pointer.To(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		params.StorageAccountAccessKey = utils.String(v.(string))
+		params.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	_, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName, params)

--- a/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -174,12 +175,12 @@ func (SynapseSqlPoolExtendedAuditingPolicyResource) Exists(ctx context.Context, 
 	resp, err := client.Synapse.SqlPoolExtendedBlobAuditingPoliciesClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (SynapseSqlPoolExtendedAuditingPolicyResource) template(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_resource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -236,18 +237,18 @@ func resourceSynapseSqlPoolCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	sqlPoolInfo := synapse.SQLPool{
 		Location: workspace.Location,
 		SQLPoolResourceProperties: &synapse.SQLPoolResourceProperties{
-			CreateMode:         synapse.CreateMode(*utils.String(mode)),
+			CreateMode:         synapse.CreateMode(*pointer.To(mode)),
 			StorageAccountType: storageAccountType,
 		},
 		Sku: &synapse.Sku{
-			Name: utils.String(d.Get("sku_name").(string)),
+			Name: pointer.To(d.Get("sku_name").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	switch mode {
 	case DefaultCreateMode:
-		sqlPoolInfo.Collation = utils.String(d.Get("collation").(string))
+		sqlPoolInfo.Collation = pointer.To(d.Get("collation").(string))
 	case RecoveryCreateMode:
 		recoveryDatabaseId := constructSourceDatabaseId(d.Get("recovery_database_id").(string))
 
@@ -255,7 +256,7 @@ func resourceSynapseSqlPoolCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("`recovery_database_id` must be set when `create_mode` is %q", RecoveryCreateMode)
 		}
 
-		sqlPoolInfo.RecoverableDatabaseID = utils.String(recoveryDatabaseId)
+		sqlPoolInfo.RecoverableDatabaseID = pointer.To(recoveryDatabaseId)
 	case PointInTimeRestoreCreateMode:
 		restore := d.Get("restore").([]interface{})
 		if len(restore) == 0 || restore[0] == nil {
@@ -271,7 +272,7 @@ func resourceSynapseSqlPoolCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 
 		sqlPoolInfo.RestorePointInTime = &date.Time{Time: vTime}
-		sqlPoolInfo.SourceDatabaseID = utils.String(sourceDatabaseId)
+		sqlPoolInfo.SourceDatabaseID = pointer.To(sourceDatabaseId)
 	}
 
 	future, err := sqlClient.Create(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, sqlPoolInfo)
@@ -362,7 +363,7 @@ func resourceSynapseSqlPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	if d.HasChanges("sku_name", "tags") {
 		sqlPoolInfo := synapse.SQLPoolPatchInfo{
 			Sku: &synapse.Sku{
-				Name: utils.String(d.Get("sku_name").(string)),
+				Name: pointer.To(d.Get("sku_name").(string)),
 			},
 			Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 		}

--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -171,12 +172,12 @@ func (r SynapseSqlPoolResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.Synapse.SqlPoolClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Sql Pool %q (Workspace %q / Resource Group %q): %+v", id.Name, id.WorkspaceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseSqlPoolResource) template(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -254,19 +255,19 @@ func expandSQLPoolSecurityAlertPolicy(d *pluginsdk.ResourceData) *synapse.SQLPoo
 	}
 
 	if v, ok := d.GetOk("email_account_admins_enabled"); ok {
-		props.EmailAccountAdmins = utils.Bool(v.(bool))
+		props.EmailAccountAdmins = pointer.To(v.(bool))
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
-		props.RetentionDays = utils.Int32(int32(v.(int)))
+		props.RetentionDays = pointer.To(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_endpoint"); ok {
-		props.StorageEndpoint = utils.String(v.(string))
+		props.StorageEndpoint = pointer.To(v.(string))
 	}
 
 	return &policy

--- a/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -64,12 +65,12 @@ func (SynapseSqlPoolSecurityAlertPolicyResource) Exists(ctx context.Context, cli
 	resp, err := client.Synapse.SqlPoolSecurityAlertPolicyClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseSqlPoolSecurityAlertPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_baseline_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_baseline_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -102,12 +103,12 @@ func (SynapseSqlPoolVulnerabilityAssessmentBaselineResource) Exists(ctx context.
 	resp, err := client.Synapse.SQLPoolVulnerabilityAssessmentRuleBaselinesClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName, id.RuleName, synapse.VulnerabilityAssessmentPolicyBaselineName(id.BaselineName))
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseSqlPoolVulnerabilityAssessmentBaselineResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -210,11 +211,11 @@ func expandSqlPoolVulnerabilityAssessment(d *pluginsdk.ResourceData) *synapse.SQ
 	props := vulnerabilityAssessment.SQLPoolVulnerabilityAssessmentProperties
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_container_sas_key"); ok {
-		props.StorageContainerSasKey = utils.String(v.(string))
+		props.StorageContainerSasKey = pointer.To(v.(string))
 	}
 
 	if _, ok := d.GetOk("recurring_scans"); ok {

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -64,12 +65,12 @@ func (SynapseSqlPoolVulnerabilityAssessmentResource) Exists(ctx context.Context,
 	resp, err := client.Synapse.SqlPoolVulnerabilityAssessmentsClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseSqlPoolVulnerabilityAssessmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_workload_classifier_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_classifier_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
@@ -130,12 +131,12 @@ func resourceSynapseSQLPoolWorkloadClassifierCreateUpdate(d *pluginsdk.ResourceD
 
 	parameters := synapse.WorkloadClassifier{
 		WorkloadClassifierProperties: &synapse.WorkloadClassifierProperties{
-			Context:    utils.String(d.Get("context").(string)),
-			EndTime:    utils.String(d.Get("end_time").(string)),
-			Importance: utils.String(d.Get("importance").(string)),
-			Label:      utils.String(d.Get("label").(string)),
-			MemberName: utils.String(d.Get("member_name").(string)),
-			StartTime:  utils.String(d.Get("start_time").(string)),
+			Context:    pointer.To(d.Get("context").(string)),
+			EndTime:    pointer.To(d.Get("end_time").(string)),
+			Importance: pointer.To(d.Get("importance").(string)),
+			Label:      pointer.To(d.Get("label").(string)),
+			MemberName: pointer.To(d.Get("member_name").(string)),
+			StartTime:  pointer.To(d.Get("start_time").(string)),
 		},
 	}
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName, id.WorkloadGroupName, id.WorkloadClassifierName, parameters)

--- a/internal/services/synapse/synapse_sql_pool_workload_classifier_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_classifier_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -101,12 +102,12 @@ func (r SynapseWorkloadClassifierResource) Exists(ctx context.Context, client *c
 	resp, err := client.Synapse.SQLPoolWorkloadClassifierClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName, id.WorkloadGroupName, id.WorkloadClassifierName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseWorkloadClassifierResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_sql_pool_workload_group_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_group_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
@@ -118,16 +119,16 @@ func resourceSynapseSQLPoolWorkloadGroupCreateUpdate(d *pluginsdk.ResourceData, 
 
 	parameters := synapse.WorkloadGroup{
 		WorkloadGroupProperties: &synapse.WorkloadGroupProperties{
-			Importance:                   utils.String(d.Get("importance").(string)),
-			MaxResourcePercent:           utils.Int32(int32(d.Get("max_resource_percent").(int))),
-			MaxResourcePercentPerRequest: utils.Float(d.Get("max_resource_percent_per_request").(float64)),
-			MinResourcePercent:           utils.Int32(int32(d.Get("min_resource_percent").(int))),
-			MinResourcePercentPerRequest: utils.Float(d.Get("min_resource_percent_per_request").(float64)),
+			Importance:                   pointer.To(d.Get("importance").(string)),
+			MaxResourcePercent:           pointer.To(int32(d.Get("max_resource_percent").(int))),
+			MaxResourcePercentPerRequest: pointer.To(d.Get("max_resource_percent_per_request").(float64)),
+			MinResourcePercent:           pointer.To(int32(d.Get("min_resource_percent").(int))),
+			MinResourcePercentPerRequest: pointer.To(d.Get("min_resource_percent_per_request").(float64)),
 		},
 	}
 
 	if timeout, ok := d.GetOk("query_execution_timeout_in_seconds"); ok {
-		parameters.QueryExecutionTimeout = utils.Int32(int32(timeout.(int)))
+		parameters.QueryExecutionTimeout = pointer.To(int32(timeout.(int)))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName, id.WorkloadGroupName, parameters)

--- a/internal/services/synapse/synapse_sql_pool_workload_group_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_group_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -101,12 +102,12 @@ func (r SynapseWorkloadGroupResource) Exists(ctx context.Context, client *client
 	resp, err := client.Synapse.SQLPoolWorkloadGroupClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.SqlPoolName, id.WorkloadGroupName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseWorkloadGroupResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_aad_admin_resource.go
+++ b/internal/services/synapse/synapse_workspace_aad_admin_resource.go
@@ -79,10 +79,10 @@ func resourceSynapseWorkspaceAADAdminCreateUpdate(d *pluginsdk.ResourceData, met
 
 	aadAdmin := &synapse.WorkspaceAadAdminInfo{
 		AadAdminProperties: &synapse.AadAdminProperties{
-			TenantID:          utils.String(d.Get("tenant_id").(string)),
-			Login:             utils.String(d.Get("login").(string)),
-			AdministratorType: utils.String("ActiveDirectory"),
-			Sid:               utils.String(d.Get("object_id").(string)),
+			TenantID:          pointer.To(d.Get("tenant_id").(string)),
+			Login:             pointer.To(d.Get("login").(string)),
+			AdministratorType: pointer.To("ActiveDirectory"),
+			Sid:               pointer.To(d.Get("object_id").(string)),
 		},
 	}
 

--- a/internal/services/synapse/synapse_workspace_aad_admin_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_aad_admin_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -42,12 +43,12 @@ func (r SynapseWorkspaceAADAdminResource) Exists(ctx context.Context, client *cl
 	resp, err := client.Synapse.WorkspaceAadAdminsClient.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Workspace %q (Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseWorkspaceAADAdminResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource.go
+++ b/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -113,15 +114,15 @@ func resourceSynapseWorkspaceExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Res
 	params := synapse.ExtendedServerBlobAuditingPolicy{
 		ExtendedServerBlobAuditingPolicyProperties: &synapse.ExtendedServerBlobAuditingPolicyProperties{
 			State:                       synapse.BlobAuditingPolicyStateEnabled,
-			StorageEndpoint:             utils.String(d.Get("storage_endpoint").(string)),
-			IsStorageSecondaryKeyInUse:  utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
-			RetentionDays:               utils.Int32(int32(d.Get("retention_in_days").(int))),
-			IsAzureMonitorTargetEnabled: utils.Bool(d.Get("log_monitoring_enabled").(bool)),
+			StorageEndpoint:             pointer.To(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse:  pointer.To(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:               pointer.To(int32(d.Get("retention_in_days").(int))),
+			IsAzureMonitorTargetEnabled: pointer.To(d.Get("log_monitoring_enabled").(bool)),
 		},
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		params.StorageAccountAccessKey = utils.String(v.(string))
+		params.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, params)

--- a/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -174,12 +175,12 @@ func (SynapseWorkspaceExtendedAuditingPolicyResource) Exists(ctx context.Context
 	resp, err := client.Synapse.WorkspaceExtendedBlobAuditingPoliciesClient.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (SynapseWorkspaceExtendedAuditingPolicyResource) template(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
@@ -86,7 +87,7 @@ func resourceSynapseWorkspaceKeysCreateUpdate(d *pluginsdk.ResourceData, meta in
 
 	keyProperties := synapse.KeyProperties{
 		IsActiveCMK: &isActiveCMK,
-		KeyVaultURL: utils.String(key.(string)),
+		KeyVaultURL: pointer.To(key.(string)),
 	}
 
 	synapseKey := synapse.Key{

--- a/internal/services/synapse/synapse_workspace_key_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_key_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -64,12 +65,12 @@ func (r SynapseWorkspaceKeysResource) Exists(ctx context.Context, client *client
 	resp, err := client.Synapse.KeysClient.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.KeyName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Workspace Key %q (Workspace %q): %+v", id.KeyName, id.WorkspaceName, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseWorkspaceKeysResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -302,17 +302,17 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	workspaceInfo := synapse.Workspace{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		WorkspaceProperties: &synapse.WorkspaceProperties{
 			DefaultDataLakeStorage:           expandArmWorkspaceDataLakeStorageAccountDetails(d.Get("storage_data_lake_gen2_filesystem_id").(string)),
-			ManagedVirtualNetwork:            utils.String(managedVirtualNetwork),
+			ManagedVirtualNetwork:            pointer.To(managedVirtualNetwork),
 			PublicNetworkAccess:              publicNetworkAccess,
-			SQLAdministratorLogin:            utils.String(d.Get("sql_administrator_login").(string)),
-			SQLAdministratorLoginPassword:    utils.String(d.Get("sql_administrator_login_password").(string)),
-			ManagedResourceGroupName:         utils.String(d.Get("managed_resource_group_name").(string)),
+			SQLAdministratorLogin:            pointer.To(d.Get("sql_administrator_login").(string)),
+			SQLAdministratorLoginPassword:    pointer.To(d.Get("sql_administrator_login_password").(string)),
+			ManagedResourceGroupName:         pointer.To(d.Get("managed_resource_group_name").(string)),
 			WorkspaceRepositoryConfiguration: expandWorkspaceRepositoryConfiguration(d),
 			Encryption:                       expandEncryptionDetails(d),
-			AzureADOnlyAuthentication:        utils.Bool(d.Get("azuread_authentication_only").(bool)),
+			AzureADOnlyAuthentication:        pointer.To(d.Get("azuread_authentication_only").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -325,13 +325,13 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	if purviewId, ok := d.GetOk("purview_id"); ok {
 		workspaceInfo.PurviewConfiguration = &synapse.PurviewConfiguration{
-			PurviewResourceID: utils.String(purviewId.(string)),
+			PurviewResourceID: pointer.To(purviewId.(string)),
 		}
 	}
 
 	if computeSubnetId, ok := d.GetOk("compute_subnet_id"); ok {
 		workspaceInfo.VirtualNetworkProfile = &synapse.VirtualNetworkProfile{
-			ComputeSubnetID: utils.String(computeSubnetId.(string)),
+			ComputeSubnetID: pointer.To(computeSubnetId.(string)),
 		}
 	}
 
@@ -339,7 +339,7 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	if dataExfiltrationProtectionEnabled {
 		workspaceInfo.ManagedVirtualNetworkSettings = &synapse.ManagedVirtualNetworkSettings{
-			PreventDataExfiltration: utils.Bool(dataExfiltrationProtectionEnabled),
+			PreventDataExfiltration: pointer.To(dataExfiltrationProtectionEnabled),
 		}
 	}
 
@@ -489,7 +489,7 @@ func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		workspacePatchInfo := synapse.WorkspacePatchInfo{
 			Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 			WorkspacePatchProperties: &synapse.WorkspacePatchProperties{
-				SQLAdministratorLoginPassword:    utils.String(d.Get("sql_administrator_login_password").(string)),
+				SQLAdministratorLoginPassword:    pointer.To(d.Get("sql_administrator_login_password").(string)),
 				WorkspaceRepositoryConfiguration: expandWorkspaceRepositoryConfiguration(d),
 				Encryption:                       expandEncryptionDetails(d),
 				PublicNetworkAccess:              publicNetworkAccess,
@@ -505,7 +505,7 @@ func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 		if purviewId, ok := d.GetOk("purview_id"); ok {
 			workspacePatchInfo.PurviewConfiguration = &synapse.PurviewConfiguration{
-				PurviewResourceID: utils.String(purviewId.(string)),
+				PurviewResourceID: pointer.To(purviewId.(string)),
 			}
 		}
 
@@ -665,8 +665,8 @@ func synapseWorkspaceProvisioningStateRefreshFunc(ctx context.Context, client *s
 func expandArmWorkspaceDataLakeStorageAccountDetails(storageDataLakeGen2FilesystemId string) *synapse.DataLakeStorageAccountDetails {
 	uri, _ := url.Parse(storageDataLakeGen2FilesystemId)
 	return &synapse.DataLakeStorageAccountDetails{
-		AccountURL: utils.String(fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)), // https://storageaccountname.dfs.core.windows.net/filesystemname -> https://storageaccountname.dfs.core.windows.net
-		Filesystem: utils.String(strings.TrimPrefix(uri.Path, "/")),            // https://storageaccountname.dfs.core.windows.net/filesystemname -> filesystemname
+		AccountURL: pointer.To(fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)), // https://storageaccountname.dfs.core.windows.net/filesystemname -> https://storageaccountname.dfs.core.windows.net
+		Filesystem: pointer.To(strings.TrimPrefix(uri.Path, "/")),            // https://storageaccountname.dfs.core.windows.net/filesystemname -> filesystemname
 	}
 }
 
@@ -674,13 +674,13 @@ func expandWorkspaceRepositoryConfiguration(d *pluginsdk.ResourceData) *synapse.
 	if azdoList, ok := d.GetOk("azure_devops_repo"); ok {
 		azdo := azdoList.([]interface{})[0].(map[string]interface{})
 		config := synapse.WorkspaceRepositoryConfiguration{
-			Type:                utils.String(workspaceVSTSConfiguration),
-			AccountName:         utils.String(azdo["account_name"].(string)),
-			CollaborationBranch: utils.String(azdo["branch_name"].(string)),
-			LastCommitID:        utils.String(azdo["last_commit_id"].(string)),
-			ProjectName:         utils.String(azdo["project_name"].(string)),
-			RepositoryName:      utils.String(azdo["repository_name"].(string)),
-			RootFolder:          utils.String(azdo["root_folder"].(string)),
+			Type:                pointer.To(workspaceVSTSConfiguration),
+			AccountName:         pointer.To(azdo["account_name"].(string)),
+			CollaborationBranch: pointer.To(azdo["branch_name"].(string)),
+			LastCommitID:        pointer.To(azdo["last_commit_id"].(string)),
+			ProjectName:         pointer.To(azdo["project_name"].(string)),
+			RepositoryName:      pointer.To(azdo["repository_name"].(string)),
+			RootFolder:          pointer.To(azdo["root_folder"].(string)),
 		}
 		if azdoTenantId := uuid.FromStringOrNil(azdo["tenant_id"].(string)); azdoTenantId != uuid.Nil {
 			config.TenantID = &azdoTenantId
@@ -691,13 +691,13 @@ func expandWorkspaceRepositoryConfiguration(d *pluginsdk.ResourceData) *synapse.
 	if githubList, ok := d.GetOk("github_repo"); ok {
 		github := githubList.([]interface{})[0].(map[string]interface{})
 		return &synapse.WorkspaceRepositoryConfiguration{
-			Type:                utils.String(workspaceGitHubConfiguration),
-			AccountName:         utils.String(github["account_name"].(string)),
-			CollaborationBranch: utils.String(github["branch_name"].(string)),
-			HostName:            utils.String(github["git_url"].(string)),
-			LastCommitID:        utils.String(github["last_commit_id"].(string)),
-			RepositoryName:      utils.String(github["repository_name"].(string)),
-			RootFolder:          utils.String(github["root_folder"].(string)),
+			Type:                pointer.To(workspaceGitHubConfiguration),
+			AccountName:         pointer.To(github["account_name"].(string)),
+			CollaborationBranch: pointer.To(github["branch_name"].(string)),
+			HostName:            pointer.To(github["git_url"].(string)),
+			LastCommitID:        pointer.To(github["last_commit_id"].(string)),
+			RepositoryName:      pointer.To(github["repository_name"].(string)),
+			RootFolder:          pointer.To(github["root_folder"].(string)),
 		}
 	}
 
@@ -729,8 +729,8 @@ func expandEncryptionDetails(d *pluginsdk.ResourceData) *synapse.EncryptionDetai
 		encryptionDetails := &synapse.EncryptionDetails{
 			Cmk: &synapse.CustomerManagedKeyDetails{
 				Key: &synapse.WorkspaceKeyDetails{
-					Name:        utils.String(cmk["key_name"].(string)),
-					KeyVaultURL: utils.String(cmk["key_versionless_id"].(string)),
+					Name:        pointer.To(cmk["key_name"].(string)),
+					KeyVaultURL: pointer.To(cmk["key_versionless_id"].(string)),
 				},
 			},
 		}
@@ -872,8 +872,8 @@ func flattenIdentity(input *synapse.ManagedIdentity) (interface{}, error) {
 		if input.UserAssignedIdentities != nil {
 			for k, v := range input.UserAssignedIdentities {
 				identityIds[k] = identity.UserAssignedIdentityDetails{
-					ClientId:    utils.String(v.ClientID.String()),
-					PrincipalId: utils.String(v.PrincipalID.String()),
+					ClientId:    pointer.To(v.ClientID.String()),
+					PrincipalId: pointer.To(v.PrincipalID.String()),
 				}
 			}
 		}

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -240,12 +241,12 @@ func (r SynapseWorkspaceResource) Exists(ctx context.Context, client *clients.Cl
 	resp, err := client.Synapse.WorkspaceClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Workspace %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseWorkspaceResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_security_alert_policy_resource.go
+++ b/internal/services/synapse/synapse_workspace_security_alert_policy_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -262,19 +263,19 @@ func expandServerSecurityAlertPolicy(d *pluginsdk.ResourceData) *synapse.ServerS
 	}
 
 	if v, ok := d.GetOk("email_account_admins_enabled"); ok {
-		props.EmailAccountAdmins = utils.Bool(v.(bool))
+		props.EmailAccountAdmins = pointer.To(v.(bool))
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
-		props.RetentionDays = utils.Int32(int32(v.(int)))
+		props.RetentionDays = pointer.To(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_endpoint"); ok {
-		props.StorageEndpoint = utils.String(v.(string))
+		props.StorageEndpoint = pointer.To(v.(string))
 	}
 
 	return &policy

--- a/internal/services/synapse/synapse_workspace_security_alert_policy_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_security_alert_policy_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -64,12 +65,12 @@ func (SynapseWorkspaceSecurityAlertPolicyResource) Exists(ctx context.Context, c
 	resp, err := client.Synapse.WorkspaceSecurityAlertPolicyClient.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseWorkspaceSecurityAlertPolicyResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_sql_aad_admin_resource.go
+++ b/internal/services/synapse/synapse_workspace_sql_aad_admin_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -78,10 +79,10 @@ func resourceSynapseWorkspaceSqlAADAdminCreateUpdate(d *pluginsdk.ResourceData, 
 
 	aadAdmin := &synapse.WorkspaceAadAdminInfo{
 		AadAdminProperties: &synapse.AadAdminProperties{
-			TenantID:          utils.String(d.Get("tenant_id").(string)),
-			Login:             utils.String(d.Get("login").(string)),
-			AdministratorType: utils.String("ActiveDirectory"),
-			Sid:               utils.String(d.Get("object_id").(string)),
+			TenantID:          pointer.To(d.Get("tenant_id").(string)),
+			Login:             pointer.To(d.Get("login").(string)),
+			AdministratorType: pointer.To("ActiveDirectory"),
+			Sid:               pointer.To(d.Get("object_id").(string)),
 		},
 	}
 

--- a/internal/services/synapse/synapse_workspace_sql_aad_admin_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_sql_aad_admin_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -42,12 +43,12 @@ func (r SynapseWorkspaceSqlAADAdminResource) Exists(ctx context.Context, client 
 	resp, err := client.Synapse.WorkspaceAadAdminsClient.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Synapse Workspace %q (Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r SynapseWorkspaceSqlAADAdminResource) basic(data acceptance.TestData) string {

--- a/internal/services/synapse/synapse_workspace_vulnerability_assessment_resource.go
+++ b/internal/services/synapse/synapse_workspace_vulnerability_assessment_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/synapse/validate"
@@ -209,11 +210,11 @@ func expandServerVulnerabilityAssessment(d *pluginsdk.ResourceData) *synapse.Ser
 	props := vulnerabilityAssessment.ServerVulnerabilityAssessmentProperties
 
 	if v, ok := d.GetOk("storage_account_access_key"); ok {
-		props.StorageAccountAccessKey = utils.String(v.(string))
+		props.StorageAccountAccessKey = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("storage_container_sas_key"); ok {
-		props.StorageContainerSasKey = utils.String(v.(string))
+		props.StorageContainerSasKey = pointer.To(v.(string))
 	}
 
 	if _, ok := d.GetOk("recurring_scans"); ok {
@@ -234,11 +235,11 @@ func expandRecurringScans(d *pluginsdk.ResourceData) *synapse.VulnerabilityAsses
 	v := vs[0].(map[string]interface{})
 
 	if enabled, ok := v["enabled"]; ok {
-		props.IsEnabled = utils.Bool(enabled.(bool))
+		props.IsEnabled = pointer.To(enabled.(bool))
 	}
 
 	if emailSubscriptionAdmins, ok := v["email_subscription_admins_enabled"]; ok {
-		props.EmailSubscriptionAdmins = utils.Bool(emailSubscriptionAdmins.(bool))
+		props.EmailSubscriptionAdmins = pointer.To(emailSubscriptionAdmins.(bool))
 	}
 
 	if _, ok := v["emails"]; ok {

--- a/internal/services/synapse/synapse_workspace_vulnerability_assessment_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_vulnerability_assessment_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -64,12 +65,12 @@ func (SynapseWorkspaceVulnerabilityAssessmentResource) Exists(ctx context.Contex
 	resp, err := client.Synapse.WorkspaceVulnerabilityAssessmentsClient.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return pointer.To(resp.ID != nil), nil
 }
 
 func (r SynapseWorkspaceVulnerabilityAssessmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_availability_set_resource.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_availability_set_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/systemcentervirtualmachinemanager/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SystemCenterVirtualMachineManagerAvailabilitySetModel struct {
@@ -106,12 +105,12 @@ func (r SystemCenterVirtualMachineManagerAvailabilitySetResource) Create() sdk.R
 			parameters := availabilitysets.AvailabilitySet{
 				Location: location.Normalize(model.Location),
 				ExtendedLocation: availabilitysets.ExtendedLocation{
-					Type: utils.String("customLocation"),
-					Name: utils.String(model.CustomLocationId),
+					Type: pointer.To("customLocation"),
+					Name: pointer.To(model.CustomLocationId),
 				},
 				Properties: &availabilitysets.AvailabilitySetProperties{
-					AvailabilitySetName: utils.String(id.AvailabilitySetName),
-					VMmServerId:         utils.String(scvmmServerId.ID()),
+					AvailabilitySetName: pointer.To(id.AvailabilitySetName),
+					VMmServerId:         pointer.To(scvmmServerId.ID()),
 				},
 				Tags: pointer.To(model.Tags),
 			}

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_availability_set_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_availability_set_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/systemcentervirtualmachinemanager/2023-10-07/availabilitysets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SystemCenterVirtualMachineManagerAvailabilitySetResource struct{}
@@ -128,7 +128,7 @@ func (r SystemCenterVirtualMachineManagerAvailabilitySetResource) Exists(ctx con
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SystemCenterVirtualMachineManagerAvailabilitySetResource) basic(data acceptance.TestData) string {

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_cloud_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_cloud_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/systemcentervirtualmachinemanager/2023-10-07/clouds"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SystemCenterVirtualMachineManagerCloudResource struct{}
@@ -128,7 +128,7 @@ func (r SystemCenterVirtualMachineManagerCloudResource) Exists(ctx context.Conte
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SystemCenterVirtualMachineManagerCloudResource) basic(data acceptance.TestData) string {

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_server_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/systemcentervirtualmachinemanager/2023-10-07/vmmservers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SystemCenterVirtualMachineManagerServerResource struct{}
@@ -114,7 +114,7 @@ func (r SystemCenterVirtualMachineManagerServerResource) Exists(ctx context.Cont
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SystemCenterVirtualMachineManagerServerResource) basic(data acceptance.TestData) string {

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_virtual_machine_template_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_virtual_machine_template_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/systemcentervirtualmachinemanager/2023-10-07/virtualmachinetemplates"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SystemCenterVirtualMachineManagerVirtualMachineTemplateResource struct{}
@@ -128,7 +128,7 @@ func (r SystemCenterVirtualMachineManagerVirtualMachineTemplateResource) Exists(
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SystemCenterVirtualMachineManagerVirtualMachineTemplateResource) basic(data acceptance.TestData) string {

--- a/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_virtual_network_resource_test.go
+++ b/internal/services/systemcentervirtualmachinemanager/system_center_virtual_machine_manager_virtual_network_resource_test.go
@@ -9,12 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/systemcentervirtualmachinemanager/2023-10-07/virtualnetworks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type SystemCenterVirtualMachineManagerVirtualNetworkResource struct{}
@@ -128,7 +128,7 @@ func (r SystemCenterVirtualMachineManagerVirtualNetworkResource) Exists(ctx cont
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SystemCenterVirtualMachineManagerVirtualNetworkResource) basic(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
