### PR TITLE
New Resource: `azurerm_dns_cname_record_public_ip_address_association`

### DIFF
--- a/internal/services/dns/dns_cname_record_public_ip_address_association_resource.go
+++ b/internal/services/dns/dns_cname_record_public_ip_address_association_resource.go
@@ -1,0 +1,250 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dns
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipaddresses"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type DnsCnameRecordPublicIpAddressAssociationResource struct{}
+
+var _ sdk.Resource = DnsCnameRecordPublicIpAddressAssociationResource{}
+
+type DnsCnameRecordPublicIpAddressAssociationModel struct {
+	CnameRecordId     string `tfschema:"dns_cname_record_id"`
+	PublicIpAddressId string `tfschema:"public_ip_address_id"`
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"dns_cname_record_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: recordsets.ValidateRecordTypeID,
+		},
+		"public_ip_address_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidatePublicIPAddressID,
+		},
+	}
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) ModelObject() interface{} {
+	return &DnsCnameRecordPublicIpAddressAssociationModel{}
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) ResourceType() string {
+	return "azurerm_dns_cname_record_public_ip_address_association"
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return parse.DnsCnameRecordPublicIpAddressAssociationIDValidation
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model DnsCnameRecordPublicIpAddressAssociationModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			dnsClient := metadata.Client.Dns.RecordSets
+			publicIpClient := metadata.Client.Network.PublicIPAddresses
+
+			cnameRecordId, err := recordsets.ParseRecordTypeID(model.CnameRecordId)
+			if err != nil {
+				return err
+			}
+
+			if cnameRecordId.RecordType != recordsets.RecordTypeCNAME {
+				return fmt.Errorf("expected record type to be CNAME but got %s", cnameRecordId.RecordType)
+			}
+
+			publicIpAddressId, err := commonids.ParsePublicIPAddressID(model.PublicIpAddressId)
+			if err != nil {
+				return err
+			}
+
+			locks.ByName(cnameRecordId.RelativeRecordSetName, "azurerm_dns_cname_record")
+			defer locks.UnlockByName(cnameRecordId.RelativeRecordSetName, "azurerm_dns_cname_record")
+
+			locks.ByName(publicIpAddressId.PublicIPAddressesName, "azurerm_public_ip")
+			defer locks.UnlockByName(publicIpAddressId.PublicIPAddressesName, "azurerm_public_ip")
+
+			cnameRecord, err := dnsClient.Get(ctx, *cnameRecordId)
+			if err != nil {
+				if response.WasNotFound(cnameRecord.HttpResponse) {
+					return fmt.Errorf("CNAME Record %s was not found", cnameRecordId)
+				}
+				return fmt.Errorf("retrieving CNAME Record %s: %+v", cnameRecordId, err)
+			}
+
+			if cnameRecord.Model == nil || cnameRecord.Model.Properties == nil {
+				return fmt.Errorf("model/properties was nil for CNAME Record %s", cnameRecordId)
+			}
+
+			fqdn := pointer.From(cnameRecord.Model.Properties.Fqdn)
+			if fqdn == "" {
+				return fmt.Errorf("FQDN was empty for CNAME Record %s", cnameRecordId)
+			}
+
+			publicIp, err := publicIpClient.Get(ctx, *publicIpAddressId, publicipaddresses.DefaultGetOperationOptions())
+			if err != nil {
+				if response.WasNotFound(publicIp.HttpResponse) {
+					return fmt.Errorf("Public IP Address %s was not found", publicIpAddressId)
+				}
+				return fmt.Errorf("retrieving Public IP Address %s: %+v", publicIpAddressId, err)
+			}
+
+			if publicIp.Model == nil || publicIp.Model.Properties == nil {
+				return fmt.Errorf("model/properties was nil for Public IP Address %s", publicIpAddressId)
+			}
+
+			if publicIp.Model.Properties.DnsSettings != nil && publicIp.Model.Properties.DnsSettings.ReverseFqdn != nil {
+				existingReverseFqdn := *publicIp.Model.Properties.DnsSettings.ReverseFqdn
+				if existingReverseFqdn != "" && existingReverseFqdn != fqdn {
+					return fmt.Errorf("Public IP Address %s already has a reverse_fqdn set to %q, cannot set to %q", publicIpAddressId, existingReverseFqdn, fqdn)
+				}
+			}
+
+			if publicIp.Model.Properties.DnsSettings == nil {
+				publicIp.Model.Properties.DnsSettings = &publicipaddresses.PublicIPAddressDnsSettings{}
+			}
+			publicIp.Model.Properties.DnsSettings.ReverseFqdn = pointer.To(fqdn)
+
+			if err := publicIpClient.CreateOrUpdateThenPoll(ctx, *publicIpAddressId, *publicIp.Model); err != nil {
+				return fmt.Errorf("updating reverse_fqdn for Public IP Address %s: %+v", publicIpAddressId, err)
+			}
+
+			resourceId := parse.NewDnsCnameRecordPublicIpAddressAssociationId(*cnameRecordId, *publicIpAddressId)
+			metadata.SetID(&resourceId)
+
+			return nil
+		},
+	}
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			publicIpClient := metadata.Client.Network.PublicIPAddresses
+			dnsClient := metadata.Client.Dns.RecordSets
+
+			resourceId, err := parse.DnsCnameRecordPublicIpAddressAssociationID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			cnameRecord, err := dnsClient.Get(ctx, resourceId.CnameRecordId)
+			if err != nil {
+				if response.WasNotFound(cnameRecord.HttpResponse) {
+					log.Printf("[DEBUG] CNAME Record %s was not found - removing from state", resourceId.CnameRecordId)
+					return metadata.MarkAsGone(&resourceId.CnameRecordId)
+				}
+				return fmt.Errorf("retrieving CNAME Record %s: %+v", resourceId.CnameRecordId, err)
+			}
+
+			publicIp, err := publicIpClient.Get(ctx, resourceId.PublicIpAddressId, publicipaddresses.DefaultGetOperationOptions())
+			if err != nil {
+				if response.WasNotFound(publicIp.HttpResponse) {
+					log.Printf("[DEBUG] Public IP Address %s was not found - removing from state", resourceId.PublicIpAddressId)
+					return metadata.MarkAsGone(&resourceId.PublicIpAddressId)
+				}
+				return fmt.Errorf("retrieving Public IP Address %s: %+v", resourceId.PublicIpAddressId, err)
+			}
+
+			if publicIp.Model == nil || publicIp.Model.Properties == nil {
+				log.Printf("[DEBUG] Public IP Address %s has no properties - removing from state", resourceId.PublicIpAddressId)
+				return metadata.MarkAsGone(&resourceId.PublicIpAddressId)
+			}
+
+			if publicIp.Model.Properties.DnsSettings == nil || publicIp.Model.Properties.DnsSettings.ReverseFqdn == nil {
+				log.Printf("[DEBUG] Public IP Address %s has no reverse_fqdn set - removing from state", resourceId.PublicIpAddressId)
+				return metadata.MarkAsGone(&resourceId.PublicIpAddressId)
+			}
+
+			if cnameRecord.Model == nil || cnameRecord.Model.Properties == nil {
+				log.Printf("[DEBUG] CNAME Record %s has no properties - removing from state", resourceId.CnameRecordId)
+				return metadata.MarkAsGone(&resourceId.CnameRecordId)
+			}
+
+			expectedFqdn := pointer.From(cnameRecord.Model.Properties.Fqdn)
+			actualReverseFqdn := pointer.From(publicIp.Model.Properties.DnsSettings.ReverseFqdn)
+
+			if expectedFqdn != actualReverseFqdn {
+				log.Printf("[DEBUG] Public IP Address %s reverse_fqdn (%s) does not match CNAME record FQDN (%s) - removing from state", resourceId.PublicIpAddressId, actualReverseFqdn, expectedFqdn)
+				return metadata.MarkAsGone(&resourceId.PublicIpAddressId)
+			}
+
+			state := DnsCnameRecordPublicIpAddressAssociationModel{
+				CnameRecordId:     resourceId.CnameRecordId.ID(),
+				PublicIpAddressId: resourceId.PublicIpAddressId.ID(),
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			publicIpClient := metadata.Client.Network.PublicIPAddresses
+
+			resourceId, err := parse.DnsCnameRecordPublicIpAddressAssociationID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			locks.ByName(resourceId.PublicIpAddressId.PublicIPAddressesName, "azurerm_public_ip")
+			defer locks.UnlockByName(resourceId.PublicIpAddressId.PublicIPAddressesName, "azurerm_public_ip")
+
+			publicIp, err := publicIpClient.Get(ctx, resourceId.PublicIpAddressId, publicipaddresses.DefaultGetOperationOptions())
+			if err != nil {
+				if response.WasNotFound(publicIp.HttpResponse) {
+					return nil
+				}
+				return fmt.Errorf("retrieving Public IP Address %s: %+v", resourceId.PublicIpAddressId, err)
+			}
+
+			if publicIp.Model == nil || publicIp.Model.Properties == nil {
+				return nil
+			}
+
+			if publicIp.Model.Properties.DnsSettings != nil {
+				publicIp.Model.Properties.DnsSettings.ReverseFqdn = nil
+			}
+
+			if err := publicIpClient.CreateOrUpdateThenPoll(ctx, resourceId.PublicIpAddressId, *publicIp.Model); err != nil {
+				return fmt.Errorf("removing reverse_fqdn from Public IP Address %s: %+v", resourceId.PublicIpAddressId, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/dns/dns_cname_record_public_ip_address_association_resource.go
+++ b/internal/services/dns/dns_cname_record_public_ip_address_association_resource.go
@@ -97,36 +97,36 @@ func (r DnsCnameRecordPublicIpAddressAssociationResource) Create() sdk.ResourceF
 			cnameRecord, err := dnsClient.Get(ctx, *cnameRecordId)
 			if err != nil {
 				if response.WasNotFound(cnameRecord.HttpResponse) {
-					return fmt.Errorf("CNAME Record %s was not found", cnameRecordId)
+					return fmt.Errorf("cname record %s was not found", cnameRecordId)
 				}
-				return fmt.Errorf("retrieving CNAME Record %s: %+v", cnameRecordId, err)
+				return fmt.Errorf("retrieving cname record %s: %+v", cnameRecordId, err)
 			}
 
 			if cnameRecord.Model == nil || cnameRecord.Model.Properties == nil {
-				return fmt.Errorf("model/properties was nil for CNAME Record %s", cnameRecordId)
+				return fmt.Errorf("model/properties was nil for cname record %s", cnameRecordId)
 			}
 
 			fqdn := pointer.From(cnameRecord.Model.Properties.Fqdn)
 			if fqdn == "" {
-				return fmt.Errorf("FQDN was empty for CNAME Record %s", cnameRecordId)
+				return fmt.Errorf("fqdn was empty for cname record %s", cnameRecordId)
 			}
 
 			publicIp, err := publicIpClient.Get(ctx, *publicIpAddressId, publicipaddresses.DefaultGetOperationOptions())
 			if err != nil {
 				if response.WasNotFound(publicIp.HttpResponse) {
-					return fmt.Errorf("Public IP Address %s was not found", publicIpAddressId)
+					return fmt.Errorf("public ip address %s was not found", publicIpAddressId)
 				}
-				return fmt.Errorf("retrieving Public IP Address %s: %+v", publicIpAddressId, err)
+				return fmt.Errorf("retrieving public ip address %s: %+v", publicIpAddressId, err)
 			}
 
 			if publicIp.Model == nil || publicIp.Model.Properties == nil {
-				return fmt.Errorf("model/properties was nil for Public IP Address %s", publicIpAddressId)
+				return fmt.Errorf("model/properties was nil for public ip address %s", publicIpAddressId)
 			}
 
 			if publicIp.Model.Properties.DnsSettings != nil && publicIp.Model.Properties.DnsSettings.ReverseFqdn != nil {
 				existingReverseFqdn := *publicIp.Model.Properties.DnsSettings.ReverseFqdn
 				if existingReverseFqdn != "" && existingReverseFqdn != fqdn {
-					return fmt.Errorf("Public IP Address %s already has a reverse_fqdn set to %q, cannot set to %q", publicIpAddressId, existingReverseFqdn, fqdn)
+					return fmt.Errorf("public ip address %s already has a reverse_fqdn set to %q, cannot set to %q", publicIpAddressId, existingReverseFqdn, fqdn)
 				}
 			}
 
@@ -136,7 +136,7 @@ func (r DnsCnameRecordPublicIpAddressAssociationResource) Create() sdk.ResourceF
 			publicIp.Model.Properties.DnsSettings.ReverseFqdn = pointer.To(fqdn)
 
 			if err := publicIpClient.CreateOrUpdateThenPoll(ctx, *publicIpAddressId, *publicIp.Model); err != nil {
-				return fmt.Errorf("updating reverse_fqdn for Public IP Address %s: %+v", publicIpAddressId, err)
+				return fmt.Errorf("updating reverse_fqdn for public ip address %s: %+v", publicIpAddressId, err)
 			}
 
 			resourceId := parse.NewDnsCnameRecordPublicIpAddressAssociationId(*cnameRecordId, *publicIpAddressId)
@@ -165,7 +165,7 @@ func (r DnsCnameRecordPublicIpAddressAssociationResource) Read() sdk.ResourceFun
 					log.Printf("[DEBUG] CNAME Record %s was not found - removing from state", resourceId.CnameRecordId)
 					return metadata.MarkAsGone(&resourceId.CnameRecordId)
 				}
-				return fmt.Errorf("retrieving CNAME Record %s: %+v", resourceId.CnameRecordId, err)
+				return fmt.Errorf("retrieving cname record %s: %+v", resourceId.CnameRecordId, err)
 			}
 
 			publicIp, err := publicIpClient.Get(ctx, resourceId.PublicIpAddressId, publicipaddresses.DefaultGetOperationOptions())
@@ -174,7 +174,7 @@ func (r DnsCnameRecordPublicIpAddressAssociationResource) Read() sdk.ResourceFun
 					log.Printf("[DEBUG] Public IP Address %s was not found - removing from state", resourceId.PublicIpAddressId)
 					return metadata.MarkAsGone(&resourceId.PublicIpAddressId)
 				}
-				return fmt.Errorf("retrieving Public IP Address %s: %+v", resourceId.PublicIpAddressId, err)
+				return fmt.Errorf("retrieving public ip address %s: %+v", resourceId.PublicIpAddressId, err)
 			}
 
 			if publicIp.Model == nil || publicIp.Model.Properties == nil {
@@ -229,7 +229,7 @@ func (r DnsCnameRecordPublicIpAddressAssociationResource) Delete() sdk.ResourceF
 				if response.WasNotFound(publicIp.HttpResponse) {
 					return nil
 				}
-				return fmt.Errorf("retrieving Public IP Address %s: %+v", resourceId.PublicIpAddressId, err)
+				return fmt.Errorf("retrieving public ip address %s: %+v", resourceId.PublicIpAddressId, err)
 			}
 
 			if publicIp.Model == nil || publicIp.Model.Properties == nil {
@@ -241,7 +241,7 @@ func (r DnsCnameRecordPublicIpAddressAssociationResource) Delete() sdk.ResourceF
 			}
 
 			if err := publicIpClient.CreateOrUpdateThenPoll(ctx, resourceId.PublicIpAddressId, *publicIp.Model); err != nil {
-				return fmt.Errorf("removing reverse_fqdn from Public IP Address %s: %+v", resourceId.PublicIpAddressId, err)
+				return fmt.Errorf("removing reverse_fqdn from public ip address %s: %+v", resourceId.PublicIpAddressId, err)
 			}
 
 			return nil

--- a/internal/services/dns/dns_cname_record_public_ip_address_association_resource_test.go
+++ b/internal/services/dns/dns_cname_record_public_ip_address_association_resource_test.go
@@ -1,0 +1,139 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dns_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipaddresses"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dns/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type DnsCnameRecordPublicIpAddressAssociationResource struct{}
+
+func TestAccDnsCnameRecordPublicIpAddressAssociation_basic(t *testing.T) {
+	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
+		t.Skip("Skipping as ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_dns_cname_record_public_ip_address_association", "test")
+	r := DnsCnameRecordPublicIpAddressAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDnsCnameRecordPublicIpAddressAssociation_requiresImport(t *testing.T) {
+	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
+		t.Skip("Skipping as ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_dns_cname_record_public_ip_address_association", "test")
+	r := DnsCnameRecordPublicIpAddressAssociationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.DnsCnameRecordPublicIpAddressAssociationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	publicIp, err := client.Network.PublicIPAddresses.Get(ctx, id.PublicIpAddressId, publicipaddresses.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(publicIp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving Public IP Address %s: %+v", id.PublicIpAddressId, err)
+	}
+
+	if publicIp.Model == nil || publicIp.Model.Properties == nil {
+		return pointer.To(false), nil
+	}
+
+	if publicIp.Model.Properties.DnsSettings == nil || publicIp.Model.Properties.DnsSettings.ReverseFqdn == nil {
+		return pointer.To(false), nil
+	}
+
+	return pointer.To(*publicIp.Model.Properties.DnsSettings.ReverseFqdn != ""), nil
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) basic(data acceptance.TestData) string {
+	dnsZone := os.Getenv("ARM_TEST_DNS_ZONE")
+	dataResourceGroup := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_dns_zone" "test" {
+  name                = "%[3]s"
+  resource_group_name = "%[4]s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = "acctestpip%[1]d"
+}
+
+resource "azurerm_dns_cname_record" "test" {
+  name                = "myarecord%[1]d"
+  zone_name           = data.azurerm_dns_zone.test.name
+  resource_group_name = data.azurerm_dns_zone.test.resource_group_name
+  ttl                 = 300
+  record              = azurerm_public_ip.test.fqdn
+}
+
+resource "azurerm_dns_cname_record_public_ip_address_association" "test" {
+  dns_cname_record_id  = azurerm_dns_cname_record.test.id
+  public_ip_address_id = azurerm_public_ip.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, dnsZone, dataResourceGroup)
+}
+
+func (r DnsCnameRecordPublicIpAddressAssociationResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dns_cname_record_public_ip_address_association" "import" {
+  dns_cname_record_id  = azurerm_dns_cname_record_public_ip_address_association.test.dns_cname_record_id
+  public_ip_address_id = azurerm_dns_cname_record_public_ip_address_association.test.public_ip_address_id
+}
+`, r.basic(data))
+}

--- a/internal/services/dns/parse/dns_cname_record_public_ip_address_association.go
+++ b/internal/services/dns/parse/dns_cname_record_public_ip_address_association.go
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets"
+)
+
+var _ resourceids.Id = DnsCnameRecordPublicIpAddressAssociationId{}
+
+type DnsCnameRecordPublicIpAddressAssociationId struct {
+	CnameRecordId     recordsets.RecordTypeId
+	PublicIpAddressId commonids.PublicIPAddressId
+}
+
+func NewDnsCnameRecordPublicIpAddressAssociationId(cnameRecordId recordsets.RecordTypeId, publicIpAddressId commonids.PublicIPAddressId) DnsCnameRecordPublicIpAddressAssociationId {
+	return DnsCnameRecordPublicIpAddressAssociationId{
+		CnameRecordId:     cnameRecordId,
+		PublicIpAddressId: publicIpAddressId,
+	}
+}
+
+func (id DnsCnameRecordPublicIpAddressAssociationId) ID() string {
+	return fmt.Sprintf("%s|%s", id.CnameRecordId.ID(), id.PublicIpAddressId.ID())
+}
+
+func (id DnsCnameRecordPublicIpAddressAssociationId) String() string {
+	components := []string{
+		fmt.Sprintf("CnameRecordId %s", id.CnameRecordId.ID()),
+		fmt.Sprintf("PublicIpAddressId %s", id.PublicIpAddressId.ID()),
+	}
+	return fmt.Sprintf("DNS CNAME Record Public IP Address Association: %s", strings.Join(components, " / "))
+}
+
+func DnsCnameRecordPublicIpAddressAssociationID(input string) (DnsCnameRecordPublicIpAddressAssociationId, error) {
+	parts := strings.Split(input, "|")
+	if len(parts) != 2 {
+		return DnsCnameRecordPublicIpAddressAssociationId{}, fmt.Errorf("expected ID to be in the format {CnameRecordId}|{PublicIpAddressId} but got %q", input)
+	}
+
+	cnameRecordId, err := recordsets.ParseRecordTypeID(parts[0])
+	if err != nil {
+		return DnsCnameRecordPublicIpAddressAssociationId{}, fmt.Errorf("parsing CNAME Record ID: %+v", err)
+	}
+
+	if cnameRecordId.RecordType != recordsets.RecordTypeCNAME {
+		return DnsCnameRecordPublicIpAddressAssociationId{}, fmt.Errorf("expected record type to be CNAME but got %s", cnameRecordId.RecordType)
+	}
+
+	publicIpAddressId, err := commonids.ParsePublicIPAddressID(parts[1])
+	if err != nil {
+		return DnsCnameRecordPublicIpAddressAssociationId{}, fmt.Errorf("parsing Public IP Address ID: %+v", err)
+	}
+
+	if cnameRecordId == nil || publicIpAddressId == nil {
+		return DnsCnameRecordPublicIpAddressAssociationId{}, fmt.Errorf("parse error, both CnameRecordId and PublicIpAddressId should not be nil")
+	}
+
+	return DnsCnameRecordPublicIpAddressAssociationId{
+		CnameRecordId:     *cnameRecordId,
+		PublicIpAddressId: *publicIpAddressId,
+	}, nil
+}
+
+func DnsCnameRecordPublicIpAddressAssociationIDValidation(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := DnsCnameRecordPublicIpAddressAssociationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/dns/registration.go
+++ b/internal/services/dns/registration.go
@@ -75,6 +75,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 // Resources returns a list of Resources supported by this Service
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
+		DnsCnameRecordPublicIpAddressAssociationResource{},
 		DnsZoneResource{},
 	}
 }

--- a/website/docs/r/dns_cname_record_public_ip_address_association.html.markdown
+++ b/website/docs/r/dns_cname_record_public_ip_address_association.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "DNS"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dns_cname_record_public_ip_address_association"
+description: |-
+  Associates a DNS CNAME Record with a Public IP Address by setting the reverse FQDN.
+---
+
+# azurerm_dns_cname_record_public_ip_address_association
+
+Associates a [DNS CNAME Record](dns_cname_record.html) with a [Public IP Address](public_ip.html) by setting the `reverse_fqdn` property on the Public IP Address to the FQDN of the CNAME Record.
+
+This resource is useful for breaking circular dependencies between DNS CNAME Records and Public IP Addresses when you need to reference the FQDN of a CNAME Record in a Public IP Address configuration.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_dns_zone" "example" {
+  name                = "example.com"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_public_ip" "example" {
+  name                = "example-pip"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = "example-pip"
+}
+
+resource "azurerm_dns_cname_record" "example" {
+  name                = "www"
+  zone_name           = azurerm_dns_zone.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  ttl                 = 300
+  record              = azurerm_public_ip.example.fqdn
+}
+
+resource "azurerm_dns_cname_record_public_ip_address_association" "example" {
+  dns_cname_record_id   = azurerm_dns_cname_record.example.id
+  public_ip_address_id  = azurerm_public_ip.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `dns_cname_record_id` - (Required) The ID of the DNS CNAME Record. Changing this forces a new resource to be created.
+
+* `public_ip_address_id` - (Required) The ID of the Public IP Address. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the DNS CNAME Record Public IP Address Association.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the DNS CNAME Record Public IP Address Association.
+* `read` - (Defaults to 5 minutes) Used when retrieving the DNS CNAME Record Public IP Address Association.
+* `delete` - (Defaults to 30 minutes) Used when deleting the DNS CNAME Record Public IP Address Association.
+
+## Import
+
+DNS CNAME Record Public IP Address Associations can be imported using the `resource id` of the DNS CNAME Record and the Public IP Address separated by `|`, e.g.
+
+```shell
+terraform import azurerm_dns_cname_record_public_ip_address_association.example "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/example.com/CNAME/www|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/publicIPAddresses/mypip1"
+```

--- a/website/docs/r/dns_cname_record_public_ip_address_association.html.markdown
+++ b/website/docs/r/dns_cname_record_public_ip_address_association.html.markdown
@@ -43,8 +43,8 @@ resource "azurerm_dns_cname_record" "example" {
 }
 
 resource "azurerm_dns_cname_record_public_ip_address_association" "example" {
-  dns_cname_record_id   = azurerm_dns_cname_record.example.id
-  public_ip_address_id  = azurerm_public_ip.example.id
+  dns_cname_record_id  = azurerm_dns_cname_record.example.id
+  public_ip_address_id = azurerm_public_ip.example.id
 }
 ```
 
@@ -77,3 +77,10 @@ DNS CNAME Record Public IP Address Associations can be imported using the `resou
 ```shell
 terraform import azurerm_dns_cname_record_public_ip_address_association.example "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/example.com/CNAME/www|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/publicIPAddresses/mypip1"
 ```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.Network` - 2025-01-01
+* `Microsoft.Network` - 2018-05-01

--- a/website/docs/r/dns_cname_record_public_ip_address_association.html.markdown
+++ b/website/docs/r/dns_cname_record_public_ip_address_association.html.markdown
@@ -82,5 +82,4 @@ terraform import azurerm_dns_cname_record_public_ip_address_association.example 
 <!-- This section is generated, changes will be overwritten -->
 This resource uses the following Azure API Providers:
 
-* `Microsoft.Network` - 2025-01-01
-* `Microsoft.Network` - 2018-05-01
+* `Microsoft.Network` - 2025-01-01, 2018-05-01


### PR DESCRIPTION
Setting this to draft until confirmed with the service team that it's by design that users will need to create cname and public IP first before updating `reverse_fqdn` for public ip.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR separates the `reverse_fqdn` update to a standalone resource. This is because when `domain_name_label_scope` is used, there's a cyclic dependency issue between `public_ip` and `dns_cname_record`. i.e. `dns_cname_record` requires fqdn from `public_ip`, but `reverse_fqdn` in `public_ip` requires `dns_cname_record` to be created firstly.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_dns_cname_record_public_ip_address_association` - support for breaking cyclic dependency


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
