### PR TITLE
azurerm_cdn_frontdoor_secret: add `key_vault_id` property to allow referring Key Vault in a different subscription

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_secret_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_secret_resource_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+// NOTE: This is currently not testable due to the cert requirements of the service
 type CdnFrontdoorSecretResource struct {
 	DoNotRunFrontDoorCustomDomainTests string
 }
@@ -71,6 +72,22 @@ func TestAccCdnFrontDoorSecret_complete(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorSecret_customKeyVaultID(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_secret", "test")
+	r := CdnFrontdoorSecretResource{os.Getenv("ARM_TEST_DO_NOT_RUN_CDN_FRONT_DOOR_CUSTOM_DOMAIN")}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.customKeyVaultID(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CdnFrontdoorSecretResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FrontDoorSecretID(state.ID)
 	if err != nil {
@@ -100,6 +117,13 @@ func (r CdnFrontdoorSecretResource) preCheck(t *testing.T) {
 
 func (r CdnFrontdoorSecretResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azuread_service_principal" "frontdoor" {
+  client_id    = "205478c0-bd83-4e1b-a9d6-db63a3e1e1c8"
+  use_existing = true
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-cdn-afdx-%d"
   location = "%s"
@@ -110,7 +134,38 @@ resource "azurerm_cdn_frontdoor_profile" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "Standard_AzureFrontDoor"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+
+resource "azurerm_key_vault" "test" {
+  name                = "acct%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  access_policy {
+    tenant_id               = data.azurerm_client_config.current.tenant_id
+    object_id               = data.azurerm_client_config.current.object_id
+    secret_permissions      = ["Delete", "Get", "Set", "Purge"]
+    certificate_permissions = ["Create", "Delete", "Get", "Import", "Purge"]
+  }
+
+  access_policy {
+    tenant_id          = data.azurerm_client_config.current.tenant_id
+    object_id          = azuread_service_principal.frontdoor.object_id
+    secret_permissions = ["Get"]
+  }
+}
+
+resource "azurerm_key_vault_certificate" "test" {
+  name         = "acctest%d"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate {
+    contents = filebase64("testdata/cert.pfx")
+    password = ""
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (r CdnFrontdoorSecretResource) basic(data acceptance.TestData) string {
@@ -168,6 +223,29 @@ resource "azurerm_cdn_frontdoor_secret" "test" {
 
   secret {
     customer_certificate {
+      key_vault_certificate_id = azurerm_key_vault_certificate.test.versionless_id
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontdoorSecretResource) customKeyVaultID(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_cdn_frontdoor_secret" "test" {
+  name                     = "accTestSecret-%d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  secret {
+    customer_certificate {
+	  key_vault_id             = azurerm_key_vault.test.id
       key_vault_certificate_id = azurerm_key_vault_certificate.test.versionless_id
     }
   }

--- a/internal/services/cdn/frontdoorsecretparams/cdn_frontdoor_secret_params.go
+++ b/internal/services/cdn/frontdoorsecretparams/cdn_frontdoor_secret_params.go
@@ -67,14 +67,19 @@ func ExpandCdnFrontDoorCustomerCertificateParameters(ctx context.Context, input 
 		useLatest = true
 	}
 
-	subscriptionId := commonids.NewSubscriptionID(clients.Account.SubscriptionId)
-	keyVaultBaseId, err := clients.KeyVault.KeyVaultIDFromBaseUrl(ctx, subscriptionId, certificateId.KeyVaultBaseUrl)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving the Key Vault Resource ID from the Key Vault Base URL %q: %s", certificateId.KeyVaultBaseUrl, err)
-	}
+	var keyVaultBaseId *string
+	if customizedKeyVaultId, ok := item["key_vault_id"].(string); ok && customizedKeyVaultId != "" {
+		keyVaultBaseId = pointer.To(customizedKeyVaultId)
+	} else {
+		subscriptionId := commonids.NewSubscriptionID(clients.Account.SubscriptionId)
+		keyVaultBaseId, err = clients.KeyVault.KeyVaultIDFromBaseUrl(ctx, subscriptionId, certificateId.KeyVaultBaseUrl)
+		if err != nil {
+			return nil, fmt.Errorf("retrieving the Key Vault Resource ID from the Key Vault Base URL %q: %s", certificateId.KeyVaultBaseUrl, err)
+		}
 
-	if keyVaultBaseId == nil {
-		return nil, fmt.Errorf("unexpected nil Key Vault Resource ID retrieved from the Key Vault Base URL %q", certificateId.KeyVaultBaseUrl)
+		if keyVaultBaseId == nil {
+			return nil, fmt.Errorf("unexpected nil Key Vault Resource ID retrieved from the Key Vault Base URL %q", certificateId.KeyVaultBaseUrl)
+		}
 	}
 
 	keyVaultId, err := commonids.ParseKeyVaultID(*keyVaultBaseId)

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -128,6 +128,8 @@ A `secret` block supports the following:
 
 A `customer_certificate` block supports the following:
 
+* `key_vault_id` - (Optional) The ID of the Key Vault. Must be specified if the Key Vault of `key_vault_certificate_id` is in a different Subscription from the Front Door. Changing this forces a new resource to be created.
+
 * `key_vault_certificate_id` - (Required) The ID of the Key Vault certificate resource to use. Changing this forces a new Front Door Secret to be created.
 
 -> **Note:** If you would like to use the **latest version** of the Key Vault Certificate use the Key Vault Certificates `versionless_id` attribute as the `key_vault_certificate_id` fields value(e.g. `key_vault_certificate_id = azurerm_key_vault_certificate.example.versionless_id`).


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This change will allow to use certificates from Key Vault in different subscription than FrontDoor.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_cdn_frontdoor_secret`: add `key_vault_id` property to allow referring Key Vault in a different subscription [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
