### PR TITLE
New resource: `azurerm_container_app_environment_maintenance_configuration`

### DIFF
--- a/internal/services/containerapps/client/client.go
+++ b/internal/services/containerapps/client/client.go
@@ -18,14 +18,14 @@ import (
 )
 
 type Client struct {
-	CertificatesClient                *certificates.CertificatesClient
-	ContainerAppClient                *containerapps.ContainerAppsClient
-	ContainerAppRevisionClient        *containerappsrevisions.ContainerAppsRevisionsClient
-	DaprComponentsClient              *daprcomponents.DaprComponentsClient
-	MaintenanceConfigurationsClient   *maintenanceconfigurations.MaintenanceConfigurationsClient
-	ManagedEnvironmentClient          *managedenvironments.ManagedEnvironmentsClient
-	StorageClient                     *managedenvironmentsstorages.ManagedEnvironmentsStoragesClient
-	JobClient                         *jobs.JobsClient
+	CertificatesClient              *certificates.CertificatesClient
+	ContainerAppClient              *containerapps.ContainerAppsClient
+	ContainerAppRevisionClient      *containerappsrevisions.ContainerAppsRevisionsClient
+	DaprComponentsClient            *daprcomponents.DaprComponentsClient
+	MaintenanceConfigurationsClient *maintenanceconfigurations.MaintenanceConfigurationsClient
+	ManagedEnvironmentClient        *managedenvironments.ManagedEnvironmentsClient
+	StorageClient                   *managedenvironmentsstorages.ManagedEnvironmentsStoragesClient
+	JobClient                       *jobs.JobsClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {

--- a/internal/services/containerapps/client/client.go
+++ b/internal/services/containerapps/client/client.go
@@ -11,19 +11,21 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappsrevisions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/daprcomponents"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/jobs"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironmentsstorages"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
-	CertificatesClient         *certificates.CertificatesClient
-	ContainerAppClient         *containerapps.ContainerAppsClient
-	ContainerAppRevisionClient *containerappsrevisions.ContainerAppsRevisionsClient
-	DaprComponentsClient       *daprcomponents.DaprComponentsClient
-	ManagedEnvironmentClient   *managedenvironments.ManagedEnvironmentsClient
-	StorageClient              *managedenvironmentsstorages.ManagedEnvironmentsStoragesClient
-	JobClient                  *jobs.JobsClient
+	CertificatesClient                *certificates.CertificatesClient
+	ContainerAppClient                *containerapps.ContainerAppsClient
+	ContainerAppRevisionClient        *containerappsrevisions.ContainerAppsRevisionsClient
+	DaprComponentsClient              *daprcomponents.DaprComponentsClient
+	MaintenanceConfigurationsClient   *maintenanceconfigurations.MaintenanceConfigurationsClient
+	ManagedEnvironmentClient          *managedenvironments.ManagedEnvironmentsClient
+	StorageClient                     *managedenvironmentsstorages.ManagedEnvironmentsStoragesClient
+	JobClient                         *jobs.JobsClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -63,6 +65,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(daprComponentClient.Client, o.Authorizers.ResourceManager)
 
+	maintenanceConfigurationsClient, err := maintenanceconfigurations.NewMaintenanceConfigurationsClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Maintenance Configurations client : %+v", err)
+	}
+	o.Configure(maintenanceConfigurationsClient.Client, o.Authorizers.ResourceManager)
+
 	jobsClient, err := jobs.NewJobsClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building Jobs client : %+v", err)
@@ -70,12 +78,13 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	o.Configure(jobsClient.Client, o.Authorizers.ResourceManager)
 
 	return &Client{
-		CertificatesClient:         certificatesClient,
-		ContainerAppClient:         containerAppsClient,
-		ContainerAppRevisionClient: containerAppsRevisionsClient,
-		DaprComponentsClient:       daprComponentClient,
-		ManagedEnvironmentClient:   managedEnvironmentClient,
-		StorageClient:              managedEnvironmentStoragesClient,
-		JobClient:                  jobsClient,
+		CertificatesClient:              certificatesClient,
+		ContainerAppClient:              containerAppsClient,
+		ContainerAppRevisionClient:      containerAppsRevisionsClient,
+		DaprComponentsClient:            daprComponentClient,
+		MaintenanceConfigurationsClient: maintenanceConfigurationsClient,
+		ManagedEnvironmentClient:        managedEnvironmentClient,
+		StorageClient:                   managedEnvironmentStoragesClient,
+		JobClient:                       jobsClient,
 	}, nil
 }

--- a/internal/services/containerapps/container_app_environment_maintenance_configuration_resource.go
+++ b/internal/services/containerapps/container_app_environment_maintenance_configuration_resource.go
@@ -1,0 +1,257 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type ContainerAppEnvironmentMaintenanceConfigurationResource struct{}
+
+type ContainerAppEnvironmentMaintenanceConfigurationModel struct {
+	Name                      string           `tfschema:"name"`
+	ContainerAppEnvironmentId string           `tfschema:"container_app_environment_id"`
+	ScheduledEntries          []ScheduledEntry `tfschema:"scheduled_entry"`
+}
+
+type ScheduledEntry struct {
+	WeekDay       string `tfschema:"week_day"`
+	StartHourUtc  int64  `tfschema:"start_hour_utc"`
+	DurationHours int64  `tfschema:"duration_hours"`
+}
+
+var _ sdk.ResourceWithUpdate = ContainerAppEnvironmentMaintenanceConfigurationResource{}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) ModelObject() interface{} {
+	return &ContainerAppEnvironmentMaintenanceConfigurationModel{}
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) ResourceType() string {
+	return "azurerm_container_app_environment_maintenance_configuration"
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return maintenanceconfigurations.ValidateMaintenanceConfigurationID
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "The name for this Maintenance Configuration. The only allowed value is `default`.",
+		},
+
+		"container_app_environment_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: maintenanceconfigurations.ValidateManagedEnvironmentID,
+			Description:  "The ID of the Container App Environment to which this Maintenance Configuration belongs.",
+		},
+
+		"scheduled_entry": {
+			Type:        pluginsdk.TypeList,
+			Required:    true,
+			MinItems:    1,
+			Description: "A list of scheduled entries specifying the maintenance windows.",
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"week_day": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(maintenanceconfigurations.PossibleValuesForWeekDay(), false),
+						Description:  "The day of the week for the maintenance window. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday`, and `Wednesday`.",
+					},
+					"start_hour_utc": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(0, 23),
+						Description:  "The start hour of the maintenance window in UTC. Possible values are between `0` and `23`.",
+					},
+					"duration_hours": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntBetween(8, 24),
+						Description:  "The duration of the maintenance window in hours. Possible values are between `8` and `24`.",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.MaintenanceConfigurationsClient
+
+			var model ContainerAppEnvironmentMaintenanceConfigurationModel
+
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			containerAppEnvironmentId, err := maintenanceconfigurations.ParseManagedEnvironmentID(model.ContainerAppEnvironmentId)
+			if err != nil {
+				return err
+			}
+
+			id := maintenanceconfigurations.NewMaintenanceConfigurationID(metadata.Client.Account.SubscriptionId, containerAppEnvironmentId.ResourceGroupName, containerAppEnvironmentId.ManagedEnvironmentName, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			maintenanceConfig := maintenanceconfigurations.MaintenanceConfigurationResource{
+				Properties: &maintenanceconfigurations.ScheduledEntries{
+					ScheduledEntries: expandScheduledEntries(model.ScheduledEntries),
+				},
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, id, maintenanceConfig); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.MaintenanceConfigurationsClient
+
+			id, err := maintenanceconfigurations.ParseMaintenanceConfigurationID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			var state ContainerAppEnvironmentMaintenanceConfigurationModel
+
+			state.Name = id.MaintenanceConfigurationName
+			state.ContainerAppEnvironmentId = maintenanceconfigurations.NewManagedEnvironmentID(id.SubscriptionId, id.ResourceGroupName, id.ManagedEnvironmentName).ID()
+
+			if model := existing.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.ScheduledEntries = flattenScheduledEntries(props.ScheduledEntries)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.MaintenanceConfigurationsClient
+
+			id, err := maintenanceconfigurations.ParseMaintenanceConfigurationID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.MaintenanceConfigurationsClient
+
+			id, err := maintenanceconfigurations.ParseMaintenanceConfigurationID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model ContainerAppEnvironmentMaintenanceConfigurationModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			maintenanceConfig := maintenanceconfigurations.MaintenanceConfigurationResource{
+				Properties: &maintenanceconfigurations.ScheduledEntries{
+					ScheduledEntries: expandScheduledEntries(model.ScheduledEntries),
+				},
+			}
+
+			if _, err := client.CreateOrUpdate(ctx, *id, maintenanceConfig); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandScheduledEntries(input []ScheduledEntry) []maintenanceconfigurations.ScheduledEntry {
+	result := make([]maintenanceconfigurations.ScheduledEntry, 0)
+
+	for _, v := range input {
+		result = append(result, maintenanceconfigurations.ScheduledEntry{
+			WeekDay:       maintenanceconfigurations.WeekDay(v.WeekDay),
+			StartHourUtc:  v.StartHourUtc,
+			DurationHours: v.DurationHours,
+		})
+	}
+
+	return result
+}
+
+func flattenScheduledEntries(input []maintenanceconfigurations.ScheduledEntry) []ScheduledEntry {
+	result := make([]ScheduledEntry, 0)
+
+	for _, v := range input {
+		result = append(result, ScheduledEntry{
+			WeekDay:       string(v.WeekDay),
+			StartHourUtc:  v.StartHourUtc,
+			DurationHours: v.DurationHours,
+		})
+	}
+
+	return result
+}

--- a/internal/services/containerapps/container_app_environment_maintenance_configuration_resource.go
+++ b/internal/services/containerapps/container_app_environment_maintenance_configuration_resource.go
@@ -18,14 +18,13 @@ import (
 type ContainerAppEnvironmentMaintenanceConfigurationResource struct{}
 
 type ContainerAppEnvironmentMaintenanceConfigurationModel struct {
-	Name                      string           `tfschema:"name"`
-	ContainerAppEnvironmentId string           `tfschema:"container_app_environment_id"`
-	ScheduledEntries          []ScheduledEntry `tfschema:"scheduled_entry"`
+	ContainerAppEnvironmentId string              `tfschema:"container_app_environment_id"`
+	MaintenanceWindows        []MaintenanceWindow `tfschema:"maintenance_window"`
 }
 
-type ScheduledEntry struct {
-	WeekDay       string `tfschema:"week_day"`
-	StartHourUtc  int64  `tfschema:"start_hour_utc"`
+type MaintenanceWindow struct {
+	DayOfWeek     string `tfschema:"day_of_week"`
+	StartHourInUtc int64  `tfschema:"start_hour_in_utc"`
 	DurationHours int64  `tfschema:"duration_hours"`
 }
 
@@ -45,14 +44,6 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) IDValidationFun
 
 func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
-		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-			Description:  "The name for this Maintenance Configuration. The only allowed value is `default`.",
-		},
-
 		"container_app_environment_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -61,20 +52,21 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Arguments() map
 			Description:  "The ID of the Container App Environment to which this Maintenance Configuration belongs.",
 		},
 
-		"scheduled_entry": {
+		"maintenance_window": {
 			Type:        pluginsdk.TypeList,
 			Required:    true,
 			MinItems:    1,
-			Description: "A list of scheduled entries specifying the maintenance windows.",
+			MaxItems:    1,
+			Description: "A `maintenance_window` block as defined below.",
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"week_day": {
+					"day_of_week": {
 						Type:         pluginsdk.TypeString,
 						Required:     true,
 						ValidateFunc: validation.StringInSlice(maintenanceconfigurations.PossibleValuesForWeekDay(), false),
 						Description:  "The day of the week for the maintenance window. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday`, and `Wednesday`.",
 					},
-					"start_hour_utc": {
+					"start_hour_in_utc": {
 						Type:         pluginsdk.TypeInt,
 						Required:     true,
 						ValidateFunc: validation.IntBetween(0, 23),
@@ -105,7 +97,7 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Create() sdk.Re
 			var model ContainerAppEnvironmentMaintenanceConfigurationModel
 
 			if err := metadata.Decode(&model); err != nil {
-				return err
+				return fmt.Errorf("decoding: %+v", err)
 			}
 
 			containerAppEnvironmentId, err := maintenanceconfigurations.ParseManagedEnvironmentID(model.ContainerAppEnvironmentId)
@@ -113,7 +105,7 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Create() sdk.Re
 				return err
 			}
 
-			id := maintenanceconfigurations.NewMaintenanceConfigurationID(metadata.Client.Account.SubscriptionId, containerAppEnvironmentId.ResourceGroupName, containerAppEnvironmentId.ManagedEnvironmentName, model.Name)
+			id := maintenanceconfigurations.NewMaintenanceConfigurationID(metadata.Client.Account.SubscriptionId, containerAppEnvironmentId.ResourceGroupName, containerAppEnvironmentId.ManagedEnvironmentName, "default")
 
 			existing, err := client.Get(ctx, id)
 			if err != nil {
@@ -127,7 +119,7 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Create() sdk.Re
 
 			maintenanceConfig := maintenanceconfigurations.MaintenanceConfigurationResource{
 				Properties: &maintenanceconfigurations.ScheduledEntries{
-					ScheduledEntries: expandScheduledEntries(model.ScheduledEntries),
+					ScheduledEntries: expandMaintenanceWindow(model.MaintenanceWindows),
 				},
 			}
 
@@ -158,17 +150,16 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Read() sdk.Reso
 				if response.WasNotFound(existing.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
 			var state ContainerAppEnvironmentMaintenanceConfigurationModel
 
-			state.Name = id.MaintenanceConfigurationName
 			state.ContainerAppEnvironmentId = maintenanceconfigurations.NewManagedEnvironmentID(id.SubscriptionId, id.ResourceGroupName, id.ManagedEnvironmentName).ID()
 
 			if model := existing.Model; model != nil {
 				if props := model.Properties; props != nil {
-					state.ScheduledEntries = flattenScheduledEntries(props.ScheduledEntries)
+					state.MaintenanceWindows = flattenMaintenanceWindow(props.ScheduledEntries)
 				}
 			}
 
@@ -208,15 +199,23 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Update() sdk.Re
 				return err
 			}
 
-			var model ContainerAppEnvironmentMaintenanceConfigurationModel
-			if err := metadata.Decode(&model); err != nil {
-				return err
+			existing, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			if existing.Model == nil || existing.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: model or properties was nil", *id)
 			}
 
-			maintenanceConfig := maintenanceconfigurations.MaintenanceConfigurationResource{
-				Properties: &maintenanceconfigurations.ScheduledEntries{
-					ScheduledEntries: expandScheduledEntries(model.ScheduledEntries),
-				},
+			maintenanceConfig := *existing.Model
+
+			var model ContainerAppEnvironmentMaintenanceConfigurationModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			if metadata.ResourceData.HasChange("maintenance_window") {
+				maintenanceConfig.Properties.ScheduledEntries = expandMaintenanceWindow(model.MaintenanceWindows)
 			}
 
 			if _, err := client.CreateOrUpdate(ctx, *id, maintenanceConfig); err != nil {
@@ -228,30 +227,32 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Update() sdk.Re
 	}
 }
 
-func expandScheduledEntries(input []ScheduledEntry) []maintenanceconfigurations.ScheduledEntry {
-	result := make([]maintenanceconfigurations.ScheduledEntry, 0)
-
-	for _, v := range input {
-		result = append(result, maintenanceconfigurations.ScheduledEntry{
-			WeekDay:       maintenanceconfigurations.WeekDay(v.WeekDay),
-			StartHourUtc:  v.StartHourUtc,
-			DurationHours: v.DurationHours,
-		})
+func expandMaintenanceWindow(input []MaintenanceWindow) []maintenanceconfigurations.ScheduledEntry {
+	if len(input) == 0 {
+		return []maintenanceconfigurations.ScheduledEntry{}
 	}
 
-	return result
+	v := input[0]
+	return []maintenanceconfigurations.ScheduledEntry{
+		{
+			WeekDay:       maintenanceconfigurations.WeekDay(v.DayOfWeek),
+			StartHourUtc:  v.StartHourInUtc,
+			DurationHours: v.DurationHours,
+		},
+	}
 }
 
-func flattenScheduledEntries(input []maintenanceconfigurations.ScheduledEntry) []ScheduledEntry {
-	result := make([]ScheduledEntry, 0)
-
-	for _, v := range input {
-		result = append(result, ScheduledEntry{
-			WeekDay:       string(v.WeekDay),
-			StartHourUtc:  v.StartHourUtc,
-			DurationHours: v.DurationHours,
-		})
+func flattenMaintenanceWindow(input []maintenanceconfigurations.ScheduledEntry) []MaintenanceWindow {
+	if len(input) == 0 {
+		return []MaintenanceWindow{}
 	}
 
-	return result
+	v := input[0]
+	return []MaintenanceWindow{
+		{
+			DayOfWeek:      string(v.WeekDay),
+			StartHourInUtc: v.StartHourUtc,
+			DurationHours:  v.DurationHours,
+		},
+	}
 }

--- a/internal/services/containerapps/container_app_environment_maintenance_configuration_resource.go
+++ b/internal/services/containerapps/container_app_environment_maintenance_configuration_resource.go
@@ -23,9 +23,9 @@ type ContainerAppEnvironmentMaintenanceConfigurationModel struct {
 }
 
 type MaintenanceWindow struct {
-	DayOfWeek     string `tfschema:"day_of_week"`
+	DayOfWeek      string `tfschema:"day_of_week"`
 	StartHourInUtc int64  `tfschema:"start_hour_in_utc"`
-	DurationHours int64  `tfschema:"duration_hours"`
+	DurationHours  int64  `tfschema:"duration_hours"`
 }
 
 var _ sdk.ResourceWithUpdate = ContainerAppEnvironmentMaintenanceConfigurationResource{}
@@ -55,7 +55,6 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Arguments() map
 		"maintenance_window": {
 			Type:        pluginsdk.TypeList,
 			Required:    true,
-			MinItems:    1,
 			MaxItems:    1,
 			Description: "A `maintenance_window` block as defined below.",
 			Elem: &pluginsdk.Resource{

--- a/internal/services/containerapps/container_app_environment_maintenance_configuration_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_maintenance_configuration_resource_test.go
@@ -1,0 +1,175 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ContainerAppEnvironmentMaintenanceConfigurationResource struct{}
+
+func TestAccContainerAppEnvironmentMaintenanceConfiguration_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_maintenance_configuration", "test")
+	r := ContainerAppEnvironmentMaintenanceConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppEnvironmentMaintenanceConfiguration_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_maintenance_configuration", "test")
+	r := ContainerAppEnvironmentMaintenanceConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppEnvironmentMaintenanceConfiguration_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment_maintenance_configuration", "test")
+	r := ContainerAppEnvironmentMaintenanceConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := maintenanceconfigurations.ParseMaintenanceConfigurationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ContainerApps.MaintenanceConfigurationsClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+	if response.WasNotFound(resp.HttpResponse) {
+		return pointer.To(false), nil
+	}
+
+	return pointer.To(true), nil
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_container_app_environment_maintenance_configuration" "test" {
+  name                         = "default"
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  scheduled_entry {
+    week_day       = "Sunday"
+    start_hour_utc = 1
+    duration_hours = 8
+  }
+}
+`, r.template(data))
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_container_app_environment_maintenance_configuration" "test" {
+  name                         = "default"
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  scheduled_entry {
+    week_day       = "Saturday"
+    start_hour_utc = 2
+    duration_hours = 10
+  }
+}
+`, r.template(data))
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app_environment_maintenance_configuration" "import" {
+  name                         = azurerm_container_app_environment_maintenance_configuration.test.name
+  container_app_environment_id = azurerm_container_app_environment_maintenance_configuration.test.container_app_environment_id
+
+  scheduled_entry {
+    week_day       = "Sunday"
+    start_hour_utc = 1
+    duration_hours = 8
+  }
+}
+`, r.basic(data))
+}
+
+func (r ContainerAppEnvironmentMaintenanceConfigurationResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-CAE-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_container_app_environment" "test" {
+  name                       = "acctest-CAEnv%[1]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/containerapps/container_app_environment_maintenance_configuration_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_maintenance_configuration_resource_test.go
@@ -100,13 +100,12 @@ provider "azurerm" {
 %s
 
 resource "azurerm_container_app_environment_maintenance_configuration" "test" {
-  name                         = "default"
   container_app_environment_id = azurerm_container_app_environment.test.id
 
-  scheduled_entry {
-    week_day       = "Sunday"
-    start_hour_utc = 1
-    duration_hours = 8
+  maintenance_window {
+    day_of_week       = "Sunday"
+    start_hour_in_utc = 1
+    duration_hours    = 8
   }
 }
 `, r.template(data))
@@ -121,13 +120,12 @@ provider "azurerm" {
 %s
 
 resource "azurerm_container_app_environment_maintenance_configuration" "test" {
-  name                         = "default"
   container_app_environment_id = azurerm_container_app_environment.test.id
 
-  scheduled_entry {
-    week_day       = "Saturday"
-    start_hour_utc = 2
-    duration_hours = 10
+  maintenance_window {
+    day_of_week       = "Saturday"
+    start_hour_in_utc = 2
+    duration_hours    = 10
   }
 }
 `, r.template(data))
@@ -138,13 +136,12 @@ func (r ContainerAppEnvironmentMaintenanceConfigurationResource) requiresImport(
 %s
 
 resource "azurerm_container_app_environment_maintenance_configuration" "import" {
-  name                         = azurerm_container_app_environment_maintenance_configuration.test.name
   container_app_environment_id = azurerm_container_app_environment_maintenance_configuration.test.container_app_environment_id
 
-  scheduled_entry {
-    week_day       = "Sunday"
-    start_hour_utc = 1
-    duration_hours = 8
+  maintenance_window {
+    day_of_week       = azurerm_container_app_environment_maintenance_configuration.test.maintenance_window.0.day_of_week
+    start_hour_in_utc = azurerm_container_app_environment_maintenance_configuration.test.maintenance_window.0.start_hour_in_utc
+    duration_hours    = azurerm_container_app_environment_maintenance_configuration.test.maintenance_window.0.duration_hours
   }
 }
 `, r.basic(data))

--- a/internal/services/containerapps/registration.go
+++ b/internal/services/containerapps/registration.go
@@ -44,6 +44,7 @@ func (r Registration) Resources() []sdk.Resource {
 		ContainerAppEnvironmentCertificateResource{},
 		ContainerAppEnvironmentCustomDomainResource{},
 		ContainerAppEnvironmentDaprComponentResource{},
+		ContainerAppEnvironmentMaintenanceConfigurationResource{},
 		ContainerAppEnvironmentManagedCertificateResource{},
 		ContainerAppEnvironmentResource{},
 		ContainerAppEnvironmentStorageResource{},

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/README.md
@@ -1,0 +1,90 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations` Documentation
+
+The `maintenanceconfigurations` SDK allows for interaction with Azure Resource Manager `containerapps` (API Version `2025-07-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations"
+```
+
+
+### Client Initialization
+
+```go
+client := maintenanceconfigurations.NewMaintenanceConfigurationsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `MaintenanceConfigurationsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := maintenanceconfigurations.NewMaintenanceConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedEnvironmentName", "maintenanceConfigurationName")
+
+payload := maintenanceconfigurations.MaintenanceConfigurationResource{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MaintenanceConfigurationsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := maintenanceconfigurations.NewMaintenanceConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedEnvironmentName", "maintenanceConfigurationName")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MaintenanceConfigurationsClient.Get`
+
+```go
+ctx := context.TODO()
+id := maintenanceconfigurations.NewMaintenanceConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedEnvironmentName", "maintenanceConfigurationName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `MaintenanceConfigurationsClient.List`
+
+```go
+ctx := context.TODO()
+id := maintenanceconfigurations.NewManagedEnvironmentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedEnvironmentName")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/client.go
@@ -1,0 +1,26 @@
+package maintenanceconfigurations
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MaintenanceConfigurationsClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewMaintenanceConfigurationsClientWithBaseURI(sdkApi sdkEnv.Api) (*MaintenanceConfigurationsClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "maintenanceconfigurations", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating MaintenanceConfigurationsClient: %+v", err)
+	}
+
+	return &MaintenanceConfigurationsClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/constants.go
@@ -1,0 +1,66 @@
+package maintenanceconfigurations
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WeekDay string
+
+const (
+	WeekDayFriday    WeekDay = "Friday"
+	WeekDayMonday    WeekDay = "Monday"
+	WeekDaySaturday  WeekDay = "Saturday"
+	WeekDaySunday    WeekDay = "Sunday"
+	WeekDayThursday  WeekDay = "Thursday"
+	WeekDayTuesday   WeekDay = "Tuesday"
+	WeekDayWednesday WeekDay = "Wednesday"
+)
+
+func PossibleValuesForWeekDay() []string {
+	return []string{
+		string(WeekDayFriday),
+		string(WeekDayMonday),
+		string(WeekDaySaturday),
+		string(WeekDaySunday),
+		string(WeekDayThursday),
+		string(WeekDayTuesday),
+		string(WeekDayWednesday),
+	}
+}
+
+func (s *WeekDay) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseWeekDay(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseWeekDay(input string) (*WeekDay, error) {
+	vals := map[string]WeekDay{
+		"friday":    WeekDayFriday,
+		"monday":    WeekDayMonday,
+		"saturday":  WeekDaySaturday,
+		"sunday":    WeekDaySunday,
+		"thursday":  WeekDayThursday,
+		"tuesday":   WeekDayTuesday,
+		"wednesday": WeekDayWednesday,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WeekDay(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/id_maintenanceconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/id_maintenanceconfiguration.go
@@ -1,0 +1,139 @@
+package maintenanceconfigurations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&MaintenanceConfigurationId{})
+}
+
+var _ resourceids.ResourceId = &MaintenanceConfigurationId{}
+
+// MaintenanceConfigurationId is a struct representing the Resource ID for a Maintenance Configuration
+type MaintenanceConfigurationId struct {
+	SubscriptionId               string
+	ResourceGroupName            string
+	ManagedEnvironmentName       string
+	MaintenanceConfigurationName string
+}
+
+// NewMaintenanceConfigurationID returns a new MaintenanceConfigurationId struct
+func NewMaintenanceConfigurationID(subscriptionId string, resourceGroupName string, managedEnvironmentName string, maintenanceConfigurationName string) MaintenanceConfigurationId {
+	return MaintenanceConfigurationId{
+		SubscriptionId:               subscriptionId,
+		ResourceGroupName:            resourceGroupName,
+		ManagedEnvironmentName:       managedEnvironmentName,
+		MaintenanceConfigurationName: maintenanceConfigurationName,
+	}
+}
+
+// ParseMaintenanceConfigurationID parses 'input' into a MaintenanceConfigurationId
+func ParseMaintenanceConfigurationID(input string) (*MaintenanceConfigurationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&MaintenanceConfigurationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := MaintenanceConfigurationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseMaintenanceConfigurationIDInsensitively parses 'input' case-insensitively into a MaintenanceConfigurationId
+// note: this method should only be used for API response data and not user input
+func ParseMaintenanceConfigurationIDInsensitively(input string) (*MaintenanceConfigurationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&MaintenanceConfigurationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := MaintenanceConfigurationId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *MaintenanceConfigurationId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ManagedEnvironmentName, ok = input.Parsed["managedEnvironmentName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", input)
+	}
+
+	if id.MaintenanceConfigurationName, ok = input.Parsed["maintenanceConfigurationName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", input)
+	}
+
+	return nil
+}
+
+// ValidateMaintenanceConfigurationID checks that 'input' can be parsed as a Maintenance Configuration ID
+func ValidateMaintenanceConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseMaintenanceConfigurationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Maintenance Configuration ID
+func (id MaintenanceConfigurationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s/maintenanceConfigurations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ManagedEnvironmentName, id.MaintenanceConfigurationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Maintenance Configuration ID
+func (id MaintenanceConfigurationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftApp", "Microsoft.App", "Microsoft.App"),
+		resourceids.StaticSegment("staticManagedEnvironments", "managedEnvironments", "managedEnvironments"),
+		resourceids.UserSpecifiedSegment("managedEnvironmentName", "managedEnvironmentName"),
+		resourceids.StaticSegment("staticMaintenanceConfigurations", "maintenanceConfigurations", "maintenanceConfigurations"),
+		resourceids.UserSpecifiedSegment("maintenanceConfigurationName", "maintenanceConfigurationName"),
+	}
+}
+
+// String returns a human-readable description of this Maintenance Configuration ID
+func (id MaintenanceConfigurationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Managed Environment Name: %q", id.ManagedEnvironmentName),
+		fmt.Sprintf("Maintenance Configuration Name: %q", id.MaintenanceConfigurationName),
+	}
+	return fmt.Sprintf("Maintenance Configuration (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/id_managedenvironment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/id_managedenvironment.go
@@ -1,0 +1,130 @@
+package maintenanceconfigurations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ManagedEnvironmentId{})
+}
+
+var _ resourceids.ResourceId = &ManagedEnvironmentId{}
+
+// ManagedEnvironmentId is a struct representing the Resource ID for a Managed Environment
+type ManagedEnvironmentId struct {
+	SubscriptionId         string
+	ResourceGroupName      string
+	ManagedEnvironmentName string
+}
+
+// NewManagedEnvironmentID returns a new ManagedEnvironmentId struct
+func NewManagedEnvironmentID(subscriptionId string, resourceGroupName string, managedEnvironmentName string) ManagedEnvironmentId {
+	return ManagedEnvironmentId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroupName:      resourceGroupName,
+		ManagedEnvironmentName: managedEnvironmentName,
+	}
+}
+
+// ParseManagedEnvironmentID parses 'input' into a ManagedEnvironmentId
+func ParseManagedEnvironmentID(input string) (*ManagedEnvironmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ManagedEnvironmentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ManagedEnvironmentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseManagedEnvironmentIDInsensitively parses 'input' case-insensitively into a ManagedEnvironmentId
+// note: this method should only be used for API response data and not user input
+func ParseManagedEnvironmentIDInsensitively(input string) (*ManagedEnvironmentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ManagedEnvironmentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ManagedEnvironmentId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ManagedEnvironmentId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ManagedEnvironmentName, ok = input.Parsed["managedEnvironmentName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", input)
+	}
+
+	return nil
+}
+
+// ValidateManagedEnvironmentID checks that 'input' can be parsed as a Managed Environment ID
+func ValidateManagedEnvironmentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseManagedEnvironmentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Managed Environment ID
+func (id ManagedEnvironmentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.App/managedEnvironments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ManagedEnvironmentName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Managed Environment ID
+func (id ManagedEnvironmentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftApp", "Microsoft.App", "Microsoft.App"),
+		resourceids.StaticSegment("staticManagedEnvironments", "managedEnvironments", "managedEnvironments"),
+		resourceids.UserSpecifiedSegment("managedEnvironmentName", "managedEnvironmentName"),
+	}
+}
+
+// String returns a human-readable description of this Managed Environment ID
+func (id ManagedEnvironmentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Managed Environment Name: %q", id.ManagedEnvironmentName),
+	}
+	return fmt.Sprintf("Managed Environment (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_createorupdate.go
@@ -1,0 +1,58 @@
+package maintenanceconfigurations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *MaintenanceConfigurationResource
+}
+
+// CreateOrUpdate ...
+func (c MaintenanceConfigurationsClient) CreateOrUpdate(ctx context.Context, id MaintenanceConfigurationId, input MaintenanceConfigurationResource) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model MaintenanceConfigurationResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_delete.go
@@ -1,0 +1,47 @@
+package maintenanceconfigurations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c MaintenanceConfigurationsClient) Delete(ctx context.Context, id MaintenanceConfigurationId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_get.go
@@ -1,0 +1,53 @@
+package maintenanceconfigurations
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *MaintenanceConfigurationResource
+}
+
+// Get ...
+func (c MaintenanceConfigurationsClient) Get(ctx context.Context, id MaintenanceConfigurationId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model MaintenanceConfigurationResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/method_list.go
@@ -1,0 +1,105 @@
+package maintenanceconfigurations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]MaintenanceConfigurationResource
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []MaintenanceConfigurationResource
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c MaintenanceConfigurationsClient) List(ctx context.Context, id ManagedEnvironmentId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListCustomPager{},
+		Path:       fmt.Sprintf("%s/maintenanceConfigurations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]MaintenanceConfigurationResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c MaintenanceConfigurationsClient) ListComplete(ctx context.Context, id ManagedEnvironmentId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, MaintenanceConfigurationResourceOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c MaintenanceConfigurationsClient) ListCompleteMatchingPredicate(ctx context.Context, id ManagedEnvironmentId, predicate MaintenanceConfigurationResourceOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]MaintenanceConfigurationResource, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/model_maintenanceconfigurationresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/model_maintenanceconfigurationresource.go
@@ -1,0 +1,16 @@
+package maintenanceconfigurations
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MaintenanceConfigurationResource struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *ScheduledEntries      `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/model_scheduledentries.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/model_scheduledentries.go
@@ -1,0 +1,8 @@
+package maintenanceconfigurations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledEntries struct {
+	ScheduledEntries []ScheduledEntry `json:"scheduledEntries"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/model_scheduledentry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/model_scheduledentry.go
@@ -1,0 +1,10 @@
+package maintenanceconfigurations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ScheduledEntry struct {
+	DurationHours int64   `json:"durationHours"`
+	StartHourUtc  int64   `json:"startHourUtc"`
+	WeekDay       WeekDay `json:"weekDay"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/predicates.go
@@ -1,0 +1,27 @@
+package maintenanceconfigurations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MaintenanceConfigurationResourceOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p MaintenanceConfigurationResourceOperationPredicate) Matches(input MaintenanceConfigurationResource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations/version.go
@@ -1,0 +1,10 @@
+package maintenanceconfigurations
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-07-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/maintenanceconfigurations/2025-07-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -430,6 +430,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/cont
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerappsrevisions
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/daprcomponents
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/jobs
+github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/maintenanceconfigurations
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironmentsstorages
 github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2025-09-01/containerinstance

--- a/website/docs/r/container_app_environment_maintenance_configuration.html.markdown
+++ b/website/docs/r/container_app_environment_maintenance_configuration.html.markdown
@@ -1,0 +1,97 @@
+---
+subcategory: "Container Apps"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_container_app_environment_maintenance_configuration"
+description: |-
+  Manages a Container App Environment Maintenance Configuration.
+---
+
+# azurerm_container_app_environment_maintenance_configuration
+
+Manages a Container App Environment Maintenance Configuration.
+
+~> **Note:** Planned maintenance is a paid feature. For more information, see [Azure Container Apps planned maintenance](https://learn.microsoft.com/en-us/azure/container-apps/planned-maintenance).
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "acctest-01"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_container_app_environment" "example" {
+  name                       = "myEnvironment"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+}
+
+resource "azurerm_container_app_environment_maintenance_configuration" "example" {
+  name                         = "default"
+  container_app_environment_id = azurerm_container_app_environment.example.id
+
+  scheduled_entry {
+    week_day       = "Sunday"
+    start_hour_utc = 1
+    duration_hours = 8
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name for this Maintenance Configuration. The only allowed value is `default`. Changing this forces a new resource to be created.
+
+* `container_app_environment_id` - (Required) The ID of the Container App Environment to which this Maintenance Configuration belongs. Changing this forces a new resource to be created.
+
+* `scheduled_entry` - (Required) One or more `scheduled_entry` blocks as defined below.
+
+---
+
+A `scheduled_entry` block supports the following:
+
+* `week_day` - (Required) The day of the week for the maintenance window. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday`, and `Wednesday`.
+
+* `start_hour_utc` - (Required) The start hour of the maintenance window in UTC. Possible values are between `0` and `23`.
+
+* `duration_hours` - (Required) The duration of the maintenance window in hours. Possible values are between `8` and `24`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Container App Environment Maintenance Configuration.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Container App Environment Maintenance Configuration.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Container App Environment Maintenance Configuration.
+* `update` - (Defaults to 30 minutes) Used when updating the Container App Environment Maintenance Configuration.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Container App Environment Maintenance Configuration.
+
+## Import
+
+A Container App Environment Maintenance Configuration can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_container_app_environment_maintenance_configuration.example "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.App/managedEnvironments/myEnvironment/maintenanceConfigurations/default"
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.App` - 2025-07-01

--- a/website/docs/r/container_app_environment_maintenance_configuration.html.markdown
+++ b/website/docs/r/container_app_environment_maintenance_configuration.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_log_analytics_workspace" "example" {
-  name                = "acctest-01"
+  name                = "example-01"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "PerGB2018"
@@ -36,13 +36,12 @@ resource "azurerm_container_app_environment" "example" {
 }
 
 resource "azurerm_container_app_environment_maintenance_configuration" "example" {
-  name                         = "default"
   container_app_environment_id = azurerm_container_app_environment.example.id
 
-  scheduled_entry {
-    week_day       = "Sunday"
-    start_hour_utc = 1
-    duration_hours = 8
+  maintenance_window {
+    day_of_week       = "Sunday"
+    start_hour_in_utc = 1
+    duration_hours    = 8
   }
 }
 ```
@@ -51,19 +50,17 @@ resource "azurerm_container_app_environment_maintenance_configuration" "example"
 
 The following arguments are supported:
 
-* `name` - (Required) The name for this Maintenance Configuration. The only allowed value is `default`. Changing this forces a new resource to be created.
-
 * `container_app_environment_id` - (Required) The ID of the Container App Environment to which this Maintenance Configuration belongs. Changing this forces a new resource to be created.
 
-* `scheduled_entry` - (Required) One or more `scheduled_entry` blocks as defined below.
+* `maintenance_window` - (Required) A `maintenance_window` block as defined below.
 
 ---
 
-A `scheduled_entry` block supports the following:
+A `maintenance_window` block supports the following:
 
-* `week_day` - (Required) The day of the week for the maintenance window. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday`, and `Wednesday`.
+* `day_of_week` - (Required) The day of the week for the maintenance window. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday`, and `Wednesday`.
 
-* `start_hour_utc` - (Required) The start hour of the maintenance window in UTC. Possible values are between `0` and `23`.
+* `start_hour_in_utc` - (Required) The start hour of the maintenance window in UTC. Possible values are between `0` and `23`.
 
 * `duration_hours` - (Required) The duration of the maintenance window in hours. Possible values are between `8` and `24`.
 


### PR DESCRIPTION
…ration resource

This adds support for Azure Container Apps Environment maintenance configuration:
- New resource: azurerm_container_app_environment_maintenance_configuration
- Allows configuring planned maintenance windows for Container App Environments
- Vendored maintenanceconfigurations SDK package (2025-07-01 API version)
- Includes acceptance tests and documentation

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR add support for `azurerm_container_app_environment_maintenance_configuration`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
--- PASS: TestAccContainerAppEnvironmentMaintenanceConfiguration_basic (588.53s)
--- PASS: TestAccContainerAppEnvironmentMaintenanceConfiguration_update (628.13s)
--- PASS: TestAccContainerAppEnvironmentMaintenanceConfiguration_requiresImport (538.12s)
PASS
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31485 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
