### PR TITLE
`azurerm_data_factory_managed_private_endpoint` - fix `TestAccDataFactoryManagedPrivateEndpoint_privateServiceLink`

### DIFF
--- a/internal/services/datafactory/custompollers/data_factory_managed_private_endpoint_delete_poller.go
+++ b/internal/services/datafactory/custompollers/data_factory_managed_private_endpoint_delete_poller.go
@@ -1,0 +1,51 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/managedprivateendpoints"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &dataFactoryManagedPrivateEndpointDeletePoller{}
+
+type dataFactoryManagedPrivateEndpointDeletePoller struct {
+	client *managedprivateendpoints.ManagedPrivateEndpointsClient
+	id     managedprivateendpoints.ManagedPrivateEndpointId
+}
+
+var (
+	pollingSuccess = pollers.PollResult{
+		Status: pollers.PollingStatusSucceeded,
+	}
+	pollingInProgress = pollers.PollResult{
+		PollInterval: 1 * time.Minute,
+		Status:       pollers.PollingStatusInProgress,
+	}
+)
+
+func NewDataFactoryManagedPrivateEndpointDeletePoller(client *managedprivateendpoints.ManagedPrivateEndpointsClient, id managedprivateendpoints.ManagedPrivateEndpointId) *dataFactoryManagedPrivateEndpointDeletePoller {
+	return &dataFactoryManagedPrivateEndpointDeletePoller{
+		client: client,
+		id:     id,
+	}
+}
+
+func (p dataFactoryManagedPrivateEndpointDeletePoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := p.client.Get(ctx, p.id, managedprivateendpoints.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return &pollingSuccess, nil
+		} else {
+			return nil, fmt.Errorf("retrieving %s: %+v", p.id, err)
+		}
+	}
+
+	return &pollingInProgress, nil
+}

--- a/internal/services/datafactory/data_factory_managed_private_endpoint_resource.go
+++ b/internal/services/datafactory/data_factory_managed_private_endpoint_resource.go
@@ -274,7 +274,7 @@ func getManagedPrivateEndpointProvisionStatus(ctx context.Context, client *manag
 func getManagedPrivateEndpointDeletionStatus(ctx context.Context, client *managedprivateendpoints.ManagedPrivateEndpointsClient, id managedprivateendpoints.ManagedPrivateEndpointId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := client.Get(ctx, id, managedprivateendpoints.DefaultGetOperationOptions())
-		if err != nil && response.WasNotFound(resp.HttpResponse) {
+		if err != nil {
 			if response.WasNotFound(resp.HttpResponse) {
 				return resp, "NotFound", nil
 			} else {

--- a/internal/services/datafactory/data_factory_managed_private_endpoint_resource.go
+++ b/internal/services/datafactory/data_factory_managed_private_endpoint_resource.go
@@ -14,9 +14,11 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/managedprivateendpoints"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/privatelinkservices"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/datafactory/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -219,15 +221,10 @@ func resourceDataFactoryManagedPrivateEndpointDelete(d *pluginsdk.ResourceData, 
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
-	stateConf := &pluginsdk.StateChangeConf{
-		Pending:    []string{"Exists"},
-		Target:     []string{"NotFound"},
-		Refresh:    getManagedPrivateEndpointDeletionStatus(ctx, client, *id),
-		MinTimeout: 1 * time.Minute,
-		Timeout:    d.Timeout(pluginsdk.TimeoutDelete),
-	}
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("waiting for %s to be deleted: %+v", id.ID(), err)
+	pollerType := custompollers.NewDataFactoryManagedPrivateEndpointDeletePoller(client, *id)
+	poller := pollers.NewPoller(pollerType, 1*time.Minute, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	if err := poller.PollUntilDone(ctx); err != nil {
+		return err
 	}
 
 	return nil
@@ -268,20 +265,5 @@ func getManagedPrivateEndpointProvisionStatus(ctx context.Context, client *manag
 		}
 
 		return resp, *resp.Model.Properties.ProvisioningState, nil
-	}
-}
-
-func getManagedPrivateEndpointDeletionStatus(ctx context.Context, client *managedprivateendpoints.ManagedPrivateEndpointsClient, id managedprivateendpoints.ManagedPrivateEndpointId) pluginsdk.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		resp, err := client.Get(ctx, id, managedprivateendpoints.DefaultGetOperationOptions())
-		if err != nil {
-			if response.WasNotFound(resp.HttpResponse) {
-				return resp, "NotFound", nil
-			} else {
-				return nil, "", fmt.Errorf("retrieving %s: %+v", id, err)
-			}
-		} else {
-			return resp, "Exists", nil
-		}
 	}
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccDataFactoryManagedPrivateEndpoint_privateServiceLink` fails with the following error. This is due to the deletion of `azurerm_private_link_service` resource immediately after deletion is initialized for `azurerm_data_factory_managed_private_endpoint` resource. To fix the issue, `custompollers` method is used to poll the `azurerm_data_factory_managed_private_endpoint` status and wait until deletion is completed before proceeding with deletion of other resource.

```
    testcase.go:192: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: deleting Private Link Service (Subscription: "*******"
        Resource Group Name: "REDACTED"
        Private Link Service Name: "REDACTED"): performing Delete: unexpected status 400 (400 Bad Request) with error: PrivateLinkServiceWithPrivateEndpointConnectionsCannotBeDeleted: Private link service /subscriptions/*******/resourceGroups/REDACTED/providers/Microsoft.Network/privateLinkServices/REDACTED cannot be deleted since it has 1 private endpoint connections. Please delete all private endpoint connections before deleting the private link service.
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The tests run below are determined using [terraform-terracorder](https://github.com/WodansSon/terraform-terracorder).
Version 4.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_DATAFACTORY/678886?buildTab=overview
<img width="953" height="354" alt="image" src="https://github.com/user-attachments/assets/55ddef53-9ca1-4ea6-8044-cb5351a85e3c" />

Version 5.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_DATAFACTORY/678894?buildTab=overview
<img width="954" height="348" alt="image" src="https://github.com/user-attachments/assets/841bf6c8-5bc9-4d09-9f6d-e3e8be7aa2c3" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_managed_private_endpoint` - add `custompollers` method for resource deletion


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
