### PR TITLE
`azurerm_monitor_aad_diagnostic_setting` - Update information about service principal authentication

### DIFF
--- a/website/docs/r/monitor_aad_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_aad_diagnostic_setting.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an Azure Active Directory Diagnostic Setting for Azure Monitor.
 
--> **Note:** When using Service Principal authentication, the Service Principal must be assigned the _Contributor_ role at the scope `/providers/Microsoft.aadiam`. You can assign this role using the PowerShell command: `New-AzRoleAssignment -ObjectId "sp-object-id>" -Scope "/providers/Microsoft.aadiam" -RoleDefinitionName 'Contributor' -ObjectType 'ServicePrincipal'`. The assigning user must be a User Access Administrator at the root level. Refer to the [Azure elevation guide](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin) for details.
+-> **Note:** When using Service Principal authentication, the Service Principal must be assigned the _Contributor_ role at the scope `/providers/Microsoft.aadiam`. You can assign this role using the `az` CLI command: `az role assignment create --assignee-principal-type ServicePrincipal --assignee-object-id "<sp-object-id>" --scope "/providers/Microsoft.aadiam" --role "Contributor"`. The assigning user must be a User Access Administrator at the root level. Refer to the [Azure elevation guide](https://learn.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin) for details.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Documentation note on how to use the resource `azurerm_monitor_aad_diagnostic_setting` when authenticating with a service principal.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Change Log

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_monitor_aad_diagnostic_setting` - Documentation note on how to use resource when authenticating with a service principal.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #18624

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
