### PR TITLE
services `T*`/`V*`/`W*` - deprecated function clean up

### DIFF
--- a/internal/services/trafficmanager/endpoint.go
+++ b/internal/services/trafficmanager/endpoint.go
@@ -4,8 +4,8 @@
 package trafficmanager
 
 import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2022-04-01/endpoints"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func expandEndpointCustomHeaderConfig(input []interface{}) *[]endpoints.EndpointPropertiesCustomHeadersInlined {
@@ -14,8 +14,8 @@ func expandEndpointCustomHeaderConfig(input []interface{}) *[]endpoints.Endpoint
 	for _, header := range input {
 		headerBlock := header.(map[string]interface{})
 		output = append(output, endpoints.EndpointPropertiesCustomHeadersInlined{
-			Name:  utils.String(headerBlock["name"].(string)),
-			Value: utils.String(headerBlock["value"].(string)),
+			Name:  pointer.To(headerBlock["name"].(string)),
+			Value: pointer.To(headerBlock["value"].(string)),
 		})
 	}
 
@@ -52,13 +52,13 @@ func expandEndpointSubnetConfig(input []interface{}) *[]endpoints.EndpointProper
 		subnetBlock := subnet.(map[string]interface{})
 		if subnetBlock["scope"].(int) == 0 && subnetBlock["first"].(string) != "0.0.0.0" {
 			output = append(output, endpoints.EndpointPropertiesSubnetsInlined{
-				First: utils.String(subnetBlock["first"].(string)),
-				Last:  utils.String(subnetBlock["last"].(string)),
+				First: pointer.To(subnetBlock["first"].(string)),
+				Last:  pointer.To(subnetBlock["last"].(string)),
 			})
 		} else {
 			output = append(output, endpoints.EndpointPropertiesSubnetsInlined{
-				First: utils.String(subnetBlock["first"].(string)),
-				Scope: utils.Int64(int64(subnetBlock["scope"].(int))),
+				First: pointer.To(subnetBlock["first"].(string)),
+				Scope: pointer.To(int64(subnetBlock["scope"].(int))),
 			})
 		}
 	}

--- a/internal/services/trafficmanager/traffic_manager_azure_endpoint_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_azure_endpoint_resource.go
@@ -19,7 +19,6 @@ import (
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceAzureEndpoint() *pluginsdk.Resource {
@@ -178,13 +177,13 @@ func resourceAzureEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	params := endpoints.Endpoint{
-		Name: utils.String(id.EndpointName),
-		Type: utils.String(fmt.Sprintf("Microsoft.Network/trafficManagerProfiles/%s", endpoints.EndpointTypeAzureEndpoints)),
+		Name: pointer.To(id.EndpointName),
+		Type: pointer.To(fmt.Sprintf("Microsoft.Network/trafficManagerProfiles/%s", endpoints.EndpointTypeAzureEndpoints)),
 		Properties: &endpoints.EndpointProperties{
 			CustomHeaders:    expandEndpointCustomHeaderConfig(d.Get("custom_header").([]interface{})),
 			AlwaysServe:      pointer.To(endpoints.AlwaysServeDisabled),
 			EndpointStatus:   &status,
-			TargetResourceId: utils.String(d.Get("target_resource_id").(string)),
+			TargetResourceId: pointer.To(d.Get("target_resource_id").(string)),
 			Subnets:          expandEndpointSubnetConfig(d.Get("subnet").([]interface{})),
 		},
 	}
@@ -194,11 +193,11 @@ func resourceAzureEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	if priority := d.Get("priority").(int); priority != 0 {
-		params.Properties.Priority = utils.Int64(int64(priority))
+		params.Properties.Priority = pointer.To(int64(priority))
 	}
 
 	if weight := d.Get("weight").(int); weight != 0 {
-		params.Properties.Weight = utils.Int64(int64(weight))
+		params.Properties.Weight = pointer.To(int64(weight))
 	}
 
 	inputMappings := d.Get("geo_mappings").([]interface{})
@@ -314,7 +313,7 @@ func resourceAzureEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("target_resource_id") {
-		params.Properties.TargetResourceId = utils.String(d.Get("target_resource_id").(string))
+		params.Properties.TargetResourceId = pointer.To(d.Get("target_resource_id").(string))
 	}
 
 	if d.HasChange("subnet") {
@@ -323,13 +322,13 @@ func resourceAzureEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 
 	if d.HasChange("priority") {
 		if priority := d.Get("priority").(int); priority != 0 {
-			params.Properties.Priority = utils.Int64(int64(priority))
+			params.Properties.Priority = pointer.To(int64(priority))
 		}
 	}
 
 	if d.HasChange("weight") {
 		if weight := d.Get("weight").(int); weight != 0 {
-			params.Properties.Weight = utils.Int64(int64(weight))
+			params.Properties.Weight = pointer.To(int64(weight))
 		}
 	}
 

--- a/internal/services/trafficmanager/traffic_manager_azure_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_azure_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2022-04-01/endpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AzureEndpointResource struct{}
@@ -132,12 +132,12 @@ func (r AzureEndpointResource) Exists(ctx context.Context, client *clients.Clien
 	resp, err := client.TrafficManager.EndpointsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r AzureEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/trafficmanager/traffic_manager_external_endpoint_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_external_endpoint_resource.go
@@ -19,7 +19,6 @@ import (
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceExternalEndpoint() *pluginsdk.Resource {
@@ -186,13 +185,13 @@ func resourceExternalEndpointCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	params := endpoints.Endpoint{
-		Name: utils.String(id.EndpointName),
-		Type: utils.String(fmt.Sprintf("Microsoft.Network/trafficManagerProfiles/%s", endpoints.EndpointTypeExternalEndpoints)),
+		Name: pointer.To(id.EndpointName),
+		Type: pointer.To(fmt.Sprintf("Microsoft.Network/trafficManagerProfiles/%s", endpoints.EndpointTypeExternalEndpoints)),
 		Properties: &endpoints.EndpointProperties{
 			AlwaysServe:    pointer.To(endpoints.AlwaysServeDisabled),
 			CustomHeaders:  expandEndpointCustomHeaderConfig(d.Get("custom_header").([]interface{})),
 			EndpointStatus: &status,
-			Target:         utils.String(d.Get("target").(string)),
+			Target:         pointer.To(d.Get("target").(string)),
 			Subnets:        expandEndpointSubnetConfig(d.Get("subnet").([]interface{})),
 		},
 	}
@@ -202,15 +201,15 @@ func resourceExternalEndpointCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if priority := d.Get("priority").(int); priority != 0 {
-		params.Properties.Priority = utils.Int64(int64(priority))
+		params.Properties.Priority = pointer.To(int64(priority))
 	}
 
 	if weight := d.Get("weight").(int); weight != 0 {
-		params.Properties.Weight = utils.Int64(int64(weight))
+		params.Properties.Weight = pointer.To(int64(weight))
 	}
 
 	if endpointLocation := d.Get("endpoint_location").(string); endpointLocation != "" {
-		params.Properties.EndpointLocation = utils.String(endpointLocation)
+		params.Properties.EndpointLocation = pointer.To(endpointLocation)
 	}
 
 	inputMappings := d.Get("geo_mappings").([]interface{})
@@ -327,7 +326,7 @@ func resourceExternalEndpointUpdate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if d.HasChange("target") {
-		params.Properties.Target = utils.String(d.Get("target").(string))
+		params.Properties.Target = pointer.To(d.Get("target").(string))
 	}
 
 	if d.HasChange("subnet") {
@@ -336,19 +335,19 @@ func resourceExternalEndpointUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	if d.HasChange("priority") {
 		if priority := d.Get("priority").(int); priority != 0 {
-			params.Properties.Priority = utils.Int64(int64(priority))
+			params.Properties.Priority = pointer.To(int64(priority))
 		}
 	}
 
 	if d.HasChange("weight") {
 		if weight := d.Get("weight").(int); weight != 0 {
-			params.Properties.Weight = utils.Int64(int64(weight))
+			params.Properties.Weight = pointer.To(int64(weight))
 		}
 	}
 
 	if d.HasChange("endpoint_location") {
 		if endpointLocation := d.Get("endpoint_location").(string); endpointLocation != "" {
-			params.Properties.EndpointLocation = utils.String(endpointLocation)
+			params.Properties.EndpointLocation = pointer.To(endpointLocation)
 		} else {
 			params.Properties.EndpointLocation = nil
 		}

--- a/internal/services/trafficmanager/traffic_manager_external_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_external_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2022-04-01/endpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type ExternalEndpointResource struct{}
@@ -147,11 +147,11 @@ func (r ExternalEndpointResource) Exists(ctx context.Context, client *clients.Cl
 	resp, err := client.TrafficManager.EndpointsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r ExternalEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/trafficmanager/traffic_manager_nested_endpoint_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_nested_endpoint_resource.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2022-04-01/endpoints"
@@ -19,7 +20,6 @@ import (
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceNestedEndpoint() *pluginsdk.Resource {
@@ -198,37 +198,37 @@ func resourceNestedEndpointCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	params := endpoints.Endpoint{
-		Name: utils.String(id.EndpointName),
-		Type: utils.String(fmt.Sprintf("Microsoft.Network/trafficManagerProfiles/%s", endpoints.EndpointTypeNestedEndpoints)),
+		Name: pointer.To(id.EndpointName),
+		Type: pointer.To(fmt.Sprintf("Microsoft.Network/trafficManagerProfiles/%s", endpoints.EndpointTypeNestedEndpoints)),
 		Properties: &endpoints.EndpointProperties{
 			CustomHeaders:     expandEndpointCustomHeaderConfig(d.Get("custom_header").([]interface{})),
 			EndpointStatus:    &status,
-			MinChildEndpoints: utils.Int64(int64(d.Get("minimum_child_endpoints").(int))),
-			TargetResourceId:  utils.String(d.Get("target_resource_id").(string)),
+			MinChildEndpoints: pointer.To(int64(d.Get("minimum_child_endpoints").(int))),
+			TargetResourceId:  pointer.To(d.Get("target_resource_id").(string)),
 			Subnets:           expandEndpointSubnetConfig(d.Get("subnet").([]interface{})),
 		},
 	}
 
 	if weight := d.Get("weight").(int); weight != 0 {
-		params.Properties.Weight = utils.Int64(int64(weight))
+		params.Properties.Weight = pointer.To(int64(weight))
 	}
 
 	minChildEndpointsIPv4 := d.Get("minimum_required_child_endpoints_ipv4").(int)
 	if minChildEndpointsIPv4 > 0 {
-		params.Properties.MinChildEndpointsIPv4 = utils.Int64(int64(minChildEndpointsIPv4))
+		params.Properties.MinChildEndpointsIPv4 = pointer.To(int64(minChildEndpointsIPv4))
 	}
 
 	minChildEndpointsIPv6 := d.Get("minimum_required_child_endpoints_ipv6").(int)
 	if minChildEndpointsIPv6 > 0 {
-		params.Properties.MinChildEndpointsIPv6 = utils.Int64(int64(minChildEndpointsIPv6))
+		params.Properties.MinChildEndpointsIPv6 = pointer.To(int64(minChildEndpointsIPv6))
 	}
 
 	if priority := d.Get("priority").(int); priority != 0 {
-		params.Properties.Priority = utils.Int64(int64(priority))
+		params.Properties.Priority = pointer.To(int64(priority))
 	}
 
 	if endpointLocation := d.Get("endpoint_location").(string); endpointLocation != "" {
-		params.Properties.EndpointLocation = utils.String(endpointLocation)
+		params.Properties.EndpointLocation = pointer.To(endpointLocation)
 	}
 
 	inputMappings := d.Get("geo_mappings").([]interface{})

--- a/internal/services/trafficmanager/traffic_manager_nested_endpoint_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_nested_endpoint_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2022-04-01/endpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NestedEndpointResource struct{}
@@ -132,11 +132,11 @@ func (r NestedEndpointResource) Exists(ctx context.Context, client *clients.Clie
 	resp, err := client.TrafficManager.EndpointsClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r NestedEndpointResource) basic(data acceptance.TestData) string {

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -23,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceArmTrafficManagerProfile() *pluginsdk.Resource {
@@ -220,8 +220,8 @@ func resourceArmTrafficManagerProfileCreate(d *pluginsdk.ResourceData, meta inte
 	trafficRoutingMethod := profiles.TrafficRoutingMethod(d.Get("traffic_routing_method").(string))
 	// No existing profile - start from a new struct.
 	profile := profiles.Profile{
-		Name:     utils.String(id.TrafficManagerProfileName),
-		Location: utils.String("global"), // must be provided in request
+		Name:     pointer.To(id.TrafficManagerProfileName),
+		Location: pointer.To("global"), // must be provided in request
 		Properties: &profiles.ProfileProperties{
 			TrafficRoutingMethod: &trafficRoutingMethod,
 			DnsConfig:            expandArmTrafficManagerDNSConfig(d),
@@ -231,7 +231,7 @@ func resourceArmTrafficManagerProfileCreate(d *pluginsdk.ResourceData, meta inte
 	}
 
 	if maxReturn, ok := d.GetOk("max_return"); ok {
-		profile.Properties.MaxReturn = utils.Int64(int64(maxReturn.(int)))
+		profile.Properties.MaxReturn = pointer.To(int64(maxReturn.(int)))
 	}
 
 	if status, ok := d.GetOk("profile_status"); ok {
@@ -345,7 +345,7 @@ func resourceArmTrafficManagerProfileUpdate(d *pluginsdk.ResourceData, meta inte
 
 	if d.HasChange("max_return") {
 		if maxReturn, ok := d.GetOk("max_return"); ok {
-			update.Properties.MaxReturn = utils.Int64(int64(maxReturn.(int)))
+			update.Properties.MaxReturn = pointer.To(int64(maxReturn.(int)))
 		}
 	}
 
@@ -400,11 +400,11 @@ func expandArmTrafficManagerMonitorConfig(d *pluginsdk.ResourceData) *profiles.M
 	cfg := profiles.MonitorConfig{
 		Protocol:                  &protocol,
 		CustomHeaders:             customHeaders,
-		Port:                      utils.Int64(int64(monitor["port"].(int))),
-		Path:                      utils.String(monitor["path"].(string)),
-		IntervalInSeconds:         utils.Int64(int64(monitor["interval_in_seconds"].(int))),
-		TimeoutInSeconds:          utils.Int64(int64(monitor["timeout_in_seconds"].(int))),
-		ToleratedNumberOfFailures: utils.Int64(int64(monitor["tolerated_number_of_failures"].(int))),
+		Port:                      pointer.To(int64(monitor["port"].(int))),
+		Path:                      pointer.To(monitor["path"].(string)),
+		IntervalInSeconds:         pointer.To(int64(monitor["interval_in_seconds"].(int))),
+		TimeoutInSeconds:          pointer.To(int64(monitor["timeout_in_seconds"].(int))),
+		ToleratedNumberOfFailures: pointer.To(int64(monitor["tolerated_number_of_failures"].(int))),
 	}
 
 	if v, ok := monitor["expected_status_code_ranges"].([]interface{}); ok {
@@ -414,8 +414,8 @@ func expandArmTrafficManagerMonitorConfig(d *pluginsdk.ResourceData) *profiles.M
 			min, _ := strconv.Atoi(parts[0])
 			max, _ := strconv.Atoi(parts[1])
 			ranges = append(ranges, profiles.MonitorConfigExpectedStatusCodeRangesInlined{
-				Min: utils.Int64(int64(min)),
-				Max: utils.Int64(int64(max)),
+				Min: pointer.To(int64(min)),
+				Max: pointer.To(int64(max)),
 			})
 		}
 		cfg.ExpectedStatusCodeRanges = &ranges
@@ -434,8 +434,8 @@ func expandArmTrafficManagerCustomHeadersConfig(d []interface{}) *[]profiles.Mon
 	for i, v := range d {
 		ch := v.(map[string]interface{})
 		customHeaders[i] = profiles.MonitorConfigCustomHeadersInlined{
-			Name:  utils.String(ch["name"].(string)),
-			Value: utils.String(ch["value"].(string)),
+			Name:  pointer.To(ch["name"].(string)),
+			Value: pointer.To(ch["value"].(string)),
 		}
 	}
 

--- a/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2022-04-01/profiles"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type TrafficManagerProfileResource struct{}
@@ -253,12 +253,12 @@ func (r TrafficManagerProfileResource) Exists(ctx context.Context, client *clien
 	resp, err := client.TrafficManager.ProfilesClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r TrafficManagerProfileResource) template(data acceptance.TestData) string {

--- a/internal/services/vmware/vmware_cluster_resource.go
+++ b/internal/services/vmware/vmware_cluster_resource.go
@@ -182,7 +182,7 @@ func resourceVmwareClusterUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 		Properties: &clusters.ClusterUpdateProperties{},
 	}
 	if d.HasChange("cluster_node_count") {
-		clusterUpdate.Properties.ClusterSize = utils.Int64(int64(d.Get("cluster_node_count").(int)))
+		clusterUpdate.Properties.ClusterSize = pointer.To(int64(d.Get("cluster_node_count").(int)))
 	}
 
 	if err := client.UpdateThenPoll(ctx, *id, clusterUpdate); err != nil {

--- a/internal/services/vmware/vmware_cluster_resource_test.go
+++ b/internal/services/vmware/vmware_cluster_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VmwareClusterResource struct{}
@@ -96,7 +96,7 @@ func (VmwareClusterResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VmwareClusterResource) basic(data acceptance.TestData) string {

--- a/internal/services/vmware/vmware_express_route_authorization_resource_test.go
+++ b/internal/services/vmware/vmware_express_route_authorization_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/authorizations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VmwareExpressRouteAuthorizationResource struct{}
@@ -61,7 +61,7 @@ func (VmwareExpressRouteAuthorizationResource) Exists(ctx context.Context, clien
 		return nil, fmt.Errorf("retrieving %q: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VmwareExpressRouteAuthorizationResource) basic(data acceptance.TestData) string {

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/vmware/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type NetappFileVolumeAttachment struct {
@@ -96,7 +96,7 @@ func (r NetappFileVolumeAttachmentResource) Create() sdk.ResourceFunc {
 			}
 
 			input := datastores.Datastore{
-				Name: utils.String(state.Name),
+				Name: pointer.To(state.Name),
 				Properties: &datastores.DatastoreProperties{
 					NetAppVolume: &datastores.NetAppVolume{
 						Id: state.NetAppVolumeId,

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VmwareNetappFileVolumeAttachmentResource struct{}
@@ -42,11 +42,11 @@ func (r VmwareNetappFileVolumeAttachmentResource) Exists(ctx context.Context, cl
 	resp, err := client.Vmware.DataStoreClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r VmwareNetappFileVolumeAttachmentResource) basic(data acceptance.TestData) string {

--- a/internal/services/vmware/vmware_private_cloud_resource.go
+++ b/internal/services/vmware/vmware_private_cloud_resource.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceVmwarePrivateCloud() *pluginsdk.Resource {
@@ -235,8 +234,8 @@ func resourceVmwarePrivateCloudCreate(d *pluginsdk.ResourceData, meta interface{
 			},
 			NetworkBlock:    d.Get("network_subnet_cidr").(string),
 			Internet:        &internet,
-			NsxtPassword:    utils.String(d.Get("nsxt_password").(string)),
-			VcenterPassword: utils.String(d.Get("vcenter_password").(string)),
+			NsxtPassword:    pointer.To(d.Get("nsxt_password").(string)),
+			VcenterPassword: pointer.To(d.Get("vcenter_password").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}

--- a/internal/services/vmware/vmware_private_cloud_resource_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_test.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VmwarePrivateCloudResource struct{}
@@ -111,7 +111,7 @@ func (VmwarePrivateCloudResource) Exists(ctx context.Context, clients *clients.C
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (VmwarePrivateCloudResource) template(data acceptance.TestData) string {

--- a/internal/services/voiceservices/voice_services_communications_gateway_resource.go
+++ b/internal/services/voiceservices/voice_services_communications_gateway_resource.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -18,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CommunicationsGatewayModel struct {
@@ -497,9 +498,9 @@ func expandServiceRegionPropertiesModel(inputList []ServiceRegionPropertiesModel
 		}
 
 		output.PrimaryRegionProperties = communicationsgateways.PrimaryRegionProperties{
-			AllowedMediaSourceAddressPrefixes:     utils.StringSlice(v.AllowedMediaSourceAddressPrefixes),
-			AllowedSignalingSourceAddressPrefixes: utils.StringSlice(v.AllowedSignalingSourceAddressPrefixes),
-			EsrpAddresses:                         utils.StringSlice(v.EsrpAddresses),
+			AllowedMediaSourceAddressPrefixes:     pointer.To(v.AllowedMediaSourceAddressPrefixes),
+			AllowedSignalingSourceAddressPrefixes: pointer.To(v.AllowedSignalingSourceAddressPrefixes),
+			EsrpAddresses:                         pointer.To(v.EsrpAddresses),
 			OperatorAddresses:                     v.OperatorAddresses,
 		}
 

--- a/internal/services/voiceservices/voice_services_communications_gateway_resource_test.go
+++ b/internal/services/voiceservices/voice_services_communications_gateway_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-04-03/communicationsgateways"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type VoiceServicesCommunicationsGatewayTestResource struct{}
@@ -99,11 +99,11 @@ func (r VoiceServicesCommunicationsGatewayTestResource) Exists(ctx context.Conte
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r VoiceServicesCommunicationsGatewayTestResource) template(data acceptance.TestData) string {

--- a/internal/services/voiceservices/voice_services_communications_gateway_test_line_resource_test.go
+++ b/internal/services/voiceservices/voice_services_communications_gateway_test_line_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-04-03/testlines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type CommunicationsGatewayTestLineTestResource struct{}
@@ -92,11 +92,11 @@ func (r CommunicationsGatewayTestLineTestResource) Exists(ctx context.Context, c
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r CommunicationsGatewayTestLineTestResource) template(data acceptance.TestData) string {

--- a/internal/services/web/app_service.go
+++ b/internal/services/web/app_service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -1024,7 +1025,7 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 	setting := input[0].(map[string]interface{})
 
 	if v, ok := setting["enabled"]; ok {
-		siteAuthSettingsProperties.Enabled = utils.Bool(v.(bool))
+		siteAuthSettingsProperties.Enabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := setting["additional_login_params"]; ok {
@@ -1054,19 +1055,19 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 	}
 
 	if v, ok := setting["issuer"]; ok {
-		siteAuthSettingsProperties.Issuer = utils.String(v.(string))
+		siteAuthSettingsProperties.Issuer = pointer.To(v.(string))
 	}
 
 	if v, ok := setting["runtime_version"]; ok {
-		siteAuthSettingsProperties.RuntimeVersion = utils.String(v.(string))
+		siteAuthSettingsProperties.RuntimeVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := setting["token_refresh_extension_hours"]; ok {
-		siteAuthSettingsProperties.TokenRefreshExtensionHours = utils.Float(v.(float64))
+		siteAuthSettingsProperties.TokenRefreshExtensionHours = pointer.To(v.(float64))
 	}
 
 	if v, ok := setting["token_store_enabled"]; ok {
-		siteAuthSettingsProperties.TokenStoreEnabled = utils.Bool(v.(bool))
+		siteAuthSettingsProperties.TokenStoreEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := setting["unauthenticated_client_action"]; ok {
@@ -1084,11 +1085,11 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 			activeDirectorySetting := setting.(map[string]interface{})
 
 			if v, ok := activeDirectorySetting["client_id"]; ok {
-				siteAuthSettingsProperties.ClientID = utils.String(v.(string))
+				siteAuthSettingsProperties.ClientID = pointer.To(v.(string))
 			}
 
 			if v, ok := activeDirectorySetting["client_secret"]; ok {
-				siteAuthSettingsProperties.ClientSecret = utils.String(v.(string))
+				siteAuthSettingsProperties.ClientSecret = pointer.To(v.(string))
 			}
 
 			if v, ok := activeDirectorySetting["allowed_audiences"]; ok {
@@ -1111,11 +1112,11 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 			facebookSetting := setting.(map[string]interface{})
 
 			if v, ok := facebookSetting["app_id"]; ok {
-				siteAuthSettingsProperties.FacebookAppID = utils.String(v.(string))
+				siteAuthSettingsProperties.FacebookAppID = pointer.To(v.(string))
 			}
 
 			if v, ok := facebookSetting["app_secret"]; ok {
-				siteAuthSettingsProperties.FacebookAppSecret = utils.String(v.(string))
+				siteAuthSettingsProperties.FacebookAppSecret = pointer.To(v.(string))
 			}
 
 			if v, ok := facebookSetting["oauth_scopes"]; ok {
@@ -1138,11 +1139,11 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 			googleSetting := setting.(map[string]interface{})
 
 			if v, ok := googleSetting["client_id"]; ok {
-				siteAuthSettingsProperties.GoogleClientID = utils.String(v.(string))
+				siteAuthSettingsProperties.GoogleClientID = pointer.To(v.(string))
 			}
 
 			if v, ok := googleSetting["client_secret"]; ok {
-				siteAuthSettingsProperties.GoogleClientSecret = utils.String(v.(string))
+				siteAuthSettingsProperties.GoogleClientSecret = pointer.To(v.(string))
 			}
 
 			if v, ok := googleSetting["oauth_scopes"]; ok {
@@ -1165,11 +1166,11 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 			microsoftSetting := setting.(map[string]interface{})
 
 			if v, ok := microsoftSetting["client_id"]; ok {
-				siteAuthSettingsProperties.MicrosoftAccountClientID = utils.String(v.(string))
+				siteAuthSettingsProperties.MicrosoftAccountClientID = pointer.To(v.(string))
 			}
 
 			if v, ok := microsoftSetting["client_secret"]; ok {
-				siteAuthSettingsProperties.MicrosoftAccountClientSecret = utils.String(v.(string))
+				siteAuthSettingsProperties.MicrosoftAccountClientSecret = pointer.To(v.(string))
 			}
 
 			if v, ok := microsoftSetting["oauth_scopes"]; ok {
@@ -1192,11 +1193,11 @@ func expandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 			twitterSetting := setting.(map[string]interface{})
 
 			if v, ok := twitterSetting["consumer_key"]; ok {
-				siteAuthSettingsProperties.TwitterConsumerKey = utils.String(v.(string))
+				siteAuthSettingsProperties.TwitterConsumerKey = pointer.To(v.(string))
 			}
 
 			if v, ok := twitterSetting["consumer_secret"]; ok {
-				siteAuthSettingsProperties.TwitterConsumerSecret = utils.String(v.(string))
+				siteAuthSettingsProperties.TwitterConsumerSecret = pointer.To(v.(string))
 			}
 		}
 	}
@@ -1500,8 +1501,8 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 
 					logs.ApplicationLogs.AzureBlobStorage = &web.AzureBlobStorageApplicationLogsConfig{
 						Level:           web.LogLevel(storageConfig["level"].(string)),
-						SasURL:          utils.String(storageConfig["sas_url"].(string)),
-						RetentionInDays: utils.Int32(int32(storageConfig["retention_in_days"].(int))),
+						SasURL:          pointer.To(storageConfig["sas_url"].(string)),
+						RetentionInDays: pointer.To(int32(storageConfig["retention_in_days"].(int))),
 					}
 				}
 			}
@@ -1526,9 +1527,9 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 					fileSystemConfig := config.(map[string]interface{})
 
 					logs.HTTPLogs.FileSystem = &web.FileSystemHTTPLogsConfig{
-						RetentionInMb:   utils.Int32(int32(fileSystemConfig["retention_in_mb"].(int))),
-						RetentionInDays: utils.Int32(int32(fileSystemConfig["retention_in_days"].(int))),
-						Enabled:         utils.Bool(true),
+						RetentionInMb:   pointer.To(int32(fileSystemConfig["retention_in_mb"].(int))),
+						RetentionInDays: pointer.To(int32(fileSystemConfig["retention_in_days"].(int))),
+						Enabled:         pointer.To(true),
 					}
 				}
 			}
@@ -1540,9 +1541,9 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 					storageConfig := config.(map[string]interface{})
 
 					logs.HTTPLogs.AzureBlobStorage = &web.AzureBlobStorageHTTPLogsConfig{
-						SasURL:          utils.String(storageConfig["sas_url"].(string)),
-						RetentionInDays: utils.Int32(int32(storageConfig["retention_in_days"].(int))),
-						Enabled:         utils.Bool(true),
+						SasURL:          pointer.To(storageConfig["sas_url"].(string)),
+						RetentionInDays: pointer.To(int32(storageConfig["retention_in_days"].(int))),
+						Enabled:         pointer.To(true),
 					}
 				}
 			}
@@ -1551,13 +1552,13 @@ func expandAppServiceLogs(input interface{}) web.SiteLogsConfigProperties {
 
 	if v, ok := config["detailed_error_messages_enabled"]; ok {
 		logs.DetailedErrorMessages = &web.EnabledConfig{
-			Enabled: utils.Bool(v.(bool)),
+			Enabled: pointer.To(v.(bool)),
 		}
 	}
 
 	if v, ok := config["failed_request_tracing_enabled"]; ok {
 		logs.FailedRequestsTracing = &web.EnabledConfig{
-			Enabled: utils.Bool(v.(bool)),
+			Enabled: pointer.To(v.(bool)),
 		}
 	}
 
@@ -1620,11 +1621,11 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	config := configs[0].(map[string]interface{})
 
 	if v, ok := config["always_on"]; ok {
-		siteConfig.AlwaysOn = utils.Bool(v.(bool))
+		siteConfig.AlwaysOn = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["app_command_line"]; ok {
-		siteConfig.AppCommandLine = utils.String(v.(string))
+		siteConfig.AppCommandLine = pointer.To(v.(string))
 	}
 
 	if v, ok := config["default_documents"]; ok {
@@ -1639,31 +1640,31 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["dotnet_framework_version"]; ok {
-		siteConfig.NetFrameworkVersion = utils.String(v.(string))
+		siteConfig.NetFrameworkVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["java_version"]; ok {
-		siteConfig.JavaVersion = utils.String(v.(string))
+		siteConfig.JavaVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["java_container"]; ok {
-		siteConfig.JavaContainer = utils.String(v.(string))
+		siteConfig.JavaContainer = pointer.To(v.(string))
 	}
 
 	if v, ok := config["java_container_version"]; ok {
-		siteConfig.JavaContainerVersion = utils.String(v.(string))
+		siteConfig.JavaContainerVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["linux_fx_version"]; ok {
-		siteConfig.LinuxFxVersion = utils.String(v.(string))
+		siteConfig.LinuxFxVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["windows_fx_version"]; ok {
-		siteConfig.WindowsFxVersion = utils.String(v.(string))
+		siteConfig.WindowsFxVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["http2_enabled"]; ok {
-		siteConfig.HTTP20Enabled = utils.Bool(v.(bool))
+		siteConfig.HTTP20Enabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["ip_restriction"]; ok {
@@ -1675,7 +1676,7 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["scm_use_main_ip_restriction"]; ok {
-		siteConfig.ScmIPSecurityRestrictionsUseMain = utils.Bool(v.(bool))
+		siteConfig.ScmIPSecurityRestrictionsUseMain = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["scm_ip_restriction"]; ok {
@@ -1688,7 +1689,7 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["local_mysql_enabled"]; ok {
-		siteConfig.LocalMySQLEnabled = utils.Bool(v.(bool))
+		siteConfig.LocalMySQLEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["managed_pipeline_mode"]; ok {
@@ -1696,27 +1697,27 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["php_version"]; ok {
-		siteConfig.PhpVersion = utils.String(v.(string))
+		siteConfig.PhpVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["python_version"]; ok {
-		siteConfig.PythonVersion = utils.String(v.(string))
+		siteConfig.PythonVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["remote_debugging_enabled"]; ok {
-		siteConfig.RemoteDebuggingEnabled = utils.Bool(v.(bool))
+		siteConfig.RemoteDebuggingEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["remote_debugging_version"]; ok {
-		siteConfig.RemoteDebuggingVersion = utils.String(v.(string))
+		siteConfig.RemoteDebuggingVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["use_32_bit_worker_process"]; ok {
-		siteConfig.Use32BitWorkerProcess = utils.Bool(v.(bool))
+		siteConfig.Use32BitWorkerProcess = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["websockets_enabled"]; ok {
-		siteConfig.WebSocketsEnabled = utils.Bool(v.(bool))
+		siteConfig.WebSocketsEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["scm_type"]; ok {
@@ -1728,11 +1729,11 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["health_check_path"]; ok {
-		siteConfig.HealthCheckPath = utils.String(v.(string))
+		siteConfig.HealthCheckPath = pointer.To(v.(string))
 	}
 
 	if v, ok := config["number_of_workers"]; ok && v.(int) != 0 {
-		siteConfig.NumberOfWorkers = utils.Int32(int32(v.(int)))
+		siteConfig.NumberOfWorkers = pointer.To(int32(v.(int)))
 	}
 
 	if v, ok := config["min_tls_version"]; ok {
@@ -1745,19 +1746,19 @@ func expandAppServiceSiteConfig(input interface{}) (*web.SiteConfig, error) {
 	}
 
 	if v, ok := config["auto_swap_slot_name"]; ok {
-		siteConfig.AutoSwapSlotName = utils.String(v.(string))
+		siteConfig.AutoSwapSlotName = pointer.To(v.(string))
 	}
 
 	if v, ok := config["acr_use_managed_identity_credentials"]; ok {
-		siteConfig.AcrUseManagedIdentityCreds = utils.Bool(v.(bool))
+		siteConfig.AcrUseManagedIdentityCreds = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["acr_user_managed_identity_client_id"]; ok {
-		siteConfig.AcrUserManagedIdentityID = utils.String(v.(string))
+		siteConfig.AcrUserManagedIdentityID = pointer.To(v.(string))
 	}
 
 	if v, ok := config["vnet_route_all_enabled"]; ok {
-		siteConfig.VnetRouteAllEnabled = utils.Bool(v.(bool))
+		siteConfig.VnetRouteAllEnabled = pointer.To(v.(bool))
 	}
 
 	return siteConfig, nil
@@ -1959,10 +1960,10 @@ func expandAppServiceStorageAccounts(input []interface{}) map[string]*web.AzureS
 
 		output[saName] = &web.AzureStorageInfoValue{
 			Type:        web.AzureStorageType(saType),
-			AccountName: utils.String(saAccountName),
-			ShareName:   utils.String(saShareName),
-			AccessKey:   utils.String(saAccessKey),
-			MountPath:   utils.String(saMountPath),
+			AccountName: pointer.To(saAccountName),
+			ShareName:   pointer.To(saShareName),
+			AccessKey:   pointer.To(saAccessKey),
+			MountPath:   pointer.To(saMountPath),
 		}
 	}
 
@@ -2048,7 +2049,7 @@ func expandAppServiceIpRestriction(input interface{}) ([]web.IPSecurityRestricti
 		}
 
 		if priority != 0 {
-			ipSecurityRestriction.Priority = utils.Int32(int32(priority))
+			ipSecurityRestriction.Priority = pointer.To(int32(priority))
 		}
 
 		if action != "" {

--- a/internal/services/web/app_service_active_slot_resource_test.go
+++ b/internal/services/web/app_service_active_slot_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -63,7 +64,7 @@ func (r AppServiceActiveSlotResource) Exists(ctx context.Context, clients *clien
 	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service %q (Resource Group %s): %+v", id.SiteName, id.ResourceGroup, err)
 	}
@@ -74,7 +75,7 @@ func (r AppServiceActiveSlotResource) Exists(ctx context.Context, clients *clien
 
 	target := state.Attributes["resource_group_name"]
 
-	return utils.Bool(*resp.SlotSwapStatus.SourceSlotName == target), nil
+	return pointer.To(*resp.SlotSwapStatus.SourceSlotName == target), nil
 }
 
 func (AppServiceActiveSlotResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/app_service_certificate_binding_resource_test.go
+++ b/internal/services/web/app_service_certificate_binding_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -87,29 +88,29 @@ func (t AppServiceCertificateBindingResource) Exists(ctx context.Context, client
 	binding, err := clients.Web.AppServicesClient.GetHostNameBinding(ctx, id.HostnameBindingId.ResourceGroup, id.SiteName, id.HostnameBindingId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(binding.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Hostname Binding %q (resource group %q) to check for Certificate Binding %q: %+v", id.HostnameBindingId.Name, id.HostnameBindingId.ResourceGroup, id.HostnameBindingId.Name, err)
 	}
 	certificate, err := clients.Web.CertificatesClient.Get(ctx, id.CertificateId.ResourceGroup, id.CertificateId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(certificate.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Certificate %q (resource group %q) to check for Certificate Binding: %+v", id.CertificateId.Name, id.CertificateId.ResourceGroup, err)
 	}
 	bindingProps := binding.HostNameBindingProperties
 	if bindingProps == nil || bindingProps.Thumbprint == nil {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 	certProps := certificate.CertificateProperties
 	if certProps == nil || certProps.Thumbprint == nil {
 		return nil, fmt.Errorf("reading Certificate thumbprint for verification on binding")
 	}
 	if *certProps.Thumbprint != *bindingProps.Thumbprint {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (t AppServiceCertificateBindingResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/app_service_certificate_order_resource.go
+++ b/internal/services/web/app_service_certificate_order_resource.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/migration"
@@ -200,7 +201,7 @@ func resourceAppServiceCertificateOrderCreateUpdate(d *pluginsdk.ResourceData, m
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 	distinguishedName := d.Get("distinguished_name").(string)
 	csr := d.Get("csr").(string)
@@ -209,11 +210,11 @@ func resourceAppServiceCertificateOrderCreateUpdate(d *pluginsdk.ResourceData, m
 	validityInYears := d.Get("validity_in_years").(int)
 
 	properties := web.AppServiceCertificateOrderProperties{
-		DistinguishedName: utils.String(distinguishedName),
-		Csr:               utils.String(csr),
-		KeySize:           utils.Int32(int32(keySize)),
-		AutoRenew:         utils.Bool(autoRenew),
-		ValidityInYears:   utils.Int32(int32(validityInYears)),
+		DistinguishedName: pointer.To(distinguishedName),
+		Csr:               pointer.To(csr),
+		KeySize:           pointer.To(int32(keySize)),
+		AutoRenew:         pointer.To(autoRenew),
+		ValidityInYears:   pointer.To(int32(validityInYears)),
 	}
 
 	switch d.Get("product_type").(string) {
@@ -227,7 +228,7 @@ func resourceAppServiceCertificateOrderCreateUpdate(d *pluginsdk.ResourceData, m
 
 	certificateOrder := web.AppServiceCertificateOrder{
 		AppServiceCertificateOrderProperties: &properties,
-		Location:                             utils.String(location),
+		Location:                             pointer.To(location),
 		Tags:                                 tags.Expand(t),
 	}
 
@@ -269,8 +270,8 @@ func resourceAppServiceCertificateOrderRead(d *pluginsdk.ResourceData, meta inte
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	if props := resp.AppServiceCertificateOrderProperties; props != nil {

--- a/internal/services/web/app_service_certificate_order_resource_test.go
+++ b/internal/services/web/app_service_certificate_order_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -164,11 +165,11 @@ func (r AppServiceCertificateOrderResource) Exists(ctx context.Context, clients 
 	resp, err := clients.Web.CertificatesOrderClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Certificate Order %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceCertificateOrderResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/app_service_certificate_resource.go
+++ b/internal/services/web/app_service_certificate_resource.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
@@ -58,7 +59,7 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 	log.Printf("[INFO] preparing arguments for App Service Certificate creation.")
 
 	id := parse.NewCertificateID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	pfxBlob := d.Get("pfx_blob").(string)
 	password := d.Get("password").(string)
 	customizedKeyVaultId := d.Get("key_vault_id").(string)
@@ -81,9 +82,9 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 	certificate := web.Certificate{
 		CertificateProperties: &web.CertificateProperties{
-			Password: utils.String(password),
+			Password: pointer.To(password),
 		},
-		Location: utils.String(location),
+		Location: pointer.To(location),
 		Tags:     tags.Expand(t),
 	}
 
@@ -107,7 +108,7 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 
 		var keyVaultId *string
 		if customizedKeyVaultId != "" {
-			keyVaultId = utils.String(customizedKeyVaultId)
+			keyVaultId = pointer.To(customizedKeyVaultId)
 		} else {
 			keyVaultBaseUrl := parsedSecretId.KeyVaultBaseUrl
 
@@ -122,7 +123,7 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 		}
 
 		certificate.KeyVaultID = keyVaultId
-		certificate.KeyVaultSecretName = utils.String(parsedSecretId.Name)
+		certificate.KeyVaultSecretName = pointer.To(parsedSecretId.Name)
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, certificate); err != nil {
@@ -157,8 +158,8 @@ func resourceAppServiceCertificateRead(d *pluginsdk.ResourceData, meta interface
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	if props := resp.CertificateProperties; props != nil {

--- a/internal/services/web/app_service_certificate_resource_test.go
+++ b/internal/services/web/app_service_certificate_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -103,11 +104,11 @@ func (r AppServiceCertificateResource) Exists(ctx context.Context, clients *clie
 	resp, err := clients.Web.CertificatesClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Certificate %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceCertificateResource) pfx(data acceptance.TestData) string {

--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -111,7 +112,7 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 
 	properties := web.HostNameBinding{
 		HostNameBindingProperties: &web.HostNameBindingProperties{
-			SiteName: utils.String(appServiceName),
+			SiteName: pointer.To(appServiceName),
 		},
 	}
 
@@ -128,7 +129,7 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 			return fmt.Errorf("`ssl_state` must be specified when `thumbprint` is set")
 		}
 
-		properties.Thumbprint = utils.String(thumbprint)
+		properties.Thumbprint = pointer.To(thumbprint)
 	}
 
 	if _, err := client.CreateOrUpdateHostNameBinding(ctx, resourceGroup, appServiceName, hostname, properties); err != nil {

--- a/internal/services/web/app_service_custom_hostname_binding_resource_test.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -132,12 +133,12 @@ func (r ServiceCustomHostnameBindingResource) Exists(ctx context.Context, client
 	resp, err := clients.Web.AppServicesClient.GetHostNameBinding(ctx, id.ResourceGroup, id.AppServiceName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Custom Hostname Binding %q (App Service %q / Resource Group %q): %+v", id.Name, id.AppServiceName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(resp.HostNameBindingProperties != nil), nil
+	return pointer.To(resp.HostNameBindingProperties != nil), nil
 }
 
 func (ServiceCustomHostnameBindingResource) basicConfig(data acceptance.TestData, appServiceName string, domain string) string {

--- a/internal/services/web/app_service_hybrid_connection_resource.go
+++ b/internal/services/web/app_service_hybrid_connection_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -143,10 +144,10 @@ func resourceAppServiceHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, m
 	connectionEnvelope := web.HybridConnection{
 		HybridConnectionProperties: &web.HybridConnectionProperties{
 			RelayArmURI:  &relayArmURI,
-			Hostname:     utils.String(d.Get("hostname").(string)),
+			Hostname:     pointer.To(d.Get("hostname").(string)),
 			Port:         &port,
-			SendKeyName:  utils.String(d.Get("send_key_name").(string)),
-			SendKeyValue: utils.String(""), // The service creates this no matter what is sent, but the API requires the field to be set
+			SendKeyName:  pointer.To(d.Get("send_key_name").(string)),
+			SendKeyValue: pointer.To(""), // The service creates this no matter what is sent, but the API requires the field to be set
 		},
 	}
 

--- a/internal/services/web/app_service_hybrid_connection_resource_test.go
+++ b/internal/services/web/app_service_hybrid_connection_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -109,12 +110,12 @@ func (r AppServiceHybridConnectionResource) Exists(ctx context.Context, clients 
 	resp, err := clients.Web.AppServicesClient.GetHybridConnection(ctx, id.ResourceGroup, id.SiteName, id.HybridConnectionNamespaceName, id.RelayName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Hybrid Connection for App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceHybridConnectionResource) template(data acceptance.TestData) string {

--- a/internal/services/web/app_service_managed_certificate_resource.go
+++ b/internal/services/web/app_service_managed_certificate_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -149,11 +150,11 @@ func resourceAppServiceManagedCertificateCreateUpdate(d *pluginsdk.ResourceData,
 
 	certificate := web.Certificate{
 		CertificateProperties: &web.CertificateProperties{
-			CanonicalName: utils.String(customHostnameBindingId.Name),
-			ServerFarmID:  utils.String(appServicePlanIDRaw),
+			CanonicalName: pointer.To(customHostnameBindingId.Name),
+			ServerFarmID:  pointer.To(appServicePlanIDRaw),
 			Password:      new(string),
 		},
-		Location: utils.String(appServiceLocation),
+		Location: pointer.To(appServiceLocation),
 		Tags:     tags.Expand(t),
 	}
 

--- a/internal/services/web/app_service_managed_certificate_resource_test.go
+++ b/internal/services/web/app_service_managed_certificate_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -86,12 +87,12 @@ func (t AppServiceManagedCertificateResource) Exists(ctx context.Context, client
 	resp, err := clients.Web.CertificatesClient.Get(ctx, id.ResourceGroup, id.CertificateName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("App Service Managed Certificate %q (resource group %q) does not exist", id.CertificateName, id.ResourceGroup)
 	}
 
-	return utils.Bool(resp.CertificateProperties != nil), nil
+	return pointer.To(resp.CertificateProperties != nil), nil
 }
 
 func (t AppServiceManagedCertificateResource) basicLinux(data acceptance.TestData) string {

--- a/internal/services/web/app_service_plan_resource_test.go
+++ b/internal/services/web/app_service_plan_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -246,17 +247,17 @@ func (r AppServicePlanResource) Exists(ctx context.Context, clients *clients.Cli
 	resp, err := clients.Web.AppServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Plan %q (Resource Group %q): %+v", id.ServerFarmName, id.ResourceGroup, err)
 	}
 
 	// The SDK defines 404 as an "ok" status code..
 	if utils.ResponseWasNotFound(resp.Response) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServicePlanResource) basicWindows(data acceptance.TestData) string {

--- a/internal/services/web/app_service_public_certificate_resource_test.go
+++ b/internal/services/web/app_service_public_certificate_resource_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AppServicePublicCertificateResource struct{}
@@ -58,11 +58,11 @@ func (r AppServicePublicCertificateResource) Exists(ctx context.Context, clients
 	resp, err := clients.AppService.WebAppsClient.GetPublicCertificate(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Public Certificate %s: %+v", *id, err)
 	}
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServicePublicCertificateResource) basicAppService(data acceptance.TestData) string {

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
@@ -249,7 +249,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 
 	availabilityRequest := web.ResourceNameAvailabilityRequest{
-		Name: utils.String(id.SiteName),
+		Name: pointer.To(id.SiteName),
 		Type: web.CheckNameResourceTypesMicrosoftWebsites,
 	}
 
@@ -266,8 +266,8 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf("'App Service Environment' %q or Resource Group %q does not exist", aspID.ServerFarmName, aspID.ResourceGroup)
 	}
 	if aspDetails.HostingEnvironmentProfile != nil {
-		availabilityRequest.Name = utils.String(fmt.Sprintf("%s.%s.appserviceenvironment.net", id.SiteName, *aspDetails.HostingEnvironmentProfile.Name))
-		availabilityRequest.IsFqdn = utils.Bool(true)
+		availabilityRequest.Name = pointer.To(fmt.Sprintf("%s.%s.appserviceenvironment.net", id.SiteName, *aspDetails.HostingEnvironmentProfile.Name))
+		availabilityRequest.IsFqdn = pointer.To(true)
 	}
 	available, err := client.CheckNameAvailability(ctx, availabilityRequest)
 	if err != nil {
@@ -278,7 +278,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		return fmt.Errorf("the name %q used for the App Service needs to be globally unique and isn't available: %s", id.SiteName, *available.Message)
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	enabled := d.Get("enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
 	t := d.Get("tags").(map[string]interface{})
@@ -292,15 +292,15 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID: utils.String(appServicePlanId),
-			Enabled:      utils.Bool(enabled),
-			HTTPSOnly:    utils.Bool(httpsOnly),
+			ServerFarmID: pointer.To(appServicePlanId),
+			Enabled:      pointer.To(enabled),
+			HTTPSOnly:    pointer.To(httpsOnly),
 			SiteConfig:   siteConfig,
 		},
 	}
 
 	if v, ok := d.GetOk("key_vault_reference_identity_id"); ok {
-		siteEnvelope.KeyVaultReferenceIdentity = utils.String(v.(string))
+		siteEnvelope.KeyVaultReferenceIdentity = pointer.To(v.(string))
 	}
 
 	if _, ok := d.GetOk("identity"); ok {
@@ -311,9 +311,9 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		siteEnvelope.Identity = appServiceIdentity
 	}
 
-	siteEnvelope.ClientAffinityEnabled = utils.Bool(d.Get("client_affinity_enabled").(bool))
+	siteEnvelope.ClientAffinityEnabled = pointer.To(d.Get("client_affinity_enabled").(bool))
 
-	siteEnvelope.ClientCertEnabled = utils.Bool(d.Get("client_cert_enabled").(bool))
+	siteEnvelope.ClientCertEnabled = pointer.To(d.Get("client_cert_enabled").(bool))
 	if *siteEnvelope.ClientCertEnabled {
 		if clientCertMode, ok := d.GetOk("client_cert_mode"); ok {
 			siteEnvelope.ClientCertMode = web.ClientCertMode(clientCertMode.(string))
@@ -355,7 +355,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	authSettings := expandAppServiceAuthSettings(authSettingsRaw)
 
 	auth := web.SiteAuthSettings{
-		ID:                         utils.String(id.ID()),
+		ID:                         pointer.To(id.ID()),
 		SiteAuthSettingsProperties: &authSettings,
 	}
 
@@ -366,7 +366,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	logsConfig := expandAppServiceLogs(d.Get("logs"))
 
 	logs := web.SiteLogsConfig{
-		ID:                       utils.String(id.ID()),
+		ID:                       pointer.To(id.ID()),
 		SiteLogsConfigProperties: &logsConfig,
 	}
 
@@ -394,7 +394,7 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
@@ -410,7 +410,7 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 	appSettings := expandAppServiceAppSettings(d)
 	if vnetRouteAll, ok := appSettings["WEBSITE_VNET_ROUTE_ALL"]; ok {
 		if !d.HasChange("site_config.0.vnet_route_all_enabled") { // Only update the property if it's not set explicitly
-			siteConfig.VnetRouteAllEnabled = utils.Bool(strings.EqualFold(*vnetRouteAll, "true"))
+			siteConfig.VnetRouteAllEnabled = pointer.To(strings.EqualFold(*vnetRouteAll, "true"))
 		}
 	}
 
@@ -418,18 +418,18 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID: utils.String(appServicePlanId),
-			Enabled:      utils.Bool(enabled),
-			HTTPSOnly:    utils.Bool(httpsOnly),
+			ServerFarmID: pointer.To(appServicePlanId),
+			Enabled:      pointer.To(enabled),
+			HTTPSOnly:    pointer.To(httpsOnly),
 			SiteConfig:   siteConfig,
 		},
 	}
 
 	if v, ok := d.GetOk("key_vault_reference_identity_id"); ok {
-		siteEnvelope.KeyVaultReferenceIdentity = utils.String(v.(string))
+		siteEnvelope.KeyVaultReferenceIdentity = pointer.To(v.(string))
 	}
 
-	siteEnvelope.ClientCertEnabled = utils.Bool(d.Get("client_cert_enabled").(bool))
+	siteEnvelope.ClientCertEnabled = pointer.To(d.Get("client_cert_enabled").(bool))
 
 	if *siteEnvelope.ClientCertEnabled {
 		if clientCertMode, ok := d.GetOk("client_cert_mode"); ok {
@@ -476,7 +476,7 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		authSettingsRaw := d.Get("auth_settings").([]interface{})
 		authSettingsProperties := expandAppServiceAuthSettings(authSettingsRaw)
 		authSettings := web.SiteAuthSettings{
-			ID:                         utils.String(d.Id()),
+			ID:                         pointer.To(d.Id()),
 			SiteAuthSettingsProperties: &authSettingsProperties,
 		}
 
@@ -502,7 +502,7 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		affinity := d.Get("client_affinity_enabled").(bool)
 
 		sitePatchResource := web.SitePatchResource{
-			ID: utils.String(d.Id()),
+			ID: pointer.To(d.Id()),
 			SitePatchResourceProperties: &web.SitePatchResourceProperties{
 				ClientAffinityEnabled: &affinity,
 			},
@@ -557,7 +557,7 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 	if d.HasChange("logs") || (hasLogs && d.HasChange("app_settings")) {
 		logs := expandAppServiceLogs(d.Get("logs"))
 		logsResource := web.SiteLogsConfig{
-			ID:                       utils.String(d.Id()),
+			ID:                       pointer.To(d.Id()),
 			SiteLogsConfigProperties: &logs,
 		}
 
@@ -703,8 +703,8 @@ func resourceAppServiceRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	d.Set("name", id.SiteName)
 	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	if props := resp.SiteProperties; props != nil {
@@ -823,7 +823,7 @@ func expandAppServiceAppSettings(d *pluginsdk.ResourceData) map[string]*string {
 	output := make(map[string]*string, len(input))
 
 	for k, v := range input {
-		output[k] = utils.String(v.(string))
+		output[k] = pointer.To(v.(string))
 	}
 
 	return output
@@ -841,7 +841,7 @@ func expandAppServiceConnectionStrings(d *pluginsdk.ResourceData) map[string]*we
 		csValue := vals["value"].(string)
 
 		output[csName] = &web.ConnStringValueTypePair{
-			Value: utils.String(csValue),
+			Value: pointer.To(csValue),
 			Type:  web.ConnectionStringType(csType),
 		}
 	}

--- a/internal/services/web/app_service_resource_test.go
+++ b/internal/services/web/app_service_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -1955,17 +1956,17 @@ func (r AppServiceResource) Exists(ctx context.Context, clients *clients.Client,
 	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
 
 	// The SDK defines 404 as an "ok" status code..
 	if utils.ResponseWasNotFound(resp.Response) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/app_service_schedule_backup.go
+++ b/internal/services/web/app_service_schedule_backup.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func schemaAppServiceBackup() *pluginsdk.Schema {
@@ -101,9 +101,9 @@ func expandAppServiceBackup(input []interface{}) *web.BackupRequest {
 
 	request := &web.BackupRequest{
 		BackupRequestProperties: &web.BackupRequestProperties{
-			BackupName:        utils.String(name),
-			StorageAccountURL: utils.String(storageAccountUrl),
-			Enabled:           utils.Bool(enabled),
+			BackupName:        pointer.To(name),
+			StorageAccountURL: pointer.To(storageAccountUrl),
+			Enabled:           pointer.To(enabled),
 		},
 	}
 
@@ -113,7 +113,7 @@ func expandAppServiceBackup(input []interface{}) *web.BackupRequest {
 		backupSchedule := web.BackupSchedule{}
 
 		if v, ok := schedule["frequency_interval"].(int); ok {
-			backupSchedule.FrequencyInterval = utils.Int32(int32(v))
+			backupSchedule.FrequencyInterval = pointer.To(int32(v))
 		}
 
 		if v, ok := schedule["frequency_unit"]; ok {
@@ -121,11 +121,11 @@ func expandAppServiceBackup(input []interface{}) *web.BackupRequest {
 		}
 
 		if v, ok := schedule["keep_at_least_one_backup"]; ok {
-			backupSchedule.KeepAtLeastOneBackup = utils.Bool(v.(bool))
+			backupSchedule.KeepAtLeastOneBackup = pointer.To(v.(bool))
 		}
 
 		if v, ok := schedule["retention_period_in_days"].(int); ok {
-			backupSchedule.RetentionPeriodInDays = utils.Int32(int32(v))
+			backupSchedule.RetentionPeriodInDays = pointer.To(int32(v))
 		}
 
 		if v, ok := schedule["start_time"].(string); ok {

--- a/internal/services/web/app_service_site_source_control.go
+++ b/internal/services/web/app_service_site_source_control.go
@@ -7,8 +7,8 @@ import (
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func schemaAppServiceSiteSourceControl() *pluginsdk.Schema {
@@ -114,11 +114,11 @@ func expandAppServiceSiteSourceControl(d *pluginsdk.ResourceData) *web.SiteSourc
 	sourceControl := sourceControlRaw[0].(map[string]interface{})
 
 	result := &web.SiteSourceControlProperties{
-		RepoURL:                   utils.String(sourceControl["repo_url"].(string)),
-		Branch:                    utils.String(sourceControl["branch"].(string)),
-		IsManualIntegration:       utils.Bool(sourceControl["manual_integration"].(bool)),
-		IsMercurial:               utils.Bool(sourceControl["use_mercurial"].(bool)),
-		DeploymentRollbackEnabled: utils.Bool(sourceControl["rollback_enabled"].(bool)),
+		RepoURL:                   pointer.To(sourceControl["repo_url"].(string)),
+		Branch:                    pointer.To(sourceControl["branch"].(string)),
+		IsManualIntegration:       pointer.To(sourceControl["manual_integration"].(bool)),
+		IsMercurial:               pointer.To(sourceControl["use_mercurial"].(bool)),
+		DeploymentRollbackEnabled: pointer.To(sourceControl["rollback_enabled"].(bool)),
 	}
 
 	return result

--- a/internal/services/web/app_service_slot_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_slot_custom_hostname_binding_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -113,7 +114,7 @@ func resourceAppServiceSlotCustomHostnameBindingCreate(d *pluginsdk.ResourceData
 
 	properties := web.HostNameBinding{
 		HostNameBindingProperties: &web.HostNameBindingProperties{
-			SiteName: utils.String(id.SiteName),
+			SiteName: pointer.To(id.SiteName),
 		},
 	}
 
@@ -122,7 +123,7 @@ func resourceAppServiceSlotCustomHostnameBindingCreate(d *pluginsdk.ResourceData
 	}
 
 	if thumbprint != "" {
-		properties.Thumbprint = utils.String(thumbprint)
+		properties.Thumbprint = pointer.To(thumbprint)
 	}
 
 	if _, err := client.CreateOrUpdateHostNameBindingSlot(ctx, id.ResourceGroup, id.SiteName, id.HostNameBindingName, properties, id.SlotName); err != nil {

--- a/internal/services/web/app_service_slot_custom_hostname_binding_resource_test.go
+++ b/internal/services/web/app_service_slot_custom_hostname_binding_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -85,12 +86,12 @@ func (r AppServiceSlotCustomHostnameBindingResource) Exists(ctx context.Context,
 	resp, err := clients.Web.AppServicesClient.GetHostNameBindingSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName, id.HostNameBindingName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.HostNameBindingProperties != nil), nil
+	return pointer.To(resp.HostNameBindingProperties != nil), nil
 }
 
 func (AppServiceSlotCustomHostnameBindingResource) basicConfig(data acceptance.TestData) string {

--- a/internal/services/web/app_service_slot_resource.go
+++ b/internal/services/web/app_service_slot_resource.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
@@ -201,7 +201,7 @@ func resourceAppServiceSlotCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
@@ -216,16 +216,16 @@ func resourceAppServiceSlotCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:          utils.String(appServicePlanId),
-			Enabled:               utils.Bool(enabled),
-			HTTPSOnly:             utils.Bool(httpsOnly),
+			ServerFarmID:          pointer.To(appServicePlanId),
+			Enabled:               pointer.To(enabled),
+			HTTPSOnly:             pointer.To(httpsOnly),
 			SiteConfig:            siteConfig,
 			ClientAffinityEnabled: &affinity,
 		},
 	}
 
 	if v, ok := d.GetOk("key_vault_reference_identity_id"); ok {
-		siteEnvelope.KeyVaultReferenceIdentity = utils.String(v.(string))
+		siteEnvelope.KeyVaultReferenceIdentity = pointer.To(v.(string))
 	}
 
 	if _, ok := d.GetOk("identity"); ok {
@@ -261,7 +261,7 @@ func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	siteConfig, err := expandAppServiceSiteConfig(d.Get("site_config"))
 	if err != nil {
@@ -275,19 +275,19 @@ func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID: utils.String(appServicePlanId),
-			Enabled:      utils.Bool(enabled),
-			HTTPSOnly:    utils.Bool(httpsOnly),
+			ServerFarmID: pointer.To(appServicePlanId),
+			Enabled:      pointer.To(enabled),
+			HTTPSOnly:    pointer.To(httpsOnly),
 			SiteConfig:   siteConfig,
 		},
 	}
 	if v, ok := d.GetOk("client_affinity_enabled"); ok {
 		enabled := v.(bool)
-		siteEnvelope.ClientAffinityEnabled = utils.Bool(enabled)
+		siteEnvelope.ClientAffinityEnabled = pointer.To(enabled)
 	}
 
 	if v, ok := d.GetOk("key_vault_reference_identity_id"); ok {
-		siteEnvelope.KeyVaultReferenceIdentity = utils.String(v.(string))
+		siteEnvelope.KeyVaultReferenceIdentity = pointer.To(v.(string))
 	}
 
 	createFuture, err := client.CreateOrUpdateSlot(ctx, id.ResourceGroup, id.SiteName, siteEnvelope, id.SlotName)
@@ -318,7 +318,7 @@ func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		authSettingsRaw := d.Get("auth_settings").([]interface{})
 		authSettingsProperties := expandAppServiceAuthSettings(authSettingsRaw)
 		authSettings := web.SiteAuthSettings{
-			ID:                         utils.String(d.Id()),
+			ID:                         pointer.To(d.Id()),
 			SiteAuthSettingsProperties: &authSettingsProperties,
 		}
 
@@ -348,7 +348,7 @@ func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	if d.HasChange("logs") || (hasLogs && d.HasChange("app_settings")) {
 		logs := expandAppServiceLogs(d.Get("logs"))
 		logsResource := web.SiteLogsConfig{
-			ID:                       utils.String(d.Id()),
+			ID:                       pointer.To(d.Id()),
 			SiteLogsConfigProperties: &logs,
 		}
 
@@ -387,7 +387,7 @@ func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("expanding `identity`: %+v", err)
 		}
 		sitePatchResource := web.SitePatchResource{
-			ID:       utils.String(d.Id()),
+			ID:       pointer.To(d.Id()),
 			Identity: appServiceIdentity,
 		}
 		if _, err := client.UpdateSlot(ctx, id.ResourceGroup, id.SiteName, sitePatchResource, id.SlotName); err != nil {
@@ -477,8 +477,8 @@ func resourceAppServiceSlotRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("name", id.SlotName)
 	d.Set("app_service_name", id.SiteName)
 	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	if props := resp.SiteProperties; props != nil {

--- a/internal/services/web/app_service_slot_resource_test.go
+++ b/internal/services/web/app_service_slot_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -1250,17 +1251,17 @@ func (r AppServiceSlotResource) Exists(ctx context.Context, clients *clients.Cli
 	resp, err := clients.Web.AppServicesClient.GetSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Slot %q (App Service %q / Resource Group %q): %+v", id.SlotName, id.SiteName, id.ResourceGroup, err)
 	}
 
 	// The SDK defines 404 as an "ok" status code..
 	if utils.ResponseWasNotFound(resp.Response) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r AppServiceSlotResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
@@ -122,7 +122,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsd
 
 	connectionEnvelope := web.SwiftVirtualNetwork{
 		SwiftVirtualNetworkProperties: &web.SwiftVirtualNetworkProperties{
-			SubnetResourceID: utils.String(d.Get("subnet_id").(string)),
+			SubnetResourceID: pointer.To(d.Get("subnet_id").(string)),
 		},
 	}
 	if _, err = client.CreateOrUpdateSwiftVirtualNetworkConnectionWithCheckSlot(ctx, resourceGroup, name, connectionEnvelope, slotName); err != nil {

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource_test.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -163,12 +164,12 @@ func (r AppServiceSlotVirtualNetworkSwiftConnectionResource) Exists(ctx context.
 	resp, err := clients.Web.AppServicesClient.GetSwiftVirtualNetworkConnectionSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.SwiftVirtualNetworkProperties != nil), nil
+	return pointer.To(resp.SwiftVirtualNetworkProperties != nil), nil
 }
 
 func (t AppServiceSlotVirtualNetworkSwiftConnectionResource) disappears(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/web/app_service_source_control_token_resource.go
+++ b/internal/services/web/app_service_source_control_token_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
@@ -85,8 +86,8 @@ func resourceAppServiceSourceControlTokenCreateUpdate(d *pluginsdk.ResourceData,
 
 	properties := web.SourceControl{
 		SourceControlProperties: &web.SourceControlProperties{
-			Token:       utils.String(token),
-			TokenSecret: utils.String(tokenSecret),
+			Token:       pointer.To(token),
+			TokenSecret: pointer.To(tokenSecret),
 		},
 	}
 
@@ -143,8 +144,8 @@ func resourceAppServiceSourceControlTokenDelete(d *pluginsdk.ResourceData, meta 
 
 	properties := web.SourceControl{
 		SourceControlProperties: &web.SourceControlProperties{
-			Token:       utils.String(token),
-			TokenSecret: utils.String(tokenSecret),
+			Token:       pointer.To(token),
+			TokenSecret: pointer.To(tokenSecret),
 		},
 	}
 

--- a/internal/services/web/app_service_source_control_token_resource_test.go
+++ b/internal/services/web/app_service_source_control_token_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -41,12 +42,12 @@ func (r AppServiceSourceControlTokenResource) Exists(ctx context.Context, client
 	resp, err := client.Web.BaseClient.GetSourceControl(ctx, state.ID)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", state.ID, err)
 	}
 
-	return utils.Bool(resp.SourceControlProperties != nil && resp.Token != nil && *resp.Token != ""), nil
+	return pointer.To(resp.SourceControlProperties != nil && resp.Token != nil && *resp.Token != ""), nil
 }
 
 func testAccAppServiceSourceControlToken(token, tokenSecret string) string {

--- a/internal/services/web/app_service_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_virtual_network_swift_connection_resource.go
@@ -108,7 +108,7 @@ func resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.Re
 
 	connectionEnvelope := web.SwiftVirtualNetwork{
 		SwiftVirtualNetworkProperties: &web.SwiftVirtualNetworkProperties{
-			SubnetResourceID: utils.String(d.Get("subnet_id").(string)),
+			SubnetResourceID: pointer.To(d.Get("subnet_id").(string)),
 		},
 	}
 	if _, err = client.CreateOrUpdateSwiftVirtualNetworkConnectionWithCheck(ctx, resourceGroup, name, connectionEnvelope); err != nil {

--- a/internal/services/web/app_service_virtual_network_swift_connection_resource_test.go
+++ b/internal/services/web/app_service_virtual_network_swift_connection_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -97,12 +98,12 @@ func (r AppServiceVirtualNetworkSwiftConnectionResource) Exists(ctx context.Cont
 	resp, err := clients.Web.AppServicesClient.GetSwiftVirtualNetworkConnection(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.SwiftVirtualNetworkProperties != nil), nil
+	return pointer.To(resp.SwiftVirtualNetworkProperties != nil), nil
 }
 
 func (t AppServiceVirtualNetworkSwiftConnectionResource) disappears(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/web/cors_settings.go
+++ b/internal/services/web/cors_settings.go
@@ -5,8 +5,8 @@ package web
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func SchemaWebCorsSettings() *pluginsdk.Schema {
@@ -54,7 +54,7 @@ func ExpandWebCorsSettings(input interface{}) web.CorsSettings {
 	}
 
 	if v, ok := setting["support_credentials"]; ok {
-		corsSettings.SupportCredentials = utils.Bool(v.(bool))
+		corsSettings.SupportCredentials = pointer.To(v.(bool))
 	}
 
 	return corsSettings

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func schemaAppServiceFunctionAppSiteConfig() *pluginsdk.Schema {
@@ -406,19 +406,19 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 	config := configs[0].(map[string]interface{})
 
 	if v, ok := config["always_on"]; ok {
-		siteConfig.AlwaysOn = utils.Bool(v.(bool))
+		siteConfig.AlwaysOn = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["use_32_bit_worker_process"]; ok {
-		siteConfig.Use32BitWorkerProcess = utils.Bool(v.(bool))
+		siteConfig.Use32BitWorkerProcess = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["websockets_enabled"]; ok {
-		siteConfig.WebSocketsEnabled = utils.Bool(v.(bool))
+		siteConfig.WebSocketsEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["linux_fx_version"]; ok {
-		siteConfig.LinuxFxVersion = utils.String(v.(string))
+		siteConfig.LinuxFxVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["cors"]; ok {
@@ -427,7 +427,7 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 	}
 
 	if v, ok := config["http2_enabled"]; ok {
-		siteConfig.HTTP20Enabled = utils.Bool(v.(bool))
+		siteConfig.HTTP20Enabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["ip_restriction"]; ok {
@@ -439,7 +439,7 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 	}
 
 	if v, ok := config["scm_use_main_ip_restriction"]; ok {
-		siteConfig.ScmIPSecurityRestrictionsUseMain = utils.Bool(v.(bool))
+		siteConfig.ScmIPSecurityRestrictionsUseMain = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["scm_ip_restriction"]; ok {
@@ -460,7 +460,7 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 	}
 
 	if v, ok := config["pre_warmed_instance_count"]; ok {
-		siteConfig.PreWarmedInstanceCount = utils.Int32(int32(v.(int)))
+		siteConfig.PreWarmedInstanceCount = pointer.To(int32(v.(int)))
 	}
 
 	if v, ok := config["scm_type"]; ok {
@@ -469,35 +469,35 @@ func expandFunctionAppSiteConfig(d *pluginsdk.ResourceData) (web.SiteConfig, err
 
 	// This optional parameter can only present in "slot" resources
 	if v, ok := config["auto_swap_slot_name"]; ok {
-		siteConfig.AutoSwapSlotName = utils.String(v.(string))
+		siteConfig.AutoSwapSlotName = pointer.To(v.(string))
 	}
 
 	if v, ok := config["health_check_path"]; ok {
-		siteConfig.HealthCheckPath = utils.String(v.(string))
+		siteConfig.HealthCheckPath = pointer.To(v.(string))
 	}
 
 	if v, ok := config["java_version"]; ok {
-		siteConfig.JavaVersion = utils.String(v.(string))
+		siteConfig.JavaVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["elastic_instance_minimum"]; ok && v.(int) > 0 {
-		siteConfig.MinimumElasticInstanceCount = utils.Int32(int32(v.(int)))
+		siteConfig.MinimumElasticInstanceCount = pointer.To(int32(v.(int)))
 	}
 
 	if v, ok := config["app_scale_limit"]; ok {
-		siteConfig.FunctionAppScaleLimit = utils.Int32(int32(v.(int)))
+		siteConfig.FunctionAppScaleLimit = pointer.To(int32(v.(int)))
 	}
 
 	if v, ok := config["runtime_scale_monitoring_enabled"]; ok {
-		siteConfig.FunctionsRuntimeScaleMonitoringEnabled = utils.Bool(v.(bool))
+		siteConfig.FunctionsRuntimeScaleMonitoringEnabled = pointer.To(v.(bool))
 	}
 
 	if v, ok := config["dotnet_framework_version"]; ok {
-		siteConfig.NetFrameworkVersion = utils.String(v.(string))
+		siteConfig.NetFrameworkVersion = pointer.To(v.(string))
 	}
 
 	if v, ok := config["vnet_route_all_enabled"]; ok {
-		siteConfig.VnetRouteAllEnabled = utils.Bool(v.(bool))
+		siteConfig.VnetRouteAllEnabled = pointer.To(v.(bool))
 	}
 
 	return siteConfig, nil
@@ -600,7 +600,7 @@ func expandFunctionAppConnectionStrings(d *pluginsdk.ResourceData) map[string]*w
 		csValue := vals["value"].(string)
 
 		output[csName] = &web.ConnStringValueTypePair{
-			Value: utils.String(csValue),
+			Value: pointer.To(csValue),
 			Type:  web.ConnectionStringType(csType),
 		}
 	}
@@ -649,7 +649,7 @@ func appSettingsMapToNameValuePair(input map[string]*string) *[]web.NameValuePai
 	result := make([]web.NameValuePair, 0)
 	for k, v := range input {
 		result = append(result, web.NameValuePair{
-			Name:  utils.String(k),
+			Name:  pointer.To(k),
 			Value: v,
 		})
 	}

--- a/internal/services/web/function_app_resource.go
+++ b/internal/services/web/function_app_resource.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -270,7 +270,7 @@ func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	availabilityRequest := web.ResourceNameAvailabilityRequest{
-		Name: utils.String(id.SiteName),
+		Name: pointer.To(id.SiteName),
 		Type: web.CheckNameResourceTypesMicrosoftWebsites,
 	}
 	available, err := client.CheckNameAvailability(ctx, availabilityRequest)
@@ -282,7 +282,7 @@ func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("the name %q used for the Function App needs to be globally unique and isn't available: %s", id.SiteName, *available.Message)
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	kind := "functionapp"
 	if osTypeRaw, ok := d.GetOk("os_type"); ok {
 		osType := osTypeRaw.(string)
@@ -322,17 +322,17 @@ func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:         utils.String(appServicePlanID),
-			Enabled:              utils.Bool(enabled),
-			ClientCertEnabled:    utils.Bool(clientCertEnabled),
-			HTTPSOnly:            utils.Bool(httpsOnly),
-			DailyMemoryTimeQuota: utils.Int32(int32(dailyMemoryTimeQuota)),
+			ServerFarmID:         pointer.To(appServicePlanID),
+			Enabled:              pointer.To(enabled),
+			ClientCertEnabled:    pointer.To(clientCertEnabled),
+			HTTPSOnly:            pointer.To(httpsOnly),
+			DailyMemoryTimeQuota: pointer.To(int32(dailyMemoryTimeQuota)),
 			SiteConfig:           &siteConfig,
 		},
 	}
 
 	if v, ok := d.GetOk("key_vault_reference_identity_id"); ok {
-		siteEnvelope.KeyVaultReferenceIdentity = utils.String(v.(string))
+		siteEnvelope.KeyVaultReferenceIdentity = pointer.To(v.(string))
 	}
 
 	if clientCertMode != "" {
@@ -380,7 +380,7 @@ func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	authSettings := expandAppServiceAuthSettings(authSettingsRaw)
 
 	auth := web.SiteAuthSettings{
-		ID:                         utils.String(id.ID()),
+		ID:                         pointer.To(id.ID()),
 		SiteAuthSettingsProperties: &authSettings,
 	}
 
@@ -406,7 +406,7 @@ func resourceFunctionAppUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	kind := "functionapp"
 	if osTypeRaw, ok := d.GetOk("os_type"); ok {
 		osType := osTypeRaw.(string)
@@ -462,17 +462,17 @@ func resourceFunctionAppUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:         utils.String(appServicePlanID),
-			Enabled:              utils.Bool(enabled),
-			ClientCertEnabled:    utils.Bool(clientCertEnabled),
-			HTTPSOnly:            utils.Bool(httpsOnly),
-			DailyMemoryTimeQuota: utils.Int32(int32(dailyMemoryTimeQuota)),
+			ServerFarmID:         pointer.To(appServicePlanID),
+			Enabled:              pointer.To(enabled),
+			ClientCertEnabled:    pointer.To(clientCertEnabled),
+			HTTPSOnly:            pointer.To(httpsOnly),
+			DailyMemoryTimeQuota: pointer.To(int32(dailyMemoryTimeQuota)),
 			SiteConfig:           &siteConfig,
 		},
 	}
 
 	if v, ok := d.GetOk("key_vault_reference_identity_id"); ok {
-		siteEnvelope.KeyVaultReferenceIdentity = utils.String(v.(string))
+		siteEnvelope.KeyVaultReferenceIdentity = pointer.To(v.(string))
 	}
 
 	if clientCertMode != "" {
@@ -555,7 +555,7 @@ func resourceFunctionAppUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		authSettingsRaw := d.Get("auth_settings").([]interface{})
 		authSettingsProperties := expandAppServiceAuthSettings(authSettingsRaw)
 		authSettings := web.SiteAuthSettings{
-			ID:                         utils.String(d.Id()),
+			ID:                         pointer.To(d.Id()),
 			SiteAuthSettingsProperties: &authSettingsProperties,
 		}
 
@@ -640,8 +640,8 @@ func resourceFunctionAppRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	}
 	d.Set("os_type", osType)
 
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	appServicePlanID := ""

--- a/internal/services/web/function_app_resource_test.go
+++ b/internal/services/web/function_app_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -1119,17 +1120,17 @@ func (r FunctionAppResource) Exists(ctx context.Context, clients *clients.Client
 	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Function App %q (Resource Group %q): %+v", id.SiteName, id.ResourceGroup, err)
 	}
 
 	// The SDK defines 404 as an "ok" status code..
 	if utils.ResponseWasNotFound(resp.Response) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r FunctionAppResource) hasContentShareAppSetting(shouldExist bool) func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -248,7 +248,7 @@ func resourceFunctionAppSlotCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	kind := "functionapp"
 	if osTypeRaw, ok := d.GetOk("os_type"); ok {
 		osType := osTypeRaw.(string)
@@ -281,10 +281,10 @@ func resourceFunctionAppSlotCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:         utils.String(appServicePlanID),
-			Enabled:              utils.Bool(enabled),
-			HTTPSOnly:            utils.Bool(httpsOnly),
-			DailyMemoryTimeQuota: utils.Int32(int32(dailyMemoryTimeQuota)),
+			ServerFarmID:         pointer.To(appServicePlanID),
+			Enabled:              pointer.To(enabled),
+			HTTPSOnly:            pointer.To(httpsOnly),
+			DailyMemoryTimeQuota: pointer.To(int32(dailyMemoryTimeQuota)),
 			SiteConfig:           &siteConfig,
 		},
 	}
@@ -313,7 +313,7 @@ func resourceFunctionAppSlotCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	authSettings := expandAppServiceAuthSettings(authSettingsRaw)
 
 	auth := web.SiteAuthSettings{
-		ID:                         utils.String(id.ID()),
+		ID:                         pointer.To(id.ID()),
 		SiteAuthSettingsProperties: &authSettings,
 	}
 
@@ -339,7 +339,7 @@ func resourceFunctionAppSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		return err
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	kind := "functionapp"
 	if osTypeRaw, ok := d.GetOk("os_type"); ok {
 		osType := osTypeRaw.(string)
@@ -381,10 +381,10 @@ func resourceFunctionAppSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		Location: &location,
 		Tags:     tags.Expand(t),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:         utils.String(appServicePlanID),
-			Enabled:              utils.Bool(enabled),
-			HTTPSOnly:            utils.Bool(httpsOnly),
-			DailyMemoryTimeQuota: utils.Int32(int32(dailyMemoryTimeQuota)),
+			ServerFarmID:         pointer.To(appServicePlanID),
+			Enabled:              pointer.To(enabled),
+			HTTPSOnly:            pointer.To(httpsOnly),
+			DailyMemoryTimeQuota: pointer.To(int32(dailyMemoryTimeQuota)),
 			SiteConfig:           &siteConfig,
 		},
 	}
@@ -433,7 +433,7 @@ func resourceFunctionAppSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		authSettingsRaw := d.Get("auth_settings").([]interface{})
 		authSettingsProperties := expandAppServiceAuthSettings(authSettingsRaw)
 		authSettings := web.SiteAuthSettings{
-			ID:                         utils.String(d.Id()),
+			ID:                         pointer.To(d.Id()),
 			SiteAuthSettingsProperties: &authSettingsProperties,
 		}
 
@@ -519,8 +519,8 @@ func resourceFunctionAppSlotRead(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 	d.Set("os_type", osType)
 
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
+	if loc := resp.Location; loc != nil {
+		d.Set("location", location.Normalize(*loc))
 	}
 
 	if props := resp.SiteProperties; props != nil {
@@ -732,7 +732,7 @@ func expandFunctionAppSlotConnectionStrings(d *pluginsdk.ResourceData) map[strin
 		csValue := vals["value"].(string)
 
 		output[csName] = &web.ConnStringValueTypePair{
-			Value: utils.String(csValue),
+			Value: pointer.To(csValue),
 			Type:  web.ConnectionStringType(csType),
 		}
 	}

--- a/internal/services/web/function_app_slot_resource_test.go
+++ b/internal/services/web/function_app_slot_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -667,17 +668,17 @@ func (r FunctionAppSlotResource) Exists(ctx context.Context, clients *clients.Cl
 	resp, err := clients.Web.AppServicesClient.GetSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Function App Slot %q (Function App %q / Resource Group %q): %+v", id.SlotName, id.SiteName, id.ResourceGroup, err)
 	}
 
 	// The SDK defines 404 as an "ok" status code..
 	if utils.ResponseWasNotFound(resp.Response) {
-		return utils.Bool(false), nil
+		return pointer.To(false), nil
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r FunctionAppSlotResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -141,7 +142,7 @@ func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{
 	siteEnvelope := web.StaticSiteARMResource{
 		Sku: &web.SkuDescription{
 			Name: &skuName,
-			Tier: utils.String(d.Get("sku_tier").(string)),
+			Tier: pointer.To(d.Get("sku_tier").(string)),
 		},
 		StaticSite: &web.StaticSite{},
 		Location:   &loc,
@@ -324,7 +325,7 @@ func expandStaticSiteAppSettings(d *pluginsdk.ResourceData) map[string]*string {
 	output := make(map[string]*string, len(input))
 
 	for k, v := range input {
-		output[k] = utils.String(v.(string))
+		output[k] = pointer.To(v.(string))
 	}
 
 	return output

--- a/internal/services/web/static_site_resource_custom_domain_test.go
+++ b/internal/services/web/static_site_resource_custom_domain_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -58,12 +59,12 @@ func (r StaticSiteCustomDomainResource) Exists(ctx context.Context, clients *cli
 	resp, err := clients.Web.StaticSitesClient.GetStaticSiteCustomDomain(ctx, id.ResourceGroup, id.StaticSiteName, id.CustomDomainName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Static Site %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StaticSiteCustomDomainResource) basic(data acceptance.TestData) string {

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -209,12 +210,12 @@ func (r StaticSiteResource) Exists(ctx context.Context, clients *clients.Client,
 	resp, err := clients.Web.StaticSitesClient.GetStaticSite(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving Static Site %q: %+v", id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r StaticSiteResource) basic(data acceptance.TestData) string {

--- a/internal/services/workloads/workloads_sap_discovery_virtual_instance_resource.go
+++ b/internal/services/workloads/workloads_sap_discovery_virtual_instance_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/workloads/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkloadsSAPDiscoveryVirtualInstanceModel struct {
@@ -169,7 +168,7 @@ func (r WorkloadsSAPDiscoveryVirtualInstanceResource) Create() sdk.ResourceFunc 
 
 			if v := model.ManagedResourceGroupName; v != "" {
 				parameters.Properties.ManagedResourceGroupConfiguration = &sapvirtualinstances.ManagedRGConfiguration{
-					Name: utils.String(v),
+					Name: pointer.To(v),
 				}
 			}
 

--- a/internal/services/workloads/workloads_sap_discovery_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_discovery_virtual_instance_resource_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkloadsSAPDiscoveryVirtualInstanceResource struct{}
@@ -120,11 +120,11 @@ func (r WorkloadsSAPDiscoveryVirtualInstanceResource) Exists(ctx context.Context
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WorkloadsSAPDiscoveryVirtualInstanceResource) basic(data acceptance.TestData) string {

--- a/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource.go
+++ b/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/workloads/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkloadsSAPSingleNodeVirtualInstanceModel struct {
@@ -471,10 +470,10 @@ func (r WorkloadsSAPSingleNodeVirtualInstanceResource) Create() sdk.ResourceFunc
 				Location: location.Normalize(model.Location),
 				Properties: &sapvirtualinstances.SAPVirtualInstanceProperties{
 					Configuration: sapvirtualinstances.DeploymentWithOSConfiguration{
-						AppLocation:                 utils.String(location.Normalize(model.AppLocation)),
+						AppLocation:                 pointer.To(location.Normalize(model.AppLocation)),
 						InfrastructureConfiguration: expandSingleServerConfiguration(model.SingleServerConfiguration),
 						OsSapConfiguration: &sapvirtualinstances.OsSapConfiguration{
-							SapFqdn: utils.String(model.SapFqdn),
+							SapFqdn: pointer.To(model.SapFqdn),
 						},
 					},
 					Environment:                       sapvirtualinstances.SAPEnvironmentType(model.Environment),
@@ -486,7 +485,7 @@ func (r WorkloadsSAPSingleNodeVirtualInstanceResource) Create() sdk.ResourceFunc
 
 			if v := model.ManagedResourceGroupName; v != "" {
 				parameters.Properties.ManagedResourceGroupConfiguration = &sapvirtualinstances.ManagedRGConfiguration{
-					Name: utils.String(v),
+					Name: pointer.To(v),
 				}
 			}
 
@@ -660,10 +659,10 @@ func expandSAPSingleNodeVirtualInstanceImageReference(input []SingleServerImageR
 	imageReference := input[0]
 
 	result := &sapvirtualinstances.ImageReference{
-		Offer:     utils.String(imageReference.Offer),
-		Publisher: utils.String(imageReference.Publisher),
-		Sku:       utils.String(imageReference.Sku),
-		Version:   utils.String(imageReference.Version),
+		Offer:     pointer.To(imageReference.Offer),
+		Publisher: pointer.To(imageReference.Publisher),
+		Sku:       pointer.To(imageReference.Sku),
+		Version:   pointer.To(imageReference.Version),
 	}
 
 	return result
@@ -677,12 +676,12 @@ func expandSAPSingleNodeVirtualInstanceOsProfile(input []SingleServerOSProfile) 
 	osProfile := input[0]
 
 	result := &sapvirtualinstances.OSProfile{
-		AdminUsername: utils.String(osProfile.AdminUsername),
+		AdminUsername: pointer.To(osProfile.AdminUsername),
 		OsConfiguration: &sapvirtualinstances.LinuxConfiguration{
-			DisablePasswordAuthentication: utils.Bool(true),
+			DisablePasswordAuthentication: pointer.To(true),
 			SshKeyPair: &sapvirtualinstances.SshKeyPair{
-				PrivateKey: utils.String(osProfile.SshPrivateKey),
-				PublicKey:  utils.String(osProfile.SshPublicKey),
+				PrivateKey: pointer.To(osProfile.SshPrivateKey),
+				PublicKey:  pointer.To(osProfile.SshPublicKey),
 			},
 		},
 	}
@@ -705,15 +704,15 @@ func expandSAPSingleNodeVirtualInstanceVirtualMachineFullResourceNames(input []S
 	}
 
 	if v := virtualMachineFullResourceNames.HostName; v != "" {
-		result.VirtualMachine.HostName = utils.String(v)
+		result.VirtualMachine.HostName = pointer.To(v)
 	}
 
 	if v := virtualMachineFullResourceNames.OSDiskName; v != "" {
-		result.VirtualMachine.OsDiskName = utils.String(v)
+		result.VirtualMachine.OsDiskName = pointer.To(v)
 	}
 
 	if v := virtualMachineFullResourceNames.VMName; v != "" {
-		result.VirtualMachine.VirtualMachineName = utils.String(v)
+		result.VirtualMachine.VirtualMachineName = pointer.To(v)
 	}
 
 	return result
@@ -727,7 +726,7 @@ func expandSAPSingleNodeVirtualInstanceNetworkInterfaceNames(input []string) *[]
 
 	for _, v := range input {
 		networkInterfaceName := sapvirtualinstances.NetworkInterfaceResourceNames{
-			NetworkInterfaceName: utils.String(v),
+			NetworkInterfaceName: pointer.To(v),
 		}
 
 		result = append(result, networkInterfaceName)
@@ -760,8 +759,8 @@ func expandSAPSingleNodeVirtualInstanceDiskVolumeConfigurations(input []SingleSe
 		skuName := sapvirtualinstances.DiskSkuName(v.SkuName)
 
 		result[v.VolumeName] = sapvirtualinstances.DiskVolumeConfiguration{
-			Count:  utils.Int64(v.NumberOfDisks),
-			SizeGB: utils.Int64(v.SizeGb),
+			Count:  pointer.To(v.NumberOfDisks),
+			SizeGB: pointer.To(v.SizeGb),
 			Sku: &sapvirtualinstances.DiskSku{
 				Name: &skuName,
 			},
@@ -785,7 +784,7 @@ func expandSingleServerConfiguration(input []SingleServerConfiguration) *sapvirt
 		CustomResourceNames: expandSAPSingleNodeVirtualInstanceVirtualMachineFullResourceNames(singleServerConfiguration.VirtualMachineResourceNames),
 		DbDiskConfiguration: expandSAPSingleNodeVirtualInstanceDiskVolumeConfigurations(singleServerConfiguration.DiskVolumeConfigurations),
 		NetworkConfiguration: &sapvirtualinstances.NetworkConfiguration{
-			IsSecondaryIPEnabled: utils.Bool(singleServerConfiguration.IsSecondaryIpEnabled),
+			IsSecondaryIPEnabled: pointer.To(singleServerConfiguration.IsSecondaryIpEnabled),
 		},
 		SubnetId:                    singleServerConfiguration.SubnetId,
 		VirtualMachineConfiguration: pointer.From(expandSAPSingleNodeVirtualInstanceVirtualMachineConfiguration(singleServerConfiguration.VirtualMachineConfiguration)),

--- a/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_single_node_virtual_instance_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkloadsSAPSingleNodeVirtualInstanceResource struct{}
@@ -112,11 +112,11 @@ func (r WorkloadsSAPSingleNodeVirtualInstanceResource) Exists(ctx context.Contex
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WorkloadsSAPSingleNodeVirtualInstanceResource) template(data acceptance.TestData) string {

--- a/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource.go
+++ b/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/workloads/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkloadsSAPThreeTierVirtualInstanceModel struct {
@@ -1130,9 +1129,9 @@ func (r WorkloadsSAPThreeTierVirtualInstanceResource) Create() sdk.ResourceFunc 
 			}
 
 			deploymentWithOSConfiguration := &sapvirtualinstances.DeploymentWithOSConfiguration{
-				AppLocation: utils.String(location.Normalize(model.AppLocation)),
+				AppLocation: pointer.To(location.Normalize(model.AppLocation)),
 				OsSapConfiguration: &sapvirtualinstances.OsSapConfiguration{
-					SapFqdn: utils.String(model.SapFqdn),
+					SapFqdn: pointer.To(model.SapFqdn),
 				},
 			}
 
@@ -1146,7 +1145,7 @@ func (r WorkloadsSAPThreeTierVirtualInstanceResource) Create() sdk.ResourceFunc 
 
 			if v := model.ManagedResourceGroupName; v != "" {
 				parameters.Properties.ManagedResourceGroupConfiguration = &sapvirtualinstances.ManagedRGConfiguration{
-					Name: utils.String(v),
+					Name: pointer.To(v),
 				}
 			}
 
@@ -1319,10 +1318,10 @@ func expandImageReference(input []ImageReference) *sapvirtualinstances.ImageRefe
 	imageReference := input[0]
 
 	result := &sapvirtualinstances.ImageReference{
-		Offer:     utils.String(imageReference.Offer),
-		Publisher: utils.String(imageReference.Publisher),
-		Sku:       utils.String(imageReference.Sku),
-		Version:   utils.String(imageReference.Version),
+		Offer:     pointer.To(imageReference.Offer),
+		Publisher: pointer.To(imageReference.Publisher),
+		Sku:       pointer.To(imageReference.Sku),
+		Version:   pointer.To(imageReference.Version),
 	}
 
 	return result
@@ -1336,12 +1335,12 @@ func expandOsProfile(input []OSProfile) *sapvirtualinstances.OSProfile {
 	osProfile := input[0]
 
 	result := &sapvirtualinstances.OSProfile{
-		AdminUsername: utils.String(osProfile.AdminUsername),
+		AdminUsername: pointer.To(osProfile.AdminUsername),
 		OsConfiguration: &sapvirtualinstances.LinuxConfiguration{
-			DisablePasswordAuthentication: utils.Bool(true),
+			DisablePasswordAuthentication: pointer.To(true),
 			SshKeyPair: &sapvirtualinstances.SshKeyPair{
-				PrivateKey: utils.String(osProfile.SshPrivateKey),
-				PublicKey:  utils.String(osProfile.SshPublicKey),
+				PrivateKey: pointer.To(osProfile.SshPrivateKey),
+				PublicKey:  pointer.To(osProfile.SshPublicKey),
 			},
 		},
 	}
@@ -1357,7 +1356,7 @@ func expandNetworkInterfaceNames(input []string) *[]sapvirtualinstances.NetworkI
 
 	for _, v := range input {
 		networkInterfaceName := sapvirtualinstances.NetworkInterfaceResourceNames{
-			NetworkInterfaceName: utils.String(v),
+			NetworkInterfaceName: pointer.To(v),
 		}
 
 		result = append(result, networkInterfaceName)
@@ -1390,8 +1389,8 @@ func expandDiskVolumeConfigurations(input []DiskVolumeConfiguration) *sapvirtual
 		skuName := sapvirtualinstances.DiskSkuName(v.SkuName)
 
 		result[v.VolumeName] = sapvirtualinstances.DiskVolumeConfiguration{
-			Count:  utils.Int64(v.NumberOfDisks),
-			SizeGB: utils.Int64(v.SizeGb),
+			Count:  pointer.To(v.NumberOfDisks),
+			SizeGB: pointer.To(v.SizeGb),
 			Sku: &sapvirtualinstances.DiskSku{
 				Name: &skuName,
 			},
@@ -1491,11 +1490,11 @@ func expandTransportCreateAndMount(input []TransportCreateAndMount) (*sapvirtual
 		if err != nil {
 			return nil, err
 		}
-		result.ResourceGroup = utils.String(resourceGroupId.ResourceGroupName)
+		result.ResourceGroup = pointer.To(resourceGroupId.ResourceGroupName)
 	}
 
 	if v := transportCreateAndMount.StorageAccountName; v != "" {
-		result.StorageAccountName = utils.String(v)
+		result.StorageAccountName = pointer.To(v)
 	}
 
 	return result, nil
@@ -1530,7 +1529,7 @@ func expandApplicationServerResourceNames(input []ApplicationServerResourceNames
 	}
 
 	if v := applicationServerResourceNames.AvailabilitySetName; v != "" {
-		result.AvailabilitySetName = utils.String(v)
+		result.AvailabilitySetName = pointer.To(v)
 	}
 
 	return result
@@ -1549,15 +1548,15 @@ func expandVirtualMachinesResourceNames(input []VirtualMachineResourceNames) *[]
 		}
 
 		if v := item.HostName; v != "" {
-			vmResourceNames.HostName = utils.String(v)
+			vmResourceNames.HostName = pointer.To(v)
 		}
 
 		if v := item.OSDiskName; v != "" {
-			vmResourceNames.OsDiskName = utils.String(v)
+			vmResourceNames.OsDiskName = pointer.To(v)
 		}
 
 		if v := item.VMName; v != "" {
-			vmResourceNames.VirtualMachineName = utils.String(v)
+			vmResourceNames.VirtualMachineName = pointer.To(v)
 		}
 
 		result = append(result, vmResourceNames)
@@ -1579,7 +1578,7 @@ func expandCentralServerResourceNames(input []CentralServerResourceNames) *sapvi
 	}
 
 	if v := centralServerResourceNames.AvailabilitySetName; v != "" {
-		result.AvailabilitySetName = utils.String(v)
+		result.AvailabilitySetName = pointer.To(v)
 	}
 
 	return result
@@ -1594,7 +1593,7 @@ func expandLoadBalancerResourceNames(input []LoadBalancer) *sapvirtualinstances.
 	loadBalancerResourceNames := input[0]
 
 	if v := loadBalancerResourceNames.Name; v != "" {
-		result.LoadBalancerName = utils.String(v)
+		result.LoadBalancerName = pointer.To(v)
 	}
 
 	if v := loadBalancerResourceNames.BackendPoolNames; v != nil {
@@ -1625,7 +1624,7 @@ func expandDatabaseServerResourceNames(input []DatabaseServerResourceNames) *sap
 	}
 
 	if v := databaseServerResourceNames.AvailabilitySetName; v != "" {
-		result.AvailabilitySetName = utils.String(v)
+		result.AvailabilitySetName = pointer.To(v)
 	}
 
 	return result
@@ -1640,11 +1639,11 @@ func expandSharedStorage(input []SharedStorage) *sapvirtualinstances.SharedStora
 	sharedStorage := input[0]
 
 	if v := sharedStorage.AccountName; v != "" {
-		result.SharedStorageAccountName = utils.String(v)
+		result.SharedStorageAccountName = pointer.To(v)
 	}
 
 	if v := sharedStorage.PrivateEndpointName; v != "" {
-		result.SharedStorageAccountPrivateEndPointName = utils.String(v)
+		result.SharedStorageAccountPrivateEndPointName = pointer.To(v)
 	}
 
 	return result
@@ -1660,7 +1659,7 @@ func expandThreeTierConfiguration(input []ThreeTierConfiguration) (*sapvirtualin
 		CustomResourceNames: expandResourceNames(threeTierConfiguration.ResourceNames),
 		DatabaseServer:      pointer.From(expandDatabaseServer(threeTierConfiguration.DatabaseServerConfiguration)),
 		NetworkConfiguration: &sapvirtualinstances.NetworkConfiguration{
-			IsSecondaryIPEnabled: utils.Bool(threeTierConfiguration.IsSecondaryIpEnabled),
+			IsSecondaryIPEnabled: pointer.To(threeTierConfiguration.IsSecondaryIpEnabled),
 		},
 	}
 

--- a/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
+++ b/internal/services/workloads/workloads_sap_three_tier_virtual_instance_resource_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type WorkloadsSAPThreeTierVirtualInstanceResource struct{}
@@ -132,11 +132,11 @@ func (r WorkloadsSAPThreeTierVirtualInstanceResource) Exists(ctx context.Context
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-	return utils.Bool(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r WorkloadsSAPThreeTierVirtualInstanceResource) template(data acceptance.TestData) string {


### PR DESCRIPTION
Removes usages of:

- `utils.{Type}` in favour of `pointer.To`
- `azure.NormalizeLocation` in favour of `location.Normalize`
- `pointer.To{Type}` in favour of the generic `pointer.From`
- `pointer.From{Type}` in favour of the generic `pointer.To`
