### PR TITLE
`generation` - enhancement for generating Resource Identity Tests

### DIFF
--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/apidiagnostic"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2022-08-01/logger"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/schemaz"
@@ -23,6 +24,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name api_management_api_diagnostic -properties "service_name:api_management_name,api_id:api_name,diagnostic_id:identifier"
+
 func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceApiManagementApiDiagnosticCreateUpdate,
@@ -30,16 +33,17 @@ func resourceApiManagementApiDiagnostic() *pluginsdk.Resource {
 		Update: resourceApiManagementApiDiagnosticCreateUpdate,
 		Delete: resourceApiManagementApiDiagnosticDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := apidiagnostic.ParseApiDiagnosticID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&apidiagnostic.ApiDiagnosticId{}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&apidiagnostic.ApiDiagnosticId{}),
 		},
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -270,7 +274,14 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *pluginsdk.ResourceData, m
 	if resp.Model != nil && pointer.From(resp.Model.Id) == "" {
 		return fmt.Errorf("reading ID for Diagnostic %s: ID is empty", id)
 	}
-	d.SetId(id.ID())
+
+	if d.IsNewResource() {
+		// This belongs in `create` only
+		d.SetId(id.ID())
+		if err = pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
+	}
 
 	return resourceApiManagementApiDiagnosticRead(d, meta)
 }
@@ -335,7 +346,7 @@ func resourceApiManagementApiDiagnosticRead(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, diagnosticId)
 }
 
 func resourceApiManagementApiDiagnosticDelete(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource_identity_gen_test.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource_identity_gen_test.go
@@ -34,8 +34,8 @@ func TestAccApiManagementApiDiagnostic_resourceIdentity(t *testing.T) {
 					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_api_management_api_diagnostic.test", tfjsonpath.New("service_name"), tfjsonpath.New("api_management_name")),
 				},
 			},
-			data.ImportBlockWithResourceIdentityStep(),
-			data.ImportBlockWithIDStep(),
+			data.ImportBlockWithResourceIdentityStep(false),
+			data.ImportBlockWithIDStep(false),
 		},
 	})
 }

--- a/internal/services/apimanagement/api_management_api_diagnostic_resource_identity_gen_test.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource_identity_gen_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package apimanagement_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccApiManagementApiDiagnostic_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
+	r := ApiManagementApiDiagnosticResource{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_api_management_api_diagnostic.test", tfjsonpath.New("api_id"), tfjsonpath.New("api_name")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_api_management_api_diagnostic.test", tfjsonpath.New("diagnostic_id"), tfjsonpath.New("identifier")),
+					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_api_management_api_diagnostic.test", tfjsonpath.New("service_name"), tfjsonpath.New("api_management_name")),
+				},
+			},
+			data.ImportBlockWithResourceIdentityStep(),
+			data.ImportBlockWithIDStep(),
+		},
+	})
+}

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet -service-package-name network -properties "name,resource_group_name,virtual_network_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name subnet -id "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1"
 
 var SubnetResourceName = "azurerm_subnet"
 

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name resource_group -service-package-name resource -properties "name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name resource_group -id "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1"
 
 const resourceGroupResourceName = "azurerm_resource_group"
 

--- a/internal/services/storage/storage_account_customer_managed_key_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource_identity_gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -30,6 +31,7 @@ func TestAccStorageAccountCustomerManagedKey_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/services/storage/storage_account_network_rules_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_identity_gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -30,6 +31,7 @@ func TestAccStorageAccountNetworkRules_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_storage_account_network_rules.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/services/storage/storage_account_queue_properties_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_queue_properties_resource_identity_gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -30,6 +31,7 @@ func TestAccStorageAccountQueueProperties_resourceIdentity(t *testing.T) {
 			{
 				Config: r.corsOnly(data),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_storage_account_queue_properties.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/services/storage/storage_account_static_website_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_static_website_resource_identity_gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -30,6 +31,7 @@ func TestAccStorageAccountStaticWebsite_resourceIdentity(t *testing.T) {
 			{
 				Config: r.complete(data),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_storage_account_static_website.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/services/storage/storage_blob_inventory_policy_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_identity_gen_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -30,6 +31,7 @@ func TestAccStorageBlobInventoryPolicy_resourceIdentity(t *testing.T) {
 			{
 				Config: r.basic(data),
 				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectIdentityValue("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
 					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -115,6 +115,7 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	argSet.StringVar(&d.TestName, "test-name", "basic", "(Optional) the name of the config that will be used to test Resource Identity. Defaults to `basic`.")
 	argSet.BoolVar(&d.TestExpectNonEmptyPlan, "test-expect-non-empty", false, "(Optional) Whether to expect (and ignore) a non-empty plan, to be used when the API does not return certain values during import. Defaults to `false`.")
 	argSet.BoolVar(&d.NoSubscriptionID, "", false, "(Optional) Resource does not use subscription_id in ID (e.g. managementgroupid. Defaults to `false`.")
+	argSet.BoolVar(&d.NoSubscriptionID, "no-subscription-id", false, "(Optional) Resource does not use subscription_id in ID (e.g. managementgroupid. Defaults to `false`.")
 	argSet.StringVar(&d.ExampleID, "id", "", "an example of the resource id for this resource, can be used when all the id segments and the schema property names match. Conflicts with '-properties'")
 
 	if err := argSet.Parse(args); err != nil {

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -125,8 +125,7 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	}
 
 	// check we have the essentials
-	switch {
-	case d.ResourceName == "":
+	if d.ResourceName == "" {
 		errors = append(errors, fmt.Errorf("resource name is required"))
 	}
 

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -11,11 +11,16 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/templatehelpers"
+	"github.com/iancoleman/strcase"
 	"github.com/mitchellh/cli"
 )
 
-var riOutputFileFmt = "../../services/%s/%s_resource_identity_gen_test.go"
+var riOutputFileFmt = "/%s_resource_identity_gen_test.go"
+
+var cwd, _ = os.Getwd()
 
 type ResourceIdentityCommand struct {
 	Ui cli.Ui
@@ -34,6 +39,8 @@ type resourceIdentityData struct {
 	CompareValueMap        map[string]string
 	TestName               string
 	TestExpectNonEmptyPlan bool
+	NoSubscriptionID       bool
+	ExampleID              string
 }
 
 var _ cli.Command = &ResourceIdentityCommand{}
@@ -100,13 +107,15 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	argSet := flag.NewFlagSet("ri", flag.ExitOnError)
 
 	argSet.StringVar(&d.ResourceName, "resource-name", "", "(Required) the name of the resource to generate the resource identity test for.")
-	argSet.StringVar(&d.IdentityProperties, "properties", "", "(Required) a comma separated list of schema property names that make up the resource identity for this resource. Do not include 'known' values here, only schema comparisons are supported.")
-	argSet.StringVar(&d.ServicePackageName, "service-package-name", "", "(Required) the path to the directory containing the service package to write the generated test to.")
+	argSet.StringVar(&d.IdentityProperties, "properties", "", "(Optional) a comma separated list of schema property names that make up the resource identity for this resource. Do not include 'known' values here, only schema comparisons are supported. Conflicts with '-id'")
+	argSet.StringVar(&d.ServicePackageName, "service-package-name", "", "(Optional) the path to the directory containing the service package to write the generated test to. for go generate this will be picked up from the cwd")
 	argSet.StringVar(&d.BasicTestParams, "test-params", "", "(Optional) comma separated list of additional properties that need to be passed to the basic test config for this resource.")
 	argSet.StringVar(&d.KnownValues, "known-values", "", "(Optional) comma separated list of known (aka discriminated) value names and their values for this resource type, formatted as [attribute_name]:[attribute value]. e.g. `kind:linux;functionapp,foo:bar`")
 	argSet.StringVar(&d.CompareValues, "compare-values", "", "(Optional) comma separated list of resource identity names that are contained within a schema property value, formatted as [attribute_name]:[attribute value]. e.g. `parent_name:parent_resource_id;resource_group_name,parent_resource_id`")
 	argSet.StringVar(&d.TestName, "test-name", "basic", "(Optional) the name of the config that will be used to test Resource Identity. Defaults to `basic`.")
 	argSet.BoolVar(&d.TestExpectNonEmptyPlan, "test-expect-non-empty", false, "(Optional) Whether to expect (and ignore) a non-empty plan, to be used when the API does not return certain values during import. Defaults to `false`.")
+	argSet.BoolVar(&d.NoSubscriptionID, "", false, "(Optional) Resource does not use subscription_id in ID (e.g. managementgroupid. Defaults to `false`.")
+	argSet.StringVar(&d.ExampleID, "id", "", "an example of the resource id for this resource, can be used when all the id segments and the schema property names match. Conflicts with '-properties'")
 
 	if err := argSet.Parse(args); err != nil {
 		errors = append(errors, err)
@@ -117,12 +126,11 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	switch {
 	case d.ResourceName == "":
 		errors = append(errors, fmt.Errorf("resource name is required"))
-	case d.ServicePackageName == "":
-		errors = append(errors, fmt.Errorf("service-package-path is required"))
 	}
 
 	// d.PropertyNameMap = strings.Split(d.IdentityProperties, ",")
 	if len(d.IdentityProperties) > 0 {
+		d.NoSubscriptionID = true
 		d.PropertyNameMap = map[string]string{}
 		propertiesList := strings.Split(d.IdentityProperties, ",")
 		for _, property := range propertiesList {
@@ -180,7 +188,27 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 func (d *resourceIdentityData) exec() error {
 	tpl := template.Must(template.New("identity_test.gotpl").Funcs(templatehelpers.TplFuncMap).ParseFS(Templatedir, "templates/identity_test.gotpl"))
 
-	outputPath := fmt.Sprintf(riOutputFileFmt, d.ServicePackageName, d.ResourceName)
+	outputPath := cwd + fmt.Sprintf(riOutputFileFmt, d.ResourceName)
+	cwdParts := strings.Split(cwd, "internal/services/")
+	d.ServicePackageName = cwdParts[len(cwdParts)-1]
+
+	if d.ExampleID != "" {
+		d.PropertyNameMap = make(map[string]string)
+		id := recaser.ResourceIdTypeFromResourceId(d.ExampleID)
+		if id == nil {
+			return fmt.Errorf("invalid or unregistred resource id: %s", d.ExampleID)
+		}
+		for _, s := range id.Segments() {
+			if s.Type == resourceids.UserSpecifiedSegmentType || s.Type == resourceids.ResourceGroupSegmentType {
+				if strings.HasPrefix(s.Name, d.ResourceName) {
+					d.PropertyNameMap["name"] = "name"
+					continue
+				}
+				v := strcase.ToSnake(s.Name)
+				d.PropertyNameMap[v] = v
+			}
+		}
+	}
 
 	f, err := os.Create(outputPath)
 	if err != nil {

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -130,7 +130,7 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 		errors = append(errors, fmt.Errorf("resource name is required"))
 	}
 
-	strings.TrimPrefix(d.ResourceName, "azurerm_") // catch and remove accidental provider prefix
+	d.ResourceName = strings.TrimPrefix(d.ResourceName, "azurerm_") // catch and remove accidental provider prefix
 
 	// d.PropertyNameMap = strings.Split(d.IdentityProperties, ",")
 	if len(d.IdentityProperties) > 0 {

--- a/internal/tools/generator-tests/generators/templates/identity_test.gotpl
+++ b/internal/tools/generator-tests/generators/templates/identity_test.gotpl
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	{{- if (gt (.CompareValueMap | len) 0) }}
-    customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
     {{- end }}
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
@@ -32,7 +32,7 @@ func TestAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				{{- if (gt (.TestParams | len) 0) }}
-				Config: r.{{ .TestName }}(data {{ range $v := .TestParams -}} , "{{ $v }}" {{ end }}),
+				Config: r.{{ .TestName }}(data {{ range $v := .TestParams -}} , "{{ $v }}" {{- end }}),
 				    {{- else }}
 				Config: r.{{ .TestName }}(data),
 				{{- end }}

--- a/internal/tools/generator-tests/generators/templates/identity_test.gotpl
+++ b/internal/tools/generator-tests/generators/templates/identity_test.gotpl
@@ -9,9 +9,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	{{- if (gt (.KnownValueMap | len) 0) }}
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	{{- end }}
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -21,8 +19,7 @@ import (
     {{- end }}
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
-
-{{- $resourceName := .ResourceName }}
+{{ $resourceName := .ResourceName }}
 func TestAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_{{ ToSnake $resourceName }}", "test")
 	r := {{ ToCamel $resourceName }}Resource{}
@@ -40,11 +37,14 @@ func TestAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 				Config: r.{{ .TestName }}(data),
 				{{- end }}
 				ConfigStateChecks: []statecheck.StateCheck{
+					{{- if .NoSubscriptionID }} {{- else }}
+					statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+					{{- end }}
 					{{- range $name, $val := .KnownValueMap }}
 					    {{- if (eq $name "subscription_id") }}
-					    statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test",  tfjsonpath.New("{{ $name }}"),  knownvalue.StringExact({{ $val }})),
+					statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test", tfjsonpath.New("{{ $name }}"), knownvalue.StringExact({{ $val }})),
 					    {{- else }}
-					    statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test",  tfjsonpath.New("{{ $name }}"),  knownvalue.StringExact("{{ $val }}")),
+					statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test", tfjsonpath.New("{{ $name }}"), knownvalue.StringExact("{{ $val }}")),
 					    {{- end }}
 					{{- end }}
 


### PR DESCRIPTION
- makes `-service-package` optional
- can now consume an example resource id for the resource to infer the RI properties
- now assumes `subscription_id` is present in the RI, can be disabled by `-no-subscription-id` flag