### PR TITLE
`azurerm_redhat_openshift_cluster` - fix acceptance tests

### DIFF
--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -214,7 +214,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain  = "aro-%[3]s.com"
-    version = "4.14.16"
+    version = "4.19.20"
   }
 
   network_profile {
@@ -316,11 +316,11 @@ resource "azuread_application" "test2" {
 }
 
 resource "azuread_service_principal" "test2" {
-  application_id = azuread_application.test2.application_id
+  client_id = azuread_application.test2.client_id
 }
 
 resource "azuread_service_principal_password" "test2" {
-  service_principal_id = azuread_service_principal.test2.object_id
+  service_principal_id = azuread_service_principal.test2.id
 }
 
 resource "azurerm_role_assignment" "role_network3" {
@@ -336,7 +336,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain  = "aro-%[3]s.com"
-    version = "4.14.16"
+    version = "4.19.20"
   }
 
   network_profile {
@@ -365,7 +365,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
   }
 
   service_principal {
-    client_id     = azuread_application.test2.application_id
+    client_id     = azuread_application.test2.client_id
     client_secret = azuread_service_principal_password.test2.value
   }
 
@@ -393,7 +393,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain      = "aro-%[3]s.com"
-    version     = "4.14.16"
+    version     = "4.19.20"
     pull_secret = <<SECRET
 %[4]s
 SECRET
@@ -448,7 +448,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain  = "aro-%[3]s.com"
-    version = "4.14.16"
+    version = "4.19.20"
   }
 
   network_profile {
@@ -501,7 +501,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain  = "aro-%[3]s.com"
-    version = "4.14.16"
+    version = "4.19.20"
   }
 
   network_profile {
@@ -553,7 +553,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain       = "aro-%[3]s.com"
-    version      = "4.14.16"
+    version      = "4.19.20"
     fips_enabled = true
   }
 
@@ -662,7 +662,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain  = "aro-%[3]s.com"
-    version = "4.14.16"
+    version = "4.19.20"
   }
 
   network_profile {
@@ -798,7 +798,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain  = "aro-%[3]s.com"
-    version = "4.14.16"
+    version = "4.19.20"
   }
 
   network_profile {
@@ -857,7 +857,7 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 
   cluster_profile {
     domain                      = "aro-%[3]s.com"
-    version                     = "4.14.16"
+    version                     = "4.19.20"
     managed_resource_group_name = "acctestrg-aro-infra-%[3]s"
   }
 
@@ -927,12 +927,12 @@ resource "azuread_service_principal" "test" {
 }
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = azuread_service_principal.test.object_id
+  service_principal_id = azuread_service_principal.test.id
 }
 
 data "azuread_service_principal" "redhatopenshift" {
   // This is the Azure Red Hat OpenShift RP service principal id, do NOT delete it
-  application_id = "f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"
+  client_id = "f1dd0a37-89c6-4e07-bcd1-ffd3d43d8875"
 }
 
 resource "azurerm_role_assignment" "role_network1" {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The following tests fail due to incorrect configuration of `azuread_service_principal` property. The error log is shown below. The incorrect configuration is fixed in this PR. Besides, it is found that `azurerm_redhat_openshift_cluster` resource `version` property value `4.14.16` is deprecated. Hence, latest `version` `4.19.20` is used instead.

Failed tests
```
TestAccOpenShiftCluster_basic
TestAccOpenShiftCluster_basicResourceGroupName
TestAccOpenShiftCluster_basicWithFipsEnabled
TestAccOpenShiftCluster_encryptionAtHost
TestAccOpenShiftCluster_preconfiguredNetworkSecurityGroup
TestAccOpenShiftCluster_private
TestAccOpenShiftCluster_requiresImport
TestAccOpenShiftCluster_update
TestAccOpenShiftCluster_userDefinedRouting
```

Error log
```
    testcase.go:192: Step 1/3 error: Error running pre-apply plan: exit status 1
        Error: Unsupported argument
          on terraform_plugin_test.tf line 63, in data "azuread_service_principal" "redhatopenshift":
          63:   application_id = "REDACTED"
        An argument named "application_id" is not expected here.
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The tests run are determined using [terraform-terracorder](https://github.com/WodansSon/terraform-terracorder).
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_REDHATOPENSHIFT/595425?buildTab=overview
<img width="955" height="587" alt="image" src="https://github.com/user-attachments/assets/0596c7d2-3ccd-4aa6-a3a3-584967bfc373" />

The failed tests are due to `context deadline exceeded` error during resource deletion.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_redhat_openshift_cluster` - fix acceptance tests service principal configuration and cluster version


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
