### PR TITLE
`applicationinsights`, `arckubernetes` - support for Terraform Resource Identity

### DIFF
--- a/internal/services/attestation/attestation_provider_resource_identity_gen_test.go
+++ b/internal/services/attestation/attestation_provider_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package attestation_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccAttestationProvider_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_attestation_provider", "test")
+	r := AttestationProviderResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicForResourceIdentity(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_attestation_provider.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_attestation_provider.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_attestation_provider.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/attestation/attestation_provider_resource_test.go
+++ b/internal/services/attestation/attestation_provider_resource_test.go
@@ -31,6 +31,11 @@ type AttestationProviderResource struct {
 	name string
 }
 
+func (r AttestationProviderResource) basicForResourceIdentity(data acceptance.TestData) string {
+	r.name = fmt.Sprintf("acctestap%s", data.RandomStringOfLength(10))
+	return r.basic(data)
+}
+
 func TestAccAttestationProvider_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_attestation_provider", "test")
 	r := AttestationProviderResource{

--- a/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_identity_gen_test.go
+++ b/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_identity_gen_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package automanage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccArcMachineAutomanageConfigurationAssignment_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_machine_automanage_configuration_assignment", "test")
+	r := ArcMachineAutomanageConfigurationAssignmentResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.complete(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_arc_machine_automanage_configuration_assignment.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_arc_machine_automanage_configuration_assignment.test", tfjsonpath.New("configuration_profile_assignment_name"), tfjsonpath.New("configuration_profile_assignment_name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_arc_machine_automanage_configuration_assignment.test", tfjsonpath.New("machine_name"), tfjsonpath.New("arc_machine_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_arc_machine_automanage_configuration_assignment.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("arc_machine_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/arc_machine_automanage_configuration_assignment_resource_test.go
@@ -17,12 +17,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type ArcMachineConfigurationAssignmentResource struct{}
+type ArcMachineAutomanageConfigurationAssignmentResource struct{}
 
 func TestAccArcMachineConfigurationAssignment_complete(t *testing.T) {
 	t.Skip("The deprecation check prevents the creation of a hybrid compute machine resource using os.Getenv(\"ARM_CLIENT_SECRET\")")
 	data := acceptance.BuildTestData(t, "azurerm_arc_machine_automanage_configuration_assignment", "test")
-	r := ArcMachineConfigurationAssignmentResource{}
+	r := ArcMachineAutomanageConfigurationAssignmentResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -34,7 +34,7 @@ func TestAccArcMachineConfigurationAssignment_complete(t *testing.T) {
 	})
 }
 
-func (r ArcMachineConfigurationAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r ArcMachineAutomanageConfigurationAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	client := clients.Automanage.ConfigurationProfileArcMachineAssignmentsClient
 
 	id, err := configurationprofilehcrpassignments.ParseProviders2ConfigurationProfileAssignmentID(state.ID)
@@ -52,7 +52,7 @@ func (r ArcMachineConfigurationAssignmentResource) Exists(ctx context.Context, c
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r ArcMachineConfigurationAssignmentResource) complete(data acceptance.TestData) string {
+func (r ArcMachineAutomanageConfigurationAssignmentResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/automanage/automanage_configuration_resource_identity_gen_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package automanage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccAutomanageConfiguration_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
+	r := AutomanageConfigurationResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_automanage_configuration.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_automanage_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_automanage_configuration.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/automanage/automanage_configuration_resource_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type AutoManageConfigurationProfileResource struct{}
+type AutomanageConfigurationResource struct{}
 
 func TestAccAutoManageConfigurationProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -35,7 +35,7 @@ func TestAccAutoManageConfigurationProfile_basic(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_antimalware(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.antimalware(data),
@@ -60,7 +60,7 @@ func TestAccAutoManageConfigurationProfile_antimalware(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_azureSecurityBaseline(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.azureSecurityBaseline(data),
@@ -93,7 +93,7 @@ func TestAccAutoManageConfigurationProfile_azureSecurityBaseline(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -107,7 +107,7 @@ func TestAccAutoManageConfigurationProfile_requiresImport(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_backup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.backup(data),
@@ -181,7 +181,7 @@ func TestAccAutoManageConfigurationProfile_backup(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_logAnalytics(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.logAnalytics(data),
@@ -204,7 +204,7 @@ func TestAccAutoManageConfigurationProfile_logAnalytics(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -232,7 +232,7 @@ func TestAccAutoManageConfigurationProfile_complete(t *testing.T) {
 
 func TestAccAutoManageConfigurationProfile_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
-	r := AutoManageConfigurationProfileResource{}
+	r := AutomanageConfigurationResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -265,7 +265,7 @@ func TestAccAutoManageConfigurationProfile_update(t *testing.T) {
 	})
 }
 
-func (r AutoManageConfigurationProfileResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r AutomanageConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	client := clients.Automanage.ConfigurationProfilesClient
 
 	id, err := configurationprofiles.ParseConfigurationProfileID(state.ID)
@@ -283,7 +283,7 @@ func (r AutoManageConfigurationProfileResource) Exists(ctx context.Context, clie
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r AutoManageConfigurationProfileResource) template(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -296,7 +296,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) basic(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 				%s
@@ -309,7 +309,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) antimalware(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) antimalware(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 				%s
@@ -329,7 +329,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) logAnalytics(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) logAnalytics(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 				%s
@@ -343,7 +343,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) requiresImport(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) requiresImport(data acceptance.TestData) string {
 	config := r.antimalware(data)
 	return fmt.Sprintf(`
 			%s
@@ -356,7 +356,7 @@ resource "azurerm_automanage_configuration" "import" {
 `, config, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) complete(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s
@@ -389,7 +389,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) update(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) update(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s
@@ -416,7 +416,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r AutoManageConfigurationProfileResource) azureSecurityBaseline(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) azureSecurityBaseline(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s
@@ -432,7 +432,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r AutoManageConfigurationProfileResource) azureSecurityBaselineUpdate(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) azureSecurityBaselineUpdate(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s
@@ -448,7 +448,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r AutoManageConfigurationProfileResource) backup(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) backup(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s
@@ -493,7 +493,7 @@ resource "azurerm_automanage_configuration" "test" {
 `, template, data.RandomInteger, data.RandomInteger)
 }
 
-func (r AutoManageConfigurationProfileResource) backupUpdate(data acceptance.TestData) string {
+func (r AutomanageConfigurationResource) backupUpdate(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_identity_gen_test.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_identity_gen_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package automanage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccVirtualMachineAutomanageConfigurationAssignment_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_automanage_configuration_assignment", "test")
+	r := VirtualMachineAutomanageConfigurationAssignmentResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_virtual_machine_automanage_configuration_assignment.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_machine_automanage_configuration_assignment.test", tfjsonpath.New("configuration_profile_assignment_name"), tfjsonpath.New("configuration_profile_assignment_name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_automanage_configuration_assignment.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_machine_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_automanage_configuration_assignment.test", tfjsonpath.New("virtual_machine_name"), tfjsonpath.New("virtual_machine_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
+++ b/internal/services/automanage/virtual_machine_automanage_configuration_assignment_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type VirtualMachineConfigurationAssignmentResource struct{}
+type VirtualMachineAutomanageConfigurationAssignmentResource struct{}
 
 func TestAccVirtualMachineConfigurationAssignment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_automanage_configuration_assignment", "test")
-	r := VirtualMachineConfigurationAssignmentResource{}
+	r := VirtualMachineAutomanageConfigurationAssignmentResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -35,7 +35,7 @@ func TestAccVirtualMachineConfigurationAssignment_basic(t *testing.T) {
 
 func TestAccVirtualMachineConfigurationAssignment_requireImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_automanage_configuration_assignment", "test")
-	r := VirtualMachineConfigurationAssignmentResource{}
+	r := VirtualMachineAutomanageConfigurationAssignmentResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -47,7 +47,7 @@ func TestAccVirtualMachineConfigurationAssignment_requireImport(t *testing.T) {
 	})
 }
 
-func (r VirtualMachineConfigurationAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r VirtualMachineAutomanageConfigurationAssignmentResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	client := clients.Automanage.ConfigurationProfileVMAssignmentsClient
 
 	id, err := configurationprofileassignments.ParseVirtualMachineProviders2ConfigurationProfileAssignmentID(state.ID)
@@ -65,7 +65,7 @@ func (r VirtualMachineConfigurationAssignmentResource) Exists(ctx context.Contex
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r VirtualMachineConfigurationAssignmentResource) basic(data acceptance.TestData) string {
+func (r VirtualMachineAutomanageConfigurationAssignmentResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -142,7 +142,7 @@ resource "azurerm_virtual_machine_automanage_configuration_assignment" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (r VirtualMachineConfigurationAssignmentResource) requiresImport(data acceptance.TestData) string {
+func (r VirtualMachineAutomanageConfigurationAssignmentResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 			%s

--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccount"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -26,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name batch_account -service-package-name batch -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceBatchAccount() *pluginsdk.Resource {
 	resource := &pluginsdk.Resource{
@@ -41,10 +44,7 @@ func resourceBatchAccount() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := batchaccount.ParseBatchAccountID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&batchaccount.BatchAccountId{}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -183,6 +183,10 @@ func resourceBatchAccount() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 		},
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&batchaccount.BatchAccountId{}),
+		},
 	}
 
 	return resource
@@ -293,6 +297,9 @@ func resourceBatchAccountCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
 	return resourceBatchAccountRead(d, meta)
 }
@@ -378,10 +385,12 @@ func resourceBatchAccountRead(d *pluginsdk.ResourceData, meta interface{}) error
 					d.Set("secondary_access_key", keysModel.Secondary)
 				}
 			}
-			return tags.FlattenAndSet(d, model.Tags)
+			if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+				return err
+			}
 		}
 	}
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/batch/batch_account_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_account_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package batch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccBatchAccount_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
+	r := BatchAccountResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_batch_account.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_account.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_account.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/batch/batch_application_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_application_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package batch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccBatchApplication_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_application", "test")
+	r := BatchApplicationResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicForResourceIdentity(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_batch_application.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("application_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/batch/batch_application_resource_test.go
+++ b/internal/services/batch/batch_application_resource_test.go
@@ -18,6 +18,10 @@ import (
 
 type BatchApplicationResource struct{}
 
+func (r BatchApplicationResource) basicForResourceIdentity(data acceptance.TestData) string {
+	return r.template(data, "")
+}
+
 func TestAccBatchApplication_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_application", "test")
 	r := BatchApplicationResource{}

--- a/internal/services/batch/batch_certificate_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_certificate_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package batch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccBatchCertificate_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_certificate", "test")
+	r := BatchCertificateResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicForResourceIdentity(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_batch_certificate.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_certificate.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_certificate.test", tfjsonpath.New("certificate_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_certificate.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/batch/batch_certificate_resource_test.go
+++ b/internal/services/batch/batch_certificate_resource_test.go
@@ -19,6 +19,10 @@ import (
 
 type BatchCertificateResource struct{}
 
+func (r BatchCertificateResource) basicForResourceIdentity(data acceptance.TestData) string {
+	return r.pfxWithPassword(data)
+}
+
 func TestAccBatchCertificate_PfxWithPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_certificate", "test")
 	r := BatchCertificateResource{}

--- a/internal/services/batch/batch_pool_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_pool_resource_identity_gen_test.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package batch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccBatchPool_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_batch_pool.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("pool_name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds Terraform Resource Identity support to the following resources:

**Application Insights:**
- `azurerm_application_insights`
- `azurerm_application_insights_standard_web_test`
- `azurerm_application_insights_web_test`
- `azurerm_application_insights_workbook`
- `azurerm_application_insights_workbook_template`

**Arc Kubernetes:**
- `azurerm_arc_kubernetes_provisioned_cluster`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.


## Testing 

Resource Identity tests generated and passing for all resources.


## Change Log

* `azurerm_application_insights` - support for Terraform Resource Identity
* `azurerm_application_insights_standard_web_test` - support for Terraform Resource Identity
* `azurerm_application_insights_web_test` - support for Terraform Resource Identity
* `azurerm_application_insights_workbook` - support for Terraform Resource Identity
* `azurerm_application_insights_workbook_template` - support for Terraform Resource Identity
* `azurerm_arc_kubernetes_provisioned_cluster` - support for Terraform Resource Identity


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Code generation and debugging assistance.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.