### PR TITLE
`azurerm_resource_group` - use new `RetryOnErrorPoller` to resolve eventual consistency issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-azure-helpers v0.75.1
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20251126.1220923
-	github.com/hashicorp/go-azure-sdk/sdk v0.20251126.1220923
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20251202.1181053
+	github.com/hashicorp/go-azure-sdk/sdk v0.20251202.1181053
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -112,10 +112,10 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.75.1 h1:trQTCMvBkuBWl5ltPQpGDw/Xe4oepz0enaUeVS0Op3M=
 github.com/hashicorp/go-azure-helpers v0.75.1/go.mod h1:tAUWC+kwZQsuNAHEIlnbojMMcC6SWQb6W1HfIeluv1E=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20251126.1220923 h1:bVKSdEeNvq+WnXWlGW/mkq2F/TJ3GoEtIgQbRjBOuRc=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20251126.1220923/go.mod h1:LYVl2M2CGDFIcNMo68xZiwcn5toaAmDZxT9DuyHKX5M=
-github.com/hashicorp/go-azure-sdk/sdk v0.20251126.1220923 h1:d0vrjXHHCbUkJQBljFIoFgCuF/fVvIOU42XS1KTsqwA=
-github.com/hashicorp/go-azure-sdk/sdk v0.20251126.1220923/go.mod h1:gD7NeaIdyqtzQeNwoPDDB6wtfOy9Hm2RVxP9PNps5rk=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20251202.1181053 h1:TB3Zhb2EqtSq90VUXcvWQ3CMfsQUupGvFiItF1mT4Qs=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20251202.1181053/go.mod h1:ob/+TfRMuGHZkLfupeTOUVj3gfBOeETB+AEnixmA7gI=
+github.com/hashicorp/go-azure-sdk/sdk v0.20251202.1181053 h1:sypXGxrd6HzRd/O3V7bIsZdI6YfJvGZL93Xf7xk1P9g=
+github.com/hashicorp/go-azure-sdk/sdk v0.20251202.1181053/go.mod h1:gD7NeaIdyqtzQeNwoPDDB6wtfOy9Hm2RVxP9PNps5rk=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -4,6 +4,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -181,9 +182,12 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 	// conditionally check for nested resources and error if they exist
 	if meta.(*clients.Client).Features.ResourceGroup.PreventDeletionIfContainsResources {
 		// Resource groups sometimes hold on to resource information after the resources have been deleted. We'll retry this check to account for that eventual consistency.
+		deletePollerContext, deletePollerCancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer deletePollerCancel()
+
 		pollerType := custompollers.NewResourceGroupPreventDeletePoller(client, *id)
-		poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
-		if err := poller.PollUntilDone(ctx); err != nil {
+		poller := pollers.NewRetryOnErrorPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow, true)
+		if err := poller.PollUntilDone(deletePollerContext); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/pollers/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/pollers/poller.go
@@ -5,10 +5,12 @@ package pollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 )
 
@@ -22,6 +24,8 @@ type Poller struct {
 
 	// latestError contains the error returned from the latest poll.
 	latestError error
+
+	retryOnError *bool
 
 	// latestResponse contains the polling status from the latest response.
 	latestResponse *PollResult
@@ -42,20 +46,36 @@ func NewPoller(pollerType PollerType, initialDelayDuration time.Duration, maxNum
 	}
 }
 
+func NewRetryOnErrorPoller(pollerType PollerType, initialDelayDuration time.Duration, maxNumberOfDroppedConnections int, retryOnError bool) Poller {
+	return Poller{
+		initialDelayDuration:          initialDelayDuration,
+		maxNumberOfDroppedConnections: maxNumberOfDroppedConnections,
+		poller:                        pollerType,
+		retryOnError:                  pointer.To(retryOnError),
+	}
+}
+
+func (p *Poller) AllowRetryOnError(allow bool) {
+	p.retryOnError = &allow
+}
+
 // LatestResponse returns the latest HTTP Response returned when polling
 func (p *Poller) LatestResponse() *client.Response {
 	if p.latestError != nil {
-		if v, ok := p.latestError.(PollingCancelledError); ok {
-			return v.HttpResponse
+		var c PollingCancelledError
+		if errors.As(p.latestError, &c) {
+			return c.HttpResponse
 		}
-		if _, ok := p.latestError.(PollingDroppedConnectionError); ok {
+		var dc PollingDroppedConnectionError
+		if errors.As(p.latestError, &dc) {
 			return nil
 		}
-		if v, ok := p.latestError.(PollingFailedError); ok {
-			return v.HttpResponse
+		var f PollingFailedError
+		if errors.As(p.latestError, &f) {
+			return f.HttpResponse
 		}
 
-		if p.latestError == context.DeadlineExceeded {
+		if errors.Is(p.latestError, context.DeadlineExceeded) {
 			return nil
 		}
 	}
@@ -70,18 +90,21 @@ func (p *Poller) LatestResponse() *client.Response {
 // LatestStatus returns the latest status returned when polling
 func (p *Poller) LatestStatus() PollingStatus {
 	if p.latestError != nil {
-		if _, ok := p.latestError.(PollingCancelledError); ok {
+		if errors.As(p.latestError, &PollingCancelledError{}) {
 			return PollingStatusCancelled
 		}
-		if _, ok := p.latestError.(PollingDroppedConnectionError); ok {
+
+		if errors.As(p.latestError, &PollingDroppedConnectionError{}) {
 			// we could look to expose a status for this, but we likely wouldn't handle this any differently
 			// to it being unknown, so I (@tombuildsstuff) think this is reasonable for now?
 			return PollingStatusUnknown
 		}
-		if _, ok := p.latestError.(PollingFailedError); ok {
+
+		if errors.As(p.latestError, &PollingFailedError{}) {
 			return PollingStatusFailed
 		}
-		if p.latestError == context.DeadlineExceeded {
+
+		if errors.Is(p.latestError, context.DeadlineExceeded) {
 			return PollingStatusUnknown
 		}
 	}
@@ -115,12 +138,7 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 			}
 			endTime := time.Now().Add(retryDuration)
 
-			select { // nolint: gosimple
-			case <-time.After(time.Until(endTime)):
-				{
-					break
-				}
-			}
+			<-time.After(time.Until(endTime))
 
 			p.latestResponse, p.latestError = p.poller.Poll(ctx)
 
@@ -129,7 +147,7 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 			if p.latestResponse == nil && p.latestError == nil {
 				// connection drops can either have no response/error (where we have no context)
 				connectionHasBeenDropped = true
-			} else if _, ok := p.latestError.(PollingDroppedConnectionError); ok {
+			} else if errors.As(p.latestError, &PollingDroppedConnectionError{}) {
 				// or have an error with more details (e.g. server not found, connection reset etc.)
 				connectionHasBeenDropped = true
 			}
@@ -148,7 +166,9 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 			}
 
 			if p.latestError != nil {
-				break
+				if !pointer.From(p.retryOnError) {
+					break
+				}
 			}
 
 			if response := p.latestResponse; response != nil {
@@ -196,6 +216,9 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 		break
 	case <-ctx.Done():
 		{
+			if pointer.From(p.retryOnError) {
+				return p.latestError
+			}
 			p.latestResponse = nil
 			p.latestError = ctx.Err()
 			return p.latestError

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,7 +166,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20251126.1220923
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20251202.1181053
 ## explicit; go 1.24.1
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -1264,7 +1264,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapappli
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapcentralserverinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapdatabaseinstances
 github.com/hashicorp/go-azure-sdk/resource-manager/workloads/2024-09-01/sapvirtualinstances
-# github.com/hashicorp/go-azure-sdk/sdk v0.20251126.1220923
+# github.com/hashicorp/go-azure-sdk/sdk v0.20251202.1181053
 ## explicit; go 1.24.1
 github.com/hashicorp/go-azure-sdk/sdk/auth
 github.com/hashicorp/go-azure-sdk/sdk/auth/autorest


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The default `go-azure-sdk` poller implementation short-circuits when it encounters an error, this PR includes an update to the SDK and the `azurerm_resource_group` resource to use the modified/new `RetryOnErrorPoller` to allow the custom `ResourceGroupPreventDeletePoller` to return errors, without the `PollUntilDone` function exiting.

- fix prevent delete functionality on `azurerm_resource_group`
- bumps `go-azure-sdk` to `v0.20251202.1181053`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="319" height="157" alt="image" src="https://github.com/user-attachments/assets/ff024e23-6006-4872-8660-6d1cd1c99da6" />

single failure was a transient error, succeeded on subsequent run

<img width="523" height="41" alt="image" src="https://github.com/user-attachments/assets/2d674a05-7f98-4b05-aba6-6c98f59aabb9" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31201


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
