### PR TITLE
`services/storage_account`: Remove a redundant if-branch in resourceStorageAccountFlatten

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2124,155 +2124,153 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 	var primaryEndpoints *storageaccounts.Endpoints
 	var secondaryEndpoints *storageaccounts.Endpoints
 	var routingPreference *storageaccounts.RoutingPreference
-	if account != nil {
-		if account.Kind != nil {
-			accountKind = *account.Kind
+	if account.Kind != nil {
+		accountKind = *account.Kind
+	}
+	d.Set("account_kind", string(accountKind))
+
+	var accountTier storageaccounts.SkuTier
+	accountReplicationType := ""
+	provisionBillingModelVer := ""
+	if sku := account.Sku; sku != nil {
+		skuNameSegs := strings.Split(string(sku.Name), "_")
+		accountTierAndProvisionBillingModelVer := skuNameSegs[0]
+		accountReplicationType = skuNameSegs[1]
+		if sku.Tier != nil {
+			accountTier = *sku.Tier
+			provisionBillingModelVer = strings.TrimPrefix(accountTierAndProvisionBillingModelVer, string(accountTier))
 		}
-		d.Set("account_kind", string(accountKind))
+	}
+	d.Set("account_tier", string(accountTier))
+	d.Set("account_replication_type", accountReplicationType)
+	d.Set("provisioned_billing_model_version", provisionBillingModelVer)
 
-		var accountTier storageaccounts.SkuTier
-		accountReplicationType := ""
-		provisionBillingModelVer := ""
-		if sku := account.Sku; sku != nil {
-			skuNameSegs := strings.Split(string(sku.Name), "_")
-			accountTierAndProvisionBillingModelVer := skuNameSegs[0]
-			accountReplicationType = skuNameSegs[1]
-			if sku.Tier != nil {
-				accountTier = *sku.Tier
-				provisionBillingModelVer = strings.TrimPrefix(accountTierAndProvisionBillingModelVer, string(accountTier))
-			}
+	d.Set("edge_zone", flattenEdgeZone(account.ExtendedLocation))
+	d.Set("location", location.Normalize(account.Location))
+
+	if props := account.Properties; props != nil {
+		primaryEndpoints = props.PrimaryEndpoints
+		routingPreference = props.RoutingPreference
+		secondaryEndpoints = props.SecondaryEndpoints
+
+		d.Set("access_tier", pointer.From(props.AccessTier))
+		d.Set("allowed_copy_scope", pointer.From(props.AllowedCopyScope))
+		if err := d.Set("azure_files_authentication", flattenAccountAzureFilesAuthentication(props.AzureFilesIdentityBasedAuthentication)); err != nil {
+			return fmt.Errorf("setting `azure_files_authentication`: %+v", err)
 		}
-		d.Set("account_tier", string(accountTier))
-		d.Set("account_replication_type", accountReplicationType)
-		d.Set("provisioned_billing_model_version", provisionBillingModelVer)
+		d.Set("cross_tenant_replication_enabled", pointer.From(props.AllowCrossTenantReplication))
+		d.Set("https_traffic_only_enabled", pointer.From(props.SupportsHTTPSTrafficOnly))
+		d.Set("is_hns_enabled", pointer.From(props.IsHnsEnabled))
+		d.Set("nfsv3_enabled", pointer.From(props.IsNfsV3Enabled))
+		d.Set("primary_location", pointer.From(props.PrimaryLocation))
+		if err := d.Set("routing", flattenAccountRoutingPreference(props.RoutingPreference)); err != nil {
+			return fmt.Errorf("setting `routing`: %+v", err)
+		}
+		d.Set("secondary_location", pointer.From(props.SecondaryLocation))
+		d.Set("sftp_enabled", pointer.From(props.IsSftpEnabled))
 
-		d.Set("edge_zone", flattenEdgeZone(account.ExtendedLocation))
-		d.Set("location", location.Normalize(account.Location))
+		// NOTE: The Storage API returns `null` rather than the default value in the API response for existing
+		// resources when a new field gets added - meaning we need to default the values below.
+		allowBlobPublicAccess := true
+		if props.AllowBlobPublicAccess != nil {
+			allowBlobPublicAccess = *props.AllowBlobPublicAccess
+		}
+		d.Set("allow_nested_items_to_be_public", allowBlobPublicAccess)
 
-		if props := account.Properties; props != nil {
-			primaryEndpoints = props.PrimaryEndpoints
-			routingPreference = props.RoutingPreference
-			secondaryEndpoints = props.SecondaryEndpoints
+		defaultToOAuthAuthentication := false
+		if props.DefaultToOAuthAuthentication != nil {
+			defaultToOAuthAuthentication = *props.DefaultToOAuthAuthentication
+		}
+		d.Set("default_to_oauth_authentication", defaultToOAuthAuthentication)
 
-			d.Set("access_tier", pointer.From(props.AccessTier))
-			d.Set("allowed_copy_scope", pointer.From(props.AllowedCopyScope))
-			if err := d.Set("azure_files_authentication", flattenAccountAzureFilesAuthentication(props.AzureFilesIdentityBasedAuthentication)); err != nil {
-				return fmt.Errorf("setting `azure_files_authentication`: %+v", err)
-			}
-			d.Set("cross_tenant_replication_enabled", pointer.From(props.AllowCrossTenantReplication))
-			d.Set("https_traffic_only_enabled", pointer.From(props.SupportsHTTPSTrafficOnly))
-			d.Set("is_hns_enabled", pointer.From(props.IsHnsEnabled))
-			d.Set("nfsv3_enabled", pointer.From(props.IsNfsV3Enabled))
-			d.Set("primary_location", pointer.From(props.PrimaryLocation))
-			if err := d.Set("routing", flattenAccountRoutingPreference(props.RoutingPreference)); err != nil {
-				return fmt.Errorf("setting `routing`: %+v", err)
-			}
-			d.Set("secondary_location", pointer.From(props.SecondaryLocation))
-			d.Set("sftp_enabled", pointer.From(props.IsSftpEnabled))
+		dnsEndpointType := storageaccounts.DnsEndpointTypeStandard
+		if props.DnsEndpointType != nil {
+			dnsEndpointType = *props.DnsEndpointType
+		}
+		d.Set("dns_endpoint_type", dnsEndpointType)
 
-			// NOTE: The Storage API returns `null` rather than the default value in the API response for existing
-			// resources when a new field gets added - meaning we need to default the values below.
-			allowBlobPublicAccess := true
-			if props.AllowBlobPublicAccess != nil {
-				allowBlobPublicAccess = *props.AllowBlobPublicAccess
-			}
-			d.Set("allow_nested_items_to_be_public", allowBlobPublicAccess)
+		isLocalEnabled := true
+		if props.IsLocalUserEnabled != nil {
+			isLocalEnabled = *props.IsLocalUserEnabled
+		}
+		d.Set("local_user_enabled", isLocalEnabled)
 
-			defaultToOAuthAuthentication := false
-			if props.DefaultToOAuthAuthentication != nil {
-				defaultToOAuthAuthentication = *props.DefaultToOAuthAuthentication
-			}
-			d.Set("default_to_oauth_authentication", defaultToOAuthAuthentication)
+		largeFileShareEnabled := false
+		if props.LargeFileSharesState != nil {
+			largeFileShareEnabled = *props.LargeFileSharesState == storageaccounts.LargeFileSharesStateEnabled
+		}
+		d.Set("large_file_share_enabled", largeFileShareEnabled)
 
-			dnsEndpointType := storageaccounts.DnsEndpointTypeStandard
-			if props.DnsEndpointType != nil {
-				dnsEndpointType = *props.DnsEndpointType
-			}
-			d.Set("dns_endpoint_type", dnsEndpointType)
+		minTlsVersion := string(storageaccounts.MinimumTlsVersionTLSOneZero)
+		if props.MinimumTlsVersion != nil {
+			minTlsVersion = string(*props.MinimumTlsVersion)
+		}
+		d.Set("min_tls_version", minTlsVersion)
 
-			isLocalEnabled := true
-			if props.IsLocalUserEnabled != nil {
-				isLocalEnabled = *props.IsLocalUserEnabled
-			}
-			d.Set("local_user_enabled", isLocalEnabled)
+		publicNetworkAccessEnabled := true
+		if props.PublicNetworkAccess != nil && *props.PublicNetworkAccess == storageaccounts.PublicNetworkAccessDisabled {
+			publicNetworkAccessEnabled = false
+		}
+		d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
 
-			largeFileShareEnabled := false
-			if props.LargeFileSharesState != nil {
-				largeFileShareEnabled = *props.LargeFileSharesState == storageaccounts.LargeFileSharesStateEnabled
-			}
-			d.Set("large_file_share_enabled", largeFileShareEnabled)
+		allowSharedKeyAccess := true
+		if props.AllowSharedKeyAccess != nil {
+			allowSharedKeyAccess = *props.AllowSharedKeyAccess
+		}
+		d.Set("shared_access_key_enabled", allowSharedKeyAccess)
 
-			minTlsVersion := string(storageaccounts.MinimumTlsVersionTLSOneZero)
-			if props.MinimumTlsVersion != nil {
-				minTlsVersion = string(*props.MinimumTlsVersion)
-			}
-			d.Set("min_tls_version", minTlsVersion)
+		if err := d.Set("custom_domain", flattenAccountCustomDomain(props.CustomDomain)); err != nil {
+			return fmt.Errorf("setting `custom_domain`: %+v", err)
+		}
+		if err := d.Set("immutability_policy", flattenAccountImmutabilityPolicy(props.ImmutableStorageWithVersioning)); err != nil {
+			return fmt.Errorf("setting `immutability_policy`: %+v", err)
+		}
+		if err := d.Set("network_rules", flattenAccountNetworkRules(props.NetworkAcls)); err != nil {
+			return fmt.Errorf("setting `network_rules`: %+v", err)
+		}
 
-			publicNetworkAccessEnabled := true
-			if props.PublicNetworkAccess != nil && *props.PublicNetworkAccess == storageaccounts.PublicNetworkAccessDisabled {
-				publicNetworkAccessEnabled = false
-			}
-			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
-
-			allowSharedKeyAccess := true
-			if props.AllowSharedKeyAccess != nil {
-				allowSharedKeyAccess = *props.AllowSharedKeyAccess
-			}
-			d.Set("shared_access_key_enabled", allowSharedKeyAccess)
-
-			if err := d.Set("custom_domain", flattenAccountCustomDomain(props.CustomDomain)); err != nil {
-				return fmt.Errorf("setting `custom_domain`: %+v", err)
-			}
-			if err := d.Set("immutability_policy", flattenAccountImmutabilityPolicy(props.ImmutableStorageWithVersioning)); err != nil {
-				return fmt.Errorf("setting `immutability_policy`: %+v", err)
-			}
-			if err := d.Set("network_rules", flattenAccountNetworkRules(props.NetworkAcls)); err != nil {
-				return fmt.Errorf("setting `network_rules`: %+v", err)
-			}
-
-			// When the encryption key type is "Service", the queue/table is not returned in the service list, so we default
-			// the encryption key type to "Service" if it is absent (must also be the default value for "Service" in the schema)
-			infrastructureEncryption := false
-			queueEncryptionKeyType := string(storageaccounts.KeyTypeService)
-			tableEncryptionKeyType := string(storageaccounts.KeyTypeService)
-			if encryption := props.Encryption; encryption != nil {
-				infrastructureEncryption = pointer.From(encryption.RequireInfrastructureEncryption)
-				if encryption.Services != nil {
-					if encryption.Services.Queue != nil && encryption.Services.Queue.KeyType != nil {
-						queueEncryptionKeyType = string(*encryption.Services.Queue.KeyType)
-					}
-					if encryption.Services.Table != nil && encryption.Services.Table.KeyType != nil {
-						tableEncryptionKeyType = string(*encryption.Services.Table.KeyType)
-					}
+		// When the encryption key type is "Service", the queue/table is not returned in the service list, so we default
+		// the encryption key type to "Service" if it is absent (must also be the default value for "Service" in the schema)
+		infrastructureEncryption := false
+		queueEncryptionKeyType := string(storageaccounts.KeyTypeService)
+		tableEncryptionKeyType := string(storageaccounts.KeyTypeService)
+		if encryption := props.Encryption; encryption != nil {
+			infrastructureEncryption = pointer.From(encryption.RequireInfrastructureEncryption)
+			if encryption.Services != nil {
+				if encryption.Services.Queue != nil && encryption.Services.Queue.KeyType != nil {
+					queueEncryptionKeyType = string(*encryption.Services.Queue.KeyType)
+				}
+				if encryption.Services.Table != nil && encryption.Services.Table.KeyType != nil {
+					tableEncryptionKeyType = string(*encryption.Services.Table.KeyType)
 				}
 			}
-			d.Set("infrastructure_encryption_enabled", infrastructureEncryption)
-			d.Set("queue_encryption_key_type", queueEncryptionKeyType)
-			d.Set("table_encryption_key_type", tableEncryptionKeyType)
+		}
+		d.Set("infrastructure_encryption_enabled", infrastructureEncryption)
+		d.Set("queue_encryption_key_type", queueEncryptionKeyType)
+		d.Set("table_encryption_key_type", tableEncryptionKeyType)
 
-			customerManagedKey := flattenAccountCustomerManagedKey(props.Encryption, env)
-			if err := d.Set("customer_managed_key", customerManagedKey); err != nil {
-				return fmt.Errorf("setting `customer_managed_key`: %+v", err)
-			}
-
-			if err := d.Set("sas_policy", flattenAccountSASPolicy(props.SasPolicy)); err != nil {
-				return fmt.Errorf("setting `sas_policy`: %+v", err)
-			}
-
-			supportLevel = availableFunctionalityForAccount(accountKind, accountTier, accountReplicationType)
+		customerManagedKey := flattenAccountCustomerManagedKey(props.Encryption, env)
+		if err := d.Set("customer_managed_key", customerManagedKey); err != nil {
+			return fmt.Errorf("setting `customer_managed_key`: %+v", err)
 		}
 
-		flattenedIdentity, err := identity.FlattenLegacySystemAndUserAssignedMap(account.Identity)
-		if err != nil {
-			return fmt.Errorf("flattening `identity`: %+v", err)
-		}
-		if err := d.Set("identity", flattenedIdentity); err != nil {
-			return fmt.Errorf("setting `identity`: %+v", err)
+		if err := d.Set("sas_policy", flattenAccountSASPolicy(props.SasPolicy)); err != nil {
+			return fmt.Errorf("setting `sas_policy`: %+v", err)
 		}
 
-		if err := tags.FlattenAndSet(d, account.Tags); err != nil {
-			return err
-		}
+		supportLevel = availableFunctionalityForAccount(accountKind, accountTier, accountReplicationType)
+	}
+
+	flattenedIdentity, err := identity.FlattenLegacySystemAndUserAssignedMap(account.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
+	if err := d.Set("identity", flattenedIdentity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
+	if err := tags.FlattenAndSet(d, account.Tags); err != nil {
+		return err
 	}
 
 	endpoints := flattenAccountEndpoints(primaryEndpoints, secondaryEndpoints, routingPreference)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Similar to #30901 I found a dead/redundant if-loop. The check for `account != nil` is already done on line 2106, with a return-statement inside the if-branch.

There are quite a lot of matches from this tool. The most of them are under this `internal/services/appservice/`. I don't know if my PR would receive attention if I fix them all at once.
 
```sh
GOTOOLCHAIN=go1.25.5 go install golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness@latest
go vet -vettool $(which nilness) ./...
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

## Change Log

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
