### PR TITLE
fix: escape unescaped dot in githubHandleRegex

### DIFF
--- a/internal/tools/preview-api-version-linter/version/parse_exceptions.go
+++ b/internal/tools/preview-api-version-linter/version/parse_exceptions.go
@@ -127,7 +127,7 @@ func validRFC3339DateOnly(s string) bool {
 	return err == nil
 }
 
-var githubHandleRegex = regexp.MustCompile(`(?i)^github.com/[a-z0-9-_]+$`)
+var githubHandleRegex = regexp.MustCompile(`(?i)^github\.com/[a-z0-9-_]+$`)
 
 func validResponsibleIndividual(s string) bool {
 	_, err := mail.ParseAddress(s)


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review
## Description
The `githubHandleRegex` in [parse_exceptions.go](cci:7://file:///Users/kt/hashi/tf/azure/azurerm-burns/internal/tools/preview-api-version-linter/version/parse_exceptions.go:0:0-0:0) had an unescaped dot before `com`, meaning the regex `github.com` could match unintended hosts like `githubXcom` (where `.` matches any character in regex). This fix escapes the dot as `github\.com` to ensure only literal `github.com` is matched.
Flagged by CodeQL static analysis.
## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
## Change Log
* `internal/tools` - Fixed unescaped dot in GitHub handle regex validation
This is a (please select all that apply):
- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change
## Related Issue(s)
N/A - Identified by CodeQL
## AI Assistance Disclosure
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs
Code generation for the regex fix.
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.
## Changes to Security Controls
No changes to security controls.