### PR TITLE
Resource Identity: `communication` service

### DIFF
--- a/internal/services/communication/communication_service_data_source_test.go
+++ b/internal/services/communication/communication_service_data_source_test.go
@@ -56,7 +56,7 @@ data "azurerm_communication_service" "test" {
   name                = azurerm_communication_service.test.name
   resource_group_name = azurerm_communication_service.test.resource_group_name
 }
-`, CommunicationServiceTestResource{}.basic(data))
+`, CommunicationServiceResource{}.basic(data))
 }
 
 func (d CommunicationServiceDataSource) complete(data acceptance.TestData) string {
@@ -67,5 +67,5 @@ data "azurerm_communication_service" "test" {
   name                = azurerm_communication_service.test.name
   resource_group_name = azurerm_communication_service.test.resource_group_name
 }
-`, CommunicationServiceTestResource{}.complete(data))
+`, CommunicationServiceResource{}.complete(data))
 }

--- a/internal/services/communication/communication_service_resource.go
+++ b/internal/services/communication/communication_service_resource.go
@@ -3,6 +3,8 @@
 
 package communication
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name communication_service -service-package-name communication -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 import (
 	"context"
 	"fmt"
@@ -12,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/communication/migration"
@@ -23,9 +26,14 @@ import (
 var (
 	_ sdk.ResourceWithUpdate         = CommunicationServiceResource{}
 	_ sdk.ResourceWithStateMigration = CommunicationServiceResource{}
+	_ sdk.ResourceWithIdentity       = CommunicationServiceResource{}
 )
 
 type CommunicationServiceResource struct{}
+
+func (CommunicationServiceResource) Identity() resourceids.ResourceId {
+	return &communicationservices.CommunicationServiceId{}
+}
 
 type CommunicationServiceResourceModel struct {
 	Name              string            `tfschema:"name"`
@@ -169,6 +177,10 @@ func (r CommunicationServiceResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}
@@ -263,6 +275,10 @@ func (CommunicationServiceResource) Read() sdk.ResourceFunc {
 				state.SecondaryConnectionString = pointer.From(model.SecondaryConnectionString)
 				state.PrimaryKey = pointer.From(model.PrimaryKey)
 				state.SecondaryKey = pointer.From(model.SecondaryKey)
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/communication/communication_service_resource_identity_gen_test.go
+++ b/internal/services/communication/communication_service_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package communication_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccCommunicationService_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
+	r := CommunicationServiceResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_communication_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_communication_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_communication_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/communication/communication_service_resource_test.go
+++ b/internal/services/communication/communication_service_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type CommunicationServiceTestResource struct{}
+type CommunicationServiceResource struct{}
 
 func TestAccCommunicationService_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
-	r := CommunicationServiceTestResource{}
+	r := CommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +36,7 @@ func TestAccCommunicationService_basic(t *testing.T) {
 
 func TestAccCommunicationService_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
-	r := CommunicationServiceTestResource{}
+	r := CommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -51,7 +51,7 @@ func TestAccCommunicationService_requiresImport(t *testing.T) {
 
 func TestAccCommunicationService_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
-	r := CommunicationServiceTestResource{}
+	r := CommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -71,7 +71,7 @@ func TestAccCommunicationService_complete(t *testing.T) {
 
 func TestAccCommunicationService_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
-	r := CommunicationServiceTestResource{}
+	r := CommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -91,7 +91,7 @@ func TestAccCommunicationService_update(t *testing.T) {
 	})
 }
 
-func (r CommunicationServiceTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r CommunicationServiceResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	clusterClient := client.Communication.ServiceClient
 	id, err := communicationservices.ParseCommunicationServiceID(state.ID)
 	if err != nil {
@@ -110,7 +110,7 @@ func (r CommunicationServiceTestResource) Exists(ctx context.Context, client *cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r CommunicationServiceTestResource) basic(data acceptance.TestData) string {
+func (r CommunicationServiceResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -121,7 +121,7 @@ resource "azurerm_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r CommunicationServiceTestResource) requiresImport(data acceptance.TestData) string {
+func (r CommunicationServiceResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 %s
@@ -134,7 +134,7 @@ resource "azurerm_communication_service" "import" {
 `, config)
 }
 
-func (r CommunicationServiceTestResource) complete(data acceptance.TestData) string {
+func (r CommunicationServiceResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -150,7 +150,7 @@ resource "azurerm_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r CommunicationServiceTestResource) update(data acceptance.TestData) string {
+func (r CommunicationServiceResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -166,7 +166,7 @@ resource "azurerm_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r CommunicationServiceTestResource) template(data acceptance.TestData) string {
+func (r CommunicationServiceResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/communication/email_communication_service_domain_resource.go
+++ b/internal/services/communication/email_communication_service_domain_resource.go
@@ -3,6 +3,8 @@
 
 package communication
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name email_communication_service_domain -service-package-name communication -properties "name" -compare-values "resource_group_name:email_service_id,email_service_name:email_service_id" -known-values "subscription_id:data.Subscriptions.Primary"
+
 import (
 	"context"
 	"fmt"
@@ -12,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/domains"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -20,9 +23,16 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-var _ sdk.ResourceWithUpdate = EmailCommunicationServiceDomainResource{}
+var (
+	_ sdk.ResourceWithUpdate   = EmailCommunicationServiceDomainResource{}
+	_ sdk.ResourceWithIdentity = EmailCommunicationServiceDomainResource{}
+)
 
 type EmailCommunicationServiceDomainResource struct{}
+
+func (EmailCommunicationServiceDomainResource) Identity() resourceids.ResourceId {
+	return &domains.DomainId{}
+}
 
 type EmailCommunicationServiceDomainResourceModel struct {
 	Name                          string            `tfschema:"name"`
@@ -159,6 +169,9 @@ func (r EmailCommunicationServiceDomainResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 
 			return nil
 		},
@@ -280,6 +293,10 @@ func (EmailCommunicationServiceDomainResource) Read() sdk.ResourceFunc {
 				}
 
 				state.Tags = pointer.From(model.Tags)
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/communication/email_communication_service_domain_resource_identity_gen_test.go
+++ b/internal/services/communication/email_communication_service_domain_resource_identity_gen_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package communication_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccEmailCommunicationServiceDomain_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
+	r := EmailCommunicationServiceDomainResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_email_communication_service_domain.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("email_service_name"), tfjsonpath.New("email_service_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("email_service_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/communication/email_communication_service_domain_resource_test.go
+++ b/internal/services/communication/email_communication_service_domain_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type EmailServiceDomainTestResource struct{}
+type EmailCommunicationServiceDomainResource struct{}
 
 func TestAccEmailServiceDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
-	r := EmailServiceDomainTestResource{}
+	r := EmailCommunicationServiceDomainResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +36,7 @@ func TestAccEmailServiceDomain_basic(t *testing.T) {
 
 func TestAccEmailServiceDomain_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
-	r := EmailServiceDomainTestResource{}
+	r := EmailCommunicationServiceDomainResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -51,7 +51,7 @@ func TestAccEmailServiceDomain_requiresImport(t *testing.T) {
 
 func TestAccEmailServiceDomain_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
-	r := EmailServiceDomainTestResource{}
+	r := EmailCommunicationServiceDomainResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -71,7 +71,7 @@ func TestAccEmailServiceDomain_update(t *testing.T) {
 	})
 }
 
-func (r EmailServiceDomainTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r EmailCommunicationServiceDomainResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	domainClient := client.Communication.DomainClient
 	id, err := domains.ParseDomainID(state.ID)
 	if err != nil {
@@ -90,7 +90,7 @@ func (r EmailServiceDomainTestResource) Exists(ctx context.Context, client *clie
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r EmailServiceDomainTestResource) basic(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -103,7 +103,7 @@ resource "azurerm_email_communication_service_domain" "test" {
 `, r.template(data))
 }
 
-func (r EmailServiceDomainTestResource) requiresImport(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 %s
@@ -117,7 +117,7 @@ resource "azurerm_email_communication_service_domain" "import" {
 `, config)
 }
 
-func (r EmailServiceDomainTestResource) complete(data acceptance.TestData, userTrackingEnabled string) string {
+func (r EmailCommunicationServiceDomainResource) complete(data acceptance.TestData, userTrackingEnabled string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -135,7 +135,7 @@ resource "azurerm_email_communication_service_domain" "test" {
 `, r.template(data), userTrackingEnabled)
 }
 
-func (r EmailServiceDomainTestResource) template(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/communication/email_communication_service_domain_sender_username_resource.go
+++ b/internal/services/communication/email_communication_service_domain_sender_username_resource.go
@@ -3,6 +3,8 @@
 
 package communication
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name email_communication_service_domain_sender_username -service-package-name communication -properties "name" -compare-values "resource_group_name:email_service_domain_id,email_service_name:email_service_domain_id,domain_name:email_service_domain_id" -known-values "subscription_id:data.Subscriptions.Primary"
+
 import (
 	"context"
 	"fmt"
@@ -11,15 +13,23 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/senderusernames"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-var _ sdk.ResourceWithUpdate = EmailCommunicationServiceDomainSenderUsernameResource{}
+var (
+	_ sdk.ResourceWithUpdate   = EmailCommunicationServiceDomainSenderUsernameResource{}
+	_ sdk.ResourceWithIdentity = EmailCommunicationServiceDomainSenderUsernameResource{}
+)
 
 type EmailCommunicationServiceDomainSenderUsernameResource struct{}
+
+func (EmailCommunicationServiceDomainSenderUsernameResource) Identity() resourceids.ResourceId {
+	return &senderusernames.SenderUsernameId{}
+}
 
 type EmailCommunicationServiceDomainSenderUsernameModel struct {
 	Name                 string `tfschema:"name"`
@@ -105,6 +115,9 @@ func (r EmailCommunicationServiceDomainSenderUsernameResource) Create() sdk.Reso
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 
 			return nil
 		},
@@ -187,6 +200,10 @@ func (EmailCommunicationServiceDomainSenderUsernameResource) Read() sdk.Resource
 				if props := model.Properties; props != nil {
 					state.DisplayName = pointer.From(props.DisplayName)
 				}
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/communication/email_communication_service_domain_sender_username_resource_identity_gen_test.go
+++ b/internal/services/communication/email_communication_service_domain_sender_username_resource_identity_gen_test.go
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package communication_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccEmailCommunicationServiceDomainSenderUsername_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
+	r := EmailCommunicationServiceDomainSenderUsernameResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("domain_name"), tfjsonpath.New("email_service_domain_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("email_service_name"), tfjsonpath.New("email_service_domain_id")),
+					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("email_service_domain_id")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/communication/email_communication_service_domain_sender_username_resource_test.go
+++ b/internal/services/communication/email_communication_service_domain_sender_username_resource_test.go
@@ -16,11 +16,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type EmailServiceDomainSenderUsernameTestResource struct{}
+type EmailCommunicationServiceDomainSenderUsernameResource struct{}
 
 func TestAccEmailServiceDomainSenderUsername_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
-	r := EmailServiceDomainSenderUsernameTestResource{}
+	r := EmailCommunicationServiceDomainSenderUsernameResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -35,7 +35,7 @@ func TestAccEmailServiceDomainSenderUsername_basic(t *testing.T) {
 
 func TestAccEmailServiceDomainSenderUsername_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
-	r := EmailServiceDomainSenderUsernameTestResource{}
+	r := EmailCommunicationServiceDomainSenderUsernameResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -50,7 +50,7 @@ func TestAccEmailServiceDomainSenderUsername_requiresImport(t *testing.T) {
 
 func TestAccEmailServiceDomainSenderUsername_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
-	r := EmailServiceDomainSenderUsernameTestResource{}
+	r := EmailCommunicationServiceDomainSenderUsernameResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -65,7 +65,7 @@ func TestAccEmailServiceDomainSenderUsername_complete(t *testing.T) {
 
 func TestAccEmailServiceDomainSenderUsername_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
-	r := EmailServiceDomainSenderUsernameTestResource{}
+	r := EmailCommunicationServiceDomainSenderUsernameResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -99,7 +99,7 @@ func TestAccEmailServiceDomainSenderUsername_update(t *testing.T) {
 	})
 }
 
-func (r EmailServiceDomainSenderUsernameTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r EmailCommunicationServiceDomainSenderUsernameResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := senderusernames.ParseSenderUsernameID(state.ID)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func (r EmailServiceDomainSenderUsernameTestResource) Exists(ctx context.Context
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r EmailServiceDomainSenderUsernameTestResource) basic(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainSenderUsernameResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -128,7 +128,7 @@ resource "azurerm_email_communication_service_domain_sender_username" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r EmailServiceDomainSenderUsernameTestResource) requiresImport(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainSenderUsernameResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -139,7 +139,7 @@ resource "azurerm_email_communication_service_domain_sender_username" "import" {
 `, r.basic(data))
 }
 
-func (r EmailServiceDomainSenderUsernameTestResource) complete(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainSenderUsernameResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -155,7 +155,7 @@ resource "azurerm_email_communication_service_domain_sender_username" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r EmailServiceDomainSenderUsernameTestResource) update(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainSenderUsernameResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -171,7 +171,7 @@ resource "azurerm_email_communication_service_domain_sender_username" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r EmailServiceDomainSenderUsernameTestResource) template(data acceptance.TestData) string {
+func (r EmailCommunicationServiceDomainSenderUsernameResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-communicationservice-%d"

--- a/internal/services/communication/email_communication_service_resource.go
+++ b/internal/services/communication/email_communication_service_resource.go
@@ -3,6 +3,8 @@
 
 package communication
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name email_communication_service -service-package-name communication -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 import (
 	"context"
 	"fmt"
@@ -12,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/communication/validate"
@@ -19,9 +22,16 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-var _ sdk.ResourceWithUpdate = EmailCommunicationServiceResource{}
+var (
+	_ sdk.ResourceWithUpdate   = EmailCommunicationServiceResource{}
+	_ sdk.ResourceWithIdentity = EmailCommunicationServiceResource{}
+)
 
 type EmailCommunicationServiceResource struct{}
+
+func (EmailCommunicationServiceResource) Identity() resourceids.ResourceId {
+	return &emailservices.EmailServiceId{}
+}
 
 type EmailCommunicationServiceResourceModel struct {
 	Name              string            `tfschema:"name"`
@@ -118,6 +128,9 @@ func (r EmailCommunicationServiceResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 
 			return nil
 		},
@@ -200,6 +213,10 @@ func (EmailCommunicationServiceResource) Read() sdk.ResourceFunc {
 				}
 
 				state.Tags = pointer.From(model.Tags)
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/communication/email_communication_service_resource_identity_gen_test.go
+++ b/internal/services/communication/email_communication_service_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package communication_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccEmailCommunicationService_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
+	r := EmailCommunicationServiceResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_email_communication_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/communication/email_communication_service_resource_test.go
+++ b/internal/services/communication/email_communication_service_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type EmailServiceTestResource struct{}
+type EmailCommunicationServiceResource struct{}
 
 func TestAccEmailService_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
-	r := EmailServiceTestResource{}
+	r := EmailCommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +36,7 @@ func TestAccEmailService_basic(t *testing.T) {
 
 func TestAccEmailService_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
-	r := EmailServiceTestResource{}
+	r := EmailCommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -51,7 +51,7 @@ func TestAccEmailService_requiresImport(t *testing.T) {
 
 func TestAccEmailService_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
-	r := EmailServiceTestResource{}
+	r := EmailCommunicationServiceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -71,7 +71,7 @@ func TestAccEmailService_update(t *testing.T) {
 	})
 }
 
-func (r EmailServiceTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r EmailCommunicationServiceResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	clusterClient := client.Communication.EmailServicesClient
 	id, err := emailservices.ParseEmailServiceID(state.ID)
 	if err != nil {
@@ -90,7 +90,7 @@ func (r EmailServiceTestResource) Exists(ctx context.Context, client *clients.Cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r EmailServiceTestResource) basic(data acceptance.TestData) string {
+func (r EmailCommunicationServiceResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -102,7 +102,7 @@ resource "azurerm_email_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r EmailServiceTestResource) requiresImport(data acceptance.TestData) string {
+func (r EmailCommunicationServiceResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 %s
@@ -115,7 +115,7 @@ resource "azurerm_email_communication_service" "import" {
 `, config)
 }
 
-func (r EmailServiceTestResource) complete(data acceptance.TestData) string {
+func (r EmailCommunicationServiceResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -131,7 +131,7 @@ resource "azurerm_email_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r EmailServiceTestResource) update(data acceptance.TestData) string {
+func (r EmailCommunicationServiceResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -147,7 +147,7 @@ resource "azurerm_email_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r EmailServiceTestResource) template(data acceptance.TestData) string {
+func (r EmailCommunicationServiceResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="330" height="143" alt="image" src="https://github.com/user-attachments/assets/3666c340-e07f-47e4-b2ce-6bf7f22d788c" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

LLMs used to generate boilerplate

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
