### PR TITLE
`azurerm_kusto_attached_database_configuration` - Add support for `database_name_override`, `database_name_prefix`, `functions_to_exclude`, and `functions_to_include` properties

### DIFF
--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -274,8 +274,8 @@ func resourceKustoAttachedDatabaseConfigurationRead(d *pluginsdk.ResourceData, m
 			}
 			d.Set("cluster_id", clusterResourceId.ID())
 			d.Set("database_name", props.DatabaseName)
-			d.Set("database_name_override", props.DatabaseNameOverride)
-			d.Set("database_name_prefix", props.DatabaseNamePrefix)
+			d.Set("database_name_override", pointer.From(props.DatabaseNameOverride))
+			d.Set("database_name_prefix", pointer.From(props.DatabaseNamePrefix))
 			d.Set("default_principal_modification_kind", props.DefaultPrincipalsModificationKind)
 			d.Set("attached_database_names", props.AttachedDatabaseNames)
 			d.Set("sharing", flattenAttachedDatabaseConfigurationTableLevelSharingProperties(props.TableLevelSharingProperties))

--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -82,6 +82,20 @@ func resourceKustoAttachedDatabaseConfiguration() *pluginsdk.Resource {
 				ValidateFunc: commonids.ValidateKustoClusterID,
 			},
 
+			"database_name_override": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				Description:  "Overrides the original database name. Relevant only when attaching to a specific database.",
+			},
+
+			"database_name_prefix": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				Description:  "Adds a prefix to the attached databases name. When following an entire cluster, that prefix would be added to all of the databases original names from leader cluster.",
+			},
+
 			"attached_database_names": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
@@ -112,6 +126,22 @@ func resourceKustoAttachedDatabaseConfiguration() *pluginsdk.Resource {
 						},
 
 						"external_tables_to_include": {
+							Type:     pluginsdk.TypeSet,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"functions_to_exclude": {
+							Type:     pluginsdk.TypeSet,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"functions_to_include": {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
 							Elem: &pluginsdk.Schema{
@@ -246,6 +276,8 @@ func resourceKustoAttachedDatabaseConfigurationRead(d *pluginsdk.ResourceData, m
 			}
 			d.Set("cluster_id", clusterResourceId.ID())
 			d.Set("database_name", props.DatabaseName)
+			d.Set("database_name_override", props.DatabaseNameOverride)
+			d.Set("database_name_prefix", props.DatabaseNamePrefix)
 			d.Set("default_principal_modification_kind", props.DefaultPrincipalsModificationKind)
 			d.Set("attached_database_names", props.AttachedDatabaseNames)
 			d.Set("sharing", flattenAttachedDatabaseConfigurationTableLevelSharingProperties(props.TableLevelSharingProperties))
@@ -297,6 +329,14 @@ func expandKustoAttachedDatabaseConfigurationProperties(d *pluginsdk.ResourceDat
 		AttachedDatabaseConfigurationProperties.DatabaseName = databaseName.(string)
 	}
 
+	if databaseNameOverride, ok := d.GetOk("database_name_override"); ok {
+		AttachedDatabaseConfigurationProperties.DatabaseNameOverride = pointer.To(databaseNameOverride.(string))
+	}
+
+	if databaseNamePrefix, ok := d.GetOk("database_name_prefix"); ok {
+		AttachedDatabaseConfigurationProperties.DatabaseNamePrefix = pointer.To(databaseNamePrefix.(string))
+	}
+
 	if defaultPrincipalModificationKind, ok := d.GetOk("default_principal_modification_kind"); ok {
 		AttachedDatabaseConfigurationProperties.DefaultPrincipalsModificationKind = attacheddatabaseconfigurations.DefaultPrincipalsModificationKind(defaultPrincipalModificationKind.(string))
 	}
@@ -316,6 +356,8 @@ func expandAttachedDatabaseConfigurationTableLevelSharingProperties(input []inte
 		TablesToExclude:            utils.ExpandStringSlice(v["tables_to_exclude"].(*pluginsdk.Set).List()),
 		ExternalTablesToInclude:    utils.ExpandStringSlice(v["external_tables_to_include"].(*pluginsdk.Set).List()),
 		ExternalTablesToExclude:    utils.ExpandStringSlice(v["external_tables_to_exclude"].(*pluginsdk.Set).List()),
+		FunctionsToInclude:         utils.ExpandStringSlice(v["functions_to_include"].(*pluginsdk.Set).List()),
+		FunctionsToExclude:         utils.ExpandStringSlice(v["functions_to_exclude"].(*pluginsdk.Set).List()),
 		MaterializedViewsToInclude: utils.ExpandStringSlice(v["materialized_views_to_include"].(*pluginsdk.Set).List()),
 		MaterializedViewsToExclude: utils.ExpandStringSlice(v["materialized_views_to_exclude"].(*pluginsdk.Set).List()),
 	}
@@ -330,6 +372,8 @@ func flattenAttachedDatabaseConfigurationTableLevelSharingProperties(input *atta
 		map[string]interface{}{
 			"external_tables_to_exclude":    utils.FlattenStringSlice(input.ExternalTablesToExclude),
 			"external_tables_to_include":    utils.FlattenStringSlice(input.ExternalTablesToInclude),
+			"functions_to_exclude":          utils.FlattenStringSlice(input.FunctionsToExclude),
+			"functions_to_include":          utils.FlattenStringSlice(input.FunctionsToInclude),
 			"materialized_views_to_exclude": utils.FlattenStringSlice(input.MaterializedViewsToExclude),
 			"materialized_views_to_include": utils.FlattenStringSlice(input.MaterializedViewsToInclude),
 			"tables_to_exclude":             utils.FlattenStringSlice(input.TablesToExclude),

--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -86,14 +86,12 @@ func resourceKustoAttachedDatabaseConfiguration() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
-				Description:  "Overrides the original database name. Relevant only when attaching to a specific database.",
 			},
 
 			"database_name_prefix": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
-				Description:  "Adds a prefix to the attached databases name. When following an entire cluster, that prefix would be added to all of the databases original names from leader cluster.",
 			},
 
 			"attached_database_names": {

--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -4,6 +4,7 @@
 package kusto
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -40,6 +41,16 @@ func resourceKustoAttachedDatabaseConfiguration() *pluginsdk.Resource {
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := attacheddatabaseconfigurations.ParseAttachedDatabaseConfigurationID(id)
 			return err
+		}),
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
+			databaseName := diff.Get("database_name").(string)
+			databaseNameOverride := diff.Get("database_name_override").(string)
+
+			if databaseName == "*" && databaseNameOverride != "" {
+				return fmt.Errorf("cannot set `database_name_override` when `database_name` is set to `*` (all databases)")
+			}
+			return nil
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{

--- a/internal/services/kusto/kusto_attached_database_configuration_resource.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource.go
@@ -83,15 +83,17 @@ func resourceKustoAttachedDatabaseConfiguration() *pluginsdk.Resource {
 			},
 
 			"database_name_override": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  validate.DatabaseName,
+				ConflictsWith: []string{"database_name_prefix"},
 			},
 
 			"database_name_prefix": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  validate.DatabaseName,
+				ConflictsWith: []string{"database_name_override"},
 			},
 
 			"attached_database_names": {

--- a/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
@@ -33,6 +33,36 @@ func TestAccKustoAttachedDatabaseConfiguration_basic(t *testing.T) {
 	})
 }
 
+func TestAccKustoAttachedDatabaseConfiguration_databaseNameOverride(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_attached_database_configuration", "test")
+	r := KustoAttachedDatabaseConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.databaseNameOverride(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoAttachedDatabaseConfiguration_databaseNamePrefix(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_attached_database_configuration", "test")
+	r := KustoAttachedDatabaseConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.databaseNamePrefix(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKustoAttachedDatabaseConfiguration_clusterResourceId(t *testing.T) {
 	if features.FivePointOh() {
 		t.Skip()
@@ -129,6 +159,8 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
   sharing {
     external_tables_to_exclude    = ["ExternalTable2"]
     external_tables_to_include    = ["ExternalTable1"]
+    functions_to_exclude          = ["Function2"]
+    functions_to_include          = ["Function1"]
     materialized_views_to_exclude = ["MaterializedViewTable2"]
     materialized_views_to_include = ["MaterializedViewTable1"]
     tables_to_exclude             = ["Table2"]
@@ -196,11 +228,131 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
   sharing {
     external_tables_to_exclude    = ["ExternalTable2"]
     external_tables_to_include    = ["ExternalTable1"]
+    functions_to_exclude          = ["Function2"]
+    functions_to_include          = ["Function1"]
     materialized_views_to_exclude = ["MaterializedViewTable2"]
     materialized_views_to_include = ["MaterializedViewTable1"]
     tables_to_exclude             = ["Table2"]
     tables_to_include             = ["Table1"]
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (KustoAttachedDatabaseConfigurationResource) databaseNameOverride(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "cluster1" {
+  name                = "acctestkc1%s"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+}
+
+resource "azurerm_kusto_cluster" "cluster2" {
+  name                = "acctestkc2%s"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+}
+
+resource "azurerm_kusto_database" "followed_database" {
+  name                = "acctestkd-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster1.name
+}
+
+resource "azurerm_kusto_database" "test" {
+  name                = "acctestkd2-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster2.name
+}
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                   = "acctestka-%d"
+  resource_group_name    = azurerm_resource_group.rg.name
+  location               = azurerm_resource_group.rg.location
+  cluster_name           = azurerm_kusto_cluster.cluster1.name
+  cluster_id             = azurerm_kusto_cluster.cluster2.id
+  database_name          = azurerm_kusto_database.test.name
+  database_name_override = "overridden-database-name"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (KustoAttachedDatabaseConfigurationResource) databaseNamePrefix(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "cluster1" {
+  name                = "acctestkc1%s"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+}
+
+resource "azurerm_kusto_cluster" "cluster2" {
+  name                = "acctestkc2%s"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+}
+
+resource "azurerm_kusto_database" "followed_database" {
+  name                = "acctestkd-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster1.name
+}
+
+resource "azurerm_kusto_database" "test" {
+  name                = "acctestkd2-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster2.name
+}
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                 = "acctestka-%d"
+  resource_group_name  = azurerm_resource_group.rg.name
+  location             = azurerm_resource_group.rg.location
+  cluster_name         = azurerm_kusto_cluster.cluster1.name
+  cluster_id           = azurerm_kusto_cluster.cluster2.id
+  database_name        = "*"
+  database_name_prefix = "prefix-"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
@@ -173,7 +173,11 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
 func (KustoAttachedDatabaseConfigurationResource) clusterResourceId(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "rg" {
@@ -240,7 +244,11 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
 func (KustoAttachedDatabaseConfigurationResource) databaseNameOverride(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "rg" {
@@ -299,7 +307,11 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
 func (KustoAttachedDatabaseConfigurationResource) databaseNamePrefix(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "rg" {

--- a/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
@@ -228,8 +228,6 @@ resource "azurerm_kusto_attached_database_configuration" "test" {
   sharing {
     external_tables_to_exclude    = ["ExternalTable2"]
     external_tables_to_include    = ["ExternalTable1"]
-    functions_to_exclude          = ["Function2"]
-    functions_to_include          = ["Function1"]
     materialized_views_to_exclude = ["MaterializedViewTable2"]
     materialized_views_to_include = ["MaterializedViewTable1"]
     tables_to_exclude             = ["Table2"]

--- a/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
+++ b/internal/services/kusto/kusto_attached_database_configuration_resource_test.go
@@ -81,6 +81,28 @@ func TestAccKustoAttachedDatabaseConfiguration_clusterResourceId(t *testing.T) {
 	})
 }
 
+func TestAccKustoAttachedDatabaseConfiguration_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_attached_database_configuration", "test")
+	r := KustoAttachedDatabaseConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (KustoAttachedDatabaseConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := attacheddatabaseconfigurations.ParseAttachedDatabaseConfigurationID(state.ID)
 	if err != nil {
@@ -101,7 +123,115 @@ func (KustoAttachedDatabaseConfigurationResource) Exists(ctx context.Context, cl
 	return &exists, nil
 }
 
-func (KustoAttachedDatabaseConfigurationResource) basic(data acceptance.TestData) string {
+func (r KustoAttachedDatabaseConfigurationResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                = "acctestka-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster1.name
+  cluster_id          = azurerm_kusto_cluster.cluster2.id
+  database_name       = azurerm_kusto_database.test.name
+
+  sharing {
+    external_tables_to_exclude    = ["ExternalTable2"]
+    external_tables_to_include    = ["ExternalTable1"]
+    functions_to_exclude          = ["Function2"]
+    functions_to_include          = ["Function1"]
+    materialized_views_to_exclude = ["MaterializedViewTable2"]
+    materialized_views_to_include = ["MaterializedViewTable1"]
+    tables_to_exclude             = ["Table2"]
+    tables_to_include             = ["Table1"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoAttachedDatabaseConfigurationResource) clusterResourceId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                = "acctestka-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster1.name
+  cluster_resource_id = azurerm_kusto_cluster.cluster2.id ### <-- Testing this deprecated property
+  database_name       = azurerm_kusto_database.test.name
+
+  sharing {
+    external_tables_to_exclude    = ["ExternalTable2"]
+    external_tables_to_include    = ["ExternalTable1"]
+    materialized_views_to_exclude = ["MaterializedViewTable2"]
+    materialized_views_to_include = ["MaterializedViewTable1"]
+    tables_to_exclude             = ["Table2"]
+    tables_to_include             = ["Table1"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoAttachedDatabaseConfigurationResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                = "acctestka-%d"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  cluster_name        = azurerm_kusto_cluster.cluster1.name
+  cluster_id          = azurerm_kusto_cluster.cluster2.id
+  database_name       = azurerm_kusto_database.test.name
+
+  sharing {
+    external_tables_to_exclude    = ["ExternalTable3", "ExternalTable4"]
+    external_tables_to_include    = ["ExternalTable1", "ExternalTable2"]
+    functions_to_exclude          = ["Function3", "Function4"]
+    functions_to_include          = ["Function1", "Function2"]
+    materialized_views_to_exclude = ["MaterializedViewTable3", "MaterializedViewTable4"]
+    materialized_views_to_include = ["MaterializedViewTable1", "MaterializedViewTable2"]
+    tables_to_exclude             = ["Table3", "Table4"]
+    tables_to_include             = ["Table1", "Table2"]
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoAttachedDatabaseConfigurationResource) databaseNameOverride(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                   = "acctestka-%d"
+  resource_group_name    = azurerm_resource_group.rg.name
+  location               = azurerm_resource_group.rg.location
+  cluster_name           = azurerm_kusto_cluster.cluster1.name
+  cluster_id             = azurerm_kusto_cluster.cluster2.id
+  database_name          = azurerm_kusto_database.test.name
+  database_name_override = "overridden-database-name"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r KustoAttachedDatabaseConfigurationResource) databaseNamePrefix(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_attached_database_configuration" "test" {
+  name                 = "acctestka-%d"
+  resource_group_name  = azurerm_resource_group.rg.name
+  location             = azurerm_resource_group.rg.location
+  cluster_name         = azurerm_kusto_cluster.cluster1.name
+  cluster_id           = azurerm_kusto_cluster.cluster2.id
+  database_name        = "*"
+  database_name_prefix = "prefix-"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (KustoAttachedDatabaseConfigurationResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -147,222 +277,5 @@ resource "azurerm_kusto_database" "test" {
   location            = azurerm_resource_group.rg.location
   cluster_name        = azurerm_kusto_cluster.cluster2.name
 }
-
-resource "azurerm_kusto_attached_database_configuration" "test" {
-  name                = "acctestka-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster1.name
-  cluster_id          = azurerm_kusto_cluster.cluster2.id
-  database_name       = azurerm_kusto_database.test.name
-
-  sharing {
-    external_tables_to_exclude    = ["ExternalTable2"]
-    external_tables_to_include    = ["ExternalTable1"]
-    functions_to_exclude          = ["Function2"]
-    functions_to_include          = ["Function1"]
-    materialized_views_to_exclude = ["MaterializedViewTable2"]
-    materialized_views_to_include = ["MaterializedViewTable1"]
-    tables_to_exclude             = ["Table2"]
-    tables_to_include             = ["Table1"]
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (KustoAttachedDatabaseConfigurationResource) clusterResourceId(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
-}
-
-resource "azurerm_resource_group" "rg" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_kusto_cluster" "cluster1" {
-  name                = "acctestkc1%s"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_kusto_cluster" "cluster2" {
-  name                = "acctestkc2%s"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_kusto_database" "followed_database" {
-  name                = "acctestkd-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster1.name
-}
-
-resource "azurerm_kusto_database" "test" {
-  name                = "acctestkd2-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster2.name
-}
-
-resource "azurerm_kusto_attached_database_configuration" "test" {
-  name                = "acctestka-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster1.name
-  cluster_resource_id = azurerm_kusto_cluster.cluster2.id ### <-- Testing this deprecated property
-  database_name       = azurerm_kusto_database.test.name
-
-  sharing {
-    external_tables_to_exclude    = ["ExternalTable2"]
-    external_tables_to_include    = ["ExternalTable1"]
-    materialized_views_to_exclude = ["MaterializedViewTable2"]
-    materialized_views_to_include = ["MaterializedViewTable1"]
-    tables_to_exclude             = ["Table2"]
-    tables_to_include             = ["Table1"]
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (KustoAttachedDatabaseConfigurationResource) databaseNameOverride(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
-}
-
-resource "azurerm_resource_group" "rg" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_kusto_cluster" "cluster1" {
-  name                = "acctestkc1%s"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_kusto_cluster" "cluster2" {
-  name                = "acctestkc2%s"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_kusto_database" "followed_database" {
-  name                = "acctestkd-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster1.name
-}
-
-resource "azurerm_kusto_database" "test" {
-  name                = "acctestkd2-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster2.name
-}
-
-resource "azurerm_kusto_attached_database_configuration" "test" {
-  name                   = "acctestka-%d"
-  resource_group_name    = azurerm_resource_group.rg.name
-  location               = azurerm_resource_group.rg.location
-  cluster_name           = azurerm_kusto_cluster.cluster1.name
-  cluster_id             = azurerm_kusto_cluster.cluster2.id
-  database_name          = azurerm_kusto_database.test.name
-  database_name_override = "overridden-database-name"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (KustoAttachedDatabaseConfigurationResource) databaseNamePrefix(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
-}
-
-resource "azurerm_resource_group" "rg" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_kusto_cluster" "cluster1" {
-  name                = "acctestkc1%s"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_kusto_cluster" "cluster2" {
-  name                = "acctestkc2%s"
-  location            = azurerm_resource_group.rg.location
-  resource_group_name = azurerm_resource_group.rg.name
-
-  sku {
-    name     = "Dev(No SLA)_Standard_D11_v2"
-    capacity = 1
-  }
-}
-
-resource "azurerm_kusto_database" "followed_database" {
-  name                = "acctestkd-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster1.name
-}
-
-resource "azurerm_kusto_database" "test" {
-  name                = "acctestkd2-%d"
-  resource_group_name = azurerm_resource_group.rg.name
-  location            = azurerm_resource_group.rg.location
-  cluster_name        = azurerm_kusto_cluster.cluster2.name
-}
-
-resource "azurerm_kusto_attached_database_configuration" "test" {
-  name                 = "acctestka-%d"
-  resource_group_name  = azurerm_resource_group.rg.name
-  location             = azurerm_resource_group.rg.location
-  cluster_name         = azurerm_kusto_cluster.cluster1.name
-  cluster_id           = azurerm_kusto_cluster.cluster2.id
-  database_name        = "*"
-  database_name_prefix = "prefix-"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -65,6 +65,8 @@ resource "azurerm_kusto_attached_database_configuration" "example" {
   sharing {
     external_tables_to_exclude    = ["ExternalTable2"]
     external_tables_to_include    = ["ExternalTable1"]
+    functions_to_exclude          = ["Function2"]
+    functions_to_include          = ["Function1"]
     materialized_views_to_exclude = ["MaterializedViewTable2"]
     materialized_views_to_include = ["MaterializedViewTable1"]
     tables_to_exclude             = ["Table2"]
@@ -89,6 +91,10 @@ The following arguments are supported:
 
 * `database_name` - (Required) The name of the database which you would like to attach, use * if you want to follow all current and future databases. Changing this forces a new resource to be created.
 
+* `database_name_override` - (Optional) Overrides the original database name. Relevant only when attaching to a specific database.
+
+* `database_name_prefix` - (Optional) Adds a prefix to the attached databases name. When following an entire cluster, that prefix would be added to all of the databases original names from leader cluster.
+
 * `default_principal_modification_kind` - (Optional) The default principals modification kind. Valid values are: `None` (default), `Replace` and `Union`. Defaults to `None`.
 
 * `sharing` - (Optional) A `sharing` block as defined below.
@@ -100,6 +106,10 @@ An `sharing` block exports the following:
 * `external_tables_to_exclude` - (Optional) List of external tables exclude from the follower database.
 
 * `external_tables_to_include` - (Optional) List of external tables to include in the follower database.
+
+* `functions_to_exclude` - (Optional) List of functions to exclude from the follower database.
+
+* `functions_to_include` - (Optional) List of functions to include in the follower database.
 
 * `materialized_views_to_exclude` - (Optional) List of materialized views exclude from the follower database.
 

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `database_name` - (Required) The name of the database which you would like to attach, use * if you want to follow all current and future databases. Changing this forces a new resource to be created.
 
-* `database_name_override` - (Optional) Overrides the original database name. Relevant only when attaching to a specific database.
+* `database_name_override` - (Optional) The database name to use for the attached database instead of using the original database name. Relevant only when attaching to a specific database.
 
 * `database_name_prefix` - (Optional) Adds a prefix to the attached databases name. When following an entire cluster, that prefix would be added to all of the databases original names from leader cluster.
 

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_kusto_attached_database_configuration" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.follower_cluster.name
-  cluster_resource_id = azurerm_kusto_cluster.followed_cluster.id
+  cluster_id = azurerm_kusto_cluster.followed_cluster.id
   database_name       = azurerm_kusto_database.example.name
 
   sharing {

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_kusto_attached_database_configuration" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.follower_cluster.name
-  cluster_id = azurerm_kusto_cluster.followed_cluster.id
+  cluster_id          = azurerm_kusto_cluster.followed_cluster.id
   database_name       = azurerm_kusto_database.example.name
 
   sharing {

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
 
 * `database_name_prefix` - (Optional) Adds a prefix to the attached databases name. When following an entire cluster, that prefix would be added to all of the databases original names from leader cluster.
 
+~> **Note:** Exactly one of  `database_name_override` and `database_name_prefix` can be specified.
+
 * `default_principal_modification_kind` - (Optional) The default principals modification kind. Valid values are: `None` (default), `Replace` and `Union`. Defaults to `None`.
 
 * `sharing` - (Optional) A `sharing` block as defined below.


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the following new properties to the `azurerm_kusto_attached_database_configuration` resource:

**Top-level properties:**
- `database_name_override` - Overrides the original database name. Relevant only when attaching to a specific database.
- `database_name_prefix` - Adds a prefix to the attached databases name. When following an entire cluster, that prefix would be added to all of the databases' original names from the leader cluster.

**Properties in the `sharing` block:**
- `functions_to_exclude` - List of functions to exclude from the follower database.
- `functions_to_include` - List of functions to include in the follower database.

These properties are already supported by the Azure API (2024-04-13) and the underlying SDK but were not exposed in the Terraform resource.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: "`resource_name_here` - description of change e.g. adding property `new_property_name_here`"


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

### New Test Cases Added:
- `TestAccKustoAttachedDatabaseConfiguration_databaseNameOverride` - Tests the `database_name_override` property
- `TestAccKustoAttachedDatabaseConfiguration_databaseNamePrefix` - Tests the `database_name_prefix` property with `database_name = "*"`

```
=== RUN   TestAccKustoAttachedDatabaseConfiguration_basic
=== PAUSE TestAccKustoAttachedDatabaseConfiguration_basic
=== CONT  TestAccKustoAttachedDatabaseConfiguration_basic
--- PASS: TestAccKustoAttachedDatabaseConfiguration_basic (1326.36s)
PASS

Process finished with the exit code 0

=== RUN   TestAccKustoAttachedDatabaseConfiguration_databaseNameOverride
=== PAUSE TestAccKustoAttachedDatabaseConfiguration_databaseNameOverride
=== CONT  TestAccKustoAttachedDatabaseConfiguration_databaseNameOverride
--- PASS: TestAccKustoAttachedDatabaseConfiguration_databaseNameOverride (1223.11s)
PASS


Process finished with the exit code 0

=== RUN   TestAccKustoAttachedDatabaseConfiguration_databaseNamePrefix
=== PAUSE TestAccKustoAttachedDatabaseConfiguration_databaseNamePrefix
=== CONT  TestAccKustoAttachedDatabaseConfiguration_databaseNamePrefix
--- PASS: TestAccKustoAttachedDatabaseConfiguration_databaseNamePrefix (1355.98s)
PASS


Process finished with the exit code 0

=== RUN   TestAccKustoAttachedDatabaseConfiguration_clusterResourceId
=== PAUSE TestAccKustoAttachedDatabaseConfiguration_clusterResourceId
=== CONT  TestAccKustoAttachedDatabaseConfiguration_clusterResourceId
--- PASS: TestAccKustoAttachedDatabaseConfiguration_clusterResourceId (1264.74s)
PASS


Process finished with the exit code 0
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_kusto_attached_database_configuration` - Add support for `database_name_override`, `database_name_prefix`, `functions_to_exclude`, and `functions_to_include` properties [GH-31470]


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

<!-- Fixes #0000 -->


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

This PR was created with the assistance of GitHub Copilot for code generation, test cases, and documentation updates.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls in this pull request.

