### PR TITLE
`azurerm_arc_kubernetes_flux_configuration` - fix acceptance test

### DIFF
--- a/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource_test.go
@@ -528,7 +528,7 @@ resource "azuread_service_principal" "test" {
 }
 
 resource "azuread_service_principal_password" "test" {
-  service_principal_id = azuread_service_principal.test.object_id
+  service_principal_id = azuread_service_principal.test.id
 }
 
 resource "azurerm_storage_account" "test" {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccArcKubernetesFluxConfiguration_azureBlobWithServicePrincipalSecret` fails due to incorrect configuration of `azurerm_arc_kubernetes_flux_configuration` resource `azuread_service_principal_password` property. The error log is shown below. The configuration is fixed in this PR.

```
    testcase.go:192: Step 1/3 error: Error running apply: exit status 1
        Error: parsing "REDACTED": parsing the ServicePrincipal ID: the number of segments didn't match
        Expected a ServicePrincipal ID that matched (containing 2 segments):
        > /servicePrincipals/servicePrincipalId
        However this value was provided (which was parsed into 0 segments):
        > REDACTED
        The following Segments are expected:
        * Segment 0 - this should be the literal value "servicePrincipals"
        * Segment 1 - this should be the user specified value for this servicePrincipalId [for example "servicePrincipalId"]
        The following Segments were parsed:
        * Segment 0 - not found
        * Segment 1 - not found
          with azuread_service_principal_password.test,
          on terraform_plugin_test.tf line 266, in resource "azuread_service_principal_password" "test":
         266:   service_principal_id = azuread_service_principal.test.object_id
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The tests run are determined using [terraform-terracorder](https://github.com/WodansSon/terraform-terracorder).
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_ARCKUBERNETES/595428?buildTab=overview
<img width="1473" height="354" alt="image" src="https://github.com/user-attachments/assets/11c0f7ba-1210-4d2e-9f46-553b2ee8fb38" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_arc_kubernetes_flux_configuration` - fix `TestAccArcKubernetesFluxConfiguration_azureBlobWithServicePrincipalSecret`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
