### PR TITLE
New List Resource: `azurerm_resource_group`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -352,6 +352,7 @@ func SupportedFrameworkServices() []sdk.FrameworkServiceRegistration {
 		mssql.Registration{},
 		network.Registration{},
 		privatedns.Registration{},
+		resource.Registration{},
 		storage.Registration{},
 	}
 

--- a/internal/services/resource/registration.go
+++ b/internal/services/resource/registration.go
@@ -4,15 +4,16 @@
 package resource
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 var (
-	_ sdk.TypedServiceRegistration                   = Registration{}
-	_ sdk.UntypedServiceRegistration                 = Registration{}
 	_ sdk.TypedServiceRegistrationWithAGitHubLabel   = Registration{}
 	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+	_ sdk.FrameworkServiceRegistration               = Registration{}
 )
 
 type Registration struct{}
@@ -75,5 +76,27 @@ func (r Registration) Resources() []sdk.Resource {
 		ResourceManagementPrivateLinkResource{},
 		ResourceDeploymentScriptAzurePowerShellResource{},
 		ResourceDeploymentScriptAzureCliResource{},
+	}
+}
+
+func (r Registration) Actions() []func() action.Action {
+	return []func() action.Action{}
+}
+
+func (r Registration) FrameworkResources() []sdk.FrameworkWrappedResource {
+	return []sdk.FrameworkWrappedResource{}
+}
+
+func (r Registration) FrameworkDataSources() []sdk.FrameworkWrappedDataSource {
+	return []sdk.FrameworkWrappedDataSource{}
+}
+
+func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{}
+}
+
+func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
+	return []sdk.FrameworkListWrappedResource{
+		ResourceGroupListResource{},
 	}
 }

--- a/internal/services/resource/resource_group_resource_list.go
+++ b/internal/services/resource/resource_group_resource_list.go
@@ -1,0 +1,142 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type (
+	ResourceGroupListResource struct{}
+	ResourceGroupListModel    struct {
+		SubscriptionId types.String `tfsdk:"subscription_id"`
+		Filter         types.String `tfsdk:"filter"`
+	}
+)
+
+var _ sdk.FrameworkListWrappedResourceWithConfig = new(ResourceGroupListResource)
+
+func (r ResourceGroupListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = resourceGroupResourceName
+}
+
+func (r ResourceGroupListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceResourceGroup()
+}
+
+func (r ResourceGroupListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = listschema.Schema{
+		Attributes: map[string]listschema.Attribute{
+			"subscription_id": listschema.StringAttribute{
+				Optional:    true,
+				Description: "The ID of the subscription to query. Defaults to the value specified in the Provider Configuration.",
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{
+						Func: validation.IsUUID,
+					},
+				},
+			},
+
+			"filter": listschema.StringAttribute{
+				Optional:    true,
+				Description: "A filter expression to filter the results by.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+		},
+	}
+}
+
+func (r ResourceGroupListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Resource.ResourceGroupsClient
+
+	var data ResourceGroupListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	results := make([]resourcegroups.ResourceGroup, 0)
+
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	options := resourcegroups.DefaultListOperationOptions()
+	if !data.Filter.IsNull() {
+		options = resourcegroups.ListOperationOptions{
+			Filter: data.Filter.ValueStringPointer(),
+		}
+	}
+
+	resp, err := client.ListComplete(ctx, commonids.NewSubscriptionID(subscriptionID), options)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", resourceGroupResourceName), err)
+		return
+	}
+	results = resp.Items
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, group := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(group.Name)
+
+			id, err := commonids.ParseResourceGroupID(pointer.From(group.Id))
+			if err != nil {
+				sdk.SetListIteratorErrorDiagnostic(result, push, "parsing Resource Group ID", err)
+				return
+			}
+
+			rd := resourceResourceGroup().Data(&terraform.InstanceState{})
+			rd.SetId(id.ID())
+
+			if err := resourceResourceGroupFlatten(rd, id, &group); err != nil {
+				sdk.SetListIteratorErrorDiagnostic(result, push, fmt.Sprintf("encoding `%s` Resource Data", resourceGroupResourceName), err)
+				return
+			}
+
+			tfTypeIdentity, err := rd.TfTypeIdentityState()
+			if err != nil {
+				sdk.SetListIteratorErrorDiagnostic(result, push, "converting Identity State", err)
+				return
+			}
+
+			if err := result.Identity.Set(ctx, *tfTypeIdentity); err != nil {
+				sdk.SetListIteratorErrorDiagnostic(result, push, "setting Identity Data", err)
+				return
+			}
+
+			tfTypeResourceState, err := rd.TfTypeResourceState()
+			if err != nil {
+				sdk.SetListIteratorErrorDiagnostic(result, push, "converting Resource State", err)
+				return
+			}
+
+			if err := result.Resource.Set(ctx, *tfTypeResourceState); err != nil {
+				sdk.SetListIteratorErrorDiagnostic(result, push, "setting Resource Data", err)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/resource/resource_group_resource_list_test.go
+++ b/internal/services/resource/resource_group_resource_list_test.go
@@ -1,0 +1,106 @@
+package resource_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccResourceGroup_list_basic(t *testing.T) {
+	r := ResourceGroupResource{}
+	listResourceAddress := "azurerm_resource_group.list"
+
+	data := acceptance.BuildTestData(t, "azurerm_network_interface", "test")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast(listResourceAddress, 4),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicQueryWithFilter(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength(listResourceAddress, 3),
+				},
+			},
+		},
+	})
+}
+
+func (r ResourceGroupResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test1" {
+  name     = "acctestRG1-%[1]d"
+  location = "%[2]s"
+
+  tags = {
+    "query" = "test-%[1]d"
+  }
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG2-%[1]d"
+  location = "%[2]s"
+
+  tags = {
+    "query" = "test-%[1]d"
+  }
+}
+
+resource "azurerm_resource_group" "test3" {
+  name     = "acctestRG3-%[1]d"
+  location = "%[2]s"
+
+  tags = {
+    "query" = "test-%[1]d"
+  }
+}
+
+resource "azurerm_resource_group" "test4" {
+  name     = "acctestRG4-%[1]d"
+  location = "%[2]s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ResourceGroupResource) basicQuery() string {
+	return `
+list "azurerm_network_interface" "list" {
+  provider = azurerm
+  config {}
+}
+`
+}
+
+func (r ResourceGroupResource) basicQueryWithFilter(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+list "azurerm_resource_group" "list" {
+  provider = azurerm
+  config {
+    filter = "tagName eq 'query' and tagValue eq 'test-%d'"
+  }
+}
+`, data.RandomInteger)
+}

--- a/internal/services/resource/resource_group_resource_test.go
+++ b/internal/services/resource/resource_group_resource_test.go
@@ -123,7 +123,7 @@ func TestAccResourceGroup_withNestedItemsAndFeatureFlag(t *testing.T) {
 	})
 }
 
-func (t ResourceGroupResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r ResourceGroupResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseResourceGroupIDInsensitively(state.ID)
 	if err != nil {
 		return nil, err
@@ -144,7 +144,7 @@ func (t ResourceGroupResource) Destroy(ctx context.Context, client *clients.Clie
 	return pointer.To(true), nil
 }
 
-func (t ResourceGroupResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r ResourceGroupResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseResourceGroupIDInsensitively(state.ID)
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (t ResourceGroupResource) Exists(ctx context.Context, client *clients.Clien
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (t ResourceGroupResource) createNetworkOutsideTerraform(name string) func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+func (r ResourceGroupResource) createNetworkOutsideTerraform(name string) func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
 	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
 		client := clients.Network.VirtualNetworks
 
@@ -189,7 +189,7 @@ func (t ResourceGroupResource) createNetworkOutsideTerraform(name string) func(c
 	}
 }
 
-func (t ResourceGroupResource) basic(data acceptance.TestData) string {
+func (r ResourceGroupResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -202,8 +202,8 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (t ResourceGroupResource) requiresImportConfig(data acceptance.TestData) string {
-	template := t.basic(data)
+func (r ResourceGroupResource) requiresImportConfig(data acceptance.TestData) string {
+	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -214,7 +214,7 @@ resource "azurerm_resource_group" "import" {
 `, template)
 }
 
-func (t ResourceGroupResource) withFeatureFlag(data acceptance.TestData, featureFlagEnabled bool) string {
+func (r ResourceGroupResource) withFeatureFlag(data acceptance.TestData, featureFlagEnabled bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -231,7 +231,7 @@ resource "azurerm_resource_group" "test" {
 `, featureFlagEnabled, data.RandomInteger, data.Locations.Primary)
 }
 
-func (t ResourceGroupResource) withTagsConfig(data acceptance.TestData) string {
+func (r ResourceGroupResource) withTagsConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -249,7 +249,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (t ResourceGroupResource) withTagsUpdatedConfig(data acceptance.TestData) string {
+func (r ResourceGroupResource) withTagsUpdatedConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -266,7 +266,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (t ResourceGroupResource) withManagedByConfig(data acceptance.TestData) string {
+func (r ResourceGroupResource) withManagedByConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/docs/list-resources/resource_group.html.markdown
+++ b/website/docs/list-resources/resource_group.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Base"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_resource_group"
+description: |-
+  Lists Resource Group resources.
+---
+
+# List resource: azurerm_resource_group
+
+~> **Note:** The `azurerm_resource_group` List Resource is in beta. Its interface and behaviour may change as the feature evolves, and breaking changes are possible. It is offered as a technical preview without compatibility guarantees until Terraform 1.14 is generally available.
+
+Lists Resource Group resources.
+
+## Example Usage
+
+### List all Resource Groups in the subscription
+
+```hcl
+list "azurerm_resource_group" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all Resource Groups in the subscription matching a filter 
+
+```hcl
+list "azurerm_resource_group" "example" {
+  provider = azurerm
+  config {
+    filter = "tagName eq 'terraform' and tagValue eq 'example'"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `subscription_id` - (Optional) The ID of the subscription to query. Defaults to the value specified in the Provider Configuration.
+
+* `filter` - (Optional) A filter expression to filter the results by.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Adds list support to `azurerm_resource_group`
- Bumps `github.com/hashicorp/terraform-plugin-testing` to `1.14.0`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

List test result:
```
--- PASS: TestAccResourceGroup_list_basic (66.79s)
```

<img width="334" height="150" alt="image" src="https://github.com/user-attachments/assets/395eb323-70bc-4542-8bf7-cadf446b8fa8" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
