### PR TITLE
azurerm_api_management_logger: fixes TestAccApiManagementLogger_update

### DIFF
--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -191,18 +191,7 @@ func TestAccApiManagementLogger_update(t *testing.T) {
 			),
 		},
 		{
-			Config: r.basicEventHub(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("buffered").HasValue("true"),
-				check.That(data.ResourceName).Key("description").HasValue(""),
-				check.That(data.ResourceName).Key("eventhub.#").HasValue("1"),
-				check.That(data.ResourceName).Key("eventhub.0.name").Exists(),
-				check.That(data.ResourceName).Key("eventhub.0.connection_string").Exists(),
-			),
-		},
-		{
-			Config: r.complete(data, "Logger from Terraform test", "false"),
+			Config: r.applicationInsightsUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("buffered").HasValue("false"),
@@ -213,36 +202,14 @@ func TestAccApiManagementLogger_update(t *testing.T) {
 			),
 		},
 		{
-			Config: r.complete(data, "Logger from Terraform update test", "true"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("buffered").HasValue("true"),
-				check.That(data.ResourceName).Key("description").HasValue("Logger from Terraform update test"),
-				check.That(data.ResourceName).Key("eventhub.#").HasValue("0"),
-				check.That(data.ResourceName).Key("application_insights.#").HasValue("1"),
-				check.That(data.ResourceName).Key("application_insights.0.instrumentation_key").Exists(),
-			),
-		},
-		{
-			Config: r.complete(data, "Logger from Terraform test", "false"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("buffered").HasValue("false"),
-				check.That(data.ResourceName).Key("description").HasValue("Logger from Terraform test"),
-				check.That(data.ResourceName).Key("eventhub.#").HasValue("0"),
-				check.That(data.ResourceName).Key("application_insights.#").HasValue("1"),
-				check.That(data.ResourceName).Key("application_insights.0.instrumentation_key").Exists(),
-			),
-		},
-		{
-			Config: r.basicEventHub(data),
+			Config: r.basicApplicationInsights(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("buffered").HasValue("true"),
 				check.That(data.ResourceName).Key("description").HasValue(""),
-				check.That(data.ResourceName).Key("eventhub.#").HasValue("1"),
-				check.That(data.ResourceName).Key("eventhub.0.name").Exists(),
-				check.That(data.ResourceName).Key("eventhub.0.connection_string").Exists(),
+				check.That(data.ResourceName).Key("eventhub.#").HasValue("0"),
+				check.That(data.ResourceName).Key("application_insights.#").HasValue("1"),
+				check.That(data.ResourceName).Key("application_insights.0.instrumentation_key").Exists(),
 			),
 		},
 	})
@@ -577,4 +544,46 @@ resource "azurerm_api_management_logger" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, description, buffered)
+}
+
+func (ApiManagementLoggerResource) applicationInsightsUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "other"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku_name = "Consumption_0"
+}
+
+resource "azurerm_api_management_logger" "test" {
+  name                = "acctestapimnglogger-%[1]d"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  description         = "Logger from Terraform test"
+  buffered            = false
+
+  application_insights {
+    instrumentation_key = azurerm_application_insights.test.instrumentation_key
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
…e because of ForceNew attributes

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
 
TestAccApiManagementLogger_update was failing with replace action error because application_insights, eventhub are mutually exclusive  and ForceNew attributes. In application_insights resource_id is also ForceNew and to test that behaviour I changed order of testcase also.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 
Local testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
