### PR TITLE
go-vcr POC approach-1 to pass httpclient

### DIFF
--- a/internal/acceptance/vcr/vcr.go
+++ b/internal/acceptance/vcr/vcr.go
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+// Package vcr provides HTTP recording/playback for acceptance tests.
+// This is a minimal POC implementation - currently a pass-through that makes real HTTP requests.
+package vcr
+
+import (
+	"net/http"
+	"testing"
+)
+
+// GetHTTPClient returns an HTTP client for acceptance tests.
+// Currently returns a simple pass-through client for POC purposes.
+// Future: Will support VCR recording/playback based on VCR_MODE environment variable.
+func GetHTTPClient(t *testing.T) *http.Client {
+	client := &http.Client{}
+	return client
+}

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -33,6 +34,7 @@ type ClientBuilder struct {
 	StorageUseAzureAD           bool
 	SubscriptionID              string
 	TerraformVersion            string
+	HttpClient                  *http.Client
 }
 
 const azureStackEnvironmentError = `
@@ -150,6 +152,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		StorageUseAzureAD:           builder.StorageUseAzureAD,
 
 		ResourceManagerEndpoint: *resourceManagerEndpoint,
+		HTTPClient:              builder.HttpClient,
 	}
 
 	if err := client.Build(ctx, o); err != nil {

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -59,6 +60,8 @@ type ClientOptions struct {
 
 	// TODO: Remove when all go-autorest clients are gone
 	SkipProviderReg bool
+
+	HTTPClient *http.Client
 }
 
 // Configure set up a resourcemanager.Client using an auth.Authorizer from hashicorp/go-azure-sdk
@@ -76,6 +79,11 @@ func (o ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer
 
 	c.AppendRequestMiddleware(requestLoggerMiddleware("AzureRM"))
 	c.AppendResponseMiddleware(responseLoggerMiddleware("AzureRM"))
+
+	// TODO: Enable once go-azure-sdk supports SetHTTPClient method
+	// This is needed for VCR testing support
+	// c.SetHTTPClient(o.HTTPClient)
+
 }
 
 // ConfigureClient sets up an autorest.Client using an autorest.Authorizer

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -80,9 +80,7 @@ func (o ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer
 	c.AppendRequestMiddleware(requestLoggerMiddleware("AzureRM"))
 	c.AppendResponseMiddleware(responseLoggerMiddleware("AzureRM"))
 
-	// TODO: Enable once go-azure-sdk supports SetHTTPClient method
-	// This is needed for VCR testing support
-	// c.SetHTTPClient(o.HTTPClient)
+	c.SetHTTPClient(o.HTTPClient)
 
 }
 

--- a/internal/provider/framework/factory_builder.go
+++ b/internal/provider/framework/factory_builder.go
@@ -5,6 +5,7 @@ package framework
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -45,8 +46,43 @@ func ProtoV5ProviderFactoriesInit(ctx context.Context, providerNames ...string) 
 	return factories
 }
 
+// ProtoV5ProviderFactoriesInitWithHTTPClient creates provider factories with a custom HTTP client.
+func ProtoV5ProviderFactoriesInitWithHTTPClient(ctx context.Context, httpClient *http.Client, providerNames ...string) map[string]func() (tfprotov5.ProviderServer, error) {
+	factories := make(map[string]func() (tfprotov5.ProviderServer, error), len(providerNames))
+
+	for _, name := range providerNames {
+		factories[name] = func() (tfprotov5.ProviderServer, error) {
+			providerServerFactory, _, err := ProtoV5ProviderServerFactoryWithHTTPClient(ctx, httpClient)
+			if err != nil {
+				return nil, err
+			}
+
+			return providerServerFactory(), nil
+		}
+	}
+
+	return factories
+}
+
 func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
 	v2Provider := provider.AzureProvider()
+
+	providers := []func() tfprotov5.ProviderServer{
+		v2Provider.GRPCProvider,
+		providerserver.NewProtocol5(NewFrameworkProvider(v2Provider)),
+	}
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return muxServer.ProviderServer, v2Provider, nil
+}
+
+// ProtoV5ProviderServerFactoryWithHTTPClient creates a provider server factory with a custom HTTP client.
+func ProtoV5ProviderServerFactoryWithHTTPClient(ctx context.Context, httpClient *http.Client) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
+	v2Provider := provider.AzureProviderWithHTTPClient(httpClient)
 
 	providers := []func() tfprotov5.ProviderServer{
 		v2Provider.GRPCProvider,

--- a/internal/provider/framework/factory_builder.go
+++ b/internal/provider/framework/factory_builder.go
@@ -52,7 +52,7 @@ func ProtoV5ProviderFactoriesInitWithHTTPClient(ctx context.Context, httpClient 
 
 	for _, name := range providerNames {
 		factories[name] = func() (tfprotov5.ProviderServer, error) {
-			providerServerFactory, _, err := ProtoV5ProviderServerFactoryWithHTTPClient(ctx, httpClient)
+			providerServerFactory, _, err := protoV5ProviderServerFactoryWithHTTPClient(ctx, httpClient)
 			if err != nil {
 				return nil, err
 			}
@@ -80,8 +80,8 @@ func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.Provide
 	return muxServer.ProviderServer, v2Provider, nil
 }
 
-// ProtoV5ProviderServerFactoryWithHTTPClient creates a provider server factory with a custom HTTP client.
-func ProtoV5ProviderServerFactoryWithHTTPClient(ctx context.Context, httpClient *http.Client) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
+// protoV5ProviderServerFactoryWithHTTPClient creates a provider server factory with a custom HTTP client.
+func protoV5ProviderServerFactoryWithHTTPClient(ctx context.Context, httpClient *http.Client) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
 	v2Provider := provider.AzureProviderWithHTTPClient(httpClient)
 
 	providers := []func() tfprotov5.ProviderServer{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -335,7 +335,7 @@ func TestAccProvider_cliAuth(t *testing.T) {
 			AzureCliSubscriptionIDHint:        d.Get("subscription_id").(string),
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -407,7 +407,7 @@ func TestAccProvider_clientCertificateAuth(t *testing.T) {
 			EnableAuthenticatingUsingClientCertificate: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -480,7 +480,7 @@ func testAccProvider_clientSecretAuthFromEnvironment(t *testing.T) {
 			EnableAuthenticatingUsingClientSecret: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -548,7 +548,7 @@ func testAccProvider_clientSecretAuthFromFiles(t *testing.T) {
 			EnableAuthenticatingUsingClientSecret: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -608,7 +608,7 @@ func TestAccProvider_genericOidcAuth(t *testing.T) {
 			OIDCAssertionToken:            *oidcToken,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -667,7 +667,7 @@ func TestAccProvider_githubOidcAuth(t *testing.T) {
 			EnableAuthenticationUsingGitHubOIDC: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -730,7 +730,7 @@ func TestAccProvider_adoOidcAuth(t *testing.T) {
 			EnableAuthenticationUsingADOPipelineOIDC: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -796,7 +796,7 @@ func TestAccProvider_aksWorkloadIdentityAuth(t *testing.T) {
 			EnableAuthenticationUsingOIDC: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	// Ensure we enable AKS Workload Identity else the configuration will not be detected

--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -22,7 +22,7 @@ func TestAccApiManagementLogger_basicEventHub(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_logger", "test")
 	r := ApiManagementLoggerResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestWithVCR(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicEventHub(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
@@ -318,6 +318,8 @@ type Client struct {
 
 	// ResponseMiddlewares is a slice of functions that are called in order before a response is parsed and returned
 	ResponseMiddlewares *[]ResponseMiddleware
+
+	HttpClient *http.Client
 }
 
 // NewClient returns a new Client configured with sensible defaults
@@ -345,6 +347,14 @@ func (c *Client) SetUserAgent(userAgent string) {
 // GetUserAgent retrieves the configured user agent for the client
 func (c *Client) GetUserAgent() string {
 	return c.UserAgent
+}
+
+func (c *Client) SetHTTPClient(httpClient *http.Client) {
+	c.HttpClient = httpClient
+}
+
+func (c *Client) GetHTTPClient() *http.Client {
+	return c.HttpClient
 }
 
 // AppendRequestMiddleware appends a request middleware function for the client
@@ -742,7 +752,10 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 			MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
 		},
 	}
-
+	// overrides httpClient with provided one
+	if c.HttpClient != nil{
+		r.HTTPClient = c.HttpClient
+	}
 	return
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/interface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/interface.go
@@ -41,6 +41,10 @@ type BaseClient interface {
 
 	// ClearResponseMiddlewares removes all response middleware functions for the client
 	ClearResponseMiddlewares()
+
+	SetHTTPClient(*http.Client)
+
+	GetHTTPClient() *http.Client
 }
 
 // RequestRetryFunc is a function that determines whether an HTTP request has failed due to eventual consistency and should be retried


### PR DESCRIPTION
Changes to passing VCR httpClient to underline go-azure-sdk. 
As It's just a POC hence made changes to vendor files instead of raising a separate azure-sdk PR.