### PR TITLE
`azurerm_private_link_service`: relaxing `nat_ip_configuration` - `name` and `primary` to conditional `ForceNew` -- to allow addition of new entry without full replacement

### DIFF
--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/privatelinkservices"
-  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -78,11 +78,11 @@ func TestAccPrivateLinkService_update(t *testing.T) {
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.env").HasValue("test"),
 			),
-      ConfigPlanChecks: resource.ConfigPlanChecks{
-        PreApply: []plancheck.PlanCheck{
-          plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
-        },
-      },
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
 		},
 		data.ImportStep(),
 		{
@@ -92,11 +92,11 @@ func TestAccPrivateLinkService_update(t *testing.T) {
 				check.That(data.ResourceName).Key("nat_ip_configuration.#").HasValue("1"),
 				check.That(data.ResourceName).Key("load_balancer_frontend_ip_configuration_ids.#").HasValue("1"),
 			),
-      ConfigPlanChecks: resource.ConfigPlanChecks{
-        PreApply: []plancheck.PlanCheck{
-          plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
-        },
-      },
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
 		},
 		data.ImportStep(),
 	})
@@ -126,11 +126,11 @@ func TestAccPrivateLinkService_move(t *testing.T) {
 				check.That(data.ResourceName).Key("nat_ip_configuration.2.private_ip_address").HasValue("10.5.2.19"),
 				check.That(data.ResourceName).Key("nat_ip_configuration.3.private_ip_address").HasValue("10.5.2.20"),
 			),
-      ConfigPlanChecks: resource.ConfigPlanChecks{
-        PreApply: []plancheck.PlanCheck{
-          plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
-        },
-      },
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
 		},
 		data.ImportStep(),
 		{

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -58,7 +58,7 @@ func TestAccPrivateLinkService_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_private_link_service", "test")
 	r := PrivateLinkServiceResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicIp(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -106,7 +106,7 @@ func TestAccPrivateLinkService_move(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_private_link_service", "test")
 	r := PrivateLinkServiceResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.moveSetup(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/privatelinkservices"
+  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -897,12 +897,20 @@ resource "azurerm_private_link_service" "test" {
     private_ip_address_version = "IPv4"
     primary                    = false
   }
+  
+  nat_ip_configuration {
+    name                       = "quaternaryIpConfiguration-%d"
+    subnet_id                  = azurerm_subnet.test.id
+    private_ip_address         = "10.5.1.43"
+    private_ip_address_version = "IPv4"
+    primary                    = false
+  }
 
   tags = {
     env = "test"
   }
 }
-`, data.RandomInteger, "UK South", data.RandomInteger, data.RandomInteger, data.RandomInteger, destinationIPAddress, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, "UK South", data.RandomInteger, data.RandomInteger, data.RandomInteger, destinationIPAddress, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (PrivateLinkServiceResource) template(data acceptance.TestData) string {

--- a/internal/services/network/private_link_service_resource_test.go
+++ b/internal/services/network/private_link_service_resource_test.go
@@ -78,6 +78,11 @@ func TestAccPrivateLinkService_update(t *testing.T) {
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.env").HasValue("test"),
 			),
+      ConfigPlanChecks: resource.ConfigPlanChecks{
+        PreApply: []plancheck.PlanCheck{
+          plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+        },
+      },
 		},
 		data.ImportStep(),
 		{
@@ -87,6 +92,11 @@ func TestAccPrivateLinkService_update(t *testing.T) {
 				check.That(data.ResourceName).Key("nat_ip_configuration.#").HasValue("1"),
 				check.That(data.ResourceName).Key("load_balancer_frontend_ip_configuration_ids.#").HasValue("1"),
 			),
+      ConfigPlanChecks: resource.ConfigPlanChecks{
+        PreApply: []plancheck.PlanCheck{
+          plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+        },
+      },
 		},
 		data.ImportStep(),
 	})
@@ -116,6 +126,11 @@ func TestAccPrivateLinkService_move(t *testing.T) {
 				check.That(data.ResourceName).Key("nat_ip_configuration.2.private_ip_address").HasValue("10.5.2.19"),
 				check.That(data.ResourceName).Key("nat_ip_configuration.3.private_ip_address").HasValue("10.5.2.20"),
 			),
+      ConfigPlanChecks: resource.ConfigPlanChecks{
+        PreApply: []plancheck.PlanCheck{
+          plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+        },
+      },
 		},
 		data.ImportStep(),
 		{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
`TestAccPrivateLinkService_update` and `TestAccPrivateLinkService_move` fail with the following log.

```
    testcase.go:173: Step 4/15 error: Pre-apply plan check(s) failed:
        'azurerm_private_link_service.test' - expected action to not be Replace, path: [[nat_ip_configuration 1 primary] [nat_ip_configuration 2 primary] [nat_ip_configuration 3 primary] [nat_ip_configuration 3 name] [nat_ip_configuration 2 name] [nat_ip_configuration 1 name]] tried to update a value that is ForceNew
```

The pre-apply plan check detects the replacement of `name` and `primary` properties in `azurerm_private_link_service` resource. These properties are assigned with `ForceNew` behavior and will be recreated when new `nat_ip_configuration` parent property elements are added. To fix the issue, `ForceNew` behavior is removed from these properties and `CustomizeDiff` is used to force resource recreation when the `name` and `primary` properties are changed in place. `TestAccPrivateLinkService_forceNewWithNatIpConfiguration` acceptance test is added to validate the customized `ForceNew` behavior of `name` and `primary` properties.

`TestAccPrivateLinkService_destinationIPAddress` fails with the following log.

```
    testcase.go:173: Step 1/6 error: Error running apply: exit status 1
        Error: creating Private Link Service (Subscription: "*******"
        Resource Group Name: "REDACTED"
        Private Link Service Name: "REDACTED"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: PrivateLinkServiceDirectConnectFeatureIpConfigurationRequirementsNotMet: For the Direct Connect feature in Private Link Service /subscriptions/*******/resourceGroups/REDACTED/providers/Microsoft.Network/privateLinkServices/REDACTED, you need at least 2 IP configurations. You’ve provided 3, which isn’t valid. Moreover, the total number of IP configurations must be a multiple of 2.
          with azurerm_private_link_service.test,
          on terraform_plugin_test.tf line 58, in resource "azurerm_private_link_service" "test":
          58: resource "azurerm_private_link_service" "test" {
```

The total number of `nat_ip_configuration` elements used in `azurerm_private_link_service` should be a multiple of two. To fix the issue, four `nat_ip_configuration` elements are applied.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORK/563965?buildTab=overview
<img width="959" height="358" alt="image" src="https://github.com/user-attachments/assets/25fe9296-05d0-4fdd-a616-601894e2ed1f" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* [BUG FIXES] `azurerm_private_link_service` - fix `TestAccPrivateLinkService_update`, `TestAccPrivateLinkService_move`, and `TestAccPrivateLinkService_destinationIPAddress`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
