### PR TITLE
`azurerm_batch_account` - fix `TestAccBatchAccount_removeStorageAccountId`

### DIFF
--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -448,9 +448,7 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 				StorageAccountId: v.(string),
 			}
 		} else {
-			parameters.Properties.AutoStorage = &batchaccount.AutoStorageBaseProperties{
-				StorageAccountId: "",
-			}
+			parameters.Properties.AutoStorage = &batchaccount.AutoStorageBaseProperties{}
 		}
 	}
 

--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -280,7 +280,7 @@ func resourceBatchAccountCreate(d *pluginsdk.ResourceData, meta interface{}) err
 			return fmt.Errorf("`storage_account_authentication_mode` is required when `storage_account_id` ")
 		}
 		parameters.Properties.AutoStorage = &batchaccount.AutoStorageBaseProperties{
-			StorageAccountId:   storageAccountId,
+			StorageAccountId:   pointer.To(storageAccountId),
 			AuthenticationMode: pointer.To(batchaccount.AutoStorageAuthenticationMode(authMode)),
 		}
 	}
@@ -445,7 +445,7 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	if d.HasChange("storage_account_id") {
 		if v, ok := d.GetOk("storage_account_id"); ok {
 			parameters.Properties.AutoStorage = &batchaccount.AutoStorageBaseProperties{
-				StorageAccountId: v.(string),
+				StorageAccountId: pointer.To(v.(string)),
 			}
 		} else {
 			parameters.Properties.AutoStorage = &batchaccount.AutoStorageBaseProperties{}
@@ -460,7 +460,7 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	storageAccountId := d.Get("storage_account_id").(string)
 	if storageAccountId != "" {
 		parameters.Properties.AutoStorage = &batchaccount.AutoStorageBaseProperties{
-			StorageAccountId:   storageAccountId,
+			StorageAccountId:   pointer.To(storageAccountId),
 			AuthenticationMode: pointer.To(batchaccount.AutoStorageAuthenticationMode(authMode)),
 		}
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccounts/model_autostoragebaseproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccounts/model_autostoragebaseproperties.go
@@ -6,5 +6,5 @@ package batchaccounts
 type AutoStorageBaseProperties struct {
 	AuthenticationMode    *AutoStorageAuthenticationMode `json:"authenticationMode,omitempty"`
 	NodeIdentityReference *ComputeNodeIdentityReference  `json:"nodeIdentityReference,omitempty"`
-	StorageAccountId      string                         `json:"storageAccountId"`
+	StorageAccountId      *string                        `json:"storageAccountId"`
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccounts/model_autostorageproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccounts/model_autostorageproperties.go
@@ -13,7 +13,7 @@ type AutoStorageProperties struct {
 	AuthenticationMode    *AutoStorageAuthenticationMode `json:"authenticationMode,omitempty"`
 	LastKeySync           string                         `json:"lastKeySync"`
 	NodeIdentityReference *ComputeNodeIdentityReference  `json:"nodeIdentityReference,omitempty"`
-	StorageAccountId      *string                        `json:"storageAccountId"`
+	StorageAccountId      string                         `json:"storageAccountId"`
 }
 
 func (o *AutoStorageProperties) GetLastKeySyncAsTime() (*time.Time, error) {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccounts/model_autostorageproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2024-07-01/batchaccounts/model_autostorageproperties.go
@@ -13,7 +13,7 @@ type AutoStorageProperties struct {
 	AuthenticationMode    *AutoStorageAuthenticationMode `json:"authenticationMode,omitempty"`
 	LastKeySync           string                         `json:"lastKeySync"`
 	NodeIdentityReference *ComputeNodeIdentityReference  `json:"nodeIdentityReference,omitempty"`
-	StorageAccountId      string                         `json:"storageAccountId"`
+	StorageAccountId      *string                        `json:"storageAccountId"`
 }
 
 func (o *AutoStorageProperties) GetLastKeySyncAsTime() (*time.Time, error) {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccBatchAccount_removeStorageAccountId` fails due to the presence of `properties.autoStorage.storageAccountId` JSON field in Azure REST API request even if the value is empty as shown in the error log below. The only way I can think of to remove `properties.autoStorage.storageAccountId` (the objective of the test) is by ensuring that `properties.autoStorage` JSON field is empty without `properties.autoStorage.storageAccountId` being declared. To fix the issue in a straightforward way, the current `go-azure-sdk` type for `properties.autoStorage.storageAccountId` can be changed from `string` to `*string` which allows complete removal of the JSON field.

```
    testcase.go:192: Step 4/9 error: Error running apply: exit status 1
        Error: updating Batch Account (Subscription: "*******"
        Resource Group Name: "REDACTED"
        Batch Account Name: "REDACTED"): unexpected status 400 (400 Bad Request) with error: LinkedInvalidPropertyId: Property id '' at path 'properties.autoStorage.storageAccountId' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'.
          with azurerm_batch_account.test,
          on terraform_plugin_test.tf line 48, in resource "azurerm_batch_account" "test":
          48: resource "azurerm_batch_account" "test" {
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_BATCH/598965?buildTab=overview
<img width="958" height="356" alt="image" src="https://github.com/user-attachments/assets/8505a8a7-b59f-4c93-961c-2202e3e4c4c4" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_batch_account` - fix `TestAccBatchAccount_removeStorageAccountId`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
