### PR TITLE
`data.azurerm_logic_app_standard` - clean up schema and 5.0 upgrade guide

### DIFF
--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -6,7 +6,6 @@ package logic
 import (
 	"fmt"
 	"log"
-	"math"
 	"strings"
 	"time"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
@@ -521,117 +519,73 @@ func schemaLogicAppStandardSiteConfigDataSource() *pluginsdk.Schema {
 
 				"linux_fx_version": {
 					Type:     pluginsdk.TypeString,
-					Optional: true,
 					Computed: true,
 				},
 
 				"min_tls_version": {
 					Type:     pluginsdk.TypeString,
-					Optional: true,
 					Computed: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(webapps.SupportedTlsVersionsOnePointTwo),
-					}, false),
 				},
 
 				"pre_warmed_instance_count": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 20),
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
 				},
 
 				"scm_ip_restriction": schemaLogicAppStandardIpRestrictionDataSource(),
 
 				"scm_use_main_ip_restriction": {
 					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Default:  false,
+					Computed: true,
 				},
 
 				"scm_min_tls_version": {
 					Type:     pluginsdk.TypeString,
-					Optional: true,
 					Computed: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(webapps.SupportedTlsVersionsOnePointTwo),
-					}, false),
 				},
 
 				"scm_type": {
 					Type:     pluginsdk.TypeString,
-					Optional: true,
 					Computed: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						string(webapps.ScmTypeBitbucketGit),
-						string(webapps.ScmTypeBitbucketHg),
-						string(webapps.ScmTypeCodePlexGit),
-						string(webapps.ScmTypeCodePlexHg),
-						string(webapps.ScmTypeDropbox),
-						string(webapps.ScmTypeExternalGit),
-						string(webapps.ScmTypeExternalHg),
-						string(webapps.ScmTypeGitHub),
-						string(webapps.ScmTypeLocalGit),
-						string(webapps.ScmTypeNone),
-						string(webapps.ScmTypeOneDrive),
-						string(webapps.ScmTypeTfs),
-						string(webapps.ScmTypeVSO),
-						string(webapps.ScmTypeVSTSRM),
-					}, false),
 				},
 
 				"use_32_bit_worker_process": {
 					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Default:  true,
+					Computed: true,
 				},
 
 				"websockets_enabled": {
 					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Default:  false,
+					Computed: true,
 				},
 
 				"health_check_path": {
 					Type:     pluginsdk.TypeString,
-					Optional: true,
+					Computed: true,
 				},
 
 				"elastic_instance_minimum": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 20),
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
 				},
 
 				"app_scale_limit": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.IntAtLeast(0),
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
 				},
 
 				"runtime_scale_monitoring_enabled": {
 					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Default:  false,
+					Computed: true,
 				},
 
 				"dotnet_framework_version": {
 					Type:     pluginsdk.TypeString,
-					Optional: true,
-					Default:  "v4.0",
-					ValidateFunc: validation.StringInSlice([]string{
-						"v4.0",
-						"v5.0",
-						"v6.0",
-						"v8.0",
-					}, false),
+					Computed: true,
 				},
 
 				"vnet_route_all_enabled": {
 					Type:     pluginsdk.TypeBool,
-					Optional: true,
 					Computed: true,
 				},
 
@@ -646,29 +600,16 @@ func schemaLogicAppStandardSiteConfigDataSource() *pluginsdk.Schema {
 	if !features.FivePointOh() {
 		schema.Elem.(*pluginsdk.Resource).Schema["public_network_access_enabled"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
-			Optional:   true,
 			Computed:   true,
 			Deprecated: "the `site_config.public_network_access_enabled` property has been superseded by the `public_network_access` property and will be removed in v5.0 of the AzureRM Provider.",
 		}
 		schema.Elem.(*pluginsdk.Resource).Schema["scm_min_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
-			Optional: true,
 			Computed: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(webapps.SupportedTlsVersionsOnePointZero),
-				string(webapps.SupportedTlsVersionsOnePointOne),
-				string(webapps.SupportedTlsVersionsOnePointTwo),
-			}, false),
 		}
 		schema.Elem.(*pluginsdk.Resource).Schema["min_tls_version"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeString,
-			Optional: true,
 			Computed: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(webapps.SupportedTlsVersionsOnePointZero),
-				string(webapps.SupportedTlsVersionsOnePointOne),
-				string(webapps.SupportedTlsVersionsOnePointTwo),
-			}, false),
 		}
 	}
 
@@ -717,43 +658,30 @@ func schemaLogicAppStandardIpRestrictionDataSource() *pluginsdk.Schema {
 				},
 
 				"name": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					Computed:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
+					Type:     pluginsdk.TypeString,
+					Computed: true,
 				},
 
 				"priority": {
-					Type:         pluginsdk.TypeInt,
-					Optional:     true,
-					Default:      65000,
-					ValidateFunc: validation.IntBetween(1, math.MaxInt32),
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
 				},
 
 				"action": {
 					Type:     pluginsdk.TypeString,
-					Default:  "Allow",
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"Allow",
-						"Deny",
-					}, false),
+					Computed: true,
 				},
 
 				// lintignore:XS003
 				"headers": {
-					Type:       pluginsdk.TypeList,
-					Optional:   true,
-					Computed:   true,
-					MaxItems:   1,
-					ConfigMode: pluginsdk.SchemaConfigModeAttr,
+					Type:     pluginsdk.TypeList,
+					Computed: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							// lintignore:S018
 							"x_forwarded_host": {
 								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 8,
+								Computed: true,
 								Elem: &pluginsdk.Schema{
 									Type: pluginsdk.TypeString,
 								},
@@ -762,35 +690,27 @@ func schemaLogicAppStandardIpRestrictionDataSource() *pluginsdk.Schema {
 							// lintignore:S018
 							"x_forwarded_for": {
 								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 8,
+								Computed: true,
 								Elem: &pluginsdk.Schema{
-									Type:         pluginsdk.TypeString,
-									ValidateFunc: validation.IsCIDR,
+									Type: pluginsdk.TypeString,
 								},
 							},
 
 							// lintignore:S018
 							"x_azure_fdid": {
 								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 8,
+								Computed: true,
 								Elem: &pluginsdk.Schema{
-									Type:         pluginsdk.TypeString,
-									ValidateFunc: validation.IsUUID,
+									Type: pluginsdk.TypeString,
 								},
 							},
 
 							// lintignore:S018
 							"x_fd_health_probe": {
 								Type:     pluginsdk.TypeSet,
-								Optional: true,
-								MaxItems: 1,
+								Computed: true,
 								Elem: &pluginsdk.Schema{
 									Type: pluginsdk.TypeString,
-									ValidateFunc: validation.StringInSlice([]string{
-										"1",
-									}, false),
 								},
 							},
 						},

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -149,11 +149,6 @@ This deprecated data source has been superseded/retired and has been removed fro
 
 * This deprecated data source has been retired and has been removed from the Azure Provider.
 
-### `azurerm_logic_app_standard`
-
-* The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.
-* The `client_certificate_mode` property now defaults to `Required` to match API default value.
-
 ### `azurerm_postgresql_server`
 
 * This deprecated data source has been retired and has been removed from the Azure Provider.
@@ -351,6 +346,7 @@ Please follow the format in the example below for listing breaking changes in re
 ### `azurerm_logic_app_standard`
 
 * The deprecated `site_config.public_network_access_enabled` property has been removed and superseded by the `public_network_access` property.
+* The `client_certificate_mode` property now defaults to `Required` to match API default value.
 * The `site_config.min_tls_version` property no longer accepts `1.0` or `1.1` as a value.
 * The `site_config.scm_min_tls_version` property no longer accepts `1.0` or `1.1` as a value.
 
@@ -537,6 +533,10 @@ Please follow the format in the example below for listing breaking changes in da
 * The deprecated `source_arm_resource_id` property has been removed in favour of the `source_resource_id` property.
 * The deprecated `metric_arm_resource_id` property has been removed in favour of the `metric_resource_id` property.
 
+### `azurerm_key_vault`
+
+* The deprecated `enable_rbac_authorization` property has been removed in favour of the `rbac_authorization_enabled` property.
+
 ### `azurerm_lb_outbound_rule`
 
 * The deprecated `enable_tcp_reset` property has been removed in favour of the `tcp_reset_enabled` property.
@@ -545,10 +545,6 @@ Please follow the format in the example below for listing breaking changes in da
 
 * The deprecated `enable_floating_ip` property has been removed in favour of the `floating_ip_enabled` property.
 * The deprecated `enable_tcp_reset` property has been removed in favour of the `tcp_reset_enabled` property.
-
-### `azurerm_key_vault`
-
-* The deprecated `enable_rbac_authorization` property has been removed in favour of the `rbac_authorization_enabled` property.
 
 ### `azurerm_logic_app_standard`
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Came across an entry in the 5.0 upgrade guide that was under the incorrect header. While fixing that, noticed the data source schema for `azurerm_logic_app_standard` contained many optional fields with validation/defaults/etc, changed to computed only fields. (related to https://github.com/hashicorp/terraform-provider-azurerm/pull/30272/files#r2244001446)

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="416" height="37" alt="image" src="https://github.com/user-attachments/assets/ab5a9edd-83fd-42fd-ac74-71c3ef1f0103" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
