### PR TITLE
`azurerm_container_app_job` - Add `identity_id` property to scaling rules

### DIFF
--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -169,6 +169,51 @@ func TestAccContainerAppJob_eventTrigger(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppJob_eventTriggerScaleRuleUserIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.eventTriggerScaleRuleUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_eventTriggerScaleRuleSystemIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.eventTriggerScaleRuleSystemIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppJob_eventTriggerScaleRuleSystemAndUserIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.eventTriggerScaleRuleSystemAndUserIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppJob_manualTrigger(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
 	r := ContainerAppJobResource{}
@@ -437,6 +482,170 @@ resource "azurerm_container_app_job" "test" {
         timeout                 = 2
         failure_count_threshold = 1
       }
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) eventTriggerScaleRuleUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  event_trigger_config {
+    parallelism = 4
+    scale {
+      max_executions              = 10
+      min_executions              = 1
+      polling_interval_in_seconds = 10
+      rules {
+        metadata = {
+          topic_name = "my-topic"
+        }
+        name             = "servicebuscalingrule"
+        identity_id      = azurerm_user_assigned_identity.test.id
+        custom_rule_type = "azure-servicebus"
+      }
+    }
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) eventTriggerScaleRuleSystemIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  event_trigger_config {
+    parallelism = 4
+    scale {
+      max_executions              = 10
+      min_executions              = 1
+      polling_interval_in_seconds = 10
+      rules {
+        metadata = {
+          topic_name = "my-topic"
+        }
+        name             = "servicebuscalingrule"
+        identity_id      = "System"
+        custom_rule_type = "azure-servicebus"
+      }
+    }
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) eventTriggerScaleRuleSystemAndUserIdentity(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acct-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  event_trigger_config {
+    parallelism = 4
+    scale {
+      max_executions              = 10
+      min_executions              = 1
+      polling_interval_in_seconds = 10
+      rules {
+        metadata = {
+          topic_name = "my-topic"
+        }
+        name             = "servicebuscalingrule"
+        identity_id      = azurerm_user_assigned_identity.test.id
+        custom_rule_type = "azure-servicebus"
+      }
+    }
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
       cpu    = 0.5
       memory = "1Gi"
     }

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -44,10 +44,11 @@ type ScaleModel struct {
 }
 
 type ScaleRule struct {
-	Auth     []ScaleRuleAuth        `tfschema:"authentication"`
-	Metadata map[string]interface{} `tfschema:"metadata"`
-	Name     string                 `tfschema:"name"`
-	Type     string                 `tfschema:"custom_rule_type"`
+	Auth       []ScaleRuleAuth        `tfschema:"authentication"`
+	IdentityID string                 `tfschema:"identity_id"`
+	Metadata   map[string]interface{} `tfschema:"metadata"`
+	Name       string                 `tfschema:"name"`
+	Type       string                 `tfschema:"custom_rule_type"`
 }
 
 type ScaleRuleAuth struct {
@@ -250,6 +251,10 @@ func ExpandContainerAppJobScaleRules(input []ScaleRule) *[]jobs.JobScaleRule {
 
 		if v.Type != "" {
 			rule.Type = pointer.To(v.Type)
+		}
+
+		if v.IdentityID != "" {
+			rule.Identity = pointer.To(v.IdentityID)
 		}
 
 		rules = append(rules, rule)
@@ -969,8 +974,9 @@ func flattenContainerAppJobScaleRules(input *[]jobs.JobScaleRule) []ScaleRule {
 
 	for _, v := range *input {
 		rule := ScaleRule{
-			Name: pointer.From(v.Name),
-			Type: pointer.From(v.Type),
+			IdentityID: pointer.From(v.Identity),
+			Name:       pointer.From(v.Name),
+			Type:       pointer.From(v.Type),
 		}
 
 		if v.Metadata != nil {

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -396,6 +396,8 @@ A `rules` block supports the following:
 
 * `authentication` - (Optional) A `authentication` block as defined below.
 
+* `identity_id` - (Optional) The ID of the identity used to authenticate with the scale rule backend. This can either be the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.
+
 ---
 
 A `authentication` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Add support for the `identity_id` property on `azurerm_container_app_job` scaling rules, allowing managed identity authentication for event-driven scale rules.

This mirrors the existing support added for `azurerm_container_app` in https://github.com/hashicorp/terraform-provider-azurerm/pull/29777. The `identity_id` field accepts either the Resource ID of a User Assigned Identity, or `System` for the System Assigned Identity.

This allows scaling rules to authenticate without less secure methods (such as PATs, SAS tokens, or connection strings).

Naming convention follows the pattern established in #29777 (`identity_id`).

- https://learn.microsoft.com/fr-fr/azure/templates/microsoft.app/jobs?pivots=deployment-language-bicep

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app_job` - add `identity_id` property to scaling rules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/26570
Related https://github.com/hashicorp/terraform-provider-azurerm/pull/26994
Related https://github.com/hashicorp/terraform-provider-azurerm/pull/29777

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Code generation and documentation assistance.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.