### PR TITLE
Docs: Standardize note syntax in contributing guides

### DIFF
--- a/contributing/topics/guide-api-version.md
+++ b/contributing/topics/guide-api-version.md
@@ -16,8 +16,7 @@ go run internal/tools/preview-api-version-linter/main.go
 
 ## Obtaining exception to use preview API
 
-> [!WARNING]
-> Using a preview API version can be risky, prone to human error, and can result in a substandard user experience. An exception is a last resort only when all the consequences are fully understood and there is no alternative.
+> **Warning:** Using a preview API version can be risky, prone to human error, and can result in a substandard user experience. An exception is a last resort only when all the consequences are fully understood and there is no alternative.
 
 To add an exception to use preview API version, the following criteria must be met:
 
@@ -27,8 +26,7 @@ To add an exception to use preview API version, the following criteria must be m
 1. There is a responsible individual with deep knowledge of the API that can be contacted in the future if required.
 1. There is an agreement between Microsoft and Hashicorp that the exception is appropriate.
 
-> [!NOTE]
-> A feature being in preview phase is not a sufficient reason to add this exception. The concept of preview should be decoupled between feature and ARM API. It is okay to leave the feature in preview phase while having the API promoted to stable. This will safeguard the API against breaking changes and ensure azurerm support for the feature can be shipped sooner to customers.
+> **Note:** A feature being in preview phase is not a sufficient reason to add this exception. The concept of preview should be decoupled between feature and ARM API. It is okay to leave the feature in preview phase while having the API promoted to stable. This will safeguard the API against breaking changes and ensure azurerm support for the feature can be shipped sooner to customers.
 
 To add an exception, insert an entry to `internal/tools/preview-api-version-linter/exceptions.yml` as per below example:
 

--- a/contributing/topics/guide-opening-a-pr.md
+++ b/contributing/topics/guide-opening-a-pr.md
@@ -133,7 +133,7 @@ Example:
 - [ ] New Feature
 
 
-> [!NOTE] If this PR changes meaningfully during the course of review please update the title and description as required.
+> **Note:** If this PR changes meaningfully during the course of review please update the title and description as required.
 
 
 

--- a/contributing/topics/guide-resource-identity.md
+++ b/contributing/topics/guide-resource-identity.md
@@ -67,7 +67,7 @@ To add Resource Identity to a typed resource, we will need to implement the `sdk
     }
     ```
    
-   > Note: While this may seem redundant given `Read()` gets called after `Create()`, this is done to prevent `Missing Resource Identity After Create` errors, in the event something errors after setting the `id` attribute.
+   > **Note:** While this may seem redundant given `Read()` gets called after `Create()`, this is done to prevent `Missing Resource Identity After Create` errors, in the event something errors after setting the `id` attribute.
 
 4. Update the `Read()` function to include a step setting the Resource Identity data into state.
 
@@ -186,7 +186,7 @@ To add Resource Identity to an untyped resource, follow the steps below.
     }
     ```
 
-   > Note: While this may seem redundant given `resourceExampleRead()` gets called after `resourceExampleCreate()`, this is done to prevent `Missing Resource Identity After Create` errors, in the event a function call errors after setting the `id` attribute.
+   > **Note:** While this may seem redundant given `resourceExampleRead()` gets called after `resourceExampleCreate()`, this is done to prevent `Missing Resource Identity After Create` errors, in the event a function call errors after setting the `id` attribute.
 
 4. Update the `resourceExampleRead` function to include a step setting the Resource Identity data into state. Resource Identity data does not have to be set manually, we can make use of the `pluginsdk.SetResourceIdentityData` helper function.
 


### PR DESCRIPTION
This PR standardizes the note syntax across the contributing documentation to use `> **Note:**` format for consistency.
### Changes
The contributing guides previously used multiple different note formats:
- `> [!NOTE]` - GitHub admonition syntax
- `> [!WARNING]` - GitHub admonition syntax  
- `> Note:` - Plain blockquote without bold
These have been standardized to:
- `> **Note:**` for informational notes
- `> **Warning:**` for warning notes
### Files Updated
- [contributing/topics/guide-api-version.md](cci:7://file:///Users/kt/hashi/tf/azure/azurerm-zoo/contributing/topics/guide-api-version.md:0:0-0:0) - Converted `> [!WARNING]` and `> [!NOTE]` to standard format
- [contributing/topics/guide-opening-a-pr.md](cci:7://file:///Users/kt/hashi/tf/azure/azurerm-zoo/contributing/topics/guide-opening-a-pr.md:0:0-0:0) - Converted `> [!NOTE]` to standard format
- [contributing/topics/guide-resource-identity.md](cci:7://file:///Users/kt/hashi/tf/azure/azurerm-zoo/contributing/topics/guide-resource-identity.md:0:0-0:0) - Converted `> Note:` to `> **Note:**`
## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
## Documentation Changes
- [x] Documentation is written in International English.
- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
## Change Log
N/A - Documentation only change
This is a (please select all that apply):
- [x] Enhancement
## AI Assistance Disclosure
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs
AI was used to identify all non-standard note formats across the contributing documentation and apply consistent formatting.
## Changes to Security Controls
No changes to security controls.