### PR TITLE
Resource Identity - wrap tests to enable external provider support

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/types"
@@ -40,6 +42,23 @@ func (td TestData) DataSourceTestInSequence(t *testing.T, steps []TestStep) {
 	}
 
 	td.runAcceptanceSequentialTest(t, testCase)
+}
+
+func (td TestData) ResourceIdentityTest(t *testing.T, steps []TestStep, sequential bool) {
+	testCase := resource.TestCase{
+		PreCheck: func() { PreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0"))),
+		},
+		Steps: steps,
+	}
+
+	if sequential {
+		td.runAcceptanceSequentialTest(t, testCase)
+		return
+	}
+
+	td.runAcceptanceTest(t, testCase)
 }
 
 func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, steps []TestStep) {

--- a/internal/services/analysisservices/analysis_services_server_resource_identity_gen_test.go
+++ b/internal/services/analysisservices/analysis_services_server_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package analysisservices_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccAnalysisServicesServer_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_analysis_services_server", "test")
 	r := AnalysisServicesServerResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_analysis_services_server.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_analysis_services_server.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_analysis_services_server.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_analysis_services_server.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_analysis_services_server.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_analysis_services_server.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/applicationinsights/application_insights_resource_identity_gen_test.go
+++ b/internal/services/applicationinsights/application_insights_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package applicationinsights_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationInsights_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights", "test")
 	r := ApplicationInsightsResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basicForResourceIdentity(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_insights.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicForResourceIdentity(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_insights.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/applicationinsights/application_insights_standard_web_test_resource_identity_gen_test.go
+++ b/internal/services/applicationinsights/application_insights_standard_web_test_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package applicationinsights_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationInsightsStandardWebTest_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
 	r := ApplicationInsightsStandardWebTestResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basicConfig(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_insights_standard_web_test.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_standard_web_test.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_standard_web_test.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicConfig(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_insights_standard_web_test.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_standard_web_test.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_standard_web_test.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/applicationinsights/application_insights_web_test_resource_identity_gen_test.go
+++ b/internal/services/applicationinsights/application_insights_web_test_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package applicationinsights_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationInsightsWebTest_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_web_test", "test")
 	r := ApplicationInsightsWebTestResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_insights_web_test.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_web_test.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_web_test.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_insights_web_test.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_web_test.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_web_test.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/applicationinsights/application_insights_workbook_resource_identity_gen_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package applicationinsights_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationInsightsWorkbook_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook", "test")
 	r := ApplicationInsightsWorkbookResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basicForResourceIdentity(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_insights_workbook.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicForResourceIdentity(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_insights_workbook.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/applicationinsights/application_insights_workbook_template_resource_identity_gen_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_template_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package applicationinsights_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationInsightsWorkbookTemplate_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook_template", "test")
 	r := ApplicationInsightsWorkbookTemplateResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_insights_workbook_template.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook_template.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook_template.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_insights_workbook_template.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook_template.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_insights_workbook_template.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/appservice/linux_function_app_resource_identity_gen_test.go
+++ b/internal/services/appservice/linux_function_app_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package appservice_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccLinuxFunctionApp_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
 	r := LinuxFunctionAppResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data, "B1"),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_linux_function_app.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, "B1"),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_linux_function_app.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_linux_function_app.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/arckubernetes/arc_kubernetes_provisioned_cluster_resource_identity_gen_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_provisioned_cluster_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package arckubernetes_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccArcKubernetesProvisionedCluster_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_arc_kubernetes_provisioned_cluster", "test")
 	r := ArcKubernetesProvisionedClusterResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_arc_kubernetes_provisioned_cluster.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_arc_kubernetes_provisioned_cluster.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_arc_kubernetes_provisioned_cluster.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_arc_kubernetes_provisioned_cluster.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_arc_kubernetes_provisioned_cluster.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_arc_kubernetes_provisioned_cluster.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/attestation/attestation_provider_resource_identity_gen_test.go
+++ b/internal/services/attestation/attestation_provider_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package attestation_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccAttestationProvider_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_attestation_provider", "test")
 	r := AttestationProviderResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basicForResourceIdentity(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_attestation_provider.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_attestation_provider.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_attestation_provider.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicForResourceIdentity(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_attestation_provider.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_attestation_provider.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_attestation_provider.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/automanage/automanage_configuration_resource_identity_gen_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package automanage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccAutomanageConfiguration_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
 	r := AutomanageConfigurationResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_automanage_configuration.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_automanage_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_automanage_configuration.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_automanage_configuration.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_automanage_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_automanage_configuration.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/batch/batch_account_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_account_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package batch_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccBatchAccount_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
 	r := BatchAccountResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_batch_account.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_account.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_account.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_batch_account.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_account.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_account.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/batch/batch_application_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_application_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package batch_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccBatchApplication_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_application", "test")
 	r := BatchApplicationResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basicForResourceIdentity(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_batch_application.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basicForResourceIdentity(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_batch_application.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_application.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/batch/batch_pool_resource_identity_gen_test.go
+++ b/internal/services/batch/batch_pool_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package batch_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccBatchPool_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
 	r := BatchPoolResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_batch_pool.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_batch_pool.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("batch_account_name"), tfjsonpath.New("account_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_batch_pool.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/communication/communication_service_resource_identity_gen_test.go
+++ b/internal/services/communication/communication_service_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package communication_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccCommunicationService_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_communication_service", "test")
 	r := CommunicationServiceResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_communication_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_communication_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_communication_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_communication_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_communication_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_communication_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/communication/email_communication_service_domain_resource_identity_gen_test.go
+++ b/internal/services/communication/email_communication_service_domain_resource_identity_gen_test.go
@@ -4,41 +4,30 @@
 package communication_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccEmailCommunicationServiceDomain_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain", "test")
 	r := EmailCommunicationServiceDomainResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_email_communication_service_domain.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("email_service_name"), tfjsonpath.New("email_service_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("email_service_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_email_communication_service_domain.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("email_service_name"), tfjsonpath.New("email_service_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("email_service_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/communication/email_communication_service_domain_sender_username_resource_identity_gen_test.go
+++ b/internal/services/communication/email_communication_service_domain_sender_username_resource_identity_gen_test.go
@@ -4,42 +4,31 @@
 package communication_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccEmailCommunicationServiceDomainSenderUsername_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service_domain_sender_username", "test")
 	r := EmailCommunicationServiceDomainSenderUsernameResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("domain_name"), tfjsonpath.New("email_service_domain_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("email_service_name"), tfjsonpath.New("email_service_domain_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("email_service_domain_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("domain_name"), tfjsonpath.New("email_service_domain_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("email_service_name"), tfjsonpath.New("email_service_domain_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_email_communication_service_domain_sender_username.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("email_service_domain_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/communication/email_communication_service_resource_identity_gen_test.go
+++ b/internal/services/communication/email_communication_service_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package communication_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccEmailCommunicationService_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_email_communication_service", "test")
 	r := EmailCommunicationServiceResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_email_communication_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_email_communication_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_email_communication_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/availability_set_resource_identity_gen_test.go
+++ b/internal/services/compute/availability_set_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccAvailabilitySet_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_availability_set", "test")
 	r := AvailabilitySetResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_availability_set.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_availability_set.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_availability_set.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/capacity_reservation_group_resource_identity_gen_test.go
+++ b/internal/services/compute/capacity_reservation_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccCapacityReservationGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation_group", "test")
 	r := CapacityReservationGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_capacity_reservation_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_capacity_reservation_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/capacity_reservation_resource_identity_gen_test.go
+++ b/internal/services/compute/capacity_reservation_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccCapacityReservation_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_capacity_reservation", "test")
 	r := CapacityReservationResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("capacity_reservation_group_name"), tfjsonpath.New("capacity_reservation_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("capacity_reservation_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("capacity_reservation_group_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("capacity_reservation_group_name"), tfjsonpath.New("capacity_reservation_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("capacity_reservation_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_capacity_reservation.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("capacity_reservation_group_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/dedicated_host_group_resource_identity_gen_test.go
+++ b/internal/services/compute/dedicated_host_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccDedicatedHostGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dedicated_host_group", "test")
 	r := DedicatedHostGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_dedicated_host_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_dedicated_host_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/dedicated_host_resource_identity_gen_test.go
+++ b/internal/services/compute/dedicated_host_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccDedicatedHost_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
 	r := DedicatedHostResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("host_group_name"), tfjsonpath.New("dedicated_host_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("dedicated_host_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("dedicated_host_group_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_dedicated_host.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("host_group_name"), tfjsonpath.New("dedicated_host_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("dedicated_host_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_dedicated_host.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("dedicated_host_group_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/gallery_application_resource_identity_gen_test.go
+++ b/internal/services/compute/gallery_application_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccGalleryApplication_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_gallery_application", "test")
 	r := GalleryApplicationResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("gallery_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("gallery_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/gallery_application_version_resource_identity_gen_test.go
+++ b/internal/services/compute/gallery_application_version_resource_identity_gen_test.go
@@ -4,41 +4,30 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccGalleryApplicationVersion_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_gallery_application_version", "test")
 	r := GalleryApplicationVersionResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("application_name"), tfjsonpath.New("gallery_application_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_application_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_application_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("gallery_application_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("application_name"), tfjsonpath.New("gallery_application_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_application_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("gallery_application_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_gallery_application_version.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("gallery_application_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/managed_disk_resource_identity_gen_test.go
+++ b/internal/services/compute/managed_disk_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccManagedDisk_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_managed_disk", "test")
 	r := ManagedDiskResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.empty(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_managed_disk.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_managed_disk.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_managed_disk.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.empty(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_managed_disk.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_managed_disk.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_managed_disk.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/proximity_placement_group_resource_identity_gen_test.go
+++ b/internal/services/compute/proximity_placement_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccProximityPlacementGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_proximity_placement_group", "test")
 	r := ProximityPlacementGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_proximity_placement_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_proximity_placement_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_proximity_placement_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/shared_image_gallery_resource_identity_gen_test.go
+++ b/internal/services/compute/shared_image_gallery_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccSharedImageGallery_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image_gallery", "test")
 	r := SharedImageGalleryResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_shared_image_gallery.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_shared_image_gallery.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image_gallery.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/shared_image_resource_identity_gen_test.go
+++ b/internal/services/compute/shared_image_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccSharedImage_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
 	r := SharedImageResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_shared_image.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_shared_image.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("gallery_name"), tfjsonpath.New("gallery_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_shared_image.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/compute/virtual_machine_extension_resource_identity_gen_test.go
+++ b/internal/services/compute/virtual_machine_extension_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package compute_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualMachineExtension_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_extension", "test")
 	r := VirtualMachineExtensionResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_machine_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_machine_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("virtual_machine_name"), tfjsonpath.New("virtual_machine_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_machine_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_machine_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_machine_extension.test", tfjsonpath.New("virtual_machine_name"), tfjsonpath.New("virtual_machine_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/firewall/firewall_policy_resource_identity_gen_test.go
+++ b/internal/services/firewall/firewall_policy_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package firewall_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccFirewallPolicy_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_firewall_policy", "test")
 	r := FirewallPolicyResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_firewall_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_firewall_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/firewall/firewall_resource_identity_gen_test.go
+++ b/internal/services/firewall/firewall_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package firewall_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccFirewall_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
 	r := FirewallResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_firewall.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_firewall.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_firewall.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/monitor/monitor_action_group_resource_identity_gen_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package monitor_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccMonitorActionGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")
 	r := MonitorActionGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_monitor_action_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_action_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_action_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_monitor_action_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_action_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_action_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_identity_gen_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package monitor_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccMonitorScheduledQueryRulesAlert_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_scheduled_query_rules_alert", "test")
 	r := MonitorScheduledQueryRulesAlertResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.AlertingActionConfigComplete(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.AlertingActionConfigComplete(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_monitor_scheduled_query_rules_alert.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/mssql/mssql_server_data_source_test.go
+++ b/internal/services/mssql/mssql_server_data_source_test.go
@@ -54,7 +54,7 @@ data "azurerm_mssql_server" "test" {
   name                = azurerm_mssql_server.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, MsSqlServerResource{}.basic(data))
+`, MssqlServerResource{}.basic(data))
 }
 
 func (MsSqlServerDataSource) complete(data acceptance.TestData) string {
@@ -65,5 +65,5 @@ data "azurerm_mssql_server" "test" {
   name                = azurerm_mssql_server.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, MsSqlServerResource{}.complete(data))
+`, MssqlServerResource{}.complete(data))
 }

--- a/internal/services/mssql/mssql_server_resource_identity_gen_test.go
+++ b/internal/services/mssql/mssql_server_resource_identity_gen_test.go
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package mssql_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+func TestAccMssqlServer_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MssqlServerResource{}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_mssql_server.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_mssql_server.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_mssql_server.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(true),
+		data.ImportBlockWithIDStep(true),
+	}, false)
+}

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type MsSqlServerResource struct{}
+type MssqlServerResource struct{}
 
 func TestAccMsSqlServer_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -43,7 +43,7 @@ func TestAccMsSqlServer_basic(t *testing.T) {
 
 func TestAccMsSqlServer_basicWithUnknownValue(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -58,7 +58,7 @@ func TestAccMsSqlServer_basicWithUnknownValue(t *testing.T) {
 
 func TestAccMsSqlServer_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -76,7 +76,7 @@ func TestAccMsSqlServer_minimumTLSVersionDisabled(t *testing.T) {
 		t.Skipf("The service require minimum TLS version to be 1.2+, skip the `disabled` testing.")
 	}
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -91,7 +91,7 @@ func TestAccMsSqlServer_minimumTLSVersionDisabled(t *testing.T) {
 
 func TestAccMsSqlServer_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -106,7 +106,7 @@ func TestAccMsSqlServer_requiresImport(t *testing.T) {
 
 func TestAccMsSqlServer_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -142,7 +142,7 @@ func TestAccMsSqlServer_update(t *testing.T) {
 
 func TestAccMsSqlServer_systemAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -157,7 +157,7 @@ func TestAccMsSqlServer_systemAssignedIdentity(t *testing.T) {
 
 func TestAccMsSqlServer_userAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -172,7 +172,7 @@ func TestAccMsSqlServer_userAssignedIdentity(t *testing.T) {
 
 func TestAccMsSqlServer_systemAndUserAssignedIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -187,7 +187,7 @@ func TestAccMsSqlServer_systemAndUserAssignedIdentity(t *testing.T) {
 
 func TestAccMsSqlServer_azureadAdmin(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -202,7 +202,7 @@ func TestAccMsSqlServer_azureadAdmin(t *testing.T) {
 
 func TestAccMsSqlServer_azureadAdminUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -238,7 +238,7 @@ func TestAccMsSqlServer_azureadAdminUpdate(t *testing.T) {
 
 func TestAccMsSqlServer_azureadAdminWithAADAuthOnly(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -253,7 +253,7 @@ func TestAccMsSqlServer_azureadAdminWithAADAuthOnly(t *testing.T) {
 
 func TestAccMsSqlServer_azureadAuthenticationOnlyWithIdentityUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -282,7 +282,7 @@ func TestAccMsSqlServer_azureadAuthenticationOnlyWithIdentityUpdate(t *testing.T
 
 func TestAccMsSqlServer_TDECMKServerDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -297,7 +297,7 @@ func TestAccMsSqlServer_TDECMKServerDeployment(t *testing.T) {
 
 func TestAccMsSqlServer_CMKServerTagsUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -326,7 +326,7 @@ func TestAccMsSqlServer_CMKServerTagsUpdate(t *testing.T) {
 
 func TestAccMsSqlServer_writeOnlyAdminLoginPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -356,7 +356,7 @@ func TestAccMsSqlServer_writeOnlyAdminLoginPassword(t *testing.T) {
 
 func TestAccMsSqlServer_updateToWriteOnlyPassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
-	r := MsSqlServerResource{}
+	r := MssqlServerResource{}
 
 	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -389,7 +389,7 @@ func TestAccMsSqlServer_updateToWriteOnlyPassword(t *testing.T) {
 	})
 }
 
-func (MsSqlServerResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (MssqlServerResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ServerID(state.ID)
 	if err != nil {
 		return nil, err
@@ -408,7 +408,7 @@ func (MsSqlServerResource) Exists(ctx context.Context, client *clients.Client, s
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r MsSqlServerResource) basic(data acceptance.TestData) string {
+func (r MssqlServerResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -425,7 +425,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) basicWithUnknownValue(data acceptance.TestData) string {
+func (r MssqlServerResource) basicWithUnknownValue(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -442,7 +442,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) basicWithMinimumTLSVersionDisabled(data acceptance.TestData) string {
+func (r MssqlServerResource) basicWithMinimumTLSVersionDisabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -462,7 +462,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) basicWithMinimumTLSVersion(data acceptance.TestData) string {
+func (r MssqlServerResource) basicWithMinimumTLSVersion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -482,7 +482,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) requiresImport(data acceptance.TestData) string {
+func (r MssqlServerResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -497,7 +497,7 @@ resource "azurerm_mssql_server" "import" {
 `, r.basic(data))
 }
 
-func (r MsSqlServerResource) complete(data acceptance.TestData) string {
+func (r MssqlServerResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -586,7 +586,7 @@ resource "azurerm_private_endpoint" "test" {
 `, r.template(data), data.RandomInteger, data.RandomIntOfLength(15))
 }
 
-func (r MsSqlServerResource) completeUpdate(data acceptance.TestData) string {
+func (r MssqlServerResource) completeUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -673,7 +673,7 @@ resource "azurerm_private_endpoint" "test" {
 `, r.template(data), data.RandomInteger, data.RandomIntOfLength(15))
 }
 
-func (r MsSqlServerResource) systemAssignedIdentity(data acceptance.TestData) string {
+func (r MssqlServerResource) systemAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -692,7 +692,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) userAssignedIdentity(data acceptance.TestData) string {
+func (r MssqlServerResource) userAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -725,7 +725,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) systemAndUserAssignedIdentity(data acceptance.TestData) string {
+func (r MssqlServerResource) systemAndUserAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -753,7 +753,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) aadAdmin(data acceptance.TestData) string {
+func (r MssqlServerResource) aadAdmin(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -777,7 +777,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) aadAdminWithAADAuthOnly(data acceptance.TestData) string {
+func (r MssqlServerResource) aadAdminWithAADAuthOnly(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -800,7 +800,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r MsSqlServerResource) updateAzureadAuthenticationOnlyWithIdentity(data acceptance.TestData, enableAzureadAuthenticationOnly bool) string {
+func (r MssqlServerResource) updateAzureadAuthenticationOnlyWithIdentity(data acceptance.TestData, enableAzureadAuthenticationOnly bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -839,7 +839,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), data.RandomInteger, enableAzureadAuthenticationOnly)
 }
 
-func (r MsSqlServerResource) tdeCMKServerDeployment(data acceptance.TestData) string {
+func (r MssqlServerResource) tdeCMKServerDeployment(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -913,7 +913,7 @@ resource "azurerm_key_vault_key" "test" {
 `, r.template(data), data.RandomInteger, data.RandomString)
 }
 
-func (r MsSqlServerResource) CMKServerTags(data acceptance.TestData, tag string) string {
+func (r MssqlServerResource) CMKServerTags(data acceptance.TestData, tag string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -991,7 +991,7 @@ resource "azurerm_key_vault_key" "test" {
 `, r.template(data), data.RandomInteger, data.RandomString, tag)
 }
 
-func (r MsSqlServerResource) CMKServerNoTags(data acceptance.TestData) string {
+func (r MssqlServerResource) CMKServerNoTags(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1065,7 +1065,7 @@ resource "azurerm_key_vault_key" "test" {
 `, r.template(data), data.RandomInteger, data.RandomString)
 }
 
-func (r MsSqlServerResource) writeOnlyAdminLoginPassword(data acceptance.TestData, secret string, version int) string {
+func (r MssqlServerResource) writeOnlyAdminLoginPassword(data acceptance.TestData, secret string, version int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1085,7 +1085,7 @@ resource "azurerm_mssql_server" "test" {
 `, r.template(data), acceptance.WriteOnlyKeyVaultSecretTemplate(data, secret), data.RandomInteger, version)
 }
 
-func (MsSqlServerResource) template(data acceptance.TestData) string {
+func (MssqlServerResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/network/application_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/application_gateway_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationGateway_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
 	r := ApplicationGatewayResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/application_security_group_resource_identity_gen_test.go
+++ b/internal/services/network/application_security_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccApplicationSecurityGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_security_group", "test")
 	r := ApplicationSecurityGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_application_security_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_application_security_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_application_security_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/bastion_host_resource_identity_gen_test.go
+++ b/internal/services/network/bastion_host_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccBastionHost_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bastion_host", "test")
 	r := BastionHostResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_bastion_host.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_bastion_host.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_bastion_host.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/ip_group_resource_identity_gen_test.go
+++ b/internal/services/network/ip_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccIpGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_ip_group", "test")
 	r := IpGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_ip_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_ip_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_ip_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/local_network_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/local_network_gateway_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccLocalNetworkGateway_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_local_network_gateway", "test")
 	r := LocalNetworkGatewayResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_local_network_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_local_network_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_local_network_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/nat_gateway_resource_identity_gen_test.go
+++ b/internal/services/network/nat_gateway_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccNatGateway_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_nat_gateway", "test")
 	r := NatGatewayResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_nat_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_nat_gateway.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_nat_gateway.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/network_interface_resource_identity_gen_test.go
+++ b/internal/services/network/network_interface_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccNetworkInterface_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_interface", "test")
 	r := NetworkInterfaceResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_network_interface.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_network_interface.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_interface.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/network_profile_resource_identity_gen_test.go
+++ b/internal/services/network/network_profile_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccNetworkProfile_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_profile", "test")
 	r := NetworkProfileResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_network_profile.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_network_profile.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_profile.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/network_security_group_resource_identity_gen_test.go
+++ b/internal/services/network/network_security_group_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccNetworkSecurityGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_security_group", "test")
 	r := NetworkSecurityGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_network_security_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_network_security_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_group.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/network_security_rule_resource_identity_gen_test.go
+++ b/internal/services/network/network_security_rule_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccNetworkSecurityRule_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_security_rule", "test")
 	r := NetworkSecurityRuleResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_network_security_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("network_security_group_name"), tfjsonpath.New("network_security_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_network_security_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("network_security_group_name"), tfjsonpath.New("network_security_group_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_network_security_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/private_endpoint_resource_identity_gen_test.go
+++ b/internal/services/network/private_endpoint_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccPrivateEndpoint_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_private_endpoint", "test")
 	r := PrivateEndpointResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_private_endpoint.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_private_endpoint.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/private_link_service_resource_identity_gen_test.go
+++ b/internal/services/network/private_link_service_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccPrivateLinkService_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_private_link_service", "test")
 	r := PrivateLinkServiceResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_private_link_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_private_link_service.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_link_service.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/public_ip_prefix_resource_identity_gen_test.go
+++ b/internal/services/network/public_ip_prefix_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccPublicIpPrefix_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 	r := PublicIpPrefixResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_public_ip_prefix.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_public_ip_prefix.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_public_ip_prefix.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/route_filter_resource_identity_gen_test.go
+++ b/internal/services/network/route_filter_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRouteFilter_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_filter", "test")
 	r := RouteFilterResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_route_filter.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_route_filter.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_filter.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/route_map_resource_identity_gen_test.go
+++ b/internal/services/network/route_map_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRouteMap_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_map", "test")
 	r := RouteMapResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data, "ident"),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_map.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, "ident"),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_map.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_map.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/route_resource_identity_gen_test.go
+++ b/internal/services/network/route_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRoute_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route", "test")
 	r := RouteResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_route.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("route_table_name"), tfjsonpath.New("route_table_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_route.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route.test", tfjsonpath.New("route_table_name"), tfjsonpath.New("route_table_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/route_server_bgp_connection_resource_identity_gen_test.go
+++ b/internal/services/network/route_server_bgp_connection_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRouteServerBgpConnection_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_server_bgp_connection", "test")
 	r := RouteServerBgpConnectionResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("route_server_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("route_server_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("route_server_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("route_server_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("route_server_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_route_server_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("route_server_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/route_server_resource_identity_gen_test.go
+++ b/internal/services/network/route_server_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRouteServer_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_server", "test")
 	r := RouteServerResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_route_server.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_route_server.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_server.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/route_table_resource_identity_gen_test.go
+++ b/internal/services/network/route_table_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRouteTable_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_route_table", "test")
 	r := RouteTableResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_route_table.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_route_table.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/subnet_resource_identity_gen_test.go
+++ b/internal/services/network/subnet_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccSubnet_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_subnet.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("virtual_network_name"), tfjsonpath.New("virtual_network_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_subnet.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet.test", tfjsonpath.New("virtual_network_name"), tfjsonpath.New("virtual_network_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/subnet_service_endpoint_storage_policy_resource_identity_gen_test.go
+++ b/internal/services/network/subnet_service_endpoint_storage_policy_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccSubnetServiceEndpointStoragePolicy_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet_service_endpoint_storage_policy", "test")
 	r := SubnetServiceEndpointStoragePolicyResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_subnet_service_endpoint_storage_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_hub_bgp_connection_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_bgp_connection_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualHubBgpConnection_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_bgp_connection", "test")
 	r := VirtualHubBgpConnectionResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("hub_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_bgp_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_hub_connection_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualHubConnection_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_connection", "test")
 	r := VirtualHubConnectionResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_connection.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_hub_ip_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_ip_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualHubIp_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_ip", "test")
 	r := VirtualHubIpResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_ip.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_hub_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualHub_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub", "test")
 	r := VirtualHubResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_virtual_hub.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_virtual_hub.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_hub_route_table_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_route_table_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualHubRouteTable_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_route_table", "test")
 	r := VirtualHubRouteTableResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_route_table.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_hub_routing_intent_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_hub_routing_intent_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualHubRoutingIntent_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_routing_intent", "test")
 	r := VirtualHubRoutingIntentResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("virtual_hub_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_virtual_hub_routing_intent.test", tfjsonpath.New("virtual_hub_name"), tfjsonpath.New("virtual_hub_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/network/virtual_network_resource_identity_gen_test.go
+++ b/internal/services/network/virtual_network_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package network_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccVirtualNetwork_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 	r := VirtualNetworkResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_virtual_network.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_virtual_network.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_virtual_network.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_identity_gen_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package postgres_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccPostgresqlFlexibleServerFirewallRule_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_firewall_rule", "test")
 	r := PostgresqlFlexibleServerFirewallRuleResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("flexible_server_name"), tfjsonpath.New("server_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("server_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("server_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("flexible_server_name"), tfjsonpath.New("server_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("server_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_postgresql_flexible_server_firewall_rule.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("server_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/privatedns/private_dns_zone_resource_identity_gen_test.go
+++ b/internal/services/privatedns/private_dns_zone_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package privatedns_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccPrivateDnsZone_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_private_dns_zone", "test")
 	r := PrivateDnsZoneResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_private_dns_zone.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_private_dns_zone.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_identity_gen_test.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package privatedns_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccPrivateDnsZoneVirtualNetworkLink_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_private_dns_zone_virtual_network_link", "test")
 	r := PrivateDnsZoneVirtualNetworkLinkResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("private_dns_zone_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("private_dns_zone_name"), tfjsonpath.New("private_dns_zone_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_private_dns_zone_virtual_network_link.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/redis/redis_firewall_rule_resource_identity_gen_test.go
+++ b/internal/services/redis/redis_firewall_rule_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package redis_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccRedisFirewallRule_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redis_firewall_rule", "test")
 	r := RedisFirewallRuleResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_redis_firewall_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("redis_name"), tfjsonpath.New("redis_cache_name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_redis_firewall_rule.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("redis_name"), tfjsonpath.New("redis_cache_name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_redis_firewall_rule.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/resource/resource_group_resource_identity_gen_test.go
+++ b/internal/services/resource/resource_group_resource_identity_gen_test.go
@@ -4,38 +4,27 @@
 package resource_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccResourceGroup_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_resource_group", "test")
 	r := ResourceGroupResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_resource_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_resource_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_resource_group.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_resource_group.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_account_customer_managed_key_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageAccountCustomerManagedKey_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_customer_managed_key", "test")
 	r := StorageAccountCustomerManagedKeyResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_customer_managed_key.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_account_local_user_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_local_user_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageAccountLocalUser_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_local_user", "test")
 	r := StorageAccountLocalUserResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.passwordOnly(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.passwordOnly(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_local_user.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_account_network_rules_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_network_rules_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageAccountNetworkRules_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_network_rules", "test")
 	r := StorageAccountNetworkRulesResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_network_rules.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_account_queue_properties_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_queue_properties_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageAccountQueueProperties_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_queue_properties", "test")
 	r := StorageAccountQueuePropertiesResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.corsOnly(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.corsOnly(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_queue_properties.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_account_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageAccount_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValue("azurerm_storage_account.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValue("azurerm_storage_account.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_account.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_account_static_website_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_account_static_website_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageAccountStaticWebsite_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account_static_website", "test")
 	r := StorageAccountStaticWebsiteResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.complete(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_account_static_website.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_blob_inventory_policy_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_identity_gen_test.go
@@ -4,39 +4,28 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageBlobInventoryPolicy_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_blob_inventory_policy", "test")
 	r := StorageBlobInventoryPolicyResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_blob_inventory_policy.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_encryption_scope_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_encryption_scope_resource_identity_gen_test.go
@@ -4,40 +4,29 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageEncryptionScope_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_encryption_scope", "test")
 	r := StorageEncryptionScopeResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.keyVaultKey(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.keyVaultKey(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("storage_account_name"), tfjsonpath.New("storage_account_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_encryption_scope.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_account_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/services/storage/storage_sync_cloud_endpoint_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_sync_cloud_endpoint_resource_identity_gen_test.go
@@ -4,41 +4,30 @@
 package storage_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
 func TestAccStorageSyncCloudEndpoint_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_sync_cloud_endpoint", "test")
 	r := StorageSyncCloudEndpointResource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				Config: r.basic(data),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_sync_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("storage_sync_service_name"), tfjsonpath.New("storage_sync_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_sync_group_id")),
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("sync_group_name"), tfjsonpath.New("storage_sync_group_id")),
-				},
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_sync_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("storage_sync_service_name"), tfjsonpath.New("storage_sync_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_sync_group_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_sync_cloud_endpoint.test", tfjsonpath.New("sync_group_name"), tfjsonpath.New("storage_sync_group_id")),
 			},
-			data.ImportBlockWithResourceIdentityStep(false),
-			data.ImportBlockWithIDStep(false),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
 }

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -34,6 +34,7 @@ type resourceIdentityData struct {
 	CompareValueMap        map[string]string
 	TestName               string
 	TestExpectNonEmptyPlan bool
+	TestSequential         bool
 }
 
 var _ cli.Command = &ResourceIdentityCommand{}
@@ -62,6 +63,9 @@ Optional args:
 		'test-name' specifies the test config name that will be used to test Resource Identity. Defaults to 'basic'.
 	- test-expect-non-empty [bool]
 		'test-expect-non-empty' indicates whether the test should expect (and ignore) a non-empty plan, to be used when the API does not return certain values during import.
+	- test-sequential [bool]
+		'test-sequential' generates a lowercase test function name (testAcc... instead of TestAcc...) and uses resource.Test instead of resource.ParallelTest.
+		This is used for resources that need to run in a sequential test suite.
 
 Example:
 generate-resource-identity -resource-name some_azure_resource -properties "resource_group_name,some_property" -test-params "customSku" -known-values "subscription_id:data.Subscriptions.Primary,kind:someApp;linux" -compare-values "parent_resource_name:parent_resource_id,resource_group_name:parent_resource_id"
@@ -107,6 +111,7 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	argSet.StringVar(&d.CompareValues, "compare-values", "", "(Optional) comma separated list of resource identity names that are contained within a schema property value, formatted as [attribute_name]:[attribute value]. e.g. `parent_name:parent_resource_id;resource_group_name,parent_resource_id`")
 	argSet.StringVar(&d.TestName, "test-name", "basic", "(Optional) the name of the config that will be used to test Resource Identity. Defaults to `basic`.")
 	argSet.BoolVar(&d.TestExpectNonEmptyPlan, "test-expect-non-empty", false, "(Optional) Whether to expect (and ignore) a non-empty plan, to be used when the API does not return certain values during import. Defaults to `false`.")
+	argSet.BoolVar(&d.TestSequential, "test-sequential", false, "(Optional) generates a lowercase test function name for use in sequential test suites. Defaults to `false`.")
 
 	if err := argSet.Parse(args); err != nil {
 		errors = append(errors, err)

--- a/internal/tools/generator-tests/generators/templates/identity_test.gotpl
+++ b/internal/tools/generator-tests/generators/templates/identity_test.gotpl
@@ -4,61 +4,54 @@
 package {{ToLower .ServicePackageName}}_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	{{- if (gt (.KnownValueMap | len) 0) }}
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	{{- end }}
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	{{- if (gt (.CompareValueMap | len) 0) }}
-    customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
-    {{- end }}
-	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+	{{- end }}
 )
 
 {{- $resourceName := .ResourceName }}
+{{- if .TestSequential }}
+func testAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
+{{- else }}
 func TestAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
+{{- end }}
 	data := acceptance.BuildTestData(t, "azurerm_{{ ToSnake $resourceName }}", "test")
 	r := {{ ToCamel $resourceName }}Resource{}
 
-	resource.ParallelTest(t, resource.TestCase{
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.12.0-rc2"))),
-		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
-		Steps: []resource.TestStep{
-			{
-				{{- if (gt (.TestParams | len) 0) }}
-				Config: r.{{ .TestName }}(data {{ range $v := .TestParams -}} , "{{ $v }}" {{ end }}),
-				    {{- else }}
-				Config: r.{{ .TestName }}(data),
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			{{- if (gt (.TestParams | len) 0) }}
+			Config: r.{{ .TestName }}(data {{ range $v := .TestParams -}} , "{{ $v }}" {{ end }}),
+				{{- else }}
+			Config: r.{{ .TestName }}(data),
+			{{- end }}
+			ConfigStateChecks: []statecheck.StateCheck{
+				{{- range $name, $val := .KnownValueMap }}
+					{{- if (eq $name "subscription_id") }}
+					statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test",  tfjsonpath.New("{{ $name }}"),  knownvalue.StringExact({{ $val }})),
+					{{- else }}
+					statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test",  tfjsonpath.New("{{ $name }}"),  knownvalue.StringExact("{{ $val }}")),
+					{{- end }}
 				{{- end }}
-				ConfigStateChecks: []statecheck.StateCheck{
-					{{- range $name, $val := .KnownValueMap }}
-					    {{- if (eq $name "subscription_id") }}
-					    statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test",  tfjsonpath.New("{{ $name }}"),  knownvalue.StringExact({{ $val }})),
-					    {{- else }}
-					    statecheck.ExpectIdentityValue("azurerm_{{ToSnake $resourceName }}.test",  tfjsonpath.New("{{ $name }}"),  knownvalue.StringExact("{{ $val }}")),
-					    {{- end }}
-					{{- end }}
 
-					{{- range $idName, $schemaName := .PropertyNameMap }}
-					statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_{{ ToSnake $resourceName }}.test", tfjsonpath.New("{{ $idName }}"), tfjsonpath.New("{{ $schemaName }}")),
-					{{- end }}
+				{{- range $idName, $schemaName := .PropertyNameMap }}
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_{{ ToSnake $resourceName }}.test", tfjsonpath.New("{{ $idName }}"), tfjsonpath.New("{{ $schemaName }}")),
+				{{- end }}
 
-					{{- range $idName, $schemaName := .CompareValueMap }}
-					customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_{{ ToSnake $resourceName}}.test", tfjsonpath.New("{{ $idName }}"), tfjsonpath.New("{{ $schemaName }}")),
-					{{- end }}
-				},
+				{{- range $idName, $schemaName := .CompareValueMap }}
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_{{ ToSnake $resourceName}}.test", tfjsonpath.New("{{ $idName }}"), tfjsonpath.New("{{ $schemaName }}")),
+				{{- end }}
 			},
-			data.ImportBlockWithResourceIdentityStep({{ .TestExpectNonEmptyPlan }}),
-			data.ImportBlockWithIDStep({{ .TestExpectNonEmptyPlan }}),
 		},
-	})
+		data.ImportBlockWithResourceIdentityStep({{ .TestExpectNonEmptyPlan }}),
+		data.ImportBlockWithIDStep({{ .TestExpectNonEmptyPlan }}),
+	}, {{ .TestSequential }})
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Wraps identity tests similar to regular resource tests to ensure external providers can be used
- Adds resource identity to `azurerm_mssql_server` as this requires an external provider to test (`random`)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

mssql:
<img width="444" height="186" alt="image" src="https://github.com/user-attachments/assets/6a3653d4-ce5a-4786-a2d4-58349bef8bf2" />

resource identity tests:

```
--- PASS: TestAccAnalysisServicesServer_resourceIdentity (226.79s)
--- PASS: TestAccApplicationInsightsWorkbook_resourceIdentity (193.96s)
--- PASS: TestAccApplicationInsightsWorkbookTemplate_resourceIdentity (200.23s)
--- PASS: TestAccApplicationInsights_resourceIdentity (217.02s)
--- PASS: TestAccApplicationInsightsWebTest_resourceIdentity (227.29s)
--- PASS: TestAccApplicationInsightsStandardWebTest_resourceIdentity (249.42s)
--- PASS: TestAccArcKubernetesProvisionedCluster_resourceIdentity (260.40s)
--- PASS: TestAccAttestationProvider_resourceIdentity (198.94s)
--- PASS: TestAccAutomanageConfiguration_resourceIdentity (186.74s)
--- PASS: TestAccBatchAccount_resourceIdentity (219.10s)
--- PASS: TestAccBatchApplication_resourceIdentity (290.90s)
--- PASS: TestAccBatchPool_resourceIdentity (322.83s)
--- PASS: TestAccCommunicationService_resourceIdentity (213.94s)
--- PASS: TestAccEmailCommunicationService_resourceIdentity (245.53s)
--- PASS: TestAccEmailCommunicationServiceDomain_resourceIdentity (269.37s)
--- PASS: TestAccEmailCommunicationServiceDomainSenderUsername_resourceIdentity (285.38s)
--- PASS: TestAccCapacityReservationGroup_resourceIdentity (172.43s)
--- PASS: TestAccDedicatedHostGroup_resourceIdentity (182.84s)
--- PASS: TestAccAvailabilitySet_resourceIdentity (193.36s)
--- PASS: TestAccSharedImageGallery_resourceIdentity (203.42s)
--- PASS: TestAccProximityPlacementGroup_resourceIdentity (218.70s)
--- PASS: TestAccManagedDisk_resourceIdentity (246.78s)
--- PASS: TestAccCapacityReservation_resourceIdentity (259.66s)
--- PASS: TestAccGalleryApplication_resourceIdentity (299.83s)
--- PASS: TestAccSharedImage_resourceIdentity (322.67s)
--- PASS: TestAccVirtualMachineExtension_resourceIdentity (413.58s)
--- PASS: TestAccDedicatedHost_resourceIdentity (423.31s)
--- PASS: TestAccGalleryApplicationVersion_resourceIdentity (922.08s)
--- PASS: TestAccFirewallPolicy_resourceIdentity (172.84s)
--- PASS: TestAccFirewall_resourceIdentity (1153.26s)
--- PASS: TestAccMonitorActionGroup_resourceIdentity (117.52s)
--- PASS: TestAccMonitorScheduledQueryRulesAlert_resourceIdentity (165.87s)
--- PASS: TestAccMssqlServer_resourceIdentity (264.21s)
--- PASS: TestAccNetworkSecurityGroup_resourceIdentity (143.20s)
--- PASS: TestAccRouteFilter_resourceIdentity (152.90s)
--- PASS: TestAccNatGateway_resourceIdentity (159.83s)
--- PASS: TestAccNetworkSecurityRule_resourceIdentity (165.22s)
--- PASS: TestAccApplicationSecurityGroup_resourceIdentity (166.32s)
--- PASS: TestAccLocalNetworkGateway_resourceIdentity (167.21s)
--- PASS: TestAccIpGroup_resourceIdentity (189.21s)
--- PASS: TestAccVirtualNetwork_resourceIdentity (190.99s)
--- PASS: TestAccPublicIpPrefix_resourceIdentity (191.48s)
--- PASS: TestAccNetworkInterface_resourceIdentity (193.74s)
--- PASS: TestAccPrivateLinkService_resourceIdentity (216.27s)
--- PASS: TestAccRouteTable_resourceIdentity (86.30s)
--- PASS: TestAccSubnetServiceEndpointStoragePolicy_resourceIdentity (94.55s)
--- PASS: TestAccNetworkProfile_resourceIdentity (284.32s)
--- PASS: TestAccSubnet_resourceIdentity (124.92s)
--- PASS: TestAccRoute_resourceIdentity (106.25s)
--- PASS: TestAccPrivateEndpoint_resourceIdentity (207.83s)
--- PASS: TestAccApplicationGateway_resourceIdentity (1036.34s)
--- PASS: TestAccBastionHost_resourceIdentity (1169.04s)
--- PASS: TestAccVirtualHubIp_resourceIdentity (1398.23s)
--- PASS: TestAccRouteServer_resourceIdentity (1469.47s)
--- PASS: TestAccVirtualHubBgpConnection_resourceIdentity (1740.83s)
--- PASS: TestAccRouteServerBgpConnection_resourceIdentity (1620.49s)
--- PASS: TestAccVirtualHub_resourceIdentity (2102.31s)
--- PASS: TestAccVirtualHubConnection_resourceIdentity (2393.34s)
--- PASS: TestAccVirtualHubRouteTable_resourceIdentity (2589.46s)
--- PASS: TestAccRouteMap_resourceIdentity (3031.99s)
--- PASS: TestAccVirtualHubRoutingIntent_resourceIdentity (3876.75s)
--- PASS: TestAccPostgresqlFlexibleServerFirewallRule_resourceIdentity (457.20s)
--- PASS: TestAccPrivateDnsZone_resourceIdentity (209.72s)
--- PASS: TestAccPrivateDnsZoneVirtualNetworkLink_resourceIdentity (369.14s)
--- PASS: TestAccRedisFirewallRule_resourceIdentity (1322.01s)
--- PASS: TestAccResourceGroup_resourceIdentity (103.13s)
--- PASS: TestAccStorageAccount_resourceIdentity (180.63s)
--- PASS: TestAccStorageAccountLocalUser_resourceIdentity (184.92s)
--- PASS: TestAccStorageAccountStaticWebsite_resourceIdentity (189.08s)
--- PASS: TestAccStorageAccountQueueProperties_resourceIdentity (197.60s)
--- PASS: TestAccStorageBlobInventoryPolicy_resourceIdentity (208.57s)
--- PASS: TestAccStorageAccountNetworkRules_resourceIdentity (222.43s)
--- PASS: TestAccStorageSyncCloudEndpoint_resourceIdentity (274.70s)
--- PASS: TestAccStorageAccountCustomerManagedKey_resourceIdentity (337.97s)
--- PASS: TestAccStorageEncryptionScope_resourceIdentity (357.19s)
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
