### PR TITLE
New Resource: `azurerm_confluent_connector`

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -77,6 +77,9 @@ service/communication:
 service/connections:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(api_connection|managed_api)((.|\n)*)###'
 
+service/confluent:
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_confluent_((.|\n)*)###'
+
 service/consumption:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_consumption_budget_((.|\n)*)###'
 

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -128,6 +128,11 @@ service/connections:
   - any-glob-to-any-file:
     - internal/services/connections/**/*
 
+service/confluent:
+- changed-files:
+  - any-glob-to-any-file:
+    - internal/services/confluent/**/*
+
 service/consumption:
 - changed-files:
   - any-glob-to-any-file:

--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -27,6 +27,7 @@ var services = mapOf(
         "communication" to "Communication",
         "compute" to "Compute",
         "confidentialledger" to "Confidential Ledger",
+        "confluent" to "Confluent",
         "connections" to "Connections",
         "consumption" to "Consumption",
         "containerapps" to "Container Apps",

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -47,6 +47,7 @@ import (
 	communication "github.com/hashicorp/terraform-provider-azurerm/internal/services/communication/client"
 	compute "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/client"
 	confidentialledger "github.com/hashicorp/terraform-provider-azurerm/internal/services/confidentialledger/client"
+	confluent "github.com/hashicorp/terraform-provider-azurerm/internal/services/confluent/client"
 	connections "github.com/hashicorp/terraform-provider-azurerm/internal/services/connections/client"
 	consumption "github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/client"
 	containerapps "github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/client"
@@ -185,6 +186,7 @@ type Client struct {
 	Communication                     *communication.Client
 	Compute                           *compute.Client
 	ConfidentialLedger                *confidentialledger.Client
+	Confluent                         *confluent.Client
 	Connections                       *connections.Client
 	Consumption                       *consumption.Client
 	ContainerApps                     *containerapps.Client
@@ -377,6 +379,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	}
 	if client.ConfidentialLedger, err = confidentialledger.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for ConfidentialLedger: %+v", err)
+	}
+	if client.Confluent, err = confluent.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for Confluent: %+v", err)
 	}
 	if client.Connections, err = connections.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Connections: %+v", err)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/communication"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/confidentialledger"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/confluent"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/connections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps"
@@ -158,6 +159,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		cognitive.Registration{},
 		communication.Registration{},
 		compute.Registration{},
+		confluent.Registration{},
 		connections.Registration{},
 		consumption.Registration{},
 		containerapps.Registration{},
@@ -261,6 +263,7 @@ func SupportedUntypedServices() []sdk.UntypedServiceRegistration {
 			cognitive.Registration{},
 			compute.Registration{},
 			confidentialledger.Registration{},
+			confluent.Registration{},
 			connections.Registration{},
 			consumption.Registration{},
 			containers.Registration{},

--- a/internal/services/confluent/client/client.go
+++ b/internal/services/confluent/client/client.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+type Client struct {
+	OrganizationResourcesClient *organizationresources.OrganizationResourcesClient
+	EnvironmentClient           *scenvironmentrecords.SCEnvironmentRecordsClient
+	ClusterClient               *scclusterrecords.SCClusterRecordsClient
+	TopicClient                 *topicrecords.TopicRecordsClient
+	ConnectorClient             *connectorresources.ConnectorResourcesClient
+}
+
+func NewClient(o *common.ClientOptions) (*Client, error) {
+	organizationResourcesClient, err := organizationresources.NewOrganizationResourcesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building OrganizationResources client: %+v", err)
+	}
+	o.Configure(organizationResourcesClient.Client, o.Authorizers.ResourceManager)
+
+	environmentClient, err := scenvironmentrecords.NewSCEnvironmentRecordsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building SCEnvironmentRecords client: %+v", err)
+	}
+	o.Configure(environmentClient.Client, o.Authorizers.ResourceManager)
+
+	clusterClient, err := scclusterrecords.NewSCClusterRecordsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building SCClusterRecords client: %+v", err)
+	}
+	o.Configure(clusterClient.Client, o.Authorizers.ResourceManager)
+
+	topicClient, err := topicrecords.NewTopicRecordsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building TopicRecords client: %+v", err)
+	}
+	o.Configure(topicClient.Client, o.Authorizers.ResourceManager)
+
+	connectorClient, err := connectorresources.NewConnectorResourcesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building ConnectorResources client: %+v", err)
+	}
+	o.Configure(connectorClient.Client, o.Authorizers.ResourceManager)
+
+	return &Client{
+		OrganizationResourcesClient: organizationResourcesClient,
+		EnvironmentClient:           environmentClient,
+		ClusterClient:               clusterClient,
+		TopicClient:                 topicClient,
+		ConnectorClient:             connectorClient,
+	}, nil
+}

--- a/internal/services/confluent/confluent_connector_resource.go
+++ b/internal/services/confluent/confluent_connector_resource.go
@@ -1,0 +1,248 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package confluent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/confluent/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type ConfluentConnectorResource struct{}
+
+type ConfluentConnectorResourceModel struct {
+	ConnectorName     string   `tfschema:"connector_name"`
+	ClusterId         string   `tfschema:"cluster_id"`
+	EnvironmentId     string   `tfschema:"environment_id"`
+	OrganizationId    string   `tfschema:"organization_id"`
+	ResourceGroupName string   `tfschema:"resource_group_name"`
+	ConnectorType     string   `tfschema:"connector_type"`
+	ConnectorClass    string   `tfschema:"connector_class"`
+
+	// Computed
+	Id            string `tfschema:"id"`
+	ConnectorId   string `tfschema:"connector_id"`
+	ConnectorState string `tfschema:"connector_state"`
+}
+
+func (r ConfluentConnectorResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"connector_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"cluster_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"environment_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"organization_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"connector_type": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(connectorresources.PossibleValuesForConnectorType(), false),
+		},
+
+		"connector_class": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringInSlice(connectorresources.PossibleValuesForConnectorClass(), false),
+		},
+	}
+}
+
+func (r ConfluentConnectorResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"connector_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"connector_state": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r ConfluentConnectorResource) ModelObject() interface{} {
+	return &ConfluentConnectorResourceModel{}
+}
+
+func (r ConfluentConnectorResource) ResourceType() string {
+	return "azurerm_confluent_connector"
+}
+
+func (r ConfluentConnectorResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Confluent.ConnectorClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model ConfluentConnectorResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := connectorresources.NewConnectorID(subscriptionId, model.ResourceGroupName, model.OrganizationId, model.EnvironmentId, model.ClusterId, model.ConnectorName)
+
+			existing, err := client.ConnectorGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_confluent_connector", id.ID())
+			}
+
+			payload := connectorresources.ConnectorResource{
+				Name:       pointer.To(model.ConnectorName),
+				Properties: expandConfluentConnectorProperties(model),
+			}
+
+			if _, err := client.ConnectorCreateOrUpdate(ctx, id, payload); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ConfluentConnectorResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Confluent.ConnectorClient
+
+			id, err := connectorresources.ParseConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.ConnectorGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			var state ConfluentConnectorResourceModel
+			state.ConnectorName = id.ConnectorName
+			state.ClusterId = id.ClusterId
+			state.EnvironmentId = id.EnvironmentId
+			state.OrganizationId = id.OrganizationName
+			state.ResourceGroupName = id.ResourceGroupName
+
+			if model := resp.Model; model != nil {
+				state.Id = pointer.From(model.Id)
+
+				props := model.Properties
+				if props.ConnectorBasicInfo != nil {
+					state.ConnectorId = pointer.From(props.ConnectorBasicInfo.ConnectorId)
+					state.ConnectorState = string(pointer.From(props.ConnectorBasicInfo.ConnectorState))
+					state.ConnectorType = string(pointer.From(props.ConnectorBasicInfo.ConnectorType))
+					state.ConnectorClass = string(pointer.From(props.ConnectorBasicInfo.ConnectorClass))
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r ConfluentConnectorResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Confluent.ConnectorClient
+
+			id, err := connectorresources.ParseConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.ConnectorDelete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ConfluentConnectorResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.ConnectorID
+}
+
+func expandConfluentConnectorProperties(model ConfluentConnectorResourceModel) connectorresources.ConnectorResourceProperties {
+	// Note: The full implementation would require handling the polymorphic types
+	// (ConnectorServiceTypeInfoBase and PartnerInfoBase) which have multiple implementations
+	// For now, we create a minimal structure that allows the connector to be created
+	// Users will need to configure the connector details through other means (e.g., Confluent portal/CLI)
+
+	props := connectorresources.ConnectorResourceProperties{}
+
+	if model.ConnectorType != "" || model.ConnectorClass != "" {
+		info := &connectorresources.ConnectorInfoBase{}
+
+		if model.ConnectorType != "" {
+			info.ConnectorType = pointer.To(connectorresources.ConnectorType(model.ConnectorType))
+		}
+
+		if model.ConnectorClass != "" {
+			info.ConnectorClass = pointer.To(connectorresources.ConnectorClass(model.ConnectorClass))
+		}
+
+		props.ConnectorBasicInfo = info
+	}
+
+	return props
+}

--- a/internal/services/confluent/confluent_connector_resource_test.go
+++ b/internal/services/confluent/confluent_connector_resource_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package confluent_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ConfluentConnectorResource struct{}
+
+func TestAccConfluentConnector_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_confluent_connector", "test")
+	r := ConfluentConnectorResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccConfluentConnector_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_confluent_connector", "test")
+	r := ConfluentConnectorResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccConfluentConnector_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_confluent_connector", "test")
+	r := ConfluentConnectorResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ConfluentConnectorResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := connectorresources.ParseConnectorID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Confluent.ConnectorClient.ConnectorGet(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r ConfluentConnectorResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-confluent-%d"
+  location = "%s"
+}
+
+resource "azurerm_confluent_organization" "test" {
+  name                = "acctest-co-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  offer_detail {
+    id           = "confluent-cloud-azure-prod"
+    plan_id      = "confluent-cloud-azure-payg-prod"
+    plan_name    = "Confluent Cloud - Pay as you Go"
+    publisher_id = "confluentinc"
+    term_unit    = "P1M"
+  }
+
+  user_detail {
+    email_address = "test-%d@example.com"
+  }
+}
+
+resource "azurerm_confluent_environment" "test" {
+  environment_id      = "env-%d"
+  organization_id     = azurerm_confluent_organization.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_confluent_cluster" "test" {
+  cluster_id          = "lkc-%d"
+  environment_id      = azurerm_confluent_environment.test.environment_id
+  organization_id     = azurerm_confluent_organization.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (r ConfluentConnectorResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_confluent_connector" "test" {
+  connector_name      = "connector-%d"
+  cluster_id          = azurerm_confluent_cluster.test.cluster_id
+  environment_id      = azurerm_confluent_environment.test.environment_id
+  organization_id     = azurerm_confluent_organization.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ConfluentConnectorResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_confluent_connector" "import" {
+  connector_name      = azurerm_confluent_connector.test.connector_name
+  cluster_id          = azurerm_confluent_connector.test.cluster_id
+  environment_id      = azurerm_confluent_connector.test.environment_id
+  organization_id     = azurerm_confluent_connector.test.organization_id
+  resource_group_name = azurerm_confluent_connector.test.resource_group_name
+}
+`, r.basic(data))
+}
+
+func (r ConfluentConnectorResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_confluent_connector" "test" {
+  connector_name      = "connector-%d"
+  cluster_id          = azurerm_confluent_cluster.test.cluster_id
+  environment_id      = azurerm_confluent_environment.test.environment_id
+  organization_id     = azurerm_confluent_organization.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  connector_type      = "SINK"
+  connector_class     = "AZUREBLOBSINK"
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/confluent/confluent_connector_resource_test.go
+++ b/internal/services/confluent/confluent_connector_resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 )
 
 type ConfluentConnectorResource struct{}
@@ -73,12 +73,12 @@ func (r ConfluentConnectorResource) Exists(ctx context.Context, client *clients.
 	resp, err := client.Confluent.ConnectorClient.ConnectorGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			return utils.Bool(false), nil
+			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return utils.Bool(true), nil
+	return pointer.To(true), nil
 }
 
 func (r ConfluentConnectorResource) template(data acceptance.TestData) string {

--- a/internal/services/confluent/registration.go
+++ b/internal/services/confluent/registration.go
@@ -1,0 +1,53 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package confluent
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type Registration struct{}
+
+var (
+	_ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
+)
+
+func (r Registration) AssociatedGitHubLabel() string {
+	return "service/confluent"
+}
+
+// Name is the name of this Service
+func (r Registration) Name() string {
+	return "Confluent"
+}
+
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Confluent",
+	}
+}
+
+// SupportedDataSources returns the supported Data Sources supported by this Service
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+// SupportedResources returns the supported Resources supported by this Service
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		ConfluentConnectorResource{},
+	}
+}
+
+// LegacyDataSources returns the supported Data Sources supported by this Service (using the pluginsdk)
+func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{}
+}
+
+// LegacyResources returns the supported Resources supported by this Service (using the pluginsdk)
+func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
+	return map[string]*pluginsdk.Resource{}
+}

--- a/internal/services/confluent/validate/confluent.go
+++ b/internal/services/confluent/validate/confluent.go
@@ -1,0 +1,29 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+// NOTE: this file is generated - manual changes will be overwritten.
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords"
+)
+
+// OrganizationID validates that the provided ID is a valid Organization ID
+var OrganizationID = organizationresources.ValidateOrganizationID
+
+// EnvironmentID validates that the provided ID is a valid Environment ID
+var EnvironmentID = scenvironmentrecords.ValidateEnvironmentID
+
+// ClusterID validates that the provided ID is a valid Cluster ID
+var ClusterID = scclusterrecords.ValidateClusterID
+
+// TopicID validates that the provided ID is a valid Topic ID
+var TopicID = topicrecords.ValidateTopicID
+
+// ConnectorID validates that the provided ID is a valid Connector ID
+var ConnectorID = connectorresources.ValidateConnectorID

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/README.md
@@ -1,0 +1,86 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources` Documentation
+
+The `connectorresources` SDK allows for interaction with Azure Resource Manager `confluent` (API Version `2024-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources"
+```
+
+
+### Client Initialization
+
+```go
+client := connectorresources.NewConnectorResourcesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ConnectorResourcesClient.ConnectorCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := connectorresources.NewConnectorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId", "connectorName")
+
+payload := connectorresources.ConnectorResource{
+	// ...
+}
+
+
+read, err := client.ConnectorCreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConnectorResourcesClient.ConnectorDelete`
+
+```go
+ctx := context.TODO()
+id := connectorresources.NewConnectorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId", "connectorName")
+
+if err := client.ConnectorDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ConnectorResourcesClient.ConnectorGet`
+
+```go
+ctx := context.TODO()
+id := connectorresources.NewConnectorID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId", "connectorName")
+
+read, err := client.ConnectorGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ConnectorResourcesClient.ConnectorList`
+
+```go
+ctx := context.TODO()
+id := connectorresources.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId")
+
+// alternatively `client.ConnectorList(ctx, id, connectorresources.DefaultConnectorListOperationOptions())` can be used to do batched pagination
+items, err := client.ConnectorListComplete(ctx, id, connectorresources.DefaultConnectorListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/client.go
@@ -1,0 +1,26 @@
+package connectorresources
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorResourcesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewConnectorResourcesClientWithBaseURI(sdkApi sdkEnv.Api) (*ConnectorResourcesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "connectorresources", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ConnectorResourcesClient: %+v", err)
+	}
+
+	return &ConnectorResourcesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/constants.go
@@ -1,0 +1,330 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AuthType string
+
+const (
+	AuthTypeKAFKAAPIKEY    AuthType = "KAFKA_API_KEY"
+	AuthTypeSERVICEACCOUNT AuthType = "SERVICE_ACCOUNT"
+)
+
+func PossibleValuesForAuthType() []string {
+	return []string{
+		string(AuthTypeKAFKAAPIKEY),
+		string(AuthTypeSERVICEACCOUNT),
+	}
+}
+
+func (s *AuthType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAuthType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAuthType(input string) (*AuthType, error) {
+	vals := map[string]AuthType{
+		"kafka_api_key":   AuthTypeKAFKAAPIKEY,
+		"service_account": AuthTypeSERVICEACCOUNT,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AuthType(input)
+	return &out, nil
+}
+
+type ConnectorClass string
+
+const (
+	ConnectorClassAZUREBLOBSINK   ConnectorClass = "AZUREBLOBSINK"
+	ConnectorClassAZUREBLOBSOURCE ConnectorClass = "AZUREBLOBSOURCE"
+)
+
+func PossibleValuesForConnectorClass() []string {
+	return []string{
+		string(ConnectorClassAZUREBLOBSINK),
+		string(ConnectorClassAZUREBLOBSOURCE),
+	}
+}
+
+func (s *ConnectorClass) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseConnectorClass(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseConnectorClass(input string) (*ConnectorClass, error) {
+	vals := map[string]ConnectorClass{
+		"azureblobsink":   ConnectorClassAZUREBLOBSINK,
+		"azureblobsource": ConnectorClassAZUREBLOBSOURCE,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConnectorClass(input)
+	return &out, nil
+}
+
+type ConnectorServiceType string
+
+const (
+	ConnectorServiceTypeAzureBlobStorageSinkConnector      ConnectorServiceType = "AzureBlobStorageSinkConnector"
+	ConnectorServiceTypeAzureBlobStorageSourceConnector    ConnectorServiceType = "AzureBlobStorageSourceConnector"
+	ConnectorServiceTypeAzureCosmosDBSinkConnector         ConnectorServiceType = "AzureCosmosDBSinkConnector"
+	ConnectorServiceTypeAzureCosmosDBSourceConnector       ConnectorServiceType = "AzureCosmosDBSourceConnector"
+	ConnectorServiceTypeAzureSynapseAnalyticsSinkConnector ConnectorServiceType = "AzureSynapseAnalyticsSinkConnector"
+)
+
+func PossibleValuesForConnectorServiceType() []string {
+	return []string{
+		string(ConnectorServiceTypeAzureBlobStorageSinkConnector),
+		string(ConnectorServiceTypeAzureBlobStorageSourceConnector),
+		string(ConnectorServiceTypeAzureCosmosDBSinkConnector),
+		string(ConnectorServiceTypeAzureCosmosDBSourceConnector),
+		string(ConnectorServiceTypeAzureSynapseAnalyticsSinkConnector),
+	}
+}
+
+func (s *ConnectorServiceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseConnectorServiceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseConnectorServiceType(input string) (*ConnectorServiceType, error) {
+	vals := map[string]ConnectorServiceType{
+		"azureblobstoragesinkconnector":      ConnectorServiceTypeAzureBlobStorageSinkConnector,
+		"azureblobstoragesourceconnector":    ConnectorServiceTypeAzureBlobStorageSourceConnector,
+		"azurecosmosdbsinkconnector":         ConnectorServiceTypeAzureCosmosDBSinkConnector,
+		"azurecosmosdbsourceconnector":       ConnectorServiceTypeAzureCosmosDBSourceConnector,
+		"azuresynapseanalyticssinkconnector": ConnectorServiceTypeAzureSynapseAnalyticsSinkConnector,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConnectorServiceType(input)
+	return &out, nil
+}
+
+type ConnectorStatus string
+
+const (
+	ConnectorStatusFAILED       ConnectorStatus = "FAILED"
+	ConnectorStatusPAUSED       ConnectorStatus = "PAUSED"
+	ConnectorStatusPROVISIONING ConnectorStatus = "PROVISIONING"
+	ConnectorStatusRUNNING      ConnectorStatus = "RUNNING"
+)
+
+func PossibleValuesForConnectorStatus() []string {
+	return []string{
+		string(ConnectorStatusFAILED),
+		string(ConnectorStatusPAUSED),
+		string(ConnectorStatusPROVISIONING),
+		string(ConnectorStatusRUNNING),
+	}
+}
+
+func (s *ConnectorStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseConnectorStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseConnectorStatus(input string) (*ConnectorStatus, error) {
+	vals := map[string]ConnectorStatus{
+		"failed":       ConnectorStatusFAILED,
+		"paused":       ConnectorStatusPAUSED,
+		"provisioning": ConnectorStatusPROVISIONING,
+		"running":      ConnectorStatusRUNNING,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConnectorStatus(input)
+	return &out, nil
+}
+
+type ConnectorType string
+
+const (
+	ConnectorTypeSINK   ConnectorType = "SINK"
+	ConnectorTypeSOURCE ConnectorType = "SOURCE"
+)
+
+func PossibleValuesForConnectorType() []string {
+	return []string{
+		string(ConnectorTypeSINK),
+		string(ConnectorTypeSOURCE),
+	}
+}
+
+func (s *ConnectorType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseConnectorType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseConnectorType(input string) (*ConnectorType, error) {
+	vals := map[string]ConnectorType{
+		"sink":   ConnectorTypeSINK,
+		"source": ConnectorTypeSOURCE,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ConnectorType(input)
+	return &out, nil
+}
+
+type DataFormatType string
+
+const (
+	DataFormatTypeAVRO     DataFormatType = "AVRO"
+	DataFormatTypeBYTES    DataFormatType = "BYTES"
+	DataFormatTypeJSON     DataFormatType = "JSON"
+	DataFormatTypePROTOBUF DataFormatType = "PROTOBUF"
+	DataFormatTypeSTRING   DataFormatType = "STRING"
+)
+
+func PossibleValuesForDataFormatType() []string {
+	return []string{
+		string(DataFormatTypeAVRO),
+		string(DataFormatTypeBYTES),
+		string(DataFormatTypeJSON),
+		string(DataFormatTypePROTOBUF),
+		string(DataFormatTypeSTRING),
+	}
+}
+
+func (s *DataFormatType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDataFormatType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDataFormatType(input string) (*DataFormatType, error) {
+	vals := map[string]DataFormatType{
+		"avro":     DataFormatTypeAVRO,
+		"bytes":    DataFormatTypeBYTES,
+		"json":     DataFormatTypeJSON,
+		"protobuf": DataFormatTypePROTOBUF,
+		"string":   DataFormatTypeSTRING,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DataFormatType(input)
+	return &out, nil
+}
+
+type PartnerConnectorType string
+
+const (
+	PartnerConnectorTypeKafkaAzureBlobStorageSink      PartnerConnectorType = "KafkaAzureBlobStorageSink"
+	PartnerConnectorTypeKafkaAzureBlobStorageSource    PartnerConnectorType = "KafkaAzureBlobStorageSource"
+	PartnerConnectorTypeKafkaAzureCosmosDBSink         PartnerConnectorType = "KafkaAzureCosmosDBSink"
+	PartnerConnectorTypeKafkaAzureCosmosDBSource       PartnerConnectorType = "KafkaAzureCosmosDBSource"
+	PartnerConnectorTypeKafkaAzureSynapseAnalyticsSink PartnerConnectorType = "KafkaAzureSynapseAnalyticsSink"
+)
+
+func PossibleValuesForPartnerConnectorType() []string {
+	return []string{
+		string(PartnerConnectorTypeKafkaAzureBlobStorageSink),
+		string(PartnerConnectorTypeKafkaAzureBlobStorageSource),
+		string(PartnerConnectorTypeKafkaAzureCosmosDBSink),
+		string(PartnerConnectorTypeKafkaAzureCosmosDBSource),
+		string(PartnerConnectorTypeKafkaAzureSynapseAnalyticsSink),
+	}
+}
+
+func (s *PartnerConnectorType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePartnerConnectorType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePartnerConnectorType(input string) (*PartnerConnectorType, error) {
+	vals := map[string]PartnerConnectorType{
+		"kafkaazureblobstoragesink":      PartnerConnectorTypeKafkaAzureBlobStorageSink,
+		"kafkaazureblobstoragesource":    PartnerConnectorTypeKafkaAzureBlobStorageSource,
+		"kafkaazurecosmosdbsink":         PartnerConnectorTypeKafkaAzureCosmosDBSink,
+		"kafkaazurecosmosdbsource":       PartnerConnectorTypeKafkaAzureCosmosDBSource,
+		"kafkaazuresynapseanalyticssink": PartnerConnectorTypeKafkaAzureSynapseAnalyticsSink,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PartnerConnectorType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/id_cluster.go
@@ -1,0 +1,148 @@
+package connectorresources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ClusterId{})
+}
+
+var _ resourceids.ResourceId = &ClusterId{}
+
+// ClusterId is a struct representing the Resource ID for a Cluster
+type ClusterId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+	ClusterId         string
+}
+
+// NewClusterID returns a new ClusterId struct
+func NewClusterID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string, clusterId string) ClusterId {
+	return ClusterId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+		ClusterId:         clusterId,
+	}
+}
+
+// ParseClusterID parses 'input' into a ClusterId
+func ParseClusterID(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseClusterIDInsensitively parses 'input' case-insensitively into a ClusterId
+// note: this method should only be used for API response data and not user input
+func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	if id.ClusterId, ok = input.Parsed["clusterId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "clusterId", input)
+	}
+
+	return nil
+}
+
+// ValidateClusterID checks that 'input' can be parsed as a Cluster ID
+func ValidateClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cluster ID
+func (id ClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s/clusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId, id.ClusterId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cluster ID
+func (id ClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+		resourceids.StaticSegment("staticClusters", "clusters", "clusters"),
+		resourceids.UserSpecifiedSegment("clusterId", "clusterId"),
+	}
+}
+
+// String returns a human-readable description of this Cluster ID
+func (id ClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+		fmt.Sprintf("Cluster: %q", id.ClusterId),
+	}
+	return fmt.Sprintf("Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/id_connector.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/id_connector.go
@@ -1,0 +1,157 @@
+package connectorresources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ConnectorId{})
+}
+
+var _ resourceids.ResourceId = &ConnectorId{}
+
+// ConnectorId is a struct representing the Resource ID for a Connector
+type ConnectorId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+	ClusterId         string
+	ConnectorName     string
+}
+
+// NewConnectorID returns a new ConnectorId struct
+func NewConnectorID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string, clusterId string, connectorName string) ConnectorId {
+	return ConnectorId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+		ClusterId:         clusterId,
+		ConnectorName:     connectorName,
+	}
+}
+
+// ParseConnectorID parses 'input' into a ConnectorId
+func ParseConnectorID(input string) (*ConnectorId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ConnectorId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ConnectorId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseConnectorIDInsensitively parses 'input' case-insensitively into a ConnectorId
+// note: this method should only be used for API response data and not user input
+func ParseConnectorIDInsensitively(input string) (*ConnectorId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ConnectorId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ConnectorId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ConnectorId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	if id.ClusterId, ok = input.Parsed["clusterId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "clusterId", input)
+	}
+
+	if id.ConnectorName, ok = input.Parsed["connectorName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "connectorName", input)
+	}
+
+	return nil
+}
+
+// ValidateConnectorID checks that 'input' can be parsed as a Connector ID
+func ValidateConnectorID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseConnectorID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Connector ID
+func (id ConnectorId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s/clusters/%s/connectors/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId, id.ClusterId, id.ConnectorName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Connector ID
+func (id ConnectorId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+		resourceids.StaticSegment("staticClusters", "clusters", "clusters"),
+		resourceids.UserSpecifiedSegment("clusterId", "clusterId"),
+		resourceids.StaticSegment("staticConnectors", "connectors", "connectors"),
+		resourceids.UserSpecifiedSegment("connectorName", "connectorName"),
+	}
+}
+
+// String returns a human-readable description of this Connector ID
+func (id ConnectorId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+		fmt.Sprintf("Cluster: %q", id.ClusterId),
+		fmt.Sprintf("Connector Name: %q", id.ConnectorName),
+	}
+	return fmt.Sprintf("Connector (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectorcreateorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectorcreateorupdate.go
@@ -1,0 +1,58 @@
+package connectorresources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConnectorResource
+}
+
+// ConnectorCreateOrUpdate ...
+func (c ConnectorResourcesClient) ConnectorCreateOrUpdate(ctx context.Context, id ConnectorId, input ConnectorResource) (result ConnectorCreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConnectorResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectordelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectordelete.go
@@ -1,0 +1,70 @@
+package connectorresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ConnectorDelete ...
+func (c ConnectorResourcesClient) ConnectorDelete(ctx context.Context, id ConnectorId) (result ConnectorDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ConnectorDeleteThenPoll performs ConnectorDelete then polls until it's completed
+func (c ConnectorResourcesClient) ConnectorDeleteThenPoll(ctx context.Context, id ConnectorId) error {
+	result, err := c.ConnectorDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ConnectorDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ConnectorDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectorget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectorget.go
@@ -1,0 +1,53 @@
+package connectorresources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ConnectorResource
+}
+
+// ConnectorGet ...
+func (c ConnectorResourcesClient) ConnectorGet(ctx context.Context, id ConnectorId) (result ConnectorGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ConnectorResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectorlist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/method_connectorlist.go
@@ -1,0 +1,138 @@
+package connectorresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ConnectorResource
+}
+
+type ConnectorListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ConnectorResource
+}
+
+type ConnectorListOperationOptions struct {
+	PageSize  *int64
+	PageToken *string
+}
+
+func DefaultConnectorListOperationOptions() ConnectorListOperationOptions {
+	return ConnectorListOperationOptions{}
+}
+
+func (o ConnectorListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ConnectorListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ConnectorListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.PageSize != nil {
+		out.Append("pageSize", fmt.Sprintf("%v", *o.PageSize))
+	}
+	if o.PageToken != nil {
+		out.Append("pageToken", fmt.Sprintf("%v", *o.PageToken))
+	}
+	return &out
+}
+
+type ConnectorListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ConnectorListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ConnectorList ...
+func (c ConnectorResourcesClient) ConnectorList(ctx context.Context, id ClusterId, options ConnectorListOperationOptions) (result ConnectorListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ConnectorListCustomPager{},
+		Path:          fmt.Sprintf("%s/connectors", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ConnectorResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ConnectorListComplete retrieves all the results into a single object
+func (c ConnectorResourcesClient) ConnectorListComplete(ctx context.Context, id ClusterId, options ConnectorListOperationOptions) (ConnectorListCompleteResult, error) {
+	return c.ConnectorListCompleteMatchingPredicate(ctx, id, options, ConnectorResourceOperationPredicate{})
+}
+
+// ConnectorListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c ConnectorResourcesClient) ConnectorListCompleteMatchingPredicate(ctx context.Context, id ClusterId, options ConnectorListOperationOptions, predicate ConnectorResourceOperationPredicate) (result ConnectorListCompleteResult, err error) {
+	items := make([]ConnectorResource, 0)
+
+	resp, err := c.ConnectorList(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ConnectorListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azureblobstoragesinkconnectorserviceinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azureblobstoragesinkconnectorserviceinfo.go
@@ -1,0 +1,52 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ConnectorServiceTypeInfoBase = AzureBlobStorageSinkConnectorServiceInfo{}
+
+type AzureBlobStorageSinkConnectorServiceInfo struct {
+	StorageAccountKey    *string `json:"storageAccountKey,omitempty"`
+	StorageAccountName   *string `json:"storageAccountName,omitempty"`
+	StorageContainerName *string `json:"storageContainerName,omitempty"`
+
+	// Fields inherited from ConnectorServiceTypeInfoBase
+
+	ConnectorServiceType ConnectorServiceType `json:"connectorServiceType"`
+}
+
+func (s AzureBlobStorageSinkConnectorServiceInfo) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return BaseConnectorServiceTypeInfoBaseImpl{
+		ConnectorServiceType: s.ConnectorServiceType,
+	}
+}
+
+var _ json.Marshaler = AzureBlobStorageSinkConnectorServiceInfo{}
+
+func (s AzureBlobStorageSinkConnectorServiceInfo) MarshalJSON() ([]byte, error) {
+	type wrapper AzureBlobStorageSinkConnectorServiceInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureBlobStorageSinkConnectorServiceInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureBlobStorageSinkConnectorServiceInfo: %+v", err)
+	}
+
+	decoded["connectorServiceType"] = "AzureBlobStorageSinkConnector"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureBlobStorageSinkConnectorServiceInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azureblobstoragesourceconnectorserviceinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azureblobstoragesourceconnectorserviceinfo.go
@@ -1,0 +1,52 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ConnectorServiceTypeInfoBase = AzureBlobStorageSourceConnectorServiceInfo{}
+
+type AzureBlobStorageSourceConnectorServiceInfo struct {
+	StorageAccountKey    *string `json:"storageAccountKey,omitempty"`
+	StorageAccountName   *string `json:"storageAccountName,omitempty"`
+	StorageContainerName *string `json:"storageContainerName,omitempty"`
+
+	// Fields inherited from ConnectorServiceTypeInfoBase
+
+	ConnectorServiceType ConnectorServiceType `json:"connectorServiceType"`
+}
+
+func (s AzureBlobStorageSourceConnectorServiceInfo) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return BaseConnectorServiceTypeInfoBaseImpl{
+		ConnectorServiceType: s.ConnectorServiceType,
+	}
+}
+
+var _ json.Marshaler = AzureBlobStorageSourceConnectorServiceInfo{}
+
+func (s AzureBlobStorageSourceConnectorServiceInfo) MarshalJSON() ([]byte, error) {
+	type wrapper AzureBlobStorageSourceConnectorServiceInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureBlobStorageSourceConnectorServiceInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureBlobStorageSourceConnectorServiceInfo: %+v", err)
+	}
+
+	decoded["connectorServiceType"] = "AzureBlobStorageSourceConnector"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureBlobStorageSourceConnectorServiceInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azurecosmosdbsinkconnectorserviceinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azurecosmosdbsinkconnectorserviceinfo.go
@@ -1,0 +1,54 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ConnectorServiceTypeInfoBase = AzureCosmosDBSinkConnectorServiceInfo{}
+
+type AzureCosmosDBSinkConnectorServiceInfo struct {
+	CosmosConnectionEndpoint     *string `json:"cosmosConnectionEndpoint,omitempty"`
+	CosmosContainersTopicMapping *string `json:"cosmosContainersTopicMapping,omitempty"`
+	CosmosDatabaseName           *string `json:"cosmosDatabaseName,omitempty"`
+	CosmosIdStrategy             *string `json:"cosmosIdStrategy,omitempty"`
+	CosmosMasterKey              *string `json:"cosmosMasterKey,omitempty"`
+
+	// Fields inherited from ConnectorServiceTypeInfoBase
+
+	ConnectorServiceType ConnectorServiceType `json:"connectorServiceType"`
+}
+
+func (s AzureCosmosDBSinkConnectorServiceInfo) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return BaseConnectorServiceTypeInfoBaseImpl{
+		ConnectorServiceType: s.ConnectorServiceType,
+	}
+}
+
+var _ json.Marshaler = AzureCosmosDBSinkConnectorServiceInfo{}
+
+func (s AzureCosmosDBSinkConnectorServiceInfo) MarshalJSON() ([]byte, error) {
+	type wrapper AzureCosmosDBSinkConnectorServiceInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureCosmosDBSinkConnectorServiceInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureCosmosDBSinkConnectorServiceInfo: %+v", err)
+	}
+
+	decoded["connectorServiceType"] = "AzureCosmosDBSinkConnector"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureCosmosDBSinkConnectorServiceInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azurecosmosdbsourceconnectorserviceinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azurecosmosdbsourceconnectorserviceinfo.go
@@ -1,0 +1,55 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ConnectorServiceTypeInfoBase = AzureCosmosDBSourceConnectorServiceInfo{}
+
+type AzureCosmosDBSourceConnectorServiceInfo struct {
+	CosmosConnectionEndpoint     *string `json:"cosmosConnectionEndpoint,omitempty"`
+	CosmosContainersTopicMapping *string `json:"cosmosContainersTopicMapping,omitempty"`
+	CosmosDatabaseName           *string `json:"cosmosDatabaseName,omitempty"`
+	CosmosMasterKey              *string `json:"cosmosMasterKey,omitempty"`
+	CosmosMessageKeyEnabled      *bool   `json:"cosmosMessageKeyEnabled,omitempty"`
+	CosmosMessageKeyField        *string `json:"cosmosMessageKeyField,omitempty"`
+
+	// Fields inherited from ConnectorServiceTypeInfoBase
+
+	ConnectorServiceType ConnectorServiceType `json:"connectorServiceType"`
+}
+
+func (s AzureCosmosDBSourceConnectorServiceInfo) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return BaseConnectorServiceTypeInfoBaseImpl{
+		ConnectorServiceType: s.ConnectorServiceType,
+	}
+}
+
+var _ json.Marshaler = AzureCosmosDBSourceConnectorServiceInfo{}
+
+func (s AzureCosmosDBSourceConnectorServiceInfo) MarshalJSON() ([]byte, error) {
+	type wrapper AzureCosmosDBSourceConnectorServiceInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureCosmosDBSourceConnectorServiceInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureCosmosDBSourceConnectorServiceInfo: %+v", err)
+	}
+
+	decoded["connectorServiceType"] = "AzureCosmosDBSourceConnector"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureCosmosDBSourceConnectorServiceInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azuresynapseanalyticssinkconnectorserviceinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_azuresynapseanalyticssinkconnectorserviceinfo.go
@@ -1,0 +1,53 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ConnectorServiceTypeInfoBase = AzureSynapseAnalyticsSinkConnectorServiceInfo{}
+
+type AzureSynapseAnalyticsSinkConnectorServiceInfo struct {
+	SynapseSqlDatabaseName *string `json:"synapseSqlDatabaseName,omitempty"`
+	SynapseSqlPassword     *string `json:"synapseSqlPassword,omitempty"`
+	SynapseSqlServerName   *string `json:"synapseSqlServerName,omitempty"`
+	SynapseSqlUser         *string `json:"synapseSqlUser,omitempty"`
+
+	// Fields inherited from ConnectorServiceTypeInfoBase
+
+	ConnectorServiceType ConnectorServiceType `json:"connectorServiceType"`
+}
+
+func (s AzureSynapseAnalyticsSinkConnectorServiceInfo) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return BaseConnectorServiceTypeInfoBaseImpl{
+		ConnectorServiceType: s.ConnectorServiceType,
+	}
+}
+
+var _ json.Marshaler = AzureSynapseAnalyticsSinkConnectorServiceInfo{}
+
+func (s AzureSynapseAnalyticsSinkConnectorServiceInfo) MarshalJSON() ([]byte, error) {
+	type wrapper AzureSynapseAnalyticsSinkConnectorServiceInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureSynapseAnalyticsSinkConnectorServiceInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureSynapseAnalyticsSinkConnectorServiceInfo: %+v", err)
+	}
+
+	decoded["connectorServiceType"] = "AzureSynapseAnalyticsSinkConnector"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureSynapseAnalyticsSinkConnectorServiceInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorinfobase.go
@@ -1,0 +1,12 @@
+package connectorresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorInfoBase struct {
+	ConnectorClass *ConnectorClass  `json:"connectorClass,omitempty"`
+	ConnectorId    *string          `json:"connectorId,omitempty"`
+	ConnectorName  *string          `json:"connectorName,omitempty"`
+	ConnectorState *ConnectorStatus `json:"connectorState,omitempty"`
+	ConnectorType  *ConnectorType   `json:"connectorType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorresource.go
@@ -1,0 +1,16 @@
+package connectorresources
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorResource struct {
+	Id         *string                     `json:"id,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties ConnectorResourceProperties `json:"properties"`
+	SystemData *systemdata.SystemData      `json:"systemData,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorresourceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorresourceproperties.go
@@ -1,0 +1,51 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorResourceProperties struct {
+	ConnectorBasicInfo       *ConnectorInfoBase           `json:"connectorBasicInfo,omitempty"`
+	ConnectorServiceTypeInfo ConnectorServiceTypeInfoBase `json:"connectorServiceTypeInfo"`
+	PartnerConnectorInfo     PartnerInfoBase              `json:"partnerConnectorInfo"`
+}
+
+var _ json.Unmarshaler = &ConnectorResourceProperties{}
+
+func (s *ConnectorResourceProperties) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		ConnectorBasicInfo *ConnectorInfoBase `json:"connectorBasicInfo,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.ConnectorBasicInfo = decoded.ConnectorBasicInfo
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ConnectorResourceProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["connectorServiceTypeInfo"]; ok {
+		impl, err := UnmarshalConnectorServiceTypeInfoBaseImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ConnectorServiceTypeInfo' for 'ConnectorResourceProperties': %+v", err)
+		}
+		s.ConnectorServiceTypeInfo = impl
+	}
+
+	if v, ok := temp["partnerConnectorInfo"]; ok {
+		impl, err := UnmarshalPartnerInfoBaseImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'PartnerConnectorInfo' for 'ConnectorResourceProperties': %+v", err)
+		}
+		s.PartnerConnectorInfo = impl
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorservicetypeinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_connectorservicetypeinfobase.go
@@ -1,0 +1,107 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorServiceTypeInfoBase interface {
+	ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl
+}
+
+var _ ConnectorServiceTypeInfoBase = BaseConnectorServiceTypeInfoBaseImpl{}
+
+type BaseConnectorServiceTypeInfoBaseImpl struct {
+	ConnectorServiceType ConnectorServiceType `json:"connectorServiceType"`
+}
+
+func (s BaseConnectorServiceTypeInfoBaseImpl) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return s
+}
+
+var _ ConnectorServiceTypeInfoBase = RawConnectorServiceTypeInfoBaseImpl{}
+
+// RawConnectorServiceTypeInfoBaseImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawConnectorServiceTypeInfoBaseImpl struct {
+	connectorServiceTypeInfoBase BaseConnectorServiceTypeInfoBaseImpl
+	Type                         string
+	Values                       map[string]interface{}
+}
+
+func (s RawConnectorServiceTypeInfoBaseImpl) ConnectorServiceTypeInfoBase() BaseConnectorServiceTypeInfoBaseImpl {
+	return s.connectorServiceTypeInfoBase
+}
+
+func UnmarshalConnectorServiceTypeInfoBaseImplementation(input []byte) (ConnectorServiceTypeInfoBase, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ConnectorServiceTypeInfoBase into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["connectorServiceType"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "AzureBlobStorageSinkConnector") {
+		var out AzureBlobStorageSinkConnectorServiceInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureBlobStorageSinkConnectorServiceInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureBlobStorageSourceConnector") {
+		var out AzureBlobStorageSourceConnectorServiceInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureBlobStorageSourceConnectorServiceInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureCosmosDBSinkConnector") {
+		var out AzureCosmosDBSinkConnectorServiceInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureCosmosDBSinkConnectorServiceInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureCosmosDBSourceConnector") {
+		var out AzureCosmosDBSourceConnectorServiceInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureCosmosDBSourceConnectorServiceInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureSynapseAnalyticsSinkConnector") {
+		var out AzureSynapseAnalyticsSinkConnectorServiceInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureSynapseAnalyticsSinkConnectorServiceInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseConnectorServiceTypeInfoBaseImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseConnectorServiceTypeInfoBaseImpl: %+v", err)
+	}
+
+	return RawConnectorServiceTypeInfoBaseImpl{
+		connectorServiceTypeInfoBase: parent,
+		Type:                         value,
+		Values:                       temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazureblobstoragesinkconnectorinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazureblobstoragesinkconnectorinfo.go
@@ -1,0 +1,60 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PartnerInfoBase = KafkaAzureBlobStorageSinkConnectorInfo{}
+
+type KafkaAzureBlobStorageSinkConnectorInfo struct {
+	ApiKey           *string         `json:"apiKey,omitempty"`
+	ApiSecret        *string         `json:"apiSecret,omitempty"`
+	AuthType         *AuthType       `json:"authType,omitempty"`
+	FlushSize        *string         `json:"flushSize,omitempty"`
+	InputFormat      *DataFormatType `json:"inputFormat,omitempty"`
+	MaxTasks         *string         `json:"maxTasks,omitempty"`
+	OutputFormat     *DataFormatType `json:"outputFormat,omitempty"`
+	ServiceAccountId *string         `json:"serviceAccountId,omitempty"`
+	TimeInterval     *string         `json:"timeInterval,omitempty"`
+	Topics           *[]string       `json:"topics,omitempty"`
+	TopicsDir        *string         `json:"topicsDir,omitempty"`
+
+	// Fields inherited from PartnerInfoBase
+
+	PartnerConnectorType PartnerConnectorType `json:"partnerConnectorType"`
+}
+
+func (s KafkaAzureBlobStorageSinkConnectorInfo) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return BasePartnerInfoBaseImpl{
+		PartnerConnectorType: s.PartnerConnectorType,
+	}
+}
+
+var _ json.Marshaler = KafkaAzureBlobStorageSinkConnectorInfo{}
+
+func (s KafkaAzureBlobStorageSinkConnectorInfo) MarshalJSON() ([]byte, error) {
+	type wrapper KafkaAzureBlobStorageSinkConnectorInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling KafkaAzureBlobStorageSinkConnectorInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling KafkaAzureBlobStorageSinkConnectorInfo: %+v", err)
+	}
+
+	decoded["partnerConnectorType"] = "KafkaAzureBlobStorageSink"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling KafkaAzureBlobStorageSinkConnectorInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazureblobstoragesourceconnectorinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazureblobstoragesourceconnectorinfo.go
@@ -1,0 +1,58 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PartnerInfoBase = KafkaAzureBlobStorageSourceConnectorInfo{}
+
+type KafkaAzureBlobStorageSourceConnectorInfo struct {
+	ApiKey           *string         `json:"apiKey,omitempty"`
+	ApiSecret        *string         `json:"apiSecret,omitempty"`
+	AuthType         *AuthType       `json:"authType,omitempty"`
+	InputFormat      *DataFormatType `json:"inputFormat,omitempty"`
+	MaxTasks         *string         `json:"maxTasks,omitempty"`
+	OutputFormat     *DataFormatType `json:"outputFormat,omitempty"`
+	ServiceAccountId *string         `json:"serviceAccountId,omitempty"`
+	TopicRegex       *string         `json:"topicRegex,omitempty"`
+	TopicsDir        *string         `json:"topicsDir,omitempty"`
+
+	// Fields inherited from PartnerInfoBase
+
+	PartnerConnectorType PartnerConnectorType `json:"partnerConnectorType"`
+}
+
+func (s KafkaAzureBlobStorageSourceConnectorInfo) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return BasePartnerInfoBaseImpl{
+		PartnerConnectorType: s.PartnerConnectorType,
+	}
+}
+
+var _ json.Marshaler = KafkaAzureBlobStorageSourceConnectorInfo{}
+
+func (s KafkaAzureBlobStorageSourceConnectorInfo) MarshalJSON() ([]byte, error) {
+	type wrapper KafkaAzureBlobStorageSourceConnectorInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling KafkaAzureBlobStorageSourceConnectorInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling KafkaAzureBlobStorageSourceConnectorInfo: %+v", err)
+	}
+
+	decoded["partnerConnectorType"] = "KafkaAzureBlobStorageSource"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling KafkaAzureBlobStorageSourceConnectorInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazurecosmosdbsinkconnectorinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazurecosmosdbsinkconnectorinfo.go
@@ -1,0 +1,60 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PartnerInfoBase = KafkaAzureCosmosDBSinkConnectorInfo{}
+
+type KafkaAzureCosmosDBSinkConnectorInfo struct {
+	ApiKey           *string         `json:"apiKey,omitempty"`
+	ApiSecret        *string         `json:"apiSecret,omitempty"`
+	AuthType         *AuthType       `json:"authType,omitempty"`
+	FlushSize        *string         `json:"flushSize,omitempty"`
+	InputFormat      *DataFormatType `json:"inputFormat,omitempty"`
+	MaxTasks         *string         `json:"maxTasks,omitempty"`
+	OutputFormat     *DataFormatType `json:"outputFormat,omitempty"`
+	ServiceAccountId *string         `json:"serviceAccountId,omitempty"`
+	TimeInterval     *string         `json:"timeInterval,omitempty"`
+	Topics           *[]string       `json:"topics,omitempty"`
+	TopicsDir        *string         `json:"topicsDir,omitempty"`
+
+	// Fields inherited from PartnerInfoBase
+
+	PartnerConnectorType PartnerConnectorType `json:"partnerConnectorType"`
+}
+
+func (s KafkaAzureCosmosDBSinkConnectorInfo) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return BasePartnerInfoBaseImpl{
+		PartnerConnectorType: s.PartnerConnectorType,
+	}
+}
+
+var _ json.Marshaler = KafkaAzureCosmosDBSinkConnectorInfo{}
+
+func (s KafkaAzureCosmosDBSinkConnectorInfo) MarshalJSON() ([]byte, error) {
+	type wrapper KafkaAzureCosmosDBSinkConnectorInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling KafkaAzureCosmosDBSinkConnectorInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling KafkaAzureCosmosDBSinkConnectorInfo: %+v", err)
+	}
+
+	decoded["partnerConnectorType"] = "KafkaAzureCosmosDBSink"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling KafkaAzureCosmosDBSinkConnectorInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazurecosmosdbsourceconnectorinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazurecosmosdbsourceconnectorinfo.go
@@ -1,0 +1,58 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PartnerInfoBase = KafkaAzureCosmosDBSourceConnectorInfo{}
+
+type KafkaAzureCosmosDBSourceConnectorInfo struct {
+	ApiKey           *string         `json:"apiKey,omitempty"`
+	ApiSecret        *string         `json:"apiSecret,omitempty"`
+	AuthType         *AuthType       `json:"authType,omitempty"`
+	InputFormat      *DataFormatType `json:"inputFormat,omitempty"`
+	MaxTasks         *string         `json:"maxTasks,omitempty"`
+	OutputFormat     *DataFormatType `json:"outputFormat,omitempty"`
+	ServiceAccountId *string         `json:"serviceAccountId,omitempty"`
+	TopicRegex       *string         `json:"topicRegex,omitempty"`
+	TopicsDir        *string         `json:"topicsDir,omitempty"`
+
+	// Fields inherited from PartnerInfoBase
+
+	PartnerConnectorType PartnerConnectorType `json:"partnerConnectorType"`
+}
+
+func (s KafkaAzureCosmosDBSourceConnectorInfo) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return BasePartnerInfoBaseImpl{
+		PartnerConnectorType: s.PartnerConnectorType,
+	}
+}
+
+var _ json.Marshaler = KafkaAzureCosmosDBSourceConnectorInfo{}
+
+func (s KafkaAzureCosmosDBSourceConnectorInfo) MarshalJSON() ([]byte, error) {
+	type wrapper KafkaAzureCosmosDBSourceConnectorInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling KafkaAzureCosmosDBSourceConnectorInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling KafkaAzureCosmosDBSourceConnectorInfo: %+v", err)
+	}
+
+	decoded["partnerConnectorType"] = "KafkaAzureCosmosDBSource"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling KafkaAzureCosmosDBSourceConnectorInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazuresynapseanalyticssinkconnectorinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_kafkaazuresynapseanalyticssinkconnectorinfo.go
@@ -1,0 +1,60 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PartnerInfoBase = KafkaAzureSynapseAnalyticsSinkConnectorInfo{}
+
+type KafkaAzureSynapseAnalyticsSinkConnectorInfo struct {
+	ApiKey           *string         `json:"apiKey,omitempty"`
+	ApiSecret        *string         `json:"apiSecret,omitempty"`
+	AuthType         *AuthType       `json:"authType,omitempty"`
+	FlushSize        *string         `json:"flushSize,omitempty"`
+	InputFormat      *DataFormatType `json:"inputFormat,omitempty"`
+	MaxTasks         *string         `json:"maxTasks,omitempty"`
+	OutputFormat     *DataFormatType `json:"outputFormat,omitempty"`
+	ServiceAccountId *string         `json:"serviceAccountId,omitempty"`
+	TimeInterval     *string         `json:"timeInterval,omitempty"`
+	Topics           *[]string       `json:"topics,omitempty"`
+	TopicsDir        *string         `json:"topicsDir,omitempty"`
+
+	// Fields inherited from PartnerInfoBase
+
+	PartnerConnectorType PartnerConnectorType `json:"partnerConnectorType"`
+}
+
+func (s KafkaAzureSynapseAnalyticsSinkConnectorInfo) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return BasePartnerInfoBaseImpl{
+		PartnerConnectorType: s.PartnerConnectorType,
+	}
+}
+
+var _ json.Marshaler = KafkaAzureSynapseAnalyticsSinkConnectorInfo{}
+
+func (s KafkaAzureSynapseAnalyticsSinkConnectorInfo) MarshalJSON() ([]byte, error) {
+	type wrapper KafkaAzureSynapseAnalyticsSinkConnectorInfo
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling KafkaAzureSynapseAnalyticsSinkConnectorInfo: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling KafkaAzureSynapseAnalyticsSinkConnectorInfo: %+v", err)
+	}
+
+	decoded["partnerConnectorType"] = "KafkaAzureSynapseAnalyticsSink"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling KafkaAzureSynapseAnalyticsSinkConnectorInfo: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_partnerinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/model_partnerinfobase.go
@@ -1,0 +1,107 @@
+package connectorresources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PartnerInfoBase interface {
+	PartnerInfoBase() BasePartnerInfoBaseImpl
+}
+
+var _ PartnerInfoBase = BasePartnerInfoBaseImpl{}
+
+type BasePartnerInfoBaseImpl struct {
+	PartnerConnectorType PartnerConnectorType `json:"partnerConnectorType"`
+}
+
+func (s BasePartnerInfoBaseImpl) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return s
+}
+
+var _ PartnerInfoBase = RawPartnerInfoBaseImpl{}
+
+// RawPartnerInfoBaseImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawPartnerInfoBaseImpl struct {
+	partnerInfoBase BasePartnerInfoBaseImpl
+	Type            string
+	Values          map[string]interface{}
+}
+
+func (s RawPartnerInfoBaseImpl) PartnerInfoBase() BasePartnerInfoBaseImpl {
+	return s.partnerInfoBase
+}
+
+func UnmarshalPartnerInfoBaseImplementation(input []byte) (PartnerInfoBase, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling PartnerInfoBase into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["partnerConnectorType"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "KafkaAzureBlobStorageSink") {
+		var out KafkaAzureBlobStorageSinkConnectorInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into KafkaAzureBlobStorageSinkConnectorInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "KafkaAzureBlobStorageSource") {
+		var out KafkaAzureBlobStorageSourceConnectorInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into KafkaAzureBlobStorageSourceConnectorInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "KafkaAzureCosmosDBSink") {
+		var out KafkaAzureCosmosDBSinkConnectorInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into KafkaAzureCosmosDBSinkConnectorInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "KafkaAzureCosmosDBSource") {
+		var out KafkaAzureCosmosDBSourceConnectorInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into KafkaAzureCosmosDBSourceConnectorInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "KafkaAzureSynapseAnalyticsSink") {
+		var out KafkaAzureSynapseAnalyticsSinkConnectorInfo
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into KafkaAzureSynapseAnalyticsSinkConnectorInfo: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BasePartnerInfoBaseImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BasePartnerInfoBaseImpl: %+v", err)
+	}
+
+	return RawPartnerInfoBaseImpl{
+		partnerInfoBase: parent,
+		Type:            value,
+		Values:          temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/predicates.go
@@ -1,0 +1,27 @@
+package connectorresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectorResourceOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p ConnectorResourceOperationPredicate) Matches(input ConnectorResource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources/version.go
@@ -1,0 +1,10 @@
+package connectorresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/connectorresources/2024-07-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/README.md
@@ -1,0 +1,331 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources` Documentation
+
+The `organizationresources` SDK allows for interaction with Azure Resource Manager `confluent` (API Version `2024-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources"
+```
+
+
+### Client Initialization
+
+```go
+client := organizationresources.NewOrganizationResourcesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessCreateRoleBinding`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.AccessCreateRoleBindingRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessCreateRoleBinding(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessInviteUser`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.AccessInviteUserAccountModel{
+	// ...
+}
+
+
+read, err := client.AccessInviteUser(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListClusters`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListClusters(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListEnvironments`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListEnvironments(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListInvitations`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListInvitations(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListRoleBindingNameList`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListRoleBindingNameList(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListRoleBindings`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListRoleBindings(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListServiceAccounts`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListServiceAccounts(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.AccessListUsers`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.AccessListUsers(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationCreate`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.OrganizationResource{
+	// ...
+}
+
+
+if err := client.OrganizationCreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationDelete`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+if err := client.OrganizationDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationGet`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+read, err := client.OrganizationGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.OrganizationListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.OrganizationListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationListBySubscription`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.OrganizationListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.OrganizationListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationListRegions`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.ListAccessRequestModel{
+	// ...
+}
+
+
+read, err := client.OrganizationListRegions(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OrganizationResourcesClient.OrganizationUpdate`
+
+```go
+ctx := context.TODO()
+id := organizationresources.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+payload := organizationresources.OrganizationResourceUpdate{
+	// ...
+}
+
+
+read, err := client.OrganizationUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/client.go
@@ -1,0 +1,26 @@
+package organizationresources
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationResourcesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewOrganizationResourcesClientWithBaseURI(sdkApi sdkEnv.Api) (*OrganizationResourcesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "organizationresources", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating OrganizationResourcesClient: %+v", err)
+	}
+
+	return &OrganizationResourcesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/constants.go
@@ -1,0 +1,137 @@
+package organizationresources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProvisionState string
+
+const (
+	ProvisionStateAccepted     ProvisionState = "Accepted"
+	ProvisionStateCanceled     ProvisionState = "Canceled"
+	ProvisionStateCreating     ProvisionState = "Creating"
+	ProvisionStateDeleted      ProvisionState = "Deleted"
+	ProvisionStateDeleting     ProvisionState = "Deleting"
+	ProvisionStateFailed       ProvisionState = "Failed"
+	ProvisionStateNotSpecified ProvisionState = "NotSpecified"
+	ProvisionStateSucceeded    ProvisionState = "Succeeded"
+	ProvisionStateUpdating     ProvisionState = "Updating"
+)
+
+func PossibleValuesForProvisionState() []string {
+	return []string{
+		string(ProvisionStateAccepted),
+		string(ProvisionStateCanceled),
+		string(ProvisionStateCreating),
+		string(ProvisionStateDeleted),
+		string(ProvisionStateDeleting),
+		string(ProvisionStateFailed),
+		string(ProvisionStateNotSpecified),
+		string(ProvisionStateSucceeded),
+		string(ProvisionStateUpdating),
+	}
+}
+
+func (s *ProvisionState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisionState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisionState(input string) (*ProvisionState, error) {
+	vals := map[string]ProvisionState{
+		"accepted":     ProvisionStateAccepted,
+		"canceled":     ProvisionStateCanceled,
+		"creating":     ProvisionStateCreating,
+		"deleted":      ProvisionStateDeleted,
+		"deleting":     ProvisionStateDeleting,
+		"failed":       ProvisionStateFailed,
+		"notspecified": ProvisionStateNotSpecified,
+		"succeeded":    ProvisionStateSucceeded,
+		"updating":     ProvisionStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisionState(input)
+	return &out, nil
+}
+
+type SaaSOfferStatus string
+
+const (
+	SaaSOfferStatusFailed                  SaaSOfferStatus = "Failed"
+	SaaSOfferStatusInProgress              SaaSOfferStatus = "InProgress"
+	SaaSOfferStatusPendingFulfillmentStart SaaSOfferStatus = "PendingFulfillmentStart"
+	SaaSOfferStatusReinstated              SaaSOfferStatus = "Reinstated"
+	SaaSOfferStatusStarted                 SaaSOfferStatus = "Started"
+	SaaSOfferStatusSubscribed              SaaSOfferStatus = "Subscribed"
+	SaaSOfferStatusSucceeded               SaaSOfferStatus = "Succeeded"
+	SaaSOfferStatusSuspended               SaaSOfferStatus = "Suspended"
+	SaaSOfferStatusUnsubscribed            SaaSOfferStatus = "Unsubscribed"
+	SaaSOfferStatusUpdating                SaaSOfferStatus = "Updating"
+)
+
+func PossibleValuesForSaaSOfferStatus() []string {
+	return []string{
+		string(SaaSOfferStatusFailed),
+		string(SaaSOfferStatusInProgress),
+		string(SaaSOfferStatusPendingFulfillmentStart),
+		string(SaaSOfferStatusReinstated),
+		string(SaaSOfferStatusStarted),
+		string(SaaSOfferStatusSubscribed),
+		string(SaaSOfferStatusSucceeded),
+		string(SaaSOfferStatusSuspended),
+		string(SaaSOfferStatusUnsubscribed),
+		string(SaaSOfferStatusUpdating),
+	}
+}
+
+func (s *SaaSOfferStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSaaSOfferStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSaaSOfferStatus(input string) (*SaaSOfferStatus, error) {
+	vals := map[string]SaaSOfferStatus{
+		"failed":                  SaaSOfferStatusFailed,
+		"inprogress":              SaaSOfferStatusInProgress,
+		"pendingfulfillmentstart": SaaSOfferStatusPendingFulfillmentStart,
+		"reinstated":              SaaSOfferStatusReinstated,
+		"started":                 SaaSOfferStatusStarted,
+		"subscribed":              SaaSOfferStatusSubscribed,
+		"succeeded":               SaaSOfferStatusSucceeded,
+		"suspended":               SaaSOfferStatusSuspended,
+		"unsubscribed":            SaaSOfferStatusUnsubscribed,
+		"updating":                SaaSOfferStatusUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SaaSOfferStatus(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/id_organization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/id_organization.go
@@ -1,0 +1,130 @@
+package organizationresources
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OrganizationId{})
+}
+
+var _ resourceids.ResourceId = &OrganizationId{}
+
+// OrganizationId is a struct representing the Resource ID for a Organization
+type OrganizationId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+}
+
+// NewOrganizationID returns a new OrganizationId struct
+func NewOrganizationID(subscriptionId string, resourceGroupName string, organizationName string) OrganizationId {
+	return OrganizationId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+	}
+}
+
+// ParseOrganizationID parses 'input' into a OrganizationId
+func ParseOrganizationID(input string) (*OrganizationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OrganizationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OrganizationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOrganizationIDInsensitively parses 'input' case-insensitively into a OrganizationId
+// note: this method should only be used for API response data and not user input
+func ParseOrganizationIDInsensitively(input string) (*OrganizationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OrganizationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OrganizationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OrganizationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	return nil
+}
+
+// ValidateOrganizationID checks that 'input' can be parsed as a Organization ID
+func ValidateOrganizationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOrganizationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Organization ID
+func (id OrganizationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Organization ID
+func (id OrganizationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+	}
+}
+
+// String returns a human-readable description of this Organization ID
+func (id OrganizationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+	}
+	return fmt.Sprintf("Organization (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesscreaterolebinding.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesscreaterolebinding.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessCreateRoleBindingOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RoleBindingRecord
+}
+
+// AccessCreateRoleBinding ...
+func (c OrganizationResourcesClient) AccessCreateRoleBinding(ctx context.Context, id OrganizationId, input AccessCreateRoleBindingRequestModel) (result AccessCreateRoleBindingOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/createRoleBinding", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RoleBindingRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accessinviteuser.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accessinviteuser.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessInviteUserOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *InvitationRecord
+}
+
+// AccessInviteUser ...
+func (c OrganizationResourcesClient) AccessInviteUser(ctx context.Context, id OrganizationId, input AccessInviteUserAccountModel) (result AccessInviteUserOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/createInvitation", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model InvitationRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistclusters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistclusters.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListClustersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessListClusterSuccessResponse
+}
+
+// AccessListClusters ...
+func (c OrganizationResourcesClient) AccessListClusters(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListClustersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listClusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessListClusterSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistenvironments.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistenvironments.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListEnvironmentsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessListEnvironmentsSuccessResponse
+}
+
+// AccessListEnvironments ...
+func (c OrganizationResourcesClient) AccessListEnvironments(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListEnvironmentsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listEnvironments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessListEnvironmentsSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistinvitations.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistinvitations.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListInvitationsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessListInvitationsSuccessResponse
+}
+
+// AccessListInvitations ...
+func (c OrganizationResourcesClient) AccessListInvitations(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListInvitationsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listInvitations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessListInvitationsSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistrolebindingnamelist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistrolebindingnamelist.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListRoleBindingNameListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessRoleBindingNameListSuccessResponse
+}
+
+// AccessListRoleBindingNameList ...
+func (c OrganizationResourcesClient) AccessListRoleBindingNameList(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListRoleBindingNameListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listRoleBindingNameList", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessRoleBindingNameListSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistrolebindings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistrolebindings.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListRoleBindingsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessListRoleBindingsSuccessResponse
+}
+
+// AccessListRoleBindings ...
+func (c OrganizationResourcesClient) AccessListRoleBindings(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListRoleBindingsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listRoleBindings", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessListRoleBindingsSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistserviceaccounts.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistserviceaccounts.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListServiceAccountsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessListServiceAccountsSuccessResponse
+}
+
+// AccessListServiceAccounts ...
+func (c OrganizationResourcesClient) AccessListServiceAccounts(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListServiceAccountsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listServiceAccounts", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessListServiceAccountsSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistusers.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_accesslistusers.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListUsersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *AccessListUsersSuccessResponse
+}
+
+// AccessListUsers ...
+func (c OrganizationResourcesClient) AccessListUsers(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result AccessListUsersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/access/default/listUsers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model AccessListUsersSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationcreate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationcreate.go
@@ -1,0 +1,75 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationCreateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OrganizationResource
+}
+
+// OrganizationCreate ...
+func (c OrganizationResourcesClient) OrganizationCreate(ctx context.Context, id OrganizationId, input OrganizationResource) (result OrganizationCreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// OrganizationCreateThenPoll performs OrganizationCreate then polls until it's completed
+func (c OrganizationResourcesClient) OrganizationCreateThenPoll(ctx context.Context, id OrganizationId, input OrganizationResource) error {
+	result, err := c.OrganizationCreate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing OrganizationCreate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after OrganizationCreate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationdelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationdelete.go
@@ -1,0 +1,71 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// OrganizationDelete ...
+func (c OrganizationResourcesClient) OrganizationDelete(ctx context.Context, id OrganizationId) (result OrganizationDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// OrganizationDeleteThenPoll performs OrganizationDelete then polls until it's completed
+func (c OrganizationResourcesClient) OrganizationDeleteThenPoll(ctx context.Context, id OrganizationId) error {
+	result, err := c.OrganizationDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing OrganizationDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after OrganizationDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationget.go
@@ -1,0 +1,53 @@
+package organizationresources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OrganizationResource
+}
+
+// OrganizationGet ...
+func (c OrganizationResourcesClient) OrganizationGet(ctx context.Context, id OrganizationId) (result OrganizationGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model OrganizationResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationlistbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationlistbyresourcegroup.go
@@ -1,0 +1,106 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]OrganizationResource
+}
+
+type OrganizationListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []OrganizationResource
+}
+
+type OrganizationListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *OrganizationListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// OrganizationListByResourceGroup ...
+func (c OrganizationResourcesClient) OrganizationListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result OrganizationListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &OrganizationListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Confluent/organizations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]OrganizationResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// OrganizationListByResourceGroupComplete retrieves all the results into a single object
+func (c OrganizationResourcesClient) OrganizationListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (OrganizationListByResourceGroupCompleteResult, error) {
+	return c.OrganizationListByResourceGroupCompleteMatchingPredicate(ctx, id, OrganizationResourceOperationPredicate{})
+}
+
+// OrganizationListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c OrganizationResourcesClient) OrganizationListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate OrganizationResourceOperationPredicate) (result OrganizationListByResourceGroupCompleteResult, err error) {
+	items := make([]OrganizationResource, 0)
+
+	resp, err := c.OrganizationListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = OrganizationListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationlistbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationlistbysubscription.go
@@ -1,0 +1,106 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]OrganizationResource
+}
+
+type OrganizationListBySubscriptionCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []OrganizationResource
+}
+
+type OrganizationListBySubscriptionCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *OrganizationListBySubscriptionCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// OrganizationListBySubscription ...
+func (c OrganizationResourcesClient) OrganizationListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result OrganizationListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &OrganizationListBySubscriptionCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Confluent/organizations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]OrganizationResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// OrganizationListBySubscriptionComplete retrieves all the results into a single object
+func (c OrganizationResourcesClient) OrganizationListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (OrganizationListBySubscriptionCompleteResult, error) {
+	return c.OrganizationListBySubscriptionCompleteMatchingPredicate(ctx, id, OrganizationResourceOperationPredicate{})
+}
+
+// OrganizationListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c OrganizationResourcesClient) OrganizationListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate OrganizationResourceOperationPredicate) (result OrganizationListBySubscriptionCompleteResult, err error) {
+	items := make([]OrganizationResource, 0)
+
+	resp, err := c.OrganizationListBySubscription(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = OrganizationListBySubscriptionCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationlistregions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationlistregions.go
@@ -1,0 +1,58 @@
+package organizationresources
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationListRegionsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ListRegionsSuccessResponse
+}
+
+// OrganizationListRegions ...
+func (c OrganizationResourcesClient) OrganizationListRegions(ctx context.Context, id OrganizationId, input ListAccessRequestModel) (result OrganizationListRegionsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/listRegions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ListRegionsSuccessResponse
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/method_organizationupdate.go
@@ -1,0 +1,57 @@
+package organizationresources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OrganizationResource
+}
+
+// OrganizationUpdate ...
+func (c OrganizationResourcesClient) OrganizationUpdate(ctx context.Context, id OrganizationId, input OrganizationResourceUpdate) (result OrganizationUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model OrganizationResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesscreaterolebindingrequestmodel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesscreaterolebindingrequestmodel.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessCreateRoleBindingRequestModel struct {
+	CrnPattern *string `json:"crn_pattern,omitempty"`
+	Principal  *string `json:"principal,omitempty"`
+	RoleName   *string `json:"role_name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accessinviteduserdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accessinviteduserdetails.go
@@ -1,0 +1,9 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessInvitedUserDetails struct {
+	AuthType     *string `json:"auth_type,omitempty"`
+	InvitedEmail *string `json:"invitedEmail,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accessinviteuseraccountmodel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accessinviteuseraccountmodel.go
@@ -1,0 +1,11 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessInviteUserAccountModel struct {
+	Email              *string                   `json:"email,omitempty"`
+	InvitedUserDetails *AccessInvitedUserDetails `json:"invitedUserDetails,omitempty"`
+	OrganizationId     *string                   `json:"organizationId,omitempty"`
+	Upn                *string                   `json:"upn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistclustersuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistclustersuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListClusterSuccessResponse struct {
+	Data     *[]ClusterRecord       `json:"data,omitempty"`
+	Kind     *string                `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistenvironmentssuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistenvironmentssuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListEnvironmentsSuccessResponse struct {
+	Data     *[]EnvironmentRecord   `json:"data,omitempty"`
+	Kind     *string                `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistinvitationssuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistinvitationssuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListInvitationsSuccessResponse struct {
+	Data     *[]InvitationRecord    `json:"data,omitempty"`
+	Kind     *string                `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistrolebindingssuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistrolebindingssuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListRoleBindingsSuccessResponse struct {
+	Data     *[]RoleBindingRecord   `json:"data,omitempty"`
+	Kind     *string                `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistserviceaccountssuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistserviceaccountssuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListServiceAccountsSuccessResponse struct {
+	Data     *[]ServiceAccountRecord `json:"data,omitempty"`
+	Kind     *string                 `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata  `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistuserssuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accesslistuserssuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessListUsersSuccessResponse struct {
+	Data     *[]UserRecord          `json:"data,omitempty"`
+	Kind     *string                `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accessrolebindingnamelistsuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_accessrolebindingnamelistsuccessresponse.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessRoleBindingNameListSuccessResponse struct {
+	Data     *[]string              `json:"data,omitempty"`
+	Kind     *string                `json:"kind,omitempty"`
+	Metadata *ConfluentListMetadata `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterbyokentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterbyokentity.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterByokEntity struct {
+	Id           *string `json:"id,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resource_name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterconfigentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterconfigentity.go
@@ -1,0 +1,8 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterConfigEntity struct {
+	Kind *string `json:"kind,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterenvironmententity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterenvironmententity.go
@@ -1,0 +1,11 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterEnvironmentEntity struct {
+	Environment  *string `json:"environment,omitempty"`
+	Id           *string `json:"id,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resource_name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusternetworkentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusternetworkentity.go
@@ -1,0 +1,11 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterNetworkEntity struct {
+	Environment  *string `json:"environment,omitempty"`
+	Id           *string `json:"id,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resource_name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterrecord.go
@@ -1,0 +1,13 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterRecord struct {
+	DisplayName *string              `json:"display_name,omitempty"`
+	Id          *string              `json:"id,omitempty"`
+	Kind        *string              `json:"kind,omitempty"`
+	Metadata    *MetadataEntity      `json:"metadata,omitempty"`
+	Spec        *ClusterSpecEntity   `json:"spec,omitempty"`
+	Status      *ClusterStatusEntity `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterspecentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterspecentity.go
@@ -1,0 +1,19 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterSpecEntity struct {
+	ApiEndpoint            *string                   `json:"api_endpoint,omitempty"`
+	Availability           *string                   `json:"availability,omitempty"`
+	Byok                   *ClusterByokEntity        `json:"byok,omitempty"`
+	Cloud                  *string                   `json:"cloud,omitempty"`
+	Config                 *ClusterConfigEntity      `json:"config,omitempty"`
+	DisplayName            *string                   `json:"display_name,omitempty"`
+	Environment            *ClusterEnvironmentEntity `json:"environment,omitempty"`
+	HTTPEndpoint           *string                   `json:"http_endpoint,omitempty"`
+	KafkaBootstrapEndpoint *string                   `json:"kafka_bootstrap_endpoint,omitempty"`
+	Network                *ClusterNetworkEntity     `json:"network,omitempty"`
+	Region                 *string                   `json:"region,omitempty"`
+	Zone                   *string                   `json:"zone,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterstatusentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_clusterstatusentity.go
@@ -1,0 +1,9 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterStatusEntity struct {
+	Cku   *int64  `json:"cku,omitempty"`
+	Phase *string `json:"phase,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_confluentlistmetadata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_confluentlistmetadata.go
@@ -1,0 +1,12 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConfluentListMetadata struct {
+	First     *string `json:"first,omitempty"`
+	Last      *string `json:"last,omitempty"`
+	Next      *string `json:"next,omitempty"`
+	Prev      *string `json:"prev,omitempty"`
+	TotalSize *int64  `json:"total_size,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_environmentrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_environmentrecord.go
@@ -1,0 +1,11 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnvironmentRecord struct {
+	DisplayName *string         `json:"display_name,omitempty"`
+	Id          *string         `json:"id,omitempty"`
+	Kind        *string         `json:"kind,omitempty"`
+	Metadata    *MetadataEntity `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_invitationrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_invitationrecord.go
@@ -1,0 +1,15 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InvitationRecord struct {
+	AcceptedAt *string         `json:"accepted_at,omitempty"`
+	AuthType   *string         `json:"auth_type,omitempty"`
+	Email      *string         `json:"email,omitempty"`
+	ExpiresAt  *string         `json:"expires_at,omitempty"`
+	Id         *string         `json:"id,omitempty"`
+	Kind       *string         `json:"kind,omitempty"`
+	Metadata   *MetadataEntity `json:"metadata,omitempty"`
+	Status     *string         `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_linkorganization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_linkorganization.go
@@ -1,0 +1,8 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LinkOrganization struct {
+	Token string `json:"token"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_listaccessrequestmodel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_listaccessrequestmodel.go
@@ -1,0 +1,8 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListAccessRequestModel struct {
+	SearchFilters *map[string]string `json:"searchFilters,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_listregionssuccessresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_listregionssuccessresponse.go
@@ -1,0 +1,8 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListRegionsSuccessResponse struct {
+	Data *[]RegionRecord `json:"data,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_metadataentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_metadataentity.go
@@ -1,0 +1,12 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MetadataEntity struct {
+	CreatedAt    *string `json:"created_at,omitempty"`
+	DeletedAt    *string `json:"deleted_at,omitempty"`
+	ResourceName *string `json:"resource_name,omitempty"`
+	Self         *string `json:"self,omitempty"`
+	UpdatedAt    *string `json:"updated_at,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_offerdetail.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_offerdetail.go
@@ -1,0 +1,16 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OfferDetail struct {
+	Id              string           `json:"id"`
+	PlanId          string           `json:"planId"`
+	PlanName        string           `json:"planName"`
+	PrivateOfferId  *string          `json:"privateOfferId,omitempty"`
+	PrivateOfferIds *[]string        `json:"privateOfferIds,omitempty"`
+	PublisherId     string           `json:"publisherId"`
+	Status          *SaaSOfferStatus `json:"status,omitempty"`
+	TermId          *string          `json:"termId,omitempty"`
+	TermUnit        string           `json:"termUnit"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_organizationresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_organizationresource.go
@@ -1,0 +1,18 @@
+package organizationresources
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationResource struct {
+	Id         *string                        `json:"id,omitempty"`
+	Location   string                         `json:"location"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties OrganizationResourceProperties `json:"properties"`
+	SystemData *systemdata.SystemData         `json:"systemData,omitempty"`
+	Tags       *map[string]string             `json:"tags,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_organizationresourceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_organizationresourceproperties.go
@@ -1,0 +1,32 @@
+package organizationresources
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationResourceProperties struct {
+	CreatedTime       *string           `json:"createdTime,omitempty"`
+	LinkOrganization  *LinkOrganization `json:"linkOrganization,omitempty"`
+	OfferDetail       OfferDetail       `json:"offerDetail"`
+	OrganizationId    *string           `json:"organizationId,omitempty"`
+	ProvisioningState *ProvisionState   `json:"provisioningState,omitempty"`
+	SsoURL            *string           `json:"ssoUrl,omitempty"`
+	UserDetail        UserDetail        `json:"userDetail"`
+}
+
+func (o *OrganizationResourceProperties) GetCreatedTimeAsTime() (*time.Time, error) {
+	if o.CreatedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *OrganizationResourceProperties) SetCreatedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_organizationresourceupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_organizationresourceupdate.go
@@ -1,0 +1,8 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationResourceUpdate struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_regionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_regionproperties.go
@@ -1,0 +1,9 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegionProperties struct {
+	Metadata *SCMetadataEntity `json:"metadata,omitempty"`
+	Spec     *RegionSpecEntity `json:"spec,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_regionrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_regionrecord.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegionRecord struct {
+	Id         *string           `json:"id,omitempty"`
+	Kind       *string           `json:"kind,omitempty"`
+	Properties *RegionProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_regionspecentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_regionspecentity.go
@@ -1,0 +1,11 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegionSpecEntity struct {
+	Cloud      *string   `json:"cloud,omitempty"`
+	Name       *string   `json:"name,omitempty"`
+	Packages   *[]string `json:"packages,omitempty"`
+	RegionName *string   `json:"regionName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_rolebindingrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_rolebindingrecord.go
@@ -1,0 +1,13 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RoleBindingRecord struct {
+	CrnPattern *string         `json:"crn_pattern,omitempty"`
+	Id         *string         `json:"id,omitempty"`
+	Kind       *string         `json:"kind,omitempty"`
+	Metadata   *MetadataEntity `json:"metadata,omitempty"`
+	Principal  *string         `json:"principal,omitempty"`
+	RoleName   *string         `json:"role_name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_scmetadataentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_scmetadataentity.go
@@ -1,0 +1,12 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCMetadataEntity struct {
+	CreatedTimestamp *string `json:"createdTimestamp,omitempty"`
+	DeletedTimestamp *string `json:"deletedTimestamp,omitempty"`
+	ResourceName     *string `json:"resourceName,omitempty"`
+	Self             *string `json:"self,omitempty"`
+	UpdatedTimestamp *string `json:"updatedTimestamp,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_serviceaccountrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_serviceaccountrecord.go
@@ -1,0 +1,12 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAccountRecord struct {
+	Description *string         `json:"description,omitempty"`
+	DisplayName *string         `json:"display_name,omitempty"`
+	Id          *string         `json:"id,omitempty"`
+	Kind        *string         `json:"kind,omitempty"`
+	Metadata    *MetadataEntity `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_userdetail.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_userdetail.go
@@ -1,0 +1,12 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserDetail struct {
+	AadEmail          *string `json:"aadEmail,omitempty"`
+	EmailAddress      string  `json:"emailAddress"`
+	FirstName         *string `json:"firstName,omitempty"`
+	LastName          *string `json:"lastName,omitempty"`
+	UserPrincipalName *string `json:"userPrincipalName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_userrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/model_userrecord.go
@@ -1,0 +1,13 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserRecord struct {
+	AuthType *string         `json:"auth_type,omitempty"`
+	Email    *string         `json:"email,omitempty"`
+	FullName *string         `json:"full_name,omitempty"`
+	Id       *string         `json:"id,omitempty"`
+	Kind     *string         `json:"kind,omitempty"`
+	Metadata *MetadataEntity `json:"metadata,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/predicates.go
@@ -1,0 +1,32 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationResourceOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p OrganizationResourceOperationPredicate) Matches(input OrganizationResource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources/version.go
@@ -1,0 +1,10 @@
+package organizationresources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/organizationresources/2024-07-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/README.md
@@ -1,0 +1,107 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords` Documentation
+
+The `scclusterrecords` SDK allows for interaction with Azure Resource Manager `confluent` (API Version `2024-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords"
+```
+
+
+### Client Initialization
+
+```go
+client := scclusterrecords.NewSCClusterRecordsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `SCClusterRecordsClient.ClusterCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := scclusterrecords.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId")
+
+payload := scclusterrecords.SCClusterRecord{
+	// ...
+}
+
+
+read, err := client.ClusterCreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SCClusterRecordsClient.ClusterDelete`
+
+```go
+ctx := context.TODO()
+id := scclusterrecords.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId")
+
+if err := client.ClusterDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `SCClusterRecordsClient.OrganizationCreateAPIKey`
+
+```go
+ctx := context.TODO()
+id := scclusterrecords.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId")
+
+payload := scclusterrecords.CreateAPIKeyModel{
+	// ...
+}
+
+
+read, err := client.OrganizationCreateAPIKey(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SCClusterRecordsClient.OrganizationGetClusterById`
+
+```go
+ctx := context.TODO()
+id := scclusterrecords.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId")
+
+read, err := client.OrganizationGetClusterById(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SCClusterRecordsClient.OrganizationListClusters`
+
+```go
+ctx := context.TODO()
+id := scclusterrecords.NewEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId")
+
+// alternatively `client.OrganizationListClusters(ctx, id, scclusterrecords.DefaultOrganizationListClustersOperationOptions())` can be used to do batched pagination
+items, err := client.OrganizationListClustersComplete(ctx, id, scclusterrecords.DefaultOrganizationListClustersOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/client.go
@@ -1,0 +1,26 @@
+package scclusterrecords
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCClusterRecordsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewSCClusterRecordsClientWithBaseURI(sdkApi sdkEnv.Api) (*SCClusterRecordsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "scclusterrecords", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating SCClusterRecordsClient: %+v", err)
+	}
+
+	return &SCClusterRecordsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/constants.go
@@ -1,0 +1,51 @@
+package scclusterrecords
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Package string
+
+const (
+	PackageADVANCED   Package = "ADVANCED"
+	PackageESSENTIALS Package = "ESSENTIALS"
+)
+
+func PossibleValuesForPackage() []string {
+	return []string{
+		string(PackageADVANCED),
+		string(PackageESSENTIALS),
+	}
+}
+
+func (s *Package) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePackage(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePackage(input string) (*Package, error) {
+	vals := map[string]Package{
+		"advanced":   PackageADVANCED,
+		"essentials": PackageESSENTIALS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Package(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/id_cluster.go
@@ -1,0 +1,148 @@
+package scclusterrecords
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ClusterId{})
+}
+
+var _ resourceids.ResourceId = &ClusterId{}
+
+// ClusterId is a struct representing the Resource ID for a Cluster
+type ClusterId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+	ClusterId         string
+}
+
+// NewClusterID returns a new ClusterId struct
+func NewClusterID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string, clusterId string) ClusterId {
+	return ClusterId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+		ClusterId:         clusterId,
+	}
+}
+
+// ParseClusterID parses 'input' into a ClusterId
+func ParseClusterID(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseClusterIDInsensitively parses 'input' case-insensitively into a ClusterId
+// note: this method should only be used for API response data and not user input
+func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	if id.ClusterId, ok = input.Parsed["clusterId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "clusterId", input)
+	}
+
+	return nil
+}
+
+// ValidateClusterID checks that 'input' can be parsed as a Cluster ID
+func ValidateClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cluster ID
+func (id ClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s/clusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId, id.ClusterId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cluster ID
+func (id ClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+		resourceids.StaticSegment("staticClusters", "clusters", "clusters"),
+		resourceids.UserSpecifiedSegment("clusterId", "clusterId"),
+	}
+}
+
+// String returns a human-readable description of this Cluster ID
+func (id ClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+		fmt.Sprintf("Cluster: %q", id.ClusterId),
+	}
+	return fmt.Sprintf("Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/id_environment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/id_environment.go
@@ -1,0 +1,139 @@
+package scclusterrecords
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&EnvironmentId{})
+}
+
+var _ resourceids.ResourceId = &EnvironmentId{}
+
+// EnvironmentId is a struct representing the Resource ID for a Environment
+type EnvironmentId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+}
+
+// NewEnvironmentID returns a new EnvironmentId struct
+func NewEnvironmentID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string) EnvironmentId {
+	return EnvironmentId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+	}
+}
+
+// ParseEnvironmentID parses 'input' into a EnvironmentId
+func ParseEnvironmentID(input string) (*EnvironmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EnvironmentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EnvironmentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseEnvironmentIDInsensitively parses 'input' case-insensitively into a EnvironmentId
+// note: this method should only be used for API response data and not user input
+func ParseEnvironmentIDInsensitively(input string) (*EnvironmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EnvironmentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EnvironmentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *EnvironmentId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	return nil
+}
+
+// ValidateEnvironmentID checks that 'input' can be parsed as a Environment ID
+func ValidateEnvironmentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseEnvironmentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Environment ID
+func (id EnvironmentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Environment ID
+func (id EnvironmentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+	}
+}
+
+// String returns a human-readable description of this Environment ID
+func (id EnvironmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+	}
+	return fmt.Sprintf("Environment (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_clustercreateorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_clustercreateorupdate.go
@@ -1,0 +1,58 @@
+package scclusterrecords
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SCClusterRecord
+}
+
+// ClusterCreateOrUpdate ...
+func (c SCClusterRecordsClient) ClusterCreateOrUpdate(ctx context.Context, id ClusterId, input SCClusterRecord) (result ClusterCreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model SCClusterRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_clusterdelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_clusterdelete.go
@@ -1,0 +1,70 @@
+package scclusterrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ClusterDelete ...
+func (c SCClusterRecordsClient) ClusterDelete(ctx context.Context, id ClusterId) (result ClusterDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ClusterDeleteThenPoll performs ClusterDelete then polls until it's completed
+func (c SCClusterRecordsClient) ClusterDeleteThenPoll(ctx context.Context, id ClusterId) error {
+	result, err := c.ClusterDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ClusterDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ClusterDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_organizationcreateapikey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_organizationcreateapikey.go
@@ -1,0 +1,58 @@
+package scclusterrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationCreateAPIKeyOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *APIKeyRecord
+}
+
+// OrganizationCreateAPIKey ...
+func (c SCClusterRecordsClient) OrganizationCreateAPIKey(ctx context.Context, id ClusterId, input CreateAPIKeyModel) (result OrganizationCreateAPIKeyOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/createAPIKey", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model APIKeyRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_organizationgetclusterbyid.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_organizationgetclusterbyid.go
@@ -1,0 +1,53 @@
+package scclusterrecords
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationGetClusterByIdOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SCClusterRecord
+}
+
+// OrganizationGetClusterById ...
+func (c SCClusterRecordsClient) OrganizationGetClusterById(ctx context.Context, id ClusterId) (result OrganizationGetClusterByIdOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model SCClusterRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_organizationlistclusters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/method_organizationlistclusters.go
@@ -1,0 +1,138 @@
+package scclusterrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationListClustersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]SCClusterRecord
+}
+
+type OrganizationListClustersCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []SCClusterRecord
+}
+
+type OrganizationListClustersOperationOptions struct {
+	PageSize  *int64
+	PageToken *string
+}
+
+func DefaultOrganizationListClustersOperationOptions() OrganizationListClustersOperationOptions {
+	return OrganizationListClustersOperationOptions{}
+}
+
+func (o OrganizationListClustersOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o OrganizationListClustersOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o OrganizationListClustersOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.PageSize != nil {
+		out.Append("pageSize", fmt.Sprintf("%v", *o.PageSize))
+	}
+	if o.PageToken != nil {
+		out.Append("pageToken", fmt.Sprintf("%v", *o.PageToken))
+	}
+	return &out
+}
+
+type OrganizationListClustersCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *OrganizationListClustersCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// OrganizationListClusters ...
+func (c SCClusterRecordsClient) OrganizationListClusters(ctx context.Context, id EnvironmentId, options OrganizationListClustersOperationOptions) (result OrganizationListClustersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &OrganizationListClustersCustomPager{},
+		Path:          fmt.Sprintf("%s/clusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]SCClusterRecord `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// OrganizationListClustersComplete retrieves all the results into a single object
+func (c SCClusterRecordsClient) OrganizationListClustersComplete(ctx context.Context, id EnvironmentId, options OrganizationListClustersOperationOptions) (OrganizationListClustersCompleteResult, error) {
+	return c.OrganizationListClustersCompleteMatchingPredicate(ctx, id, options, SCClusterRecordOperationPredicate{})
+}
+
+// OrganizationListClustersCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c SCClusterRecordsClient) OrganizationListClustersCompleteMatchingPredicate(ctx context.Context, id EnvironmentId, options OrganizationListClustersOperationOptions, predicate SCClusterRecordOperationPredicate) (result OrganizationListClustersCompleteResult, err error) {
+	items := make([]SCClusterRecord, 0)
+
+	resp, err := c.OrganizationListClusters(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = OrganizationListClustersCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyownerentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyownerentity.go
@@ -1,0 +1,11 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type APIKeyOwnerEntity struct {
+	Id           *string `json:"id,omitempty"`
+	Kind         *string `json:"kind,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyproperties.go
@@ -1,0 +1,9 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type APIKeyProperties struct {
+	Metadata *SCMetadataEntity `json:"metadata,omitempty"`
+	Spec     *APIKeySpecEntity `json:"spec,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyrecord.go
@@ -1,0 +1,10 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type APIKeyRecord struct {
+	Id         *string           `json:"id,omitempty"`
+	Kind       *string           `json:"kind,omitempty"`
+	Properties *APIKeyProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyresourceentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyresourceentity.go
@@ -1,0 +1,12 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type APIKeyResourceEntity struct {
+	Environment  *string `json:"environment,omitempty"`
+	Id           *string `json:"id,omitempty"`
+	Kind         *string `json:"kind,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyspecentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_apikeyspecentity.go
@@ -1,0 +1,12 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type APIKeySpecEntity struct {
+	Description *string               `json:"description,omitempty"`
+	Name        *string               `json:"name,omitempty"`
+	Owner       *APIKeyOwnerEntity    `json:"owner,omitempty"`
+	Resource    *APIKeyResourceEntity `json:"resource,omitempty"`
+	Secret      *string               `json:"secret,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_clusterconfigentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_clusterconfigentity.go
@@ -1,0 +1,8 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterConfigEntity struct {
+	Kind *string `json:"kind,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_clusterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_clusterproperties.go
@@ -1,0 +1,10 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterProperties struct {
+	Metadata *SCMetadataEntity    `json:"metadata,omitempty"`
+	Spec     *SCClusterSpecEntity `json:"spec,omitempty"`
+	Status   *ClusterStatusEntity `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_clusterstatusentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_clusterstatusentity.go
@@ -1,0 +1,9 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ClusterStatusEntity struct {
+	Cku   *int64  `json:"cku,omitempty"`
+	Phase *string `json:"phase,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_createapikeymodel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_createapikeymodel.go
@@ -1,0 +1,9 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateAPIKeyModel struct {
+	Description *string `json:"description,omitempty"`
+	Name        *string `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusterbyokentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusterbyokentity.go
@@ -1,0 +1,10 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCClusterByokEntity struct {
+	Id           *string `json:"id,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusternetworkenvironmententity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusternetworkenvironmententity.go
@@ -1,0 +1,11 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCClusterNetworkEnvironmentEntity struct {
+	Environment  *string `json:"environment,omitempty"`
+	Id           *string `json:"id,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusterrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusterrecord.go
@@ -1,0 +1,17 @@
+package scclusterrecords
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCClusterRecord struct {
+	Id         *string                `json:"id,omitempty"`
+	Kind       *string                `json:"kind,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *ClusterProperties     `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusterspecentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scclusterspecentity.go
@@ -1,0 +1,20 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCClusterSpecEntity struct {
+	ApiEndpoint            *string                            `json:"apiEndpoint,omitempty"`
+	Availability           *string                            `json:"availability,omitempty"`
+	Byok                   *SCClusterByokEntity               `json:"byok,omitempty"`
+	Cloud                  *string                            `json:"cloud,omitempty"`
+	Config                 *ClusterConfigEntity               `json:"config,omitempty"`
+	Environment            *SCClusterNetworkEnvironmentEntity `json:"environment,omitempty"`
+	HTTPEndpoint           *string                            `json:"httpEndpoint,omitempty"`
+	KafkaBootstrapEndpoint *string                            `json:"kafkaBootstrapEndpoint,omitempty"`
+	Name                   *string                            `json:"name,omitempty"`
+	Network                *SCClusterNetworkEnvironmentEntity `json:"network,omitempty"`
+	Package                *Package                           `json:"package,omitempty"`
+	Region                 *string                            `json:"region,omitempty"`
+	Zone                   *string                            `json:"zone,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scmetadataentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/model_scmetadataentity.go
@@ -1,0 +1,12 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCMetadataEntity struct {
+	CreatedTimestamp *string `json:"createdTimestamp,omitempty"`
+	DeletedTimestamp *string `json:"deletedTimestamp,omitempty"`
+	ResourceName     *string `json:"resourceName,omitempty"`
+	Self             *string `json:"self,omitempty"`
+	UpdatedTimestamp *string `json:"updatedTimestamp,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/predicates.go
@@ -1,0 +1,32 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCClusterRecordOperationPredicate struct {
+	Id   *string
+	Kind *string
+	Name *string
+	Type *string
+}
+
+func (p SCClusterRecordOperationPredicate) Matches(input SCClusterRecord) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords/version.go
@@ -1,0 +1,10 @@
+package scclusterrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/scclusterrecords/2024-07-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/README.md
@@ -1,0 +1,103 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords` Documentation
+
+The `scenvironmentrecords` SDK allows for interaction with Azure Resource Manager `confluent` (API Version `2024-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords"
+```
+
+
+### Client Initialization
+
+```go
+client := scenvironmentrecords.NewSCEnvironmentRecordsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `SCEnvironmentRecordsClient.EnvironmentCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := scenvironmentrecords.NewEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId")
+
+payload := scenvironmentrecords.SCEnvironmentRecord{
+	// ...
+}
+
+
+read, err := client.EnvironmentCreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SCEnvironmentRecordsClient.EnvironmentDelete`
+
+```go
+ctx := context.TODO()
+id := scenvironmentrecords.NewEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId")
+
+if err := client.EnvironmentDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `SCEnvironmentRecordsClient.OrganizationGetEnvironmentById`
+
+```go
+ctx := context.TODO()
+id := scenvironmentrecords.NewEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId")
+
+read, err := client.OrganizationGetEnvironmentById(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `SCEnvironmentRecordsClient.OrganizationListEnvironments`
+
+```go
+ctx := context.TODO()
+id := scenvironmentrecords.NewOrganizationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName")
+
+// alternatively `client.OrganizationListEnvironments(ctx, id, scenvironmentrecords.DefaultOrganizationListEnvironmentsOperationOptions())` can be used to do batched pagination
+items, err := client.OrganizationListEnvironmentsComplete(ctx, id, scenvironmentrecords.DefaultOrganizationListEnvironmentsOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `SCEnvironmentRecordsClient.OrganizationListSchemaRegistryClusters`
+
+```go
+ctx := context.TODO()
+id := scenvironmentrecords.NewEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId")
+
+// alternatively `client.OrganizationListSchemaRegistryClusters(ctx, id, scenvironmentrecords.DefaultOrganizationListSchemaRegistryClustersOperationOptions())` can be used to do batched pagination
+items, err := client.OrganizationListSchemaRegistryClustersComplete(ctx, id, scenvironmentrecords.DefaultOrganizationListSchemaRegistryClustersOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/client.go
@@ -1,0 +1,26 @@
+package scenvironmentrecords
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCEnvironmentRecordsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewSCEnvironmentRecordsClientWithBaseURI(sdkApi sdkEnv.Api) (*SCEnvironmentRecordsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "scenvironmentrecords", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating SCEnvironmentRecordsClient: %+v", err)
+	}
+
+	return &SCEnvironmentRecordsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/constants.go
@@ -1,0 +1,51 @@
+package scenvironmentrecords
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Package string
+
+const (
+	PackageADVANCED   Package = "ADVANCED"
+	PackageESSENTIALS Package = "ESSENTIALS"
+)
+
+func PossibleValuesForPackage() []string {
+	return []string{
+		string(PackageADVANCED),
+		string(PackageESSENTIALS),
+	}
+}
+
+func (s *Package) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePackage(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePackage(input string) (*Package, error) {
+	vals := map[string]Package{
+		"advanced":   PackageADVANCED,
+		"essentials": PackageESSENTIALS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Package(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/id_environment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/id_environment.go
@@ -1,0 +1,139 @@
+package scenvironmentrecords
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&EnvironmentId{})
+}
+
+var _ resourceids.ResourceId = &EnvironmentId{}
+
+// EnvironmentId is a struct representing the Resource ID for a Environment
+type EnvironmentId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+}
+
+// NewEnvironmentID returns a new EnvironmentId struct
+func NewEnvironmentID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string) EnvironmentId {
+	return EnvironmentId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+	}
+}
+
+// ParseEnvironmentID parses 'input' into a EnvironmentId
+func ParseEnvironmentID(input string) (*EnvironmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EnvironmentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EnvironmentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseEnvironmentIDInsensitively parses 'input' case-insensitively into a EnvironmentId
+// note: this method should only be used for API response data and not user input
+func ParseEnvironmentIDInsensitively(input string) (*EnvironmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&EnvironmentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := EnvironmentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *EnvironmentId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	return nil
+}
+
+// ValidateEnvironmentID checks that 'input' can be parsed as a Environment ID
+func ValidateEnvironmentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseEnvironmentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Environment ID
+func (id EnvironmentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Environment ID
+func (id EnvironmentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+	}
+}
+
+// String returns a human-readable description of this Environment ID
+func (id EnvironmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+	}
+	return fmt.Sprintf("Environment (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/id_organization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/id_organization.go
@@ -1,0 +1,130 @@
+package scenvironmentrecords
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OrganizationId{})
+}
+
+var _ resourceids.ResourceId = &OrganizationId{}
+
+// OrganizationId is a struct representing the Resource ID for a Organization
+type OrganizationId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+}
+
+// NewOrganizationID returns a new OrganizationId struct
+func NewOrganizationID(subscriptionId string, resourceGroupName string, organizationName string) OrganizationId {
+	return OrganizationId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+	}
+}
+
+// ParseOrganizationID parses 'input' into a OrganizationId
+func ParseOrganizationID(input string) (*OrganizationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OrganizationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OrganizationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOrganizationIDInsensitively parses 'input' case-insensitively into a OrganizationId
+// note: this method should only be used for API response data and not user input
+func ParseOrganizationIDInsensitively(input string) (*OrganizationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OrganizationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OrganizationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OrganizationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	return nil
+}
+
+// ValidateOrganizationID checks that 'input' can be parsed as a Organization ID
+func ValidateOrganizationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOrganizationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Organization ID
+func (id OrganizationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Organization ID
+func (id OrganizationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+	}
+}
+
+// String returns a human-readable description of this Organization ID
+func (id OrganizationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+	}
+	return fmt.Sprintf("Organization (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_environmentcreateorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_environmentcreateorupdate.go
@@ -1,0 +1,58 @@
+package scenvironmentrecords
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnvironmentCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SCEnvironmentRecord
+}
+
+// EnvironmentCreateOrUpdate ...
+func (c SCEnvironmentRecordsClient) EnvironmentCreateOrUpdate(ctx context.Context, id EnvironmentId, input SCEnvironmentRecord) (result EnvironmentCreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model SCEnvironmentRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_environmentdelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_environmentdelete.go
@@ -1,0 +1,70 @@
+package scenvironmentrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnvironmentDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// EnvironmentDelete ...
+func (c SCEnvironmentRecordsClient) EnvironmentDelete(ctx context.Context, id EnvironmentId) (result EnvironmentDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// EnvironmentDeleteThenPoll performs EnvironmentDelete then polls until it's completed
+func (c SCEnvironmentRecordsClient) EnvironmentDeleteThenPoll(ctx context.Context, id EnvironmentId) error {
+	result, err := c.EnvironmentDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing EnvironmentDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after EnvironmentDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_organizationgetenvironmentbyid.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_organizationgetenvironmentbyid.go
@@ -1,0 +1,53 @@
+package scenvironmentrecords
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationGetEnvironmentByIdOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *SCEnvironmentRecord
+}
+
+// OrganizationGetEnvironmentById ...
+func (c SCEnvironmentRecordsClient) OrganizationGetEnvironmentById(ctx context.Context, id EnvironmentId) (result OrganizationGetEnvironmentByIdOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model SCEnvironmentRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_organizationlistenvironments.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_organizationlistenvironments.go
@@ -1,0 +1,138 @@
+package scenvironmentrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationListEnvironmentsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]SCEnvironmentRecord
+}
+
+type OrganizationListEnvironmentsCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []SCEnvironmentRecord
+}
+
+type OrganizationListEnvironmentsOperationOptions struct {
+	PageSize  *int64
+	PageToken *string
+}
+
+func DefaultOrganizationListEnvironmentsOperationOptions() OrganizationListEnvironmentsOperationOptions {
+	return OrganizationListEnvironmentsOperationOptions{}
+}
+
+func (o OrganizationListEnvironmentsOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o OrganizationListEnvironmentsOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o OrganizationListEnvironmentsOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.PageSize != nil {
+		out.Append("pageSize", fmt.Sprintf("%v", *o.PageSize))
+	}
+	if o.PageToken != nil {
+		out.Append("pageToken", fmt.Sprintf("%v", *o.PageToken))
+	}
+	return &out
+}
+
+type OrganizationListEnvironmentsCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *OrganizationListEnvironmentsCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// OrganizationListEnvironments ...
+func (c SCEnvironmentRecordsClient) OrganizationListEnvironments(ctx context.Context, id OrganizationId, options OrganizationListEnvironmentsOperationOptions) (result OrganizationListEnvironmentsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &OrganizationListEnvironmentsCustomPager{},
+		Path:          fmt.Sprintf("%s/environments", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]SCEnvironmentRecord `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// OrganizationListEnvironmentsComplete retrieves all the results into a single object
+func (c SCEnvironmentRecordsClient) OrganizationListEnvironmentsComplete(ctx context.Context, id OrganizationId, options OrganizationListEnvironmentsOperationOptions) (OrganizationListEnvironmentsCompleteResult, error) {
+	return c.OrganizationListEnvironmentsCompleteMatchingPredicate(ctx, id, options, SCEnvironmentRecordOperationPredicate{})
+}
+
+// OrganizationListEnvironmentsCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c SCEnvironmentRecordsClient) OrganizationListEnvironmentsCompleteMatchingPredicate(ctx context.Context, id OrganizationId, options OrganizationListEnvironmentsOperationOptions, predicate SCEnvironmentRecordOperationPredicate) (result OrganizationListEnvironmentsCompleteResult, err error) {
+	items := make([]SCEnvironmentRecord, 0)
+
+	resp, err := c.OrganizationListEnvironments(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = OrganizationListEnvironmentsCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_organizationlistschemaregistryclusters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/method_organizationlistschemaregistryclusters.go
@@ -1,0 +1,138 @@
+package scenvironmentrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OrganizationListSchemaRegistryClustersOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]SchemaRegistryClusterRecord
+}
+
+type OrganizationListSchemaRegistryClustersCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []SchemaRegistryClusterRecord
+}
+
+type OrganizationListSchemaRegistryClustersOperationOptions struct {
+	PageSize  *int64
+	PageToken *string
+}
+
+func DefaultOrganizationListSchemaRegistryClustersOperationOptions() OrganizationListSchemaRegistryClustersOperationOptions {
+	return OrganizationListSchemaRegistryClustersOperationOptions{}
+}
+
+func (o OrganizationListSchemaRegistryClustersOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o OrganizationListSchemaRegistryClustersOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o OrganizationListSchemaRegistryClustersOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.PageSize != nil {
+		out.Append("pageSize", fmt.Sprintf("%v", *o.PageSize))
+	}
+	if o.PageToken != nil {
+		out.Append("pageToken", fmt.Sprintf("%v", *o.PageToken))
+	}
+	return &out
+}
+
+type OrganizationListSchemaRegistryClustersCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *OrganizationListSchemaRegistryClustersCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// OrganizationListSchemaRegistryClusters ...
+func (c SCEnvironmentRecordsClient) OrganizationListSchemaRegistryClusters(ctx context.Context, id EnvironmentId, options OrganizationListSchemaRegistryClustersOperationOptions) (result OrganizationListSchemaRegistryClustersOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &OrganizationListSchemaRegistryClustersCustomPager{},
+		Path:          fmt.Sprintf("%s/schemaRegistryClusters", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]SchemaRegistryClusterRecord `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// OrganizationListSchemaRegistryClustersComplete retrieves all the results into a single object
+func (c SCEnvironmentRecordsClient) OrganizationListSchemaRegistryClustersComplete(ctx context.Context, id EnvironmentId, options OrganizationListSchemaRegistryClustersOperationOptions) (OrganizationListSchemaRegistryClustersCompleteResult, error) {
+	return c.OrganizationListSchemaRegistryClustersCompleteMatchingPredicate(ctx, id, options, SchemaRegistryClusterRecordOperationPredicate{})
+}
+
+// OrganizationListSchemaRegistryClustersCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c SCEnvironmentRecordsClient) OrganizationListSchemaRegistryClustersCompleteMatchingPredicate(ctx context.Context, id EnvironmentId, options OrganizationListSchemaRegistryClustersOperationOptions, predicate SchemaRegistryClusterRecordOperationPredicate) (result OrganizationListSchemaRegistryClustersCompleteResult, err error) {
+	items := make([]SchemaRegistryClusterRecord, 0)
+
+	resp, err := c.OrganizationListSchemaRegistryClusters(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = OrganizationListSchemaRegistryClustersCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_environmentproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_environmentproperties.go
@@ -1,0 +1,9 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnvironmentProperties struct {
+	Metadata               *SCMetadataEntity       `json:"metadata,omitempty"`
+	StreamGovernanceConfig *StreamGovernanceConfig `json:"streamGovernanceConfig,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_scenvironmentrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_scenvironmentrecord.go
@@ -1,0 +1,17 @@
+package scenvironmentrecords
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCEnvironmentRecord struct {
+	Id         *string                `json:"id,omitempty"`
+	Kind       *string                `json:"kind,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *EnvironmentProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterenvironmentregionentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterenvironmentregionentity.go
@@ -1,0 +1,10 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SchemaRegistryClusterEnvironmentRegionEntity struct {
+	Id           *string `json:"id,omitempty"`
+	Related      *string `json:"related,omitempty"`
+	ResourceName *string `json:"resourceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterproperties.go
@@ -1,0 +1,10 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SchemaRegistryClusterProperties struct {
+	Metadata *SCMetadataEntity                  `json:"metadata,omitempty"`
+	Spec     *SchemaRegistryClusterSpecEntity   `json:"spec,omitempty"`
+	Status   *SchemaRegistryClusterStatusEntity `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterrecord.go
@@ -1,0 +1,10 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SchemaRegistryClusterRecord struct {
+	Id         *string                          `json:"id,omitempty"`
+	Kind       *string                          `json:"kind,omitempty"`
+	Properties *SchemaRegistryClusterProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterspecentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterspecentity.go
@@ -1,0 +1,13 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SchemaRegistryClusterSpecEntity struct {
+	Cloud        *string                                       `json:"cloud,omitempty"`
+	Environment  *SchemaRegistryClusterEnvironmentRegionEntity `json:"environment,omitempty"`
+	HTTPEndpoint *string                                       `json:"httpEndpoint,omitempty"`
+	Name         *string                                       `json:"name,omitempty"`
+	Package      *string                                       `json:"package,omitempty"`
+	Region       *SchemaRegistryClusterEnvironmentRegionEntity `json:"region,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterstatusentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_schemaregistryclusterstatusentity.go
@@ -1,0 +1,8 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SchemaRegistryClusterStatusEntity struct {
+	Phase *string `json:"phase,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_scmetadataentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_scmetadataentity.go
@@ -1,0 +1,12 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCMetadataEntity struct {
+	CreatedTimestamp *string `json:"createdTimestamp,omitempty"`
+	DeletedTimestamp *string `json:"deletedTimestamp,omitempty"`
+	ResourceName     *string `json:"resourceName,omitempty"`
+	Self             *string `json:"self,omitempty"`
+	UpdatedTimestamp *string `json:"updatedTimestamp,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_streamgovernanceconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/model_streamgovernanceconfig.go
@@ -1,0 +1,8 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StreamGovernanceConfig struct {
+	Package *Package `json:"package,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/predicates.go
@@ -1,0 +1,50 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SCEnvironmentRecordOperationPredicate struct {
+	Id   *string
+	Kind *string
+	Name *string
+	Type *string
+}
+
+func (p SCEnvironmentRecordOperationPredicate) Matches(input SCEnvironmentRecord) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type SchemaRegistryClusterRecordOperationPredicate struct {
+	Id   *string
+	Kind *string
+}
+
+func (p SchemaRegistryClusterRecordOperationPredicate) Matches(input SchemaRegistryClusterRecord) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords/version.go
@@ -1,0 +1,10 @@
+package scenvironmentrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/scenvironmentrecords/2024-07-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/README.md
@@ -1,0 +1,86 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords` Documentation
+
+The `topicrecords` SDK allows for interaction with Azure Resource Manager `confluent` (API Version `2024-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords"
+```
+
+
+### Client Initialization
+
+```go
+client := topicrecords.NewTopicRecordsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `TopicRecordsClient.TopicsCreate`
+
+```go
+ctx := context.TODO()
+id := topicrecords.NewTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId", "topicName")
+
+payload := topicrecords.TopicRecord{
+	// ...
+}
+
+
+read, err := client.TopicsCreate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TopicRecordsClient.TopicsDelete`
+
+```go
+ctx := context.TODO()
+id := topicrecords.NewTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId", "topicName")
+
+if err := client.TopicsDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `TopicRecordsClient.TopicsGet`
+
+```go
+ctx := context.TODO()
+id := topicrecords.NewTopicID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId", "topicName")
+
+read, err := client.TopicsGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `TopicRecordsClient.TopicsList`
+
+```go
+ctx := context.TODO()
+id := topicrecords.NewClusterID("12345678-1234-9876-4563-123456789012", "example-resource-group", "organizationName", "environmentId", "clusterId")
+
+// alternatively `client.TopicsList(ctx, id, topicrecords.DefaultTopicsListOperationOptions())` can be used to do batched pagination
+items, err := client.TopicsListComplete(ctx, id, topicrecords.DefaultTopicsListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/client.go
@@ -1,0 +1,26 @@
+package topicrecords
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicRecordsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewTopicRecordsClientWithBaseURI(sdkApi sdkEnv.Api) (*TopicRecordsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "topicrecords", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating TopicRecordsClient: %+v", err)
+	}
+
+	return &TopicRecordsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/id_cluster.go
@@ -1,0 +1,148 @@
+package topicrecords
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ClusterId{})
+}
+
+var _ resourceids.ResourceId = &ClusterId{}
+
+// ClusterId is a struct representing the Resource ID for a Cluster
+type ClusterId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+	ClusterId         string
+}
+
+// NewClusterID returns a new ClusterId struct
+func NewClusterID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string, clusterId string) ClusterId {
+	return ClusterId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+		ClusterId:         clusterId,
+	}
+}
+
+// ParseClusterID parses 'input' into a ClusterId
+func ParseClusterID(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseClusterIDInsensitively parses 'input' case-insensitively into a ClusterId
+// note: this method should only be used for API response data and not user input
+func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ClusterId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ClusterId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ClusterId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	if id.ClusterId, ok = input.Parsed["clusterId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "clusterId", input)
+	}
+
+	return nil
+}
+
+// ValidateClusterID checks that 'input' can be parsed as a Cluster ID
+func ValidateClusterID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseClusterID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Cluster ID
+func (id ClusterId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s/clusters/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId, id.ClusterId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Cluster ID
+func (id ClusterId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+		resourceids.StaticSegment("staticClusters", "clusters", "clusters"),
+		resourceids.UserSpecifiedSegment("clusterId", "clusterId"),
+	}
+}
+
+// String returns a human-readable description of this Cluster ID
+func (id ClusterId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+		fmt.Sprintf("Cluster: %q", id.ClusterId),
+	}
+	return fmt.Sprintf("Cluster (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/id_topic.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/id_topic.go
@@ -1,0 +1,157 @@
+package topicrecords
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&TopicId{})
+}
+
+var _ resourceids.ResourceId = &TopicId{}
+
+// TopicId is a struct representing the Resource ID for a Topic
+type TopicId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	OrganizationName  string
+	EnvironmentId     string
+	ClusterId         string
+	TopicName         string
+}
+
+// NewTopicID returns a new TopicId struct
+func NewTopicID(subscriptionId string, resourceGroupName string, organizationName string, environmentId string, clusterId string, topicName string) TopicId {
+	return TopicId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		OrganizationName:  organizationName,
+		EnvironmentId:     environmentId,
+		ClusterId:         clusterId,
+		TopicName:         topicName,
+	}
+}
+
+// ParseTopicID parses 'input' into a TopicId
+func ParseTopicID(input string) (*TopicId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&TopicId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TopicId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseTopicIDInsensitively parses 'input' case-insensitively into a TopicId
+// note: this method should only be used for API response data and not user input
+func ParseTopicIDInsensitively(input string) (*TopicId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&TopicId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := TopicId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *TopicId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.OrganizationName, ok = input.Parsed["organizationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "organizationName", input)
+	}
+
+	if id.EnvironmentId, ok = input.Parsed["environmentId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "environmentId", input)
+	}
+
+	if id.ClusterId, ok = input.Parsed["clusterId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "clusterId", input)
+	}
+
+	if id.TopicName, ok = input.Parsed["topicName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "topicName", input)
+	}
+
+	return nil
+}
+
+// ValidateTopicID checks that 'input' can be parsed as a Topic ID
+func ValidateTopicID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseTopicID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Topic ID
+func (id TopicId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Confluent/organizations/%s/environments/%s/clusters/%s/topics/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.OrganizationName, id.EnvironmentId, id.ClusterId, id.TopicName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Topic ID
+func (id TopicId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftConfluent", "Microsoft.Confluent", "Microsoft.Confluent"),
+		resourceids.StaticSegment("staticOrganizations", "organizations", "organizations"),
+		resourceids.UserSpecifiedSegment("organizationName", "organizationName"),
+		resourceids.StaticSegment("staticEnvironments", "environments", "environments"),
+		resourceids.UserSpecifiedSegment("environmentId", "environmentId"),
+		resourceids.StaticSegment("staticClusters", "clusters", "clusters"),
+		resourceids.UserSpecifiedSegment("clusterId", "clusterId"),
+		resourceids.StaticSegment("staticTopics", "topics", "topics"),
+		resourceids.UserSpecifiedSegment("topicName", "topicName"),
+	}
+}
+
+// String returns a human-readable description of this Topic ID
+func (id TopicId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Organization Name: %q", id.OrganizationName),
+		fmt.Sprintf("Environment: %q", id.EnvironmentId),
+		fmt.Sprintf("Cluster: %q", id.ClusterId),
+		fmt.Sprintf("Topic Name: %q", id.TopicName),
+	}
+	return fmt.Sprintf("Topic (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicscreate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicscreate.go
@@ -1,0 +1,58 @@
+package topicrecords
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicsCreateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TopicRecord
+}
+
+// TopicsCreate ...
+func (c TopicRecordsClient) TopicsCreate(ctx context.Context, id TopicId, input TopicRecord) (result TopicsCreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model TopicRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicsdelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicsdelete.go
@@ -1,0 +1,70 @@
+package topicrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicsDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// TopicsDelete ...
+func (c TopicRecordsClient) TopicsDelete(ctx context.Context, id TopicId) (result TopicsDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// TopicsDeleteThenPoll performs TopicsDelete then polls until it's completed
+func (c TopicRecordsClient) TopicsDeleteThenPoll(ctx context.Context, id TopicId) error {
+	result, err := c.TopicsDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing TopicsDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after TopicsDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicsget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicsget.go
@@ -1,0 +1,53 @@
+package topicrecords
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicsGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *TopicRecord
+}
+
+// TopicsGet ...
+func (c TopicRecordsClient) TopicsGet(ctx context.Context, id TopicId) (result TopicsGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model TopicRecord
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/method_topicslist.go
@@ -1,0 +1,138 @@
+package topicrecords
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicsListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]TopicRecord
+}
+
+type TopicsListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []TopicRecord
+}
+
+type TopicsListOperationOptions struct {
+	PageSize  *int64
+	PageToken *string
+}
+
+func DefaultTopicsListOperationOptions() TopicsListOperationOptions {
+	return TopicsListOperationOptions{}
+}
+
+func (o TopicsListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o TopicsListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o TopicsListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.PageSize != nil {
+		out.Append("pageSize", fmt.Sprintf("%v", *o.PageSize))
+	}
+	if o.PageToken != nil {
+		out.Append("pageToken", fmt.Sprintf("%v", *o.PageToken))
+	}
+	return &out
+}
+
+type TopicsListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *TopicsListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// TopicsList ...
+func (c TopicRecordsClient) TopicsList(ctx context.Context, id ClusterId, options TopicsListOperationOptions) (result TopicsListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &TopicsListCustomPager{},
+		Path:          fmt.Sprintf("%s/topics", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]TopicRecord `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// TopicsListComplete retrieves all the results into a single object
+func (c TopicRecordsClient) TopicsListComplete(ctx context.Context, id ClusterId, options TopicsListOperationOptions) (TopicsListCompleteResult, error) {
+	return c.TopicsListCompleteMatchingPredicate(ctx, id, options, TopicRecordOperationPredicate{})
+}
+
+// TopicsListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c TopicRecordsClient) TopicsListCompleteMatchingPredicate(ctx context.Context, id ClusterId, options TopicsListOperationOptions, predicate TopicRecordOperationPredicate) (result TopicsListCompleteResult, err error) {
+	items := make([]TopicRecord, 0)
+
+	resp, err := c.TopicsList(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = TopicsListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicmetadataentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicmetadataentity.go
@@ -1,0 +1,9 @@
+package topicrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicMetadataEntity struct {
+	ResourceName *string `json:"resourceName,omitempty"`
+	Self         *string `json:"self,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicproperties.go
@@ -1,0 +1,16 @@
+package topicrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicProperties struct {
+	Configs                 *TopicsRelatedLink   `json:"configs,omitempty"`
+	InputConfigs            *[]TopicsInputConfig `json:"inputConfigs,omitempty"`
+	Kind                    *string              `json:"kind,omitempty"`
+	Metadata                *TopicMetadataEntity `json:"metadata,omitempty"`
+	Partitions              *TopicsRelatedLink   `json:"partitions,omitempty"`
+	PartitionsCount         *string              `json:"partitionsCount,omitempty"`
+	PartitionsReassignments *TopicsRelatedLink   `json:"partitionsReassignments,omitempty"`
+	ReplicationFactor       *string              `json:"replicationFactor,omitempty"`
+	TopicId                 *string              `json:"topicId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicrecord.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicrecord.go
@@ -1,0 +1,16 @@
+package topicrecords
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicRecord struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *TopicProperties       `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicsinputconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicsinputconfig.go
@@ -1,0 +1,9 @@
+package topicrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicsInputConfig struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicsrelatedlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/model_topicsrelatedlink.go
@@ -1,0 +1,8 @@
+package topicrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicsRelatedLink struct {
+	Related *string `json:"related,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/predicates.go
@@ -1,0 +1,27 @@
+package topicrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TopicRecordOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p TopicRecordOperationPredicate) Matches(input TopicRecord) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords/version.go
@@ -1,0 +1,10 @@
+package topicrecords
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/topicrecords/2024-07-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -405,6 +405,11 @@ github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmac
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-11-01/virtualmachinescalesets
 github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger
+github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/connectorresources
+github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/organizationresources
+github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scclusterrecords
+github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/scenvironmentrecords
+github.com/hashicorp/go-azure-sdk/resource-manager/confluent/2024-07-01/topicrecords
 github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/certificates
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerapps

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -27,6 +27,7 @@ Cognitive Services
 Communication
 Compute
 Confidential Ledger
+Confluent
 Connections
 Consumption
 Container

--- a/website/docs/r/confluent_connector.html.markdown
+++ b/website/docs/r/confluent_connector.html.markdown
@@ -1,0 +1,107 @@
+---
+subcategory: "Confluent"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_confluent_connector"
+description: |-
+  Manages a Confluent Connector.
+---
+
+# azurerm_confluent_connector
+
+Manages a Confluent Kafka Connector within a Confluent Cluster on Azure.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_confluent_organization" "example" {
+  name                = "example-confluent-org"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  offer_detail {
+    id           = "confluent-cloud-azure-prod"
+    plan_id      = "confluent-cloud-azure-payg-prod"
+    plan_name    = "Confluent Cloud - Pay as you Go"
+    publisher_id = "confluentinc"
+    term_unit    = "P1M"
+  }
+
+  user_detail {
+    email_address = "user@example.com"
+  }
+}
+
+resource "azurerm_confluent_environment" "example" {
+  environment_id      = "env-12345"
+  organization_id     = azurerm_confluent_organization.example.name
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_confluent_cluster" "example" {
+  cluster_id          = "lkc-12345"
+  environment_id      = azurerm_confluent_environment.example.environment_id
+  organization_id     = azurerm_confluent_organization.example.name
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_confluent_connector" "example" {
+  connector_name      = "azure-blob-sink-connector"
+  cluster_id          = azurerm_confluent_cluster.example.cluster_id
+  environment_id      = azurerm_confluent_environment.example.environment_id
+  organization_id     = azurerm_confluent_organization.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  connector_type      = "SINK"
+  connector_class     = "AZUREBLOBSINK"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `connector_name` - (Required) The name of the Kafka connector. Changing this forces a new resource to be created.
+
+* `cluster_id` - (Required) The ID of the parent Confluent Cluster. Changing this forces a new resource to be created.
+
+* `environment_id` - (Required) The ID of the parent Confluent Environment. Changing this forces a new resource to be created.
+
+* `organization_id` - (Required) The name of the parent Confluent Organization. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Confluent Connector should exist. Changing this forces a new resource to be created.
+
+* `connector_type` - (Optional) The type of connector. Possible values are `SINK` and `SOURCE`. Changing this forces a new resource to be created.
+
+* `connector_class` - (Optional) The connector class. Possible values are `AZUREBLOBSINK` and `AZUREBLOBSOURCE`. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Confluent Connector.
+
+* `connector_id` - The Confluent Connector ID.
+
+* `connector_state` - The current state of the connector. Possible values include `RUNNING`, `FAILED`, `PAUSED`, and `PROVISIONING`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Confluent Connector.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Confluent Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Confluent Connector.
+
+## Import
+
+Confluent Connectors can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_confluent_connector.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Confluent/organizations/org1/environments/env-12345/clusters/lkc-12345/connectors/azure-blob-sink-connector
+```
+
+~> **Note:** The current implementation provides basic connector management. For detailed connector configuration (such as Azure Blob Storage connection strings, Cosmos DB settings, etc.), additional configuration may need to be performed through the Confluent Cloud portal or CLI.


### PR DESCRIPTION
overall
---
```
order | name 
0     | azurerm_confluent_organization                      
1     | azurerm_confluent_environment                       
1     | azurerm_confluent_cluster                           
2     | azurerm_confluent_topic                             
2     | azurerm_confluent_connector                         <- this one
```

This PR adds support for the `azurerm_confluent_connector` resource, which manages Confluent Cloud connectors for data integration.

The resource supports:
- Creating and managing Confluent connectors
- Configuring connector type and class
- Managing connector state

This is part of a series of PRs that will add full Confluent support to the provider.

## Related PRs

This PR is part of a split from the original PR #30897, which contained all Confluent resources. The resources have been split into separate PRs for easier review:

- #31306 - `azurerm_confluent_organization`
- #31307 - `azurerm_confluent_environment`
- #31308 - `azurerm_confluent_cluster`
- #31309 - `azurerm_confluent_topic`
- #31310 - `azurerm_confluent_connector` (this PR)

Original PR: #30897