### PR TITLE
`azurerm_kusto_eventhub_data_connection` - support for`retrieval_start_date`

### DIFF
--- a/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource_test.go
@@ -123,6 +123,35 @@ func TestAccKustoEventHubDataConnection_databaseRoutingType(t *testing.T) {
 	})
 }
 
+func TestAccKustoEventHubDataConnection_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_eventhub_data_connection", "test")
+	r := KustoEventHubDataConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withRetrievalStartDate(data, "2023-06-26T12:00:00Z"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withRetrievalStartDate(data, "2024-01-15T08:30:00Z"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KustoEventHubDataConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := dataconnections.ParseDataConnectionID(state.ID)
 	if err != nil {
@@ -295,6 +324,24 @@ resource "azurerm_kusto_eventhub_data_connection" "test" {
   database_routing_type = "Multi"
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r KustoEventHubDataConnectionResource) withRetrievalStartDate(data acceptance.TestData, retrievalStartDate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_eventhub_data_connection" "test" {
+  name                = "acctestkedc-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+
+  eventhub_id          = azurerm_eventhub.test.id
+  consumer_group       = azurerm_eventhub_consumer_group.test.name
+  retrieval_start_date = "%s"
+}
+`, r.template(data), data.RandomInteger, retrievalStartDate)
 }
 
 func (KustoEventHubDataConnectionResource) template(data acceptance.TestData) string {

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -70,9 +70,10 @@ resource "azurerm_kusto_eventhub_data_connection" "eventhub_connection" {
   eventhub_id    = azurerm_eventhub.eventhub.id
   consumer_group = azurerm_eventhub_consumer_group.consumer_group.name
 
-  table_name        = "my-table"         #(Optional)
-  mapping_rule_name = "my-table-mapping" #(Optional)
-  data_format       = "JSON"             #(Optional)
+  table_name           = "my-table"         #(Optional)
+  mapping_rule_name    = "my-table-mapping" #(Optional)
+  data_format          = "JSON"             #(Optional)
+  retrieval_start_date = "2023-06-26T12:00:00Z"
 }
 ```
 
@@ -107,6 +108,8 @@ The following arguments are supported:
 * `data_format` - (Optional) Specifies the data format of the EventHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSVE`, `TSV`, `TXT`, and `W3CLOGFILE`.
 
 * `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`. Changing this forces a new resource to be created. Defaults to `Single`.
+
+* `retrieval_start_date` - (Optional) Specifies the date after which data should be retrieved from Event Hub. When defined, the data connection retrieves existing events created since the specified retrieval start date. It can only retrieve events retained by the Event Hub, based on its retention period. The value should be in RFC3339 format (e.g., `2023-06-26T12:00:00Z`).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the `retrieval_start_date` property to the `azurerm_kusto_eventhub_data_connection` resource.

The `retrieval_start_date` property allows users to specify a date from which the data connection should start retrieving existing events from Event Hub. When defined, the data connection retrieves existing events created since the specified retrieval start date. It can only retrieve events retained by the Event Hub, based on its retention period.

This property is already supported by the Azure API (API version 2024-04-13) and is available in the Go SDK (`EventHubConnectionProperties.RetrievalStartDate`).

### Changes Made:

- Added `retrieval_start_date` schema property with RFC3339 time validation
- Split the combined `CreateUpdate` function into separate `Create` and `Update` functions for proper update handling
- Updated the expand function to set the property when provided
- Updated the read function to retrieve the property from API response
- Added test coverage with an update test case
- Updated documentation with property description and example usage


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The `retrieval_start_date` property has been added to a new `TestAccKustoEventHubDataConnection_update` test case:

```hcl
resource "azurerm_kusto_eventhub_data_connection" "test" {
  name                = "acctestkedc-%d"
  resource_group_name = azurerm_resource_group.test.name
  location            = azurerm_resource_group.test.location
  cluster_name        = azurerm_kusto_cluster.test.name
  database_name       = azurerm_kusto_database.test.name

  eventhub_id          = azurerm_eventhub.test.id
  consumer_group       = azurerm_eventhub_consumer_group.test.name
  retrieval_start_date = "2023-06-26T12:00:00Z"
}
```

To run the test:

```
go test -v ./internal/services/kusto -run TestAccKustoEventHubDataConnection_update -timeout 120m
```

Test results:

```
go test -v -timeout 120m -run "TestAccKustoEventHubDataConnection_update" ./internal/services/kusto/
=== RUN   TestAccKustoEventHubDataConnection_update
=== PAUSE TestAccKustoEventHubDataConnection_update
=== CONT  TestAccKustoEventHubDataConnection_update
--- PASS: TestAccKustoEventHubDataConnection_update (1301.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto 1316.744s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_kusto_eventhub_data_connection` - support for the `retrieval_start_date` property [GH-31445]


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

This contribution was made with the assistance of GitHub Copilot for code generation, documentation updates, and test modifications.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls (access controls, encryption, logging) in this pull request.
